### PR TITLE
fix(executor): round up detectSameComponentFromTitles threshold for n=2 epics (GH-4304)

### DIFF
--- a/.agent/knowledge/memories/pitfalls/bug_two_subtask_epic_never_decomposes.md
+++ b/.agent/knowledge/memories/pitfalls/bug_two_subtask_epic_never_decomposes.md
@@ -1,0 +1,16 @@
+---
+name: Two-subtask epics never decompose — int(n*0.8) threshold collapse (GH-4304)
+description: detectSameComponentFromTitles in internal/executor/epic.go truncated its ">80% of titles" threshold with int(), which collapses to 1 for n=2 subtasks — any word in even ONE of two titles then satisfied count>=1, so every 2-child epic was misclassified single-package-scope and direct-executed instead of decomposed. Fixed by rounding the threshold up (ceil via integer math). Recurrence risk if any similar ">=X% of N" gate reintroduces int() truncation for small N.
+type: pitfall
+---
+Root cause of the epic-lifecycle canary's persistent `child-count: 0 child issue(s) created` failures (issue #4265, alert re-triggered on every scheduled run 2026-07-13 through 2026-07-14), which autopilot repeatedly mis-attributed to whatever PR happened to merge just before each scheduled run (most recently GH-4304 → PR #4299, a dashboard-only change with zero relation to epic planning).
+
+**Why:** `detectSameComponentFromTitles` (`internal/executor/epic.go`) computes `threshold := int(float64(len(subtasks)) * 0.8)` then treats any word with `count >= threshold` as evidence all subtasks share one component/package. For `n=2`, `int(1.6) == 1` — so a word appearing in just ONE of the two titles (count=1) already meets `count >= 1`. Since virtually any two real subtask titles share at least one non-stopword ≥3 chars, this made the function return `true` almost unconditionally whenever an epic planned exactly 2 children — collapsing `isSinglePackageScope` to always-true and skipping decomposition entirely (`decomposition_skipped reason=single_package_scope`), even for subtasks touching completely unrelated files (e.g. `version.go` vs `CHANGELOG-CANARY.md`).
+
+The bug was invisible in `TestDetectSameComponentFromTitles` because every existing fixture used n=3 or n=5 subtasks, where the same truncation happens to either not matter (n=5: `int(4.0)==4`, no rounding error) or still under-triggers less severely. Nobody had a 2-subtask fixture.
+
+**How to apply:**
+- Any heuristic gate phrased as "≥X% of N items" that computes its integer threshold via `int(float64(n) * pct)` is vulnerable to this same collapse at small N — audit for `int()` truncation vs a proper ceiling when reviewing similar threshold code.
+- Fix: `threshold := (len(subtasks)*4 + 4) / 5` (integer-math `ceil(n*0.8)`), not `int(n*0.8)`.
+- When a repeating canary/alert issue keeps citing "Original PR: #NNNN" as if each new merge caused the same failure, check the failure signature first (here: `decomposition_skipped reason=single_package_scope`, unrelated to dashboard/HISTORY code) before trusting the autopilot's causal attribution — CI-post-merge issues are filed against whatever merged most recently before a scheduled canary tick, not necessarily the actual cause.
+- Test coverage gap to watch for elsewhere in this codebase: any table-driven test for a percentage/ratio threshold should include a case at the smallest N the gate can see in production (here, n=2, since `PlanEpic` can legitimately plan exactly 2 subtasks).

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -491,8 +491,14 @@ func detectSameComponentFromTitles(subtasks []PlannedSubtask) bool {
 		}
 	}
 
-	// Check if any significant word appears in >80% of titles
-	threshold := int(float64(len(subtasks)) * 0.8)
+	// Check if any significant word appears in at least 80% of titles.
+	// GH-4304: truncating int(n*0.8) collapses to 1 for n=2 (int(1.6)==1),
+	// so any word appearing in just ONE of two titles satisfied count>=1 —
+	// every 2-subtask epic was misclassified as single-package scope
+	// (observed on the epic-lifecycle canary, which always plans exactly 2
+	// children). Round the threshold up so ">=80%" is enforced correctly
+	// at every subtask count: ceil(n*0.8) via integer math (n*4+4)/5.
+	threshold := (len(subtasks)*4 + 4) / 5
 	for _, count := range wordCounts {
 		if count >= threshold {
 			return true

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -530,6 +530,28 @@ func TestDetectSameComponentFromTitles(t *testing.T) {
 			subtasks: []PlannedSubtask{},
 			expected: false,
 		},
+		{
+			// GH-4304: with n=2, int(2*0.8)==1 truncated the threshold to 1,
+			// so any word present in just ONE title (count=1) satisfied
+			// count>=1 and every two-subtask epic was misclassified as
+			// single-package scope. This is the exact shape of the
+			// epic-lifecycle canary's two children (version bump,
+			// changelog entry) — neither title shares a significant word.
+			name: "two unrelated subtasks (GH-4304 regression)",
+			subtasks: []PlannedSubtask{
+				{Title: "Version bump: increment PATCH in version.go"},
+				{Title: "Changelog entry: append canary changelog line"},
+			},
+			expected: false,
+		},
+		{
+			name: "two subtasks sharing a component word",
+			subtasks: []PlannedSubtask{
+				{Title: "dashboard layout component"},
+				{Title: "dashboard state management"},
+			},
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Fixes the real root cause of the recurring `[canary:epic-lifecycle] pipeline stall` (issue #4265): `detectSameComponentFromTitles` in `internal/executor/epic.go` computed its ">=80% of titles" threshold as `int(len(subtasks) * 0.8)`, which truncates to `1` when `len(subtasks) == 2`. Any word appearing in even ONE of two titles then satisfies `count >= 1`, so `isSinglePackageScope` returned `true` for essentially every 2-child epic plan — decomposition was silently skipped (`decomposition_skipped reason=single_package_scope`) and the epic direct-executed instead.

The epic-lifecycle canary always plans exactly 2 children (version bump + changelog entry, touching unrelated root-level files), so it has hit this collapse on every scheduled run since it started — independent of whatever PR happened to merge just before each tick. GH-4304 was auto-filed against PR #4299 (a dashboard-only HISTORY-ladder change with no relation to epic planning) purely because it was the most recent merge before the failing scheduled run; verified via the ledger (`decomposition_skipped` event on execution `GH-45`) and confirmed with a standalone repro that `detectSameComponentFromTitles` returns `true` for two titles ("Version bump…" / "Changelog entry…") that share no significant word.

- Round the threshold up via integer-math ceiling (`(n*4+4)/5`) instead of truncating, so ">=80%" is enforced correctly at every subtask count, including n=2.
- Added regression test cases for exactly 2 subtasks: unrelated titles (must NOT trigger single-scope) and titles sharing a component word (must still trigger).
- Filed a pitfall memory (`.agent/knowledge/memories/pitfalls/bug_two_subtask_epic_never_decomposes.md`) documenting the `int()` truncation trap and the test-coverage gap (no existing fixture used n=2).

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/executor/...` (full package, including new `TestDetectSameComponentFromTitles` cases)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [ ] Next scheduled `epic-lifecycle` canary run should show >=2 children created and assertions passing, once the daemon runs a build containing this commit