### PR TITLE
fix(dashboard): promote clean-terminal executions to top-of-ladder in HISTORY

### DIFF
--- a/internal/dashboard/stage_strip.go
+++ b/internal/dashboard/stage_strip.go
@@ -91,6 +91,18 @@ var mutedOutcomes = map[string]bool{
 	"infra":        true,
 }
 
+// stageStripCleanTerminalEvents are execution_events that close out a run
+// successfully without ever naming a PR-side ladder rung of their own
+// (pr_created/ci_passed/merged). A decompose-only epic parent ships no PR
+// for its own row — its stream ends running -> spec_validated -> decomposed
+// -> completed — so the running-max reducer in buildStageInfo freezes the
+// label at the last *named* rung it saw, which is "running" (GH-4298).
+var stageStripCleanTerminalEvents = map[memory.Stage]bool{
+	memory.StageCompleted:  true,
+	memory.StageNoOp:       true,
+	memory.StageDecomposed: true,
+}
+
 // stageInfoForExecution derives the history-row StageInfo from the event
 // timeline plus the authoritative executions.status. The label override is
 // status-driven, never event-driven, so GH-4023's stray-late-event guard in
@@ -148,6 +160,19 @@ func buildStageInfo(events []*memory.Event, executionFailed bool) StageInfo {
 			label = resolvedLabel
 			failed = stageStripFailureStages[e.Stage]
 		}
+	}
+
+	// GH-4298: the stream's own terminal event, not just its ladder rung,
+	// decides whether the run is done. A clean terminal (completed/no_op/
+	// decomposed) as the LAST event means the run finished without ever
+	// emitting a PR-side event of its own — promote it to the top of the
+	// ladder instead of leaving it frozen at whatever rung it last named.
+	// Failed executions are excluded so the "died at a rung" ✗ labeling
+	// (GH-4212) is untouched, and a run that already reached pr_created or
+	// higher keeps that (more specific) label.
+	if !executionFailed && !failed && stageStripCleanTerminalEvents[events[len(events)-1].Stage] && reached < stageLadderPosition(memory.StagePRCreated) {
+		reached = stageLadderTotal
+		label = memory.StageCompleted
 	}
 
 	return StageInfo{

--- a/internal/dashboard/stage_strip_test.go
+++ b/internal/dashboard/stage_strip_test.go
@@ -197,6 +197,76 @@ func TestBuildStageInfo_MaxRungHealthyPath(t *testing.T) {
 	}
 }
 
+// TestBuildStageInfo_DecomposeOnlyEpicParentTerminal covers GH-4298: a
+// decompose-only epic parent ships no PR of its own — its stream ends
+// running -> spec_validated -> decomposed -> completed, never touching
+// pr_created/ci_passed/merged. Before the fix, the running-max reducer froze
+// the label at "running" (pos 2, the highest *named* rung) forever; the run
+// must instead render a terminal label at the top of the ladder.
+func TestBuildStageInfo_DecomposeOnlyEpicParentTerminal(t *testing.T) {
+	events := []*memory.Event{
+		evt(memory.StageRunning),
+		evt(memory.StageSpecValidated),
+		evt(memory.StageDecomposed),
+		evt(memory.StageCompleted),
+	}
+	got := buildStageInfo(events, false)
+	want := StageInfo{Reached: stageLadderTotal, Label: "completed", Failed: false, Known: true}
+	if got != want {
+		t.Errorf("decompose-only epic parent: got %+v, want %+v", got, want)
+	}
+}
+
+// TestBuildStageInfo_CleanTerminalDoesNotOverrideFailure is the GH-4298
+// regression guard for GH-4212-style failure labeling: a run that died at a
+// rung must keep showing ✗ at its stage of death, never get promoted to a
+// terminal label just because the stream happens to end elsewhere.
+func TestBuildStageInfo_CleanTerminalDoesNotOverrideFailure(t *testing.T) {
+	events := []*memory.Event{
+		evt(memory.StageSpecValidated),
+		evt(memory.StageRunning),
+		evt(memory.StageFailed),
+	}
+	got := buildStageInfo(events, true)
+	want := StageInfo{Reached: 2, Label: "running", Failed: true, Known: true}
+	if got != want {
+		t.Errorf("failed-at-a-rung must not be promoted: got %+v, want %+v", got, want)
+	}
+}
+
+// TestBuildStageInfo_GenuinelyRunningStaysRunning guards the in-flight case:
+// no terminal event has been recorded yet, so the label must still read
+// "running" rather than being promoted to a terminal stage.
+func TestBuildStageInfo_GenuinelyRunningStaysRunning(t *testing.T) {
+	events := []*memory.Event{
+		evt(memory.StageQueued),
+		evt(memory.StageSpecValidated),
+		evt(memory.StageRunning),
+	}
+	got := buildStageInfo(events, false)
+	want := StageInfo{Reached: 2, Label: "running", Failed: false, Known: true}
+	if got != want {
+		t.Errorf("in-flight run must not be promoted: got %+v, want %+v", got, want)
+	}
+}
+
+// TestBuildStageInfo_HealedRowStillTerminal guards against a regression on
+// rows healed by the #4294 SelfHealExecutionAfterMerge/SelfHealExecutionByPRURL
+// backfill: those append a StageMerged event, which already names its own
+// ladder rung (pos 6) — the GH-4298 clean-terminal promotion must not be
+// needed (and must not interfere) for that path to keep rendering terminal.
+func TestBuildStageInfo_HealedRowStillTerminal(t *testing.T) {
+	events := []*memory.Event{
+		evt(memory.StageImplementationStarted),
+		evt(memory.StageMerged), // backfilled by the #4294 heal path
+	}
+	got := buildStageInfo(events, false)
+	want := StageInfo{Reached: 6, Label: "merged", Failed: false, Known: true}
+	if got != want {
+		t.Errorf("healed row: got %+v, want %+v", got, want)
+	}
+}
+
 func TestStageLadderPosition_AllStages(t *testing.T) {
 	cases := []struct {
 		stage memory.Stage


### PR DESCRIPTION
## Summary
- Fixes decompose-only epic parents freezing at "running" in HISTORY. Their event stream ends `running -> spec_validated -> decomposed -> completed`, never touching `pr_created`/`ci_passed`/`merged`, and the running-max reducer in `buildStageInfo` only tracked named ladder rungs, so the label froze at the last-named rung ("running", pos 2) forever.
- `buildStageInfo` now promotes a clean terminal event (`completed`/`no_op`/`decomposed`) that is the *last* event in the stream to the top of the ladder, but only when no higher-ranked PR-side event (`pr_created`/`ci_passed`/`merged`, pos >= 4) was recorded — so runs that legitimately reached those rungs keep their own (more specific) label.
- Failed executions and `mutedOutcomes` handling are explicitly excluded from the promotion, so GH-4212-style "died at a rung" ✗ labeling is untouched.

Part 2 of #4277 (part 1: #4294, the heal-event backfill). Supersedes the abandoned #4295.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/dashboard/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/dashboard/...`
- [x] New table-driven tests:
  - `TestBuildStageInfo_DecomposeOnlyEpicParentTerminal` — the exact `running -> spec_validated -> decomposed -> completed` sequence renders a terminal label
  - `TestBuildStageInfo_CleanTerminalDoesNotOverrideFailure` — GH-4212 failed-at-a-rung regression guard
  - `TestBuildStageInfo_GenuinelyRunningStaysRunning` — in-flight execution still shows "running"
  - `TestBuildStageInfo_HealedRowStillTerminal` — #4294 backfill-healed rows still render terminal