### PR TITLE
fix(executor): recognize bare top-level filenames in scope detection (GH-4302)

### DIFF
--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -421,6 +421,23 @@ func TestIsSinglePackageScope(t *testing.T) {
 			description: "Per the spec, persistence work lives in internal/memory/store.go.",
 			expected:    false,
 		},
+		{
+			// GH-4302: canary epic-lifecycle scenario. Two subtasks each touch a
+			// distinct bare top-level file (no directory prefix) — version.go and
+			// CHANGELOG-CANARY.md. Before the fix, bare filenames were invisible
+			// to extractUniqueDirectories, dirs stayed empty, and the fallback
+			// title-word heuristic false-positived on shared words like "canary",
+			// collapsing a genuine 2-file epic into single-package direct
+			// execution (child issues created off-pipeline with no Parent: stamp,
+			// blinding both the canary poll script and epic_reconcile.go).
+			name: "distinct bare top-level files are not single package (GH-4302)",
+			subtasks: []PlannedSubtask{
+				{Title: "Subtask 1 (version bump)", Description: "Bump the PATCH component in version.go by exactly one."},
+				{Title: "Subtask 2 (changelog entry)", Description: "Append a dated line to CHANGELOG-CANARY.md."},
+			},
+			description: "Two independent work items against two different files in this sandbox repository.",
+			expected:    false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -455,9 +472,13 @@ func TestExtractUniqueDirectories(t *testing.T) {
 			expected: 0,
 		},
 		{
+			// GH-4302: bare top-level filenames have no directory separator,
+			// but two distinct bare files must still count as 2 scope keys —
+			// otherwise they're indistinguishable from truly path-free text
+			// and fall through to the unreliable title-word heuristic.
 			name:     "files without directory prefix",
-			text:     "Update main.go and utils.go", // no slash → no directory extracted
-			expected: 0,
+			text:     "Update main.go and utils.go",
+			expected: 2,
 		},
 		{
 			name:     "deeply nested same parent",

--- a/internal/executor/scope.go
+++ b/internal/executor/scope.go
@@ -20,6 +20,17 @@ var dirOnlyPattern = regexp.MustCompile(`\b((?:[\w\-]+/)+[\w\-]+/)(?:\s|$|[),;:"
 // merge conflict (GH-3714).
 var rootConfigFilePattern = regexp.MustCompile(`\b(package(?:-lock)?\.json|tsconfig\.json|go\.(?:mod|sum)|Cargo\.(?:toml|lock)|Makefile|pnpm-lock\.yaml|yarn\.lock|vitest\.config\.\w+|eslint\.config\.\w+)\b`)
 
+// bareFilePattern matches a bare top-level filename with a common
+// source-code extension (no directory prefix). Root-level source files like
+// version.go or CHANGELOG.md have no directory component, so filePathPattern
+// (which requires at least one "/") never matches them and they were
+// entirely invisible to scope detection — two subtasks that each touched a
+// different bare top-level file looked scope-disjoint (0 directories found)
+// and fell through to the unreliable title-word heuristic instead of being
+// recognized as 2 distinct files (GH-4302: canary epic-lifecycle scenario
+// touching version.go + CHANGELOG-CANARY.md collapsed to a single task).
+var bareFilePattern = regexp.MustCompile(`\b([\w\-]+\.(?:go|py|ts|tsx|js|jsx|rs|java|rb|css|scss|html|yaml|yml|json|toml|sql|sh|md))\b`)
+
 // RootScopeKey is the pseudo-directory used to represent a shared reference to
 // a root-level config/scaffold file (see rootConfigFilePattern).
 const RootScopeKey = "<root>"
@@ -43,7 +54,11 @@ func RootConfigFileMentions(text string) map[string]bool {
 func ExtractDirectoriesFromText(text string) map[string]bool {
 	dirs := make(map[string]bool)
 
-	// Extract directories from file paths
+	// Extract directories from file paths. Also track each path's basename so
+	// a bare mention of the same file elsewhere (e.g. a title saying "update
+	// epic.go" alongside a description citing "internal/executor/epic.go")
+	// isn't double-counted as its own separate scope key below.
+	pathBasenames := make(map[string]bool)
 	matches := filePathPattern.FindAllStringSubmatch(text, -1)
 	for _, m := range matches {
 		if len(m) < 2 {
@@ -53,6 +68,7 @@ func ExtractDirectoriesFromText(text string) map[string]bool {
 		lastSlash := strings.LastIndex(filePath, "/")
 		if lastSlash > 0 {
 			dirs[filePath[:lastSlash]] = true
+			pathBasenames[filePath[lastSlash+1:]] = true
 		}
 	}
 
@@ -72,8 +88,28 @@ func ExtractDirectoriesFromText(text string) map[string]bool {
 	// Fold root-level config/scaffold file mentions into a shared pseudo-path
 	// so two issues that both invent package.json/tsconfig.json/etc. collide
 	// even though neither reference contains a directory separator.
-	if len(RootConfigFileMentions(text)) > 0 {
+	rootConfigMentions := RootConfigFileMentions(text)
+	if len(rootConfigMentions) > 0 {
 		dirs[RootScopeKey] = true
+	}
+
+	// Extract bare top-level filenames (no directory prefix, not already
+	// folded into RootScopeKey above). Each distinct bare filename is its
+	// own scope key so two different root-level source files are NOT
+	// mistaken for the same package (GH-4302).
+	for _, m := range bareFilePattern.FindAllStringSubmatchIndex(text, -1) {
+		start, end := m[2], m[3]
+		if start > 0 && text[start-1] == '/' {
+			continue // tail of a longer path already handled above
+		}
+		filename := text[start:end]
+		if rootConfigMentions[filename] {
+			continue // already folded into RootScopeKey
+		}
+		if pathBasenames[filename] {
+			continue // same file already accounted for via a full path elsewhere
+		}
+		dirs[filename] = true
 	}
 
 	return dirs

--- a/internal/executor/scope_test.go
+++ b/internal/executor/scope_test.go
@@ -75,6 +75,35 @@ func TestExtractDirectoriesFromText(t *testing.T) {
 			text: "Add a Makefile with build and test targets",
 			want: map[string]bool{RootScopeKey: true},
 		},
+		{
+			// GH-4302: bare top-level source files (not in the config/scaffold
+			// list) are not folded together — each distinct filename is its
+			// own scope key, since touching version.go doesn't conflict with
+			// touching CHANGELOG.md.
+			name: "distinct bare top-level source files are separate scope keys",
+			text: "Bump the PATCH component in version.go, and append a dated line to CHANGELOG.md",
+			want: map[string]bool{"version.go": true, "CHANGELOG.md": true},
+		},
+		{
+			name: "same bare top-level file mentioned twice collapses to one key",
+			text: "Update version.go now; update version.go again later",
+			want: map[string]bool{"version.go": true},
+		},
+		{
+			name: "bare filename tail of a longer path is not double-counted",
+			text: "Modify internal/executor/runner.go only",
+			want: map[string]bool{"internal/executor": true},
+		},
+		{
+			// GH-4052 regression guard: a bare mention of a file elsewhere
+			// already covered by a full path (e.g. a title saying "update
+			// epic.go" alongside a description citing
+			// "internal/executor/epic.go") must not add a second scope key
+			// for the same file.
+			name: "bare mention of a file already covered by a full path elsewhere is not double-counted",
+			text: "fix(executor): update epic.go\nEdit internal/executor/epic.go",
+			want: map[string]bool{"internal/executor": true},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- `isSinglePackageScope`'s directory extraction only matched file paths containing a `/`, so bare top-level files (`version.go`, `CHANGELOG-CANARY.md`, etc.) were invisible to it. An epic whose subtasks each touch a distinct bare top-level file finds zero directories and falls through to the unreliable title-word heuristic, which can false-positive on shared words and collapse a genuinely multi-file epic into single-package direct execution.
- That collapse bypasses `subIssueBody()`'s `Parent: GH-N` stamp — the child issues the executing session then creates by hand (per the issue prose) are invisible to both `epic_reconcile.go`'s child search and the epic-lifecycle canary's `find_children`.
- `ExtractDirectoriesFromText` now also extracts bare top-level filenames as their own scope keys, cross-referenced against basenames already seen in full paths so the same file mentioned once bare (e.g. in a title) and once with a directory (e.g. in a description) isn't double-counted as two separate scope keys.

## Root cause (from GH-4302: post-merge CI failure attributed to PR #4299)

PR #4299 (dashboard label rendering, `internal/dashboard/stage_strip.go`) is unrelated to this failure — the scheduled `epic-lifecycle` canary run merely landed shortly after its merge. The daemon's own `execution_events` ledger for canary run `pilot-canary-sandbox#45` shows:

```
decomposition_skipped: reason=single_package_scope complexity=epic planned_subtasks=2
```

for two subtasks touching `version.go` and `CHANGELOG-CANARY.md` — two distinct root-level files that `isSinglePackageScope` misclassified as "same package" because neither is reachable via `filePathPattern` (requires a directory separator) or `rootConfigFilePattern` (a fixed list of scaffold/lockfile names). The task then fell to direct execution; the executing Claude session, following the issue's own prose instructions, manually created two child issues and PRs without the `Parent: GH-45` stamp — work that was real and correct, but invisible to the canary's `find_children` (`gh issue list --search "\"Parent: GH-45\" in:body"`), producing `[FAIL] child-count: only 0 child issue(s) created`.

Continuation of the investigation tracked under #4265 (cross-project `task_id` collision, fixed via #4297 the same day) — this is a distinct, newly-identified root cause for the same symptom class.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/executor/...` (full package, including the two pre-existing GH-4052 regression tests that initially caught a double-counting edge case in the first pass of this fix)
- [x] `go test ./...` (whole repo)
- [x] `go vet ./...`
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/executor/...`
- [x] New table-driven cases in `scope_test.go` (`TestExtractDirectoriesFromText`) covering: distinct bare top-level files, repeated bare mention of the same file, bare mention already covered by a full path elsewhere
- [x] New case in `epic_test.go` (`TestIsSinglePackageScope`) reproducing the exact GH-4302 canary scenario (version.go + CHANGELOG-CANARY.md → not single package)
- [x] Updated the pre-existing `TestExtractUniqueDirectories` "files without directory prefix" case, which had documented the buggy behavior as intentional (`main.go` + `utils.go` → 0 dirs); now correctly expects 2