### PR TITLE
fix(autopilot): CI-fix size guard excludes test/bookkeeping additions (GH-4284)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1553,13 +1553,16 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 				"pr", prState.PRNumber, "error", err)
 			// Fall through — belt-and-suspenders: merge-time SizeFloor gate in handleCIPassed catches it.
 		} else {
-			netAdditions := 0
-			for _, f := range files {
-				netAdditions += f.Additions
-			}
-			if netAdditions > c.config.MaxCIFixPRSize {
+			// GH-4284: exclude test (`_test.go`) and bookkeeping (`.agent/**`)
+			// additions the same way SizeFloorReason does, via the shared
+			// productionAdditions helper — a well-tested PR (#4279: ~90
+			// production / ~290 test / 28 bookkeeping of 421 total) must not
+			// be mistaken for cascade contamination just because it has tests.
+			production, bookkeeping, test := productionAdditions(files)
+			if production > c.config.MaxCIFixPRSize {
 				c.log.Warn("CI fix size guard fired — failing PR exceeds size floor, refusing to spawn fix issue",
-					"pr", prState.PRNumber, "additions", netAdditions, "limit", c.config.MaxCIFixPRSize)
+					"pr", prState.PRNumber, "production_additions", production, "test_additions", test,
+					"bookkeeping_additions", bookkeeping, "limit", c.config.MaxCIFixPRSize)
 				if err := c.ghClient.ClosePullRequest(ctx, c.owner, c.repo, prState.PRNumber); err != nil {
 					c.log.Warn("CI fix size guard: failed to close oversized failed PR",
 						"pr", prState.PRNumber, "error", err)
@@ -1572,7 +1575,8 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 				}
 				// GH-3806: see the matching comment on the iteration-limit branch above.
 				prState.Stage = StageFailed
-				prState.Error = fmt.Sprintf("CI fix size guard: PR has %d additions, over limit %d (likely cascade contamination — escalate to human)", netAdditions, c.config.MaxCIFixPRSize)
+				prState.Error = fmt.Sprintf("CI fix size guard: PR has %d production additions, over limit %d%s (likely cascade contamination — escalate to human)",
+					production, c.config.MaxCIFixPRSize, excludedAdditionsSuffix(bookkeeping, test))
 				prState.TerminalLabel = github.LabelFailed
 				c.metrics.RecordPRFailed()
 				c.metrics.RecordCIRun("fail")

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -7217,6 +7217,167 @@ func TestCIFixSizeGuard_APIError_FailOpen(t *testing.T) {
 	}
 }
 
+// TestCIFixSizeGuard_WellTestedPR_AllowsFixIssue is a GH-4284 regression test
+// reproducing the #4279 shape: 421 total additions (90 production / 290 test
+// / 28 bookkeeping) — over the raw 200-line limit, but under it once test and
+// `.agent/**` additions are excluded. The guard must NOT fire (a well-tested
+// PR was previously auto-closed as "cascade contamination" for this exact shape).
+func TestCIFixSizeGuard_WellTestedPR_AllowsFixIssue(t *testing.T) {
+	issueCreated := false
+	prClosed := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/def4279/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "drift-gate", Status: "completed", Conclusion: "failure"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/issues/4276" && r.Method == http.MethodGet:
+			resp := github.Issue{Number: 4276, Body: "<!-- autopilot-meta branch:pilot/GH-4276 pr:4279 iteration:1 -->"}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/pulls/4279/files" && r.Method == http.MethodGet:
+			// #4279 shape: 90 production, 290 test, 28 bookkeeping = 408 total (>200 raw, <200 production).
+			files := []*github.PRFile{
+				{Filename: "internal/autopilot/dispatcher.go", Status: "modified", Additions: 90},
+				{Filename: "internal/autopilot/dispatcher_gh4276_test.go", Status: "added", Additions: 114},
+				{Filename: "internal/memory/store_test.go", Status: "modified", Additions: 103},
+				{Filename: "internal/autopilot/dispatcher_test.go", Status: "modified", Additions: 65},
+				{Filename: ".agent/knowledge/memories/pitfalls/gh4276-cross-project-task-id.md", Status: "added", Additions: 28},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, files))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			issueCreated = true
+			resp := github.Issue{Number: 500}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/pulls/4279" && r.Method == http.MethodPatch:
+			prClosed = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+	cfg.MaxCIFixPRSize = 200
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:    4279,
+		IssueNumber: 4276,
+		HeadSHA:     "def4279",
+		Stage:       StageCIFailed,
+	}
+
+	err := c.handleCIFailed(context.Background(), prState)
+	if err != nil {
+		t.Fatalf("handleCIFailed returned unexpected error: %v", err)
+	}
+
+	if !issueCreated {
+		t.Error("fix issue MUST be created — 90 production additions is under the 200 limit once tests/bookkeeping are excluded")
+	}
+	if !prClosed {
+		t.Error("failed PR should still be closed (normal flow: fix issue created, poller unblocked)")
+	}
+	if strings.Contains(prState.Error, "cascade contamination") {
+		t.Errorf("error must not claim cascade contamination for a well-tested PR, got: %s", prState.Error)
+	}
+}
+
+// TestCIFixSizeGuard_GenuineCascade_StillBlocksFixIssue verifies that a PR
+// with >200 PRODUCTION lines across unrelated files (no tests, no
+// bookkeeping) still trips the guard — the GH-4284 exclusion fix must not
+// weaken genuine cascade-contamination detection.
+func TestCIFixSizeGuard_GenuineCascade_StillBlocksFixIssue(t *testing.T) {
+	issueCreated := false
+	prClosed := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/cascade1/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "build", Status: "completed", Conclusion: "failure"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/issues/11" && r.Method == http.MethodGet:
+			resp := github.Issue{Number: 11, Body: "<!-- autopilot-meta branch:pilot/GH-11 pr:77 iteration:1 -->"}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/pulls/77/files" && r.Method == http.MethodGet:
+			// 300 production additions across unrelated files, no tests/bookkeeping.
+			files := []*github.PRFile{
+				{Filename: "internal/gateway/server.go", Status: "modified", Additions: 150},
+				{Filename: "internal/adapters/slack/notifier.go", Status: "modified", Additions: 150},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, files))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			issueCreated = true
+			resp := github.Issue{Number: 600}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/pulls/77" && r.Method == http.MethodPatch:
+			prClosed = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+	cfg.MaxCIFixPRSize = 200
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:    77,
+		IssueNumber: 11,
+		HeadSHA:     "cascade1",
+		Stage:       StageCIFailed,
+	}
+
+	err := c.handleCIFailed(context.Background(), prState)
+	if err != nil {
+		t.Fatalf("handleCIFailed returned unexpected error: %v", err)
+	}
+
+	if issueCreated {
+		t.Error("fix issue must NOT be created — 300 production additions is genuine cascade contamination")
+	}
+	if !prClosed {
+		t.Error("genuinely oversized failing PR must still be closed by the size guard")
+	}
+	if prState.Stage != StageFailed {
+		t.Errorf("Stage = %s, want %s", prState.Stage, StageFailed)
+	}
+	if !strings.Contains(prState.Error, "CI fix size guard") {
+		t.Errorf("error should mention size guard, got: %s", prState.Error)
+	}
+}
+
 // asyncApprovalManager returns an approval.Manager configured for async pre-merge approval.
 func asyncApprovalManager() *approval.Manager {
 	cfg := &approval.Config{

--- a/internal/autopilot/scope_guard.go
+++ b/internal/autopilot/scope_guard.go
@@ -108,29 +108,68 @@ func isBookkeepingPath(path string) bool {
 	return path == ".agent" || strings.HasPrefix(path, ".agent/")
 }
 
-// SizeFloorReason returns a non-empty reason if the PR's code additions
-// (excluding Navigator bookkeeping paths, see isBookkeepingPath) exceed
-// SizeFloorThreshold. Pilot's median PR is well under 100 additions —
-// anything over the floor is large enough that auto-merge is too aggressive
-// even on a passing CI signal. GH-4055: PR #4047 (586 total additions, 281 of
-// them `.agent/**`, 305 code) wrongly escalated under the old net-additions
-// count — bookkeeping additions are now tracked separately and excluded from
-// the gate, while still surfaced in the reason string for visibility.
-func SizeFloorReason(files []*github.PRFile) string {
-	var codeAdditions, bookkeepingAdditions int
+// isTestPath reports whether path is a Go test file. Test additions inflate
+// PR size without adding production surface area — the same rationale
+// isBookkeepingPath already applies to `.agent/**`.
+func isTestPath(path string) bool {
+	return strings.HasSuffix(path, "_test.go")
+}
+
+// productionAdditions splits a PR's file list into production additions
+// (shipped code) versus bookkeeping (isBookkeepingPath, e.g. `.agent/**`) and
+// test (isTestPath, `_test.go`) additions. Both the CI-fix size guard
+// (controller.go) and SizeFloorReason use this so they can never drift apart
+// on what counts as "real" size again — GH-4284: the CI-fix guard summed raw
+// additions with no exclusions at all, auto-closing a well-tested PR (#4279)
+// whose 421 additions were ~290 test + 28 bookkeeping and only ~90 production.
+func productionAdditions(files []*github.PRFile) (production, bookkeeping, test int) {
 	for _, f := range files {
-		if isBookkeepingPath(f.Filename) {
-			bookkeepingAdditions += f.Additions
-		} else {
-			codeAdditions += f.Additions
+		switch {
+		case isBookkeepingPath(f.Filename):
+			bookkeeping += f.Additions
+		case isTestPath(f.Filename):
+			test += f.Additions
+		default:
+			production += f.Additions
 		}
 	}
-	if codeAdditions > SizeFloorThreshold {
-		if bookkeepingAdditions > 0 {
-			return fmt.Sprintf("PR adds %d code additions (> %d threshold; %d bookkeeping additions excluded)",
-				codeAdditions, SizeFloorThreshold, bookkeepingAdditions)
+	return production, bookkeeping, test
+}
+
+// excludedAdditionsSuffix renders the "excluded" parenthetical shared by
+// SizeFloorReason and the CI-fix size guard, e.g. "; 28 bookkeeping
+// additions excluded, 290 test additions excluded". Returns "" if nothing
+// was excluded, so callers can fall back to a plain "no exclusions" message.
+func excludedAdditionsSuffix(bookkeeping, test int) string {
+	switch {
+	case bookkeeping > 0 && test > 0:
+		return fmt.Sprintf("; %d bookkeeping additions excluded, %d test additions excluded", bookkeeping, test)
+	case bookkeeping > 0:
+		return fmt.Sprintf("; %d bookkeeping additions excluded", bookkeeping)
+	case test > 0:
+		return fmt.Sprintf("; %d test additions excluded", test)
+	default:
+		return ""
+	}
+}
+
+// SizeFloorReason returns a non-empty reason if the PR's production
+// additions (excluding Navigator bookkeeping paths and Go test files, see
+// productionAdditions) exceed SizeFloorThreshold. Pilot's median PR is well
+// under 100 additions — anything over the floor is large enough that
+// auto-merge is too aggressive even on a passing CI signal. GH-4055: PR
+// #4047 (586 total additions, 281 of them `.agent/**`, 305 code) wrongly
+// escalated under the old net-additions count — bookkeeping additions are
+// tracked separately and excluded from the gate, while still surfaced in the
+// reason string for visibility. GH-4284: test additions are now excluded
+// the same way.
+func SizeFloorReason(files []*github.PRFile) string {
+	production, bookkeeping, test := productionAdditions(files)
+	if production > SizeFloorThreshold {
+		if suffix := excludedAdditionsSuffix(bookkeeping, test); suffix != "" {
+			return fmt.Sprintf("PR adds %d code additions (> %d threshold%s)", production, SizeFloorThreshold, suffix)
 		}
-		return fmt.Sprintf("PR adds %d net lines (> %d threshold)", codeAdditions, SizeFloorThreshold)
+		return fmt.Sprintf("PR adds %d net lines (> %d threshold)", production, SizeFloorThreshold)
 	}
 	return ""
 }

--- a/internal/autopilot/scope_guard_test.go
+++ b/internal/autopilot/scope_guard_test.go
@@ -159,10 +159,24 @@ func TestSizeFloorReason(t *testing.T) {
 			},
 		},
 		{
-			name: "cascade-2 contaminating PR (~512 LoC)",
+			// GH-4284: with test additions now excluded (see productionAdditions),
+			// this fixture's 272 production lines no longer cross the 500
+			// threshold on its own — cascade-2 was actually caught by
+			// ScopeDriftReason (title type/scope mismatch, see file header),
+			// which remains the primary gate for this incident class.
+			name: "cascade-2 contaminating PR (~512 LoC incl. 240 test LoC) — no floor once tests excluded",
 			files: []*github.PRFile{
 				{Filename: "internal/gateway/oauth.go", Status: "added", Additions: 244},
 				{Filename: "internal/gateway/oauth_test.go", Status: "added", Additions: 240},
+				{Filename: "internal/gateway/server.go", Status: "modified", Additions: 24},
+				{Filename: "cmd/pilot/main.go", Status: "modified", Additions: 3},
+				{Filename: "internal/config/config.go", Status: "modified", Additions: 1},
+			},
+		},
+		{
+			name: "cascade-2 shape with genuinely large production code (~512 LoC, no tests) — floor fires",
+			files: []*github.PRFile{
+				{Filename: "internal/gateway/oauth.go", Status: "added", Additions: 484},
 				{Filename: "internal/gateway/server.go", Status: "modified", Additions: 24},
 				{Filename: "cmd/pilot/main.go", Status: "modified", Additions: 3},
 				{Filename: "internal/config/config.go", Status: "modified", Additions: 1},
@@ -269,5 +283,94 @@ func TestSizeFloorReason_BookkeepingExclusion(t *testing.T) {
 				t.Errorf("expected no size-floor fire, got %q", got)
 			}
 		})
+	}
+}
+
+// TestSizeFloorReason_TestExclusion covers GH-4284: `_test.go` additions must
+// be excluded from the size-floor gate the same way `.agent/**` bookkeeping
+// already is (GH-4055) — a well-tested PR should not escalate on test bulk alone.
+func TestSizeFloorReason_TestExclusion(t *testing.T) {
+	cases := []struct {
+		name  string
+		files []*github.PRFile
+		want  bool // true if a reason is expected
+	}{
+		{
+			// #4279 shape: 90 production, 290 test, 28 bookkeeping — well
+			// under the 500-line SizeFloorThreshold on production alone.
+			name: "GH-4279 shape: 90 production + 290 test + 28 bookkeeping — no escalation",
+			files: []*github.PRFile{
+				{Filename: "internal/autopilot/dispatcher.go", Status: "modified", Additions: 90},
+				{Filename: "internal/autopilot/dispatcher_gh4276_test.go", Status: "added", Additions: 114},
+				{Filename: "internal/memory/store_test.go", Status: "modified", Additions: 103},
+				{Filename: "internal/autopilot/dispatcher_test.go", Status: "modified", Additions: 73},
+				{Filename: ".agent/knowledge/memories/pitfalls/gh4276.md", Status: "added", Additions: 28},
+			},
+		},
+		{
+			name: "501 production + 1000 test — escalates on production alone",
+			files: []*github.PRFile{
+				{Filename: "internal/autopilot/controller.go", Status: "modified", Additions: 501},
+				{Filename: "internal/autopilot/controller_test.go", Status: "modified", Additions: 1000},
+			},
+			want: true,
+		},
+		{
+			name: "0 production + 900 test — no escalation",
+			files: []*github.PRFile{
+				{Filename: "internal/autopilot/controller_test.go", Status: "added", Additions: 900},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SizeFloorReason(tc.files)
+			if tc.want && got == "" {
+				t.Errorf("expected size-floor to fire, got empty reason")
+			}
+			if !tc.want && got != "" {
+				t.Errorf("expected no size-floor fire, got %q", got)
+			}
+		})
+	}
+}
+
+// TestIsTestPath covers GH-4284 test-file classification.
+func TestIsTestPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"internal/autopilot/controller.go", false},
+		{"internal/autopilot/controller_test.go", true},
+		{".agent/tasks/foo.md", false},
+		{"internal/foo/bar_test.go", true},
+		{"internal/foo/testdata/fixture.go", false},
+	}
+	for _, tc := range cases {
+		if got := isTestPath(tc.path); got != tc.want {
+			t.Errorf("isTestPath(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+// TestProductionAdditions covers GH-4284: the shared helper used by both
+// SizeFloorReason and the CI-fix size guard must classify each file into
+// exactly one bucket (production, bookkeeping, or test).
+func TestProductionAdditions(t *testing.T) {
+	files := []*github.PRFile{
+		{Filename: "internal/autopilot/dispatcher.go", Additions: 90},
+		{Filename: "internal/autopilot/dispatcher_test.go", Additions: 65},
+		{Filename: ".agent/tasks/foo.md", Additions: 28},
+	}
+	production, bookkeeping, test := productionAdditions(files)
+	if production != 90 {
+		t.Errorf("production = %d, want 90", production)
+	}
+	if bookkeeping != 28 {
+		t.Errorf("bookkeeping = %d, want 28", bookkeeping)
+	}
+	if test != 65 {
+		t.Errorf("test = %d, want 65", test)
 	}
 }


### PR DESCRIPTION
## Summary
- The CI-fix size guard (`handleCIFailed`, controller.go:1556) summed raw `f.Additions` across all files with no exclusions — unlike its sibling `SizeFloorReason` (scope_guard.go), which GH-4055 already fixed to exclude `.agent/**` bookkeeping. This auto-closed a correct, well-tested PR (#4279, the GH-4276 cross-project task_id fix) as "cascade contamination" at 421 additions, when only ~90 of those were production code (~290 test, 28 bookkeeping).
- Factored a shared `productionAdditions(files)` helper in `scope_guard.go` that classifies each file's additions into production / bookkeeping (`.agent/**`) / test (`_test.go`) buckets, used by BOTH the CI-fix guard and `SizeFloorReason` so they can't drift apart again.
- Escalation reason strings on both guards now report excluded test + bookkeeping counts (shared `excludedAdditionsSuffix` helper).
- Left `MaxCIFixPRSize: 200` as-is — 200 production-only lines remains a defensible cascade-contamination threshold.

## Test plan
- [x] `TestCIFixSizeGuard_WellTestedPR_AllowsFixIssue` — regression test reproducing the #4279 shape (90 production / 290 test / 28 bookkeeping of ~408 total): guard does NOT fire, fix issue is created.
- [x] `TestCIFixSizeGuard_GenuineCascade_StillBlocksFixIssue` — 300 production lines across unrelated files still trips the guard.
- [x] `TestSizeFloorReason_TestExclusion`, `TestIsTestPath`, `TestProductionAdditions` — unit coverage for the new shared helper.
- [x] Updated the pre-existing cascade-2 fixture in `TestSizeFloorReason`: with test additions now excluded, that fixture's 272 production lines no longer cross the 500 merge-time threshold on their own (cascade-2 was actually caught by `ScopeDriftReason`'s title-mismatch check); added a same-shape fixture with genuinely large production code to confirm the floor still fires.
- [x] `go build ./...`, `go test ./...`, `golangci-lint run --new-from-rev=origin/main ./internal/autopilot/...` all green.