### PR TITLE
fix(dashboard): promote completed event to top-of-ladder for PR-less epic parents (GH-4293)

### DIFF
--- a/internal/dashboard/stage_strip.go
+++ b/internal/dashboard/stage_strip.go
@@ -94,9 +94,11 @@ var mutedOutcomes = map[string]bool{
 // stageInfoForExecution derives the history-row StageInfo from the event
 // timeline plus the authoritative executions.status. The label override is
 // status-driven, never event-driven, so GH-4023's stray-late-event guard in
-// buildStageInfo is untouched.
-func stageInfoForExecution(events []*memory.Event, status string) StageInfo {
-	info := buildStageInfo(events, status == "failed" || status == "stalled")
+// buildStageInfo is untouched. prURL is executions.pr_url, passed through to
+// buildStageInfo so it can distinguish a decompose-only epic parent (never
+// gets its own PR — children carry it) from an in-flight or PR-bearing run.
+func stageInfoForExecution(events []*memory.Event, status string, prURL string) StageInfo {
+	info := buildStageInfo(events, status == "failed" || status == "stalled", prURL)
 	if mutedOutcomes[status] && info.Known {
 		info.Label = truncateString(status, maxStageStripLabelWidth)
 		info.Muted = true
@@ -113,7 +115,21 @@ func stageInfoForExecution(events []*memory.Event, status string) StageInfo {
 // (e.g. a stray pr_created/failed event recorded after released, GH-4023)
 // never pulls the displayed rung backward. The Failed flag is attached to
 // whichever event defined that max rung, not to the last event in the stream.
-func buildStageInfo(events []*memory.Event, executionFailed bool) StageInfo {
+//
+// prURL is executions.pr_url. A decompose-only epic parent (GH-4190,
+// GH-4182) never reaches pr_created itself — its children own the PR — so
+// its event stream tops out below the ladder's PR rung and the strip froze
+// at "running" even after the epic's own completed event landed. When the
+// highest resolved rung is still below pr_created, a completed event is
+// present, and no PR URL was ever recorded for this execution, that
+// completed event is promoted to top-of-ladder so the row reads its
+// terminal label instead of the stale in-flight one (GH-4293). This only
+// fires on a clean completion: an executionFailed run, or one that died at
+// a rung (a failure-stage event in the stream), keeps its GH-4212 ✗ +
+// stage-of-death labeling untouched. A PR-bearing run is unaffected — it
+// either already reached pr_created (rank >= 4) or, once it has a PR, isn't
+// the decompose-only-parent case this promotion targets.
+func buildStageInfo(events []*memory.Event, executionFailed bool, prURL string) StageInfo {
 	if len(events) == 0 {
 		return StageInfo{}
 	}
@@ -124,9 +140,14 @@ func buildStageInfo(events []*memory.Event, executionFailed bool) StageInfo {
 		failed        bool
 		lastGoodPos   int
 		lastGoodStage memory.Stage
+		sawCompleted  bool
 	)
 
 	for _, e := range events {
+		if e.Stage == memory.StageCompleted {
+			sawCompleted = true
+		}
+
 		// Resolve this event's own ladder position, walking back to the
 		// last stage that named a real rung when this one doesn't (a
 		// generic failure/stall/retry carries no rung of its own).
@@ -148,6 +169,11 @@ func buildStageInfo(events []*memory.Event, executionFailed bool) StageInfo {
 			label = resolvedLabel
 			failed = stageStripFailureStages[e.Stage]
 		}
+	}
+
+	if !failed && !executionFailed && prURL == "" && sawCompleted && reached < stageLadderPosition(memory.StagePRCreated) {
+		reached = stageLadderTotal
+		label = memory.StageCompleted
 	}
 
 	return StageInfo{

--- a/internal/dashboard/stage_strip_test.go
+++ b/internal/dashboard/stage_strip_test.go
@@ -12,10 +12,10 @@ func evt(stage memory.Stage) *memory.Event {
 }
 
 func TestBuildStageInfo_NoEvents(t *testing.T) {
-	if got := buildStageInfo(nil, false); got.Known {
+	if got := buildStageInfo(nil, false, ""); got.Known {
 		t.Errorf("no events, not failed: got %+v, want Known=false", got)
 	}
-	if got := buildStageInfo(nil, true); got.Known {
+	if got := buildStageInfo(nil, true, ""); got.Known {
 		t.Errorf("no events, failed: got %+v, want Known=false", got)
 	}
 }
@@ -29,7 +29,7 @@ func TestBuildStageInfo_HappyPath(t *testing.T) {
 		evt(memory.StagePRCreated),
 		evt(memory.StageMerged),
 	}
-	got := buildStageInfo(events, false)
+	got := buildStageInfo(events, false, "")
 	want := StageInfo{Reached: 6, Label: "merged", Failed: false, Known: true}
 	if got != want {
 		t.Errorf("happy path: got %+v, want %+v", got, want)
@@ -47,7 +47,7 @@ func TestBuildStageInfo_Released(t *testing.T) {
 		evt(memory.StageMerged),
 		evt(memory.StageReleased),
 	}
-	got := buildStageInfo(events, false)
+	got := buildStageInfo(events, false, "")
 	want := StageInfo{Reached: 7, Label: "released", Failed: false, Known: true}
 	if got != want {
 		t.Errorf("released: got %+v, want %+v", got, want)
@@ -56,7 +56,7 @@ func TestBuildStageInfo_Released(t *testing.T) {
 
 func TestBuildStageInfo_SpecValidatedOnly(t *testing.T) {
 	events := []*memory.Event{evt(memory.StageSpecValidated)}
-	got := buildStageInfo(events, false)
+	got := buildStageInfo(events, false, "")
 	want := StageInfo{Reached: 1, Label: "spec_validated", Failed: false, Known: true}
 	if got != want {
 		t.Errorf("spec_validated only: got %+v, want %+v", got, want)
@@ -69,7 +69,7 @@ func TestBuildStageInfo_InProgress(t *testing.T) {
 		evt(memory.StageSpecValidated),
 		evt(memory.StageRunning),
 	}
-	got := buildStageInfo(events, false)
+	got := buildStageInfo(events, false, "")
 	want := StageInfo{Reached: 2, Label: "running", Failed: false, Known: true}
 	if got != want {
 		t.Errorf("in-progress: got %+v, want %+v", got, want)
@@ -83,7 +83,7 @@ func TestBuildStageInfo_FailedAtStageN(t *testing.T) {
 		evt(memory.StageRunning),
 		evt(memory.StageFailed),
 	}
-	got := buildStageInfo(events, true)
+	got := buildStageInfo(events, true, "")
 	want := StageInfo{Reached: 2, Label: "running", Failed: true, Known: true}
 	if got != want {
 		t.Errorf("failed-at-stage-N: got %+v, want %+v", got, want)
@@ -95,7 +95,7 @@ func TestBuildStageInfo_FailedAtStageN(t *testing.T) {
 // to, so Reached reports 0 and Label names the failure stage itself.
 func TestBuildStageInfo_FailedAsFirstEvent(t *testing.T) {
 	events := []*memory.Event{evt(memory.StageFailed)}
-	got := buildStageInfo(events, true)
+	got := buildStageInfo(events, true, "")
 	want := StageInfo{Reached: 0, Label: "failed", Failed: true, Known: true}
 	if got != want {
 		t.Errorf("failed as first event: got %+v, want %+v", got, want)
@@ -106,7 +106,7 @@ func TestBuildStageInfo_FailedAsFirstEvent(t *testing.T) {
 // directly to its own ladder rung (pr_created, reached=4) rather than
 // walking back — it names a real position, unlike a generic failure.
 func TestBuildStageInfo_CIFailed(t *testing.T) {
-	got := buildStageInfo([]*memory.Event{evt(memory.StageCIFailed)}, true)
+	got := buildStageInfo([]*memory.Event{evt(memory.StageCIFailed)}, true, "")
 	want := StageInfo{Reached: 4, Label: "ci_failed", Failed: true, Known: true}
 	if got != want {
 		t.Errorf("ci_failed: got %+v, want %+v", got, want)
@@ -114,7 +114,7 @@ func TestBuildStageInfo_CIFailed(t *testing.T) {
 }
 
 func TestBuildStageInfo_Stalled(t *testing.T) {
-	got := buildStageInfo([]*memory.Event{evt(memory.StageStalled)}, true)
+	got := buildStageInfo([]*memory.Event{evt(memory.StageStalled)}, true, "")
 	want := StageInfo{Reached: 0, Label: "stalled", Failed: true, Known: true}
 	if got != want {
 		t.Errorf("stalled with no prior stage: got %+v, want %+v", got, want)
@@ -122,7 +122,7 @@ func TestBuildStageInfo_Stalled(t *testing.T) {
 }
 
 func TestBuildStageInfo_AwaitingApproval(t *testing.T) {
-	got := buildStageInfo([]*memory.Event{evt(memory.StageAwaitingApproval)}, false)
+	got := buildStageInfo([]*memory.Event{evt(memory.StageAwaitingApproval)}, false, "")
 	want := StageInfo{Reached: 5, Label: "awaiting_approval", Failed: false, Known: true}
 	if got != want {
 		t.Errorf("awaiting_approval: got %+v, want %+v", got, want)
@@ -140,7 +140,7 @@ func TestBuildStageInfo_RetriesDoNotInflate(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		events = append(events, evt(memory.StageRunning))
 	}
-	got := buildStageInfo(events, false)
+	got := buildStageInfo(events, false, "")
 	want := StageInfo{Reached: 2, Label: "running", Failed: false, Known: true}
 	if got != want {
 		t.Errorf("retries should not inflate the rung: got %+v, want %+v", got, want)
@@ -151,7 +151,7 @@ func TestBuildStageInfo_RetriesDoNotInflate(t *testing.T) {
 // against an oversized stage/detail value.
 func TestBuildStageInfo_TruncatesLongLabel(t *testing.T) {
 	events := []*memory.Event{evt(memory.Stage(strings.Repeat("x", 40)))}
-	got := buildStageInfo(events, false)
+	got := buildStageInfo(events, false, "")
 	if len(got.Label) > maxStageStripLabelWidth {
 		t.Errorf("label length = %d, want <= %d: %q", len(got.Label), maxStageStripLabelWidth, got.Label)
 	}
@@ -170,7 +170,7 @@ func TestBuildStageInfo_MaxRungNoRegression(t *testing.T) {
 		evt(memory.StagePRCreated),
 		evt(memory.StageFailed),
 	}
-	got := buildStageInfo(events, false)
+	got := buildStageInfo(events, false, "")
 	want := StageInfo{Reached: 7, Label: "released", Failed: false, Known: true}
 	if got != want {
 		t.Errorf("max-rung no regression: got %+v, want %+v", got, want)
@@ -190,7 +190,7 @@ func TestBuildStageInfo_MaxRungHealthyPath(t *testing.T) {
 		evt(memory.StageMerged),
 		evt(memory.StageReleased),
 	}
-	got := buildStageInfo(events, false)
+	got := buildStageInfo(events, false, "")
 	want := StageInfo{Reached: 7, Label: "released", Failed: false, Known: true}
 	if got != want {
 		t.Errorf("max-rung healthy path: got %+v, want %+v", got, want)
@@ -236,7 +236,7 @@ func TestStageInfoForExecution_SkippedRun(t *testing.T) {
 		evt(memory.StageFailed),
 		evt(memory.StageSkipped),
 	}
-	got := stageInfoForExecution(events, "skipped")
+	got := stageInfoForExecution(events, "skipped", "")
 	want := StageInfo{Reached: 2, Label: "skipped", Failed: false, Known: true, Muted: true}
 	if got != want {
 		t.Errorf("skipped run: got %+v, want %+v", got, want)
@@ -250,7 +250,7 @@ func TestStageInfoForExecution_RunningPassthrough(t *testing.T) {
 		evt(memory.StageRunning),
 		evt(memory.StageSpecValidated),
 	}
-	got := stageInfoForExecution(events, "running")
+	got := stageInfoForExecution(events, "running", "")
 	want := StageInfo{Reached: 2, Label: "running", Failed: false, Known: true, Muted: false}
 	if got != want {
 		t.Errorf("running run: got %+v, want %+v", got, want)
@@ -265,10 +265,90 @@ func TestStageInfoForExecution_StalledKeepsRung(t *testing.T) {
 		evt(memory.StageRunning),
 		evt(memory.StageCommit),
 	}
-	got := stageInfoForExecution(events, "stalled")
+	got := stageInfoForExecution(events, "stalled", "")
 	want := StageInfo{Reached: 3, Label: "commit", Failed: true, Known: true, Muted: false}
 	if got != want {
 		t.Errorf("stalled run: got %+v, want %+v", got, want)
+	}
+}
+
+// TestBuildStageInfo_CompletedPromotion covers GH-4293: a decompose-only
+// epic parent (GH-4190, GH-4182) never emits its own pr_created — its
+// children own the PR — so its event stream tops out below the ladder's PR
+// rung even after a terminal completed event lands, and the row froze at
+// "running". When the highest resolved rung is below pr_created, a
+// completed event is present, and no PR URL was ever recorded, that
+// completed event is promoted to top-of-ladder. The table also guards the
+// three cases that must NOT be affected: an in-flight row with no completed
+// event, a failed-at-a-rung row (GH-4212 ✗ + stage-of-death labeling), and
+// a PR-bearing completed row (already resolves to top-of-ladder via the
+// existing lastGoodStage fallback).
+func TestBuildStageInfo_CompletedPromotion(t *testing.T) {
+	cases := []struct {
+		name            string
+		events          []*memory.Event
+		executionFailed bool
+		prURL           string
+		want            StageInfo
+	}{
+		{
+			name: "pr-less completed epic parent promotes to terminal label",
+			events: []*memory.Event{
+				evt(memory.StageSpecValidated),
+				evt(memory.StageDecomposed),
+				evt(memory.StageCompleted),
+			},
+			executionFailed: false,
+			prURL:           "",
+			want:            StageInfo{Reached: stageLadderTotal, Label: "completed", Failed: false, Known: true},
+		},
+		{
+			name: "in-flight running row with no completed event stays running",
+			events: []*memory.Event{
+				evt(memory.StageSpecValidated),
+				evt(memory.StageRunning),
+			},
+			executionFailed: false,
+			prURL:           "",
+			want:            StageInfo{Reached: 2, Label: "running", Failed: false, Known: true},
+		},
+		{
+			name: "failed-at-rung row keeps the rung label and failure flag",
+			events: []*memory.Event{
+				evt(memory.StageSpecValidated),
+				evt(memory.StageRunning),
+				evt(memory.StageCommit),
+				evt(memory.StageFailed),
+			},
+			executionFailed: true,
+			prURL:           "",
+			want:            StageInfo{Reached: 3, Label: "commit", Failed: true, Known: true},
+		},
+		{
+			name: "pr-bearing completed row keeps its top-of-ladder resolution",
+			events: []*memory.Event{
+				evt(memory.StageSpecValidated),
+				evt(memory.StageRunning),
+				evt(memory.StageCommit),
+				evt(memory.StagePRCreated),
+				evt(memory.StageCIPassed),
+				evt(memory.StageMerged),
+				evt(memory.StageReleased),
+				evt(memory.StageCompleted),
+			},
+			executionFailed: false,
+			prURL:           "https://github.com/qf-studio/pilot/pull/1",
+			want:            StageInfo{Reached: stageLadderTotal, Label: "released", Failed: false, Known: true},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := buildStageInfo(c.events, c.executionFailed, c.prURL)
+			if got != c.want {
+				t.Errorf("%s: got %+v, want %+v", c.name, got, c.want)
+			}
+		})
 	}
 }
 

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -661,7 +661,7 @@ func (m *Model) hydrateFromStore() {
 			Duration:    fmt.Sprintf("%dms", exec.DurationMs),
 			CompletedAt: completedAt,
 			PeakRSSMB:   exec.PeakRSSMB,
-			Stage:       stageInfoForExecution(events, status),
+			Stage:       stageInfoForExecution(events, status, exec.PRUrl),
 			PRUrl:       exec.PRUrl,
 		})
 	}
@@ -994,7 +994,7 @@ func storeRefreshCmd(store *memory.Store, projectPath string) tea.Cmd {
 				Duration:    fmt.Sprintf("%dms", exec.DurationMs),
 				CompletedAt: completedAt,
 				PeakRSSMB:   exec.PeakRSSMB,
-				Stage:       stageInfoForExecution(events, status),
+				Stage:       stageInfoForExecution(events, status, exec.PRUrl),
 				PRUrl:       exec.PRUrl,
 			})
 		}

--- a/internal/dashboard/tui_test.go
+++ b/internal/dashboard/tui_test.go
@@ -702,7 +702,7 @@ func TestRenderHistory_StageStrip(t *testing.T) {
 				evt(memory.StageCommit),
 				evt(memory.StagePRCreated),
 				evt(memory.StageMerged),
-			}, false),
+			}, false, ""),
 		},
 		{
 			ID:          "GH-201",
@@ -714,7 +714,7 @@ func TestRenderHistory_StageStrip(t *testing.T) {
 				evt(memory.StageQueued),
 				evt(memory.StageSpecValidated),
 				evt(memory.StageRunning),
-			}, false),
+			}, false, ""),
 		},
 		{
 			ID:          "GH-202",
@@ -727,7 +727,7 @@ func TestRenderHistory_StageStrip(t *testing.T) {
 				evt(memory.StageSpecValidated),
 				evt(memory.StageRunning),
 				evt(memory.StageFailed),
-			}, true),
+			}, true, ""),
 		},
 		// No stage evidence (pre-events execution): dim track + "–" label.
 		{

--- a/internal/dashboard/zoom.go
+++ b/internal/dashboard/zoom.go
@@ -561,7 +561,7 @@ func historyZoomCmd(store *memory.Store, projectPath string) tea.Cmd {
 				Duration:    fmt.Sprintf("%dms", exec.DurationMs),
 				CompletedAt: completedAt,
 				PeakRSSMB:   exec.PeakRSSMB,
-				Stage:       stageInfoForExecution(events, status),
+				Stage:       stageInfoForExecution(events, status, exec.PRUrl),
 				PRUrl:       exec.PRUrl,
 			})
 		}


### PR DESCRIPTION
## Summary
- `buildStageInfo` now promotes a terminal `completed` event to top-of-ladder when the highest resolved rung is below `pr_created`, no PR URL was recorded, and the run didn't fail — fixing decompose-only epic parents (GH-4190, GH-4182) that froze at "running" forever.
- Existing rank order (`stageLadderPosition`), `mutedOutcomes` handling, and the GH-4212 failed-at-rung ✗ + stage-of-death labeling are untouched.
- `stageInfoForExecution` / `buildStageInfo` now take `prURL`; the three call sites (`tui.go` x2, `zoom.go`) pass `exec.PRUrl`.

## Test plan
- [x] `TestBuildStageInfo_CompletedPromotion` table-driven cases: PR-less completed epic parent → terminal label; in-flight running (no completed event) → still "running"; failed-at-rung → unchanged ✗ + rung label; PR-bearing completed → unchanged top-of-ladder.
- [x] `go build ./...`
- [x] `go test ./internal/dashboard/...`

Closes #4293