### PR TITLE
fix(memory): backfill terminal execution_event in the three heal paths (GH-4292)

### DIFF
--- a/internal/memory/gh4292_selfheal_events_test.go
+++ b/internal/memory/gh4292_selfheal_events_test.go
@@ -1,0 +1,361 @@
+package memory
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestHealFunctions_WriteOneTerminalEventMatchingPRURLBranch covers GH-4292:
+// ResolveOrphanedRunningExecution, SelfHealExecutionAfterMerge, and
+// SelfHealExecutionByPRURL must each write exactly one terminal
+// execution_events row per healed row, of type StageMerged when a PR URL is
+// known and StageFailed otherwise.
+func TestHealFunctions_WriteOneTerminalEventMatchingPRURLBranch(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialStatus string
+		prURL         string
+		wantStage     Stage
+		heal          func(store *Store, execID, taskID, projectPath, prURL string) error
+	}{
+		{
+			name:          "ResolveOrphanedRunningExecution/merged",
+			initialStatus: "running",
+			prURL:         "https://github.com/o/r/pull/4199",
+			wantStage:     StageMerged,
+			heal: func(store *Store, execID, taskID, projectPath, prURL string) error {
+				return store.ResolveOrphanedRunningExecution(execID, prURL)
+			},
+		},
+		{
+			name:          "ResolveOrphanedRunningExecution/no-evidence",
+			initialStatus: "running",
+			prURL:         "",
+			wantStage:     StageFailed,
+			heal: func(store *Store, execID, taskID, projectPath, prURL string) error {
+				return store.ResolveOrphanedRunningExecution(execID, prURL)
+			},
+		},
+		{
+			name:          "SelfHealExecutionAfterMerge/merged",
+			initialStatus: "failed",
+			prURL:         "https://github.com/o/r/pull/4217",
+			wantStage:     StageMerged,
+			heal: func(store *Store, execID, taskID, projectPath, prURL string) error {
+				return store.SelfHealExecutionAfterMerge(taskID, projectPath, prURL)
+			},
+		},
+		{
+			name:          "SelfHealExecutionAfterMerge/no-url",
+			initialStatus: "failed",
+			prURL:         "",
+			wantStage:     StageFailed,
+			heal: func(store *Store, execID, taskID, projectPath, prURL string) error {
+				return store.SelfHealExecutionAfterMerge(taskID, projectPath, prURL)
+			},
+		},
+		{
+			name:          "SelfHealExecutionByPRURL/merged",
+			initialStatus: "failed",
+			prURL:         "https://github.com/o/r/pull/4190",
+			wantStage:     StageMerged,
+			heal: func(store *Store, execID, taskID, projectPath, prURL string) error {
+				return store.SelfHealExecutionByPRURL(prURL)
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, err := NewStore(t.TempDir())
+			if err != nil {
+				t.Fatalf("NewStore: %v", err)
+			}
+			defer func() { _ = store.Close() }()
+
+			execID := fmt.Sprintf("exec-%d", i)
+			taskID := fmt.Sprintf("GH-%d", 4300+i)
+			projectPath := "/proj"
+
+			exec := &Execution{ID: execID, TaskID: taskID, ProjectPath: projectPath, Status: tt.initialStatus}
+			if tt.name == "SelfHealExecutionByPRURL/merged" {
+				// SelfHealExecutionByPRURL matches on the row's own already-stamped
+				// pr_url column, unlike the task_id-keyed heals above.
+				exec.PRUrl = tt.prURL
+			}
+			if err := store.SaveExecution(exec); err != nil {
+				t.Fatalf("SaveExecution: %v", err)
+			}
+
+			if err := tt.heal(store, execID, taskID, projectPath, tt.prURL); err != nil {
+				t.Fatalf("heal call failed: %v", err)
+			}
+
+			events, err := store.ListExecutionEvents(execID)
+			if err != nil {
+				t.Fatalf("ListExecutionEvents: %v", err)
+			}
+			if len(events) != 1 {
+				t.Fatalf("expected exactly one terminal event, got %d: %+v", len(events), events)
+			}
+			if events[0].Stage != tt.wantStage {
+				t.Errorf("event stage = %q, want %q", events[0].Stage, tt.wantStage)
+			}
+		})
+	}
+}
+
+// TestHealFunctions_SecondCallOnHealedRowDoesNotDoubleWriteEvent verifies
+// idempotency: once a row has healed to a terminal status, it drops out of
+// each heal function's WHERE clause, so calling the same heal function again
+// selects zero candidates and writes zero additional execution_events rows.
+func TestHealFunctions_SecondCallOnHealedRowDoesNotDoubleWriteEvent(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialStatus string
+		heal          func(store *Store) error
+	}{
+		{
+			name:          "ResolveOrphanedRunningExecution",
+			initialStatus: "running",
+			heal: func(store *Store) error {
+				return store.ResolveOrphanedRunningExecution("exec-1", "https://github.com/o/r/pull/4182")
+			},
+		},
+		{
+			name:          "SelfHealExecutionAfterMerge",
+			initialStatus: "failed",
+			heal: func(store *Store) error {
+				return store.SelfHealExecutionAfterMerge("GH-1", "/proj", "https://github.com/o/r/pull/4203")
+			},
+		},
+		{
+			name:          "SelfHealExecutionByPRURL",
+			initialStatus: "failed",
+			heal: func(store *Store) error {
+				return store.SelfHealExecutionByPRURL("https://github.com/o/r/pull/4227")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, err := NewStore(t.TempDir())
+			if err != nil {
+				t.Fatalf("NewStore: %v", err)
+			}
+			defer func() { _ = store.Close() }()
+
+			exec := &Execution{ID: "exec-1", TaskID: "GH-1", ProjectPath: "/proj", Status: tt.initialStatus}
+			if tt.name == "SelfHealExecutionByPRURL" {
+				exec.PRUrl = "https://github.com/o/r/pull/4227"
+			}
+			if err := store.SaveExecution(exec); err != nil {
+				t.Fatalf("SaveExecution: %v", err)
+			}
+
+			if err := tt.heal(store); err != nil {
+				t.Fatalf("first heal call failed: %v", err)
+			}
+			if err := tt.heal(store); err != nil {
+				t.Fatalf("second heal call failed: %v", err)
+			}
+
+			events, err := store.ListExecutionEvents("exec-1")
+			if err != nil {
+				t.Fatalf("ListExecutionEvents: %v", err)
+			}
+			if len(events) != 1 {
+				t.Fatalf("expected exactly one terminal event after two calls, got %d: %+v", len(events), events)
+			}
+		})
+	}
+}
+
+// TestHealFunctions_RollbackOnEventWriteFailureLeavesStatusUntouched verifies
+// GH-4292's transactional requirement: the status UPDATE and the terminal
+// execution_events INSERT commit together. Dropping the execution_events
+// table forces the INSERT to fail after the UPDATE has already run inside the
+// same transaction — if the write were not transactional, the status would
+// still flip to its terminal value even though no event was recorded.
+func TestHealFunctions_RollbackOnEventWriteFailureLeavesStatusUntouched(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialStatus string
+		heal          func(store *Store) error
+	}{
+		{
+			name:          "ResolveOrphanedRunningExecution",
+			initialStatus: "running",
+			heal: func(store *Store) error {
+				return store.ResolveOrphanedRunningExecution("exec-1", "https://github.com/o/r/pull/4234")
+			},
+		},
+		{
+			name:          "SelfHealExecutionAfterMerge",
+			initialStatus: "failed",
+			heal: func(store *Store) error {
+				return store.SelfHealExecutionAfterMerge("GH-1", "/proj", "https://github.com/o/r/pull/4235")
+			},
+		},
+		{
+			name:          "SelfHealExecutionByPRURL",
+			initialStatus: "failed",
+			heal: func(store *Store) error {
+				return store.SelfHealExecutionByPRURL("https://github.com/o/r/pull/4236")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, err := NewStore(t.TempDir())
+			if err != nil {
+				t.Fatalf("NewStore: %v", err)
+			}
+			defer func() { _ = store.Close() }()
+
+			exec := &Execution{ID: "exec-1", TaskID: "GH-1", ProjectPath: "/proj", Status: tt.initialStatus}
+			if tt.name == "SelfHealExecutionByPRURL" {
+				exec.PRUrl = "https://github.com/o/r/pull/4236"
+			}
+			if err := store.SaveExecution(exec); err != nil {
+				t.Fatalf("SaveExecution: %v", err)
+			}
+
+			if _, err := store.DB().Exec(`DROP TABLE execution_events`); err != nil {
+				t.Fatalf("drop execution_events table: %v", err)
+			}
+
+			if err := tt.heal(store); err == nil {
+				t.Fatal("expected an error once execution_events is unwritable")
+			}
+
+			got, err := store.GetExecution("exec-1")
+			if err != nil {
+				t.Fatalf("GetExecution: %v", err)
+			}
+			if got.Status != tt.initialStatus {
+				t.Errorf("status = %q, want unchanged %q (expected rollback)", got.Status, tt.initialStatus)
+			}
+		})
+	}
+}
+
+// TestHealFunctions_BackfillsEventOnAlreadyCompletedRow is the GH-4277
+// regression: SelfHealExecutionAfterMerge / SelfHealExecutionByPRURL ran
+// against ~/.pilot/data/pilot.db pre-GH-4292 already flipped several rows
+// (GH-4199/4217/4190/4182/4203/4227/4234/4235) to status='completed' without
+// ever writing a terminal execution_events row, so their dashboard HISTORY
+// label stayed frozen at whatever stage (e.g. "running", "ci_passed",
+// "awaiting_approval") happened to be last logged. A row already sitting at
+// "completed" with no terminal ledger entry must still get the missing event
+// backfilled the next time autopilot's catch-up sweep calls these heal
+// functions for it — without re-touching status/pr_url/completed_at, which
+// are already correct.
+func TestHealFunctions_BackfillsEventOnAlreadyCompletedRow(t *testing.T) {
+	tests := []struct {
+		name string
+		heal func(store *Store) error
+	}{
+		{
+			name: "SelfHealExecutionAfterMerge",
+			heal: func(store *Store) error {
+				return store.SelfHealExecutionAfterMerge("GH-4199", "/proj", "https://github.com/qf-studio/pilot/pull/4201")
+			},
+		},
+		{
+			name: "SelfHealExecutionByPRURL",
+			heal: func(store *Store) error {
+				return store.SelfHealExecutionByPRURL("https://github.com/qf-studio/pilot/pull/4201")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, err := NewStore(t.TempDir())
+			if err != nil {
+				t.Fatalf("NewStore: %v", err)
+			}
+			defer func() { _ = store.Close() }()
+
+			completedAt := "2026-07-01T00:00:00Z"
+			exec := &Execution{
+				ID: "exec-1", TaskID: "GH-4199", ProjectPath: "/proj",
+				Status: "completed", PRUrl: "https://github.com/qf-studio/pilot/pull/4201",
+			}
+			if err := store.SaveExecution(exec); err != nil {
+				t.Fatalf("SaveExecution: %v", err)
+			}
+			// Ledger frozen mid-flight (no terminal stage), matching the live-DB
+			// evidence — the row completed but the last logged stage never advanced.
+			if err := store.InsertExecutionEvent("exec-1", StageImplementationStarted, "direct path handing off to claude for implementation"); err != nil {
+				t.Fatalf("seed InsertExecutionEvent: %v", err)
+			}
+			// Pin completed_at to a known past value so the assertion below can
+			// prove the backfill doesn't re-stamp it to "now".
+			if _, err := store.DB().Exec(`UPDATE executions SET completed_at = ? WHERE id = ?`, completedAt, "exec-1"); err != nil {
+				t.Fatalf("pin completed_at: %v", err)
+			}
+
+			if err := tt.heal(store); err != nil {
+				t.Fatalf("heal call failed: %v", err)
+			}
+
+			events, err := store.ListExecutionEvents("exec-1")
+			if err != nil {
+				t.Fatalf("ListExecutionEvents: %v", err)
+			}
+			var merged int
+			for _, e := range events {
+				if e.Stage == StageMerged {
+					merged++
+				}
+			}
+			if merged != 1 {
+				t.Fatalf("expected exactly one StageMerged backfill event, got %d of %d total events: %+v", merged, len(events), events)
+			}
+
+			got, err := store.GetExecution("exec-1")
+			if err != nil {
+				t.Fatalf("GetExecution: %v", err)
+			}
+			if got.Status != "completed" {
+				t.Errorf("status = %q, want unchanged %q", got.Status, "completed")
+			}
+			if got.CompletedAt == nil || !got.CompletedAt.Equal(mustParseRFC3339(t, completedAt)) {
+				t.Errorf("completed_at was re-stamped by the backfill, want it left untouched at %s", completedAt)
+			}
+
+			// Re-running the same heal call must not append a second event now
+			// that the ledger has a terminal entry.
+			if err := tt.heal(store); err != nil {
+				t.Fatalf("second heal call failed: %v", err)
+			}
+			events, err = store.ListExecutionEvents("exec-1")
+			if err != nil {
+				t.Fatalf("ListExecutionEvents (second call): %v", err)
+			}
+			merged = 0
+			for _, e := range events {
+				if e.Stage == StageMerged {
+					merged++
+				}
+			}
+			if merged != 1 {
+				t.Fatalf("expected still exactly one StageMerged event after a repeat call, got %d of %d: %+v", merged, len(events), events)
+			}
+		})
+	}
+}
+
+func mustParseRFC3339(t *testing.T, s string) time.Time {
+	t.Helper()
+	tm, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return tm
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -815,13 +815,34 @@ var ErrExecutionNotFound = errors.New("execution not found")
 // that guards the executions/execution_events FK; every recordExecutionEvent
 // wrapper across the executor and autopilot packages delegates here.
 func (s *Store) RecordExecutionEvent(executionID string, stage Stage, detail string) error {
-	if _, err := s.GetExecution(executionID); err != nil {
+	return recordExecutionEventOn(s.db, executionID, stage, detail)
+}
+
+// dbExecer is satisfied by both *sql.DB and *sql.Tx. recordExecutionEventOn is
+// generalized over it so the GH-4292 heal paths can run the same validate-first
+// check and insert inside their own transaction, atomically with the status
+// UPDATE they commit alongside it, instead of hand-rolling a second INSERT.
+type dbExecer interface {
+	Exec(query string, args ...interface{}) (sql.Result, error)
+	QueryRow(query string, args ...interface{}) *sql.Row
+}
+
+// recordExecutionEventOn is RecordExecutionEvent's validate-first logic,
+// generalized to run against any dbExecer rather than always the Store's own
+// s.db connection — see dbExecer's doc comment.
+func recordExecutionEventOn(db dbExecer, executionID string, stage Stage, detail string) error {
+	row := db.QueryRow(`SELECT `+executionDetailColumns+` FROM executions WHERE id = ?`, executionID)
+	if _, err := scanExecutionDetail(row); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return fmt.Errorf("%w: execution_id=%s", ErrExecutionNotFound, executionID)
 		}
 		return fmt.Errorf("failed to verify execution %s exists: %w", executionID, err)
 	}
-	return s.InsertExecutionEvent(executionID, stage, detail)
+	_, err := db.Exec(`
+		INSERT INTO execution_events (execution_id, stage, occurred_at, detail)
+		VALUES (?, ?, ?, ?)
+	`, executionID, string(stage), time.Now().UTC(), detail)
+	return err
 }
 
 // InsertExecutionEvent records a stage transition for executionID. occurred_at is
@@ -1462,23 +1483,56 @@ const orphanedRunningNoEvidenceError = "orphaned running execution: no live proc
 // Guarded by `AND status = 'running'`: a no-op (and therefore idempotent) once
 // the row has transitioned through the normal completion path, and safe to
 // call repeatedly across sweep ticks. TASK-399/GH-4209.
+//
+// GH-4292: the status UPDATE and its terminal execution_events row (StageMerged
+// when prURL is known, else StageFailed) commit in one transaction — either
+// both land or neither does — via recordExecutionEventOn, never a hand-rolled
+// INSERT. The UPDATE's `AND status = 'running'` guard makes RowsAffected == 0
+// on a second call against an already-healed row, so the event write is skipped
+// on repeat calls (idempotent, matching the doc comment above).
 func (s *Store) ResolveOrphanedRunningExecution(id, prURL string) error {
 	return s.withRetry("ResolveOrphanedRunningExecution", func() error {
-		var err error
+		tx, err := s.db.BeginTx(context.Background(), nil)
+		if err != nil {
+			return fmt.Errorf("begin tx: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
+
+		var result sql.Result
 		if prURL != "" {
-			_, err = s.db.Exec(`
+			result, err = tx.Exec(`
 				UPDATE executions
 				SET status = 'completed', error = '', completed_at = CURRENT_TIMESTAMP, pr_url = ?
 				WHERE id = ? AND status = 'running'
 			`, prURL, id)
 		} else {
-			_, err = s.db.Exec(`
+			result, err = tx.Exec(`
 				UPDATE executions
 				SET status = 'failed', error = ?, completed_at = CURRENT_TIMESTAMP
 				WHERE id = ? AND status = 'running'
 			`, orphanedRunningNoEvidenceError, id)
 		}
-		return err
+		if err != nil {
+			return err
+		}
+
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if affected == 0 {
+			return tx.Commit()
+		}
+
+		stage, detail := StageFailed, orphanedRunningNoEvidenceError
+		if prURL != "" {
+			stage, detail = StageMerged, "orphaned running execution resolved: merged "+prURL
+		}
+		if err := recordExecutionEventOn(tx, id, stage, detail); err != nil {
+			return err
+		}
+
+		return tx.Commit()
 	})
 }
 
@@ -1709,17 +1763,30 @@ func (s *Store) UpdateExecutionStatusByTaskID(taskID, projectPath, status string
 // "failed" (which always carries a non-empty error — every writer of that
 // status passes a message) stayed invisible to HasCompletedExecution, which
 // excludes rows with a non-empty error even once status flips back to "completed".
+//
+// GH-4292: the status UPDATE and a terminal execution_events row per healed
+// row (StageMerged when prURL is known, else StageFailed) commit in one
+// transaction — candidates are selected first, then each is updated and
+// logged via recordExecutionEventOn (never a hand-rolled INSERT) before the
+// commit. The WHERE clause's status IN(...) set already excludes rows this
+// method previously healed, so a repeat call against an already-healed row
+// selects zero candidates and writes zero events (idempotent).
+//
+// GH-4292/GH-4277 backfill: also picks up rows already sitting at "completed"
+// (healed by the pre-GH-4292 code, which flipped status but never wrote an
+// event) whose execution_events ledger has no terminal entry — these render
+// with a frozen HISTORY label (e.g. "running", "ci_passed") because the
+// dashboard derives that text from the ledger, not executions.status. Such a
+// row gets only the terminal event appended (its status/pr_url/completed_at
+// are already correct and are left untouched); the "already terminal-status
+// AND already has a terminal event" case remains excluded, so this is still
+// idempotent across the periodic/startup catch-up sweeps that call this
+// method unconditionally for every recently-merged PR.
 func (s *Store) SelfHealExecutionAfterMerge(taskID, projectPath, prURL string) error {
 	return s.withRetry("SelfHealExecutionAfterMerge", func() error {
-		_, err := s.db.Exec(`
-			UPDATE executions
-			SET status = 'completed',
-				error = '',
-				completed_at = CURRENT_TIMESTAMP,
-				pr_url = CASE WHEN ? <> '' THEN ? ELSE pr_url END
-			WHERE task_id = ? AND status IN ('failed', 'no_op', 'stalled', 'rate_limited', 'infra', 'skipped') AND (? = '' OR project_path = ?)
-		`, prURL, prURL, taskID, projectPath, projectPath)
-		return err
+		return healAndBackfillRows(s.db, `task_id = ? AND (? = '' OR project_path = ?) AND `+healOrBackfillCandidateClause,
+			[]interface{}{taskID, projectPath, projectPath}, prURL,
+			"self-heal after merge: "+orDefault(prURL, "no PR URL known"))
 	})
 }
 
@@ -1730,18 +1797,126 @@ func (s *Store) SelfHealExecutionAfterMerge(taskID, projectPath, prURL string) e
 // whose own already-stamped pr_url column equals prURL — covering a PR on a
 // non-standard branch whose execution row still carries the PR URL from
 // UpdateExecutionResult at creation time. No-op when prURL is empty.
+//
+// GH-4292: see SelfHealExecutionAfterMerge's doc comment — same transactional
+// status UPDATE + terminal execution_events write, same completed-row ledger
+// backfill, same idempotency argument.
 func (s *Store) SelfHealExecutionByPRURL(prURL string) error {
 	if prURL == "" {
 		return nil
 	}
 	return s.withRetry("SelfHealExecutionByPRURL", func() error {
-		_, err := s.db.Exec(`
-			UPDATE executions
-			SET status = 'completed', error = '', completed_at = CURRENT_TIMESTAMP
-			WHERE pr_url = ? AND status IN ('failed', 'no_op', 'stalled', 'rate_limited', 'infra', 'skipped')
-		`, prURL)
-		return err
+		return healAndBackfillRows(s.db, `pr_url = ? AND `+healOrBackfillCandidateClause,
+			[]interface{}{prURL}, prURL, "self-heal by PR URL: "+prURL)
 	})
+}
+
+// orDefault returns s unless it's empty, in which case it returns def — used
+// to build a human-readable execution_events detail string for the no-PR-URL
+// branch without a multi-line if/else at each call site.
+func orDefault(s, def string) string {
+	if s == "" {
+		return def
+	}
+	return s
+}
+
+// terminalEventStages is the set of execution_events stages that count as a
+// "terminal" ledger entry for GH-4292's completed-row backfill check below —
+// any of these already tells the dashboard the row reached an end state, so
+// no backfill event is needed on top of it.
+const terminalEventStages = `'merged', 'completed', 'failed', 'no_op', 'skipped', 'stalled'`
+
+// healOrBackfillCandidateClause is shared by SelfHealExecutionAfterMerge and
+// SelfHealExecutionByPRURL's WHERE clauses (GH-4292). It selects two disjoint
+// groups, both scoped by the caller's own task_id/pr_url predicate:
+//
+//   - the original non-success set ("failed", "no_op", "stalled",
+//     "rate_limited", "infra", "skipped") — genuine heal candidates, handled
+//     unconditionally (unchanged from the pre-GH-4292 behavior).
+//   - status = 'completed' rows with no terminal execution_events row yet —
+//     the GH-4277 backfill-only case: status/pr_url are already correct, only
+//     the ledger is missing its terminal entry.
+//
+// Deliberately excludes 'running'/'queued'/'pending' (in-flight — must never
+// be force-completed here; see TestSelfHealExecutionAfterMerge_ExcludesRunningQueuedPending)
+// and 'declined'/'cancelled' (an intentional non-outcome, not something a
+// coincidental later merge should silently resolve).
+const healOrBackfillCandidateClause = `(
+	status IN ('failed', 'no_op', 'stalled', 'rate_limited', 'infra', 'skipped')
+	OR (
+		status = 'completed'
+		AND NOT EXISTS (
+			SELECT 1 FROM execution_events ee
+			WHERE ee.execution_id = executions.id AND ee.stage IN (` + terminalEventStages + `)
+		)
+	)
+)`
+
+// healAndBackfillRows is the shared transaction body for SelfHealExecutionAfterMerge
+// and SelfHealExecutionByPRURL (GH-4292/GH-4277): it selects every candidate execution
+// row matching whereClause/args (healOrBackfillCandidateClause above), promotes each
+// non-success row to "completed" (stamping pr_url when prURL is non-empty, matching
+// the pre-GH-4292 UPDATE) — leaving already-'completed' rows' status/pr_url/completed_at
+// untouched — and, in the same transaction, records one terminal execution_events row
+// per row via recordExecutionEventOn: StageMerged when prURL is known, else StageFailed.
+// Selecting candidates first (rather than a single bulk UPDATE) is what makes a per-row
+// event possible.
+func healAndBackfillRows(db *sql.DB, whereClause string, whereArgs []interface{}, prURL, detail string) error {
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rows, err := tx.Query(`SELECT id, status FROM executions WHERE `+whereClause, whereArgs...)
+	if err != nil {
+		return err
+	}
+	type candidate struct {
+		id     string
+		status string
+	}
+	var candidates []candidate
+	for rows.Next() {
+		var c candidate
+		if err := rows.Scan(&c.id, &c.status); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		candidates = append(candidates, c)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+
+	stage := StageFailed
+	if prURL != "" {
+		stage = StageMerged
+	}
+
+	for _, c := range candidates {
+		if c.status != "completed" {
+			if _, err := tx.Exec(`
+				UPDATE executions
+				SET status = 'completed',
+					error = '',
+					completed_at = CURRENT_TIMESTAMP,
+					pr_url = CASE WHEN ? <> '' THEN ? ELSE pr_url END
+				WHERE id = ?
+			`, prURL, prURL, c.id); err != nil {
+				return err
+			}
+		}
+		if err := recordExecutionEventOn(tx, c.id, stage, detail); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
 }
 
 // GetExecutionStatusByTaskID returns the status of the most recent execution row


### PR DESCRIPTION
## Summary
- `ResolveOrphanedRunningExecution`, `SelfHealExecutionAfterMerge`, and `SelfHealExecutionByPRURL` now write a terminal `execution_events` row (`merged` when a PR URL is known, else `failed`) in the same transaction as the status `UPDATE`, via a tx-scoped generalization of the validate-first `RecordExecutionEvent` wrapper (#4257) — no hand-rolled `INSERT`s.
- `SelfHealExecutionAfterMerge`/`SelfHealExecutionByPRURL` also backfill the missing event on rows already healed to `completed` by the pre-fix code (which flipped status but never logged an event), without re-touching their already-correct status/pr_url/completed_at.
- Live-verified against a copy of `~/.pilot/data/pilot.db`: replaying the catch-up sweep's calls for GH-4199/4217/4190/4182/4203/4227/4234/4235 gives every one of those rows a terminal event with no manual DB edit.

Closes #4292

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/memory/... ./internal/executor/... ./internal/autopilot/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] New table-driven tests in `internal/memory/gh4292_selfheal_events_test.go`: exactly-one-event, PR-URL/no-URL branch, transactional rollback, idempotent repeat call, completed-row backfill
- [x] Manual replay against a copy of the live `pilot.db` confirming the 8 named rows get their terminal event