### PR TITLE
fix(autopilot): dedup fix-issue creation to stop duplicate autopilot-fix spam (GH-4307)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -662,6 +662,12 @@ func (c *Controller) SetMonitor(m TaskMonitor) {
 // If set, all state transitions are persisted to SQLite.
 func (c *Controller) SetStateStore(store *StateStore) {
 	c.stateStore = store
+	// GH-4307: forward to feedback loop so fix-issue creation can dedup
+	// against a re-tick, a release-scan re-discovery, or a second daemon
+	// racing the same failure signal.
+	if c.feedbackLoop != nil {
+		c.feedbackLoop.SetStateStore(store)
+	}
 }
 
 // repoKey returns this controller's "owner/repo" identity, used to scope

--- a/internal/autopilot/feedback_loop.go
+++ b/internal/autopilot/feedback_loop.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/qf-studio/pilot/internal/ghissue"
@@ -94,6 +95,7 @@ type FeedbackLoop struct {
 	repo         string
 	issueLabels  []string
 	learningLoop *memory.LearningLoop // GH-1979: optional, annotates issues with known patterns
+	stateStore   *StateStore          // GH-4307: optional, dedups fix-issue creation across retries/daemons
 	log          *slog.Logger
 }
 
@@ -111,6 +113,23 @@ func NewFeedbackLoop(ghClient *github.Client, owner, repo string, cfg *Config) *
 // SetLearningLoop injects a learning loop for pattern annotation in fix issues.
 func (f *FeedbackLoop) SetLearningLoop(ll *memory.LearningLoop) {
 	f.learningLoop = ll
+}
+
+// SetStateStore injects the persistent state store used to dedup fix-issue
+// creation. Optional: without it, CreateFailureIssue never checks for an
+// existing claim and always creates a new issue (pre-GH-4307 behavior).
+func (f *FeedbackLoop) SetStateStore(store *StateStore) {
+	f.stateStore = store
+}
+
+// spawnedFixDedupKey identifies one failure signal for idempotent fix-issue
+// creation: same PR, same failure type, same set of failed checks. Checks
+// are sorted before joining so check-order jitter across API calls can't
+// split one real failure into two dedup keys (GH-4307).
+func spawnedFixDedupKey(prNumber int, failureType FailureType, failedChecks []string) string {
+	sorted := append([]string(nil), failedChecks...)
+	sort.Strings(sorted)
+	return fmt.Sprintf("fix:pr%d:%s:%s", prNumber, failureType, strings.Join(sorted, ","))
 }
 
 // FailureType categorizes the type of failure that occurred.
@@ -155,6 +174,31 @@ func (f *FeedbackLoop) CreateFailureIssue(ctx context.Context, prState *PRState,
 		)
 	}
 
+	// GH-4307: dedup guard — a re-tick, a release-scan re-discovery, or a
+	// second daemon observing the same failure signal must not mint a second
+	// fix issue for it. The claim lives in the shared SQLite store so it
+	// holds even across process boundaries.
+	var dedupRepo, dedupKey string
+	if f.stateStore != nil {
+		dedupRepo = f.owner + "/" + f.repo
+		dedupKey = spawnedFixDedupKey(prState.PRNumber, failureType, failedChecks)
+		claimed, claimErr := f.stateStore.ClaimSpawnedFix(dedupRepo, dedupKey)
+		if claimErr != nil {
+			f.log.Warn("spawned-fix dedup check failed, proceeding without guard",
+				"pr", prState.PRNumber, "error", claimErr)
+		} else if !claimed {
+			existing, lookupErr := f.stateStore.GetSpawnedFixIssue(dedupRepo, dedupKey)
+			if lookupErr != nil {
+				f.log.Warn("duplicate fix-issue creation suppressed but issue lookup failed",
+					"pr", prState.PRNumber, "failure", failureType, "error", lookupErr)
+			} else {
+				f.log.Info("duplicate fix-issue creation suppressed",
+					"pr", prState.PRNumber, "failure", failureType, "existing_issue", existing)
+			}
+			return existing, nil
+		}
+	}
+
 	title := f.generateTitle(prState, failureType)
 
 	// GH-1979: Surface known patterns to annotate the fix issue body.
@@ -177,6 +221,12 @@ func (f *FeedbackLoop) CreateFailureIssue(ctx context.Context, prState *PRState,
 	issue, err := ghissue.CreatePilotIssue(ctx, f.ghClient, ghissue.AllowAllIssueRepos(), f.owner, f.repo, title, body, f.issueLabels)
 	if err != nil {
 		return 0, fmt.Errorf("failed to create issue: %w", err)
+	}
+
+	if dedupKey != "" {
+		if recErr := f.stateStore.RecordSpawnedFixIssue(dedupRepo, dedupKey, issue.Number); recErr != nil {
+			f.log.Warn("failed to record spawned fix issue number", "issue", issue.Number, "error", recErr)
+		}
 	}
 
 	f.log.Info("created fix issue",

--- a/internal/autopilot/spawned_fix_test.go
+++ b/internal/autopilot/spawned_fix_test.go
@@ -1,0 +1,268 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestStateStore_ClaimSpawnedFix_ExactlyOneWinner covers GH-4307: a re-tick, a
+// release-scan re-discovery, or a second daemon racing the same failure
+// signal must all lose the claim and only one call may proceed to create a
+// fix issue.
+func TestStateStore_ClaimSpawnedFix_ExactlyOneWinner(t *testing.T) {
+	store := newTestStateStore(t)
+	// Mirrors TestStateStore_ClaimScopeRelease_ExactlyOneWinner: an in-memory
+	// SQLite DB is per-connection, so concurrent goroutines below must share
+	// one connection to see the same schema/rows.
+	store.db.SetMaxOpenConns(1)
+
+	const n = 8
+	var wg sync.WaitGroup
+	results := make([]bool, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			claimed, err := store.ClaimSpawnedFix("owner/repo", "fix:pr42:ci_post_merge:")
+			if err != nil {
+				t.Errorf("ClaimSpawnedFix failed: %v", err)
+				return
+			}
+			results[i] = claimed
+		}(i)
+	}
+	wg.Wait()
+
+	winners := 0
+	for _, r := range results {
+		if r {
+			winners++
+		}
+	}
+	if winners != 1 {
+		t.Errorf("winners = %d, want exactly 1 (results: %v)", winners, results)
+	}
+}
+
+func TestStateStore_ClaimSpawnedFix_DistinctKeysBothClaim(t *testing.T) {
+	store := newTestStateStore(t)
+
+	claimed1, err := store.ClaimSpawnedFix("owner/repo", "fix:pr42:ci_post_merge:")
+	if err != nil {
+		t.Fatalf("ClaimSpawnedFix failed: %v", err)
+	}
+	if !claimed1 {
+		t.Error("first claim on a fresh key should succeed")
+	}
+
+	// Different PR number is a distinct failure signal — must claim independently.
+	claimed2, err := store.ClaimSpawnedFix("owner/repo", "fix:pr43:ci_post_merge:")
+	if err != nil {
+		t.Fatalf("ClaimSpawnedFix failed: %v", err)
+	}
+	if !claimed2 {
+		t.Error("claim on a distinct dedup key should succeed independently")
+	}
+
+	// Repeating the first key must lose the claim.
+	claimedAgain, err := store.ClaimSpawnedFix("owner/repo", "fix:pr42:ci_post_merge:")
+	if err != nil {
+		t.Fatalf("ClaimSpawnedFix failed: %v", err)
+	}
+	if claimedAgain {
+		t.Error("re-claiming an already-claimed key should fail")
+	}
+}
+
+func TestStateStore_RecordAndGetSpawnedFixIssue(t *testing.T) {
+	store := newTestStateStore(t)
+
+	// No row yet — lookup should return 0, not an error.
+	issueNum, err := store.GetSpawnedFixIssue("owner/repo", "fix:pr42:ci_post_merge:")
+	if err != nil {
+		t.Fatalf("GetSpawnedFixIssue failed: %v", err)
+	}
+	if issueNum != 0 {
+		t.Errorf("GetSpawnedFixIssue on missing row = %d, want 0", issueNum)
+	}
+
+	if _, err := store.ClaimSpawnedFix("owner/repo", "fix:pr42:ci_post_merge:"); err != nil {
+		t.Fatalf("ClaimSpawnedFix failed: %v", err)
+	}
+	// Claimed but not yet recorded — still 0 (a create may be in flight).
+	issueNum, err = store.GetSpawnedFixIssue("owner/repo", "fix:pr42:ci_post_merge:")
+	if err != nil {
+		t.Fatalf("GetSpawnedFixIssue failed: %v", err)
+	}
+	if issueNum != 0 {
+		t.Errorf("GetSpawnedFixIssue before RecordSpawnedFixIssue = %d, want 0", issueNum)
+	}
+
+	if err := store.RecordSpawnedFixIssue("owner/repo", "fix:pr42:ci_post_merge:", 4307); err != nil {
+		t.Fatalf("RecordSpawnedFixIssue failed: %v", err)
+	}
+	issueNum, err = store.GetSpawnedFixIssue("owner/repo", "fix:pr42:ci_post_merge:")
+	if err != nil {
+		t.Fatalf("GetSpawnedFixIssue failed: %v", err)
+	}
+	if issueNum != 4307 {
+		t.Errorf("GetSpawnedFixIssue = %d, want 4307", issueNum)
+	}
+}
+
+// TestFeedbackLoop_CreateFailureIssue_DedupSuppressesSecondCall verifies the
+// end-to-end guard through FeedbackLoop: two CreateFailureIssue calls for the
+// same PR/failure-type/failed-checks (the exact shape of a re-tick or a
+// release-scan re-discovery hitting the same false-positive canary check)
+// must create exactly one GitHub issue, not two (GH-4307).
+func TestFeedbackLoop_CreateFailureIssue_DedupSuppressesSecondCall(t *testing.T) {
+	createCalls := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/issues" && r.Method == "POST" {
+			createCalls++
+			var input github.IssueInput
+			_ = json.NewDecoder(r.Body).Decode(&input)
+
+			resp := github.Issue{Number: 4307}
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+
+	fl := NewFeedbackLoop(ghClient, "owner", "repo", cfg)
+	fl.SetStateStore(newTestStateStore(t))
+
+	prState := &PRState{
+		PRNumber: 42,
+		HeadSHA:  "abc1234",
+	}
+
+	first, err := fl.CreateFailureIssue(context.Background(), prState, FailureCIPostMerge, []string{"epic-lifecycle / run"}, "", 1)
+	if err != nil {
+		t.Fatalf("first CreateFailureIssue() error = %v", err)
+	}
+	if first != 4307 {
+		t.Errorf("first CreateFailureIssue() = %d, want 4307", first)
+	}
+
+	// Simulates a re-tick / release-scan re-discovery / second daemon
+	// observing the identical failure signal.
+	second, err := fl.CreateFailureIssue(context.Background(), prState, FailureCIPostMerge, []string{"epic-lifecycle / run"}, "", 1)
+	if err != nil {
+		t.Fatalf("second CreateFailureIssue() error = %v", err)
+	}
+	if second != 4307 {
+		t.Errorf("second CreateFailureIssue() = %d, want 4307 (existing issue, not a new one)", second)
+	}
+
+	if createCalls != 1 {
+		t.Errorf("createCalls = %d, want exactly 1 — duplicate must be suppressed", createCalls)
+	}
+}
+
+// TestFeedbackLoop_CreateFailureIssue_DedupDistinguishesFailedChecks verifies
+// a genuinely different failure signal (different failed checks) on the same
+// PR is NOT suppressed — the dedup key must include the check signature.
+func TestFeedbackLoop_CreateFailureIssue_DedupDistinguishesFailedChecks(t *testing.T) {
+	createCalls := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/issues" && r.Method == "POST" {
+			createCalls++
+			resp := github.Issue{Number: 100 + createCalls}
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+
+	fl := NewFeedbackLoop(ghClient, "owner", "repo", cfg)
+	fl.SetStateStore(newTestStateStore(t))
+
+	prState := &PRState{PRNumber: 42, HeadSHA: "abc1234"}
+
+	if _, err := fl.CreateFailureIssue(context.Background(), prState, FailureCIPostMerge, []string{"lint"}, "", 1); err != nil {
+		t.Fatalf("CreateFailureIssue() error = %v", err)
+	}
+	if _, err := fl.CreateFailureIssue(context.Background(), prState, FailureCIPostMerge, []string{"test"}, "", 1); err != nil {
+		t.Fatalf("CreateFailureIssue() error = %v", err)
+	}
+
+	if createCalls != 2 {
+		t.Errorf("createCalls = %d, want 2 — distinct failed-checks signature must not be deduped", createCalls)
+	}
+}
+
+// TestFeedbackLoop_CreateFailureIssue_NoStateStoreCreatesEveryTime verifies
+// the guard is opt-in: without SetStateStore, CreateFailureIssue never
+// dedups (pre-GH-4307 behavior is preserved for callers that don't wire a
+// store, e.g. existing unit tests using NewFeedbackLoop directly).
+func TestFeedbackLoop_CreateFailureIssue_NoStateStoreCreatesEveryTime(t *testing.T) {
+	createCalls := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/issues" && r.Method == "POST" {
+			createCalls++
+			resp := github.Issue{Number: 100 + createCalls}
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	fl := NewFeedbackLoop(ghClient, "owner", "repo", cfg)
+
+	prState := &PRState{PRNumber: 42, HeadSHA: "abc1234"}
+
+	for i := 0; i < 2; i++ {
+		if _, err := fl.CreateFailureIssue(context.Background(), prState, FailureCIPostMerge, []string{"lint"}, "", 1); err != nil {
+			t.Fatalf("CreateFailureIssue() error = %v", err)
+		}
+	}
+
+	if createCalls != 2 {
+		t.Errorf("createCalls = %d, want 2 — no state store means no dedup guard", createCalls)
+	}
+}
+
+func TestController_SetStateStore_ForwardsToFeedbackLoop(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+
+	c := &Controller{
+		owner:        "owner",
+		repo:         "repo",
+		config:       cfg,
+		feedbackLoop: NewFeedbackLoop(ghClient, "owner", "repo", cfg),
+	}
+
+	store := newTestStateStore(t)
+	c.SetStateStore(store)
+
+	if c.feedbackLoop.stateStore != store {
+		t.Error("SetStateStore should forward the store to the feedback loop")
+	}
+}

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -138,6 +138,19 @@ func (s *StateStore) migrate() error {
 		// tracks whether the approval-gated "🔀 Merged <sha>" Telegram follow-up
 		// has been sent, so re-entry into StageMerging cannot double-fire it.
 		`ALTER TABLE autopilot_pr_state ADD COLUMN merge_followup_posted INTEGER NOT NULL DEFAULT 0`,
+		// GH-4307: durable dedup claim for autopilot-generated fix issues, keyed
+		// on (repo, dedup_key). Without this, a re-tick, a release-scan
+		// re-discovery, or a second daemon observing the same failure signal
+		// each mint a fresh "fix(ci): resolve post-merge CI failure..." issue —
+		// this table is checked (via ClaimSpawnedFix) before every
+		// CreateFailureIssue call so only the first observation creates one.
+		`CREATE TABLE IF NOT EXISTS autopilot_spawned_fixes (
+			repo TEXT NOT NULL,
+			dedup_key TEXT NOT NULL,
+			issue_number INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (repo, dedup_key)
+		)`,
 	}
 
 	for _, m := range migrations {
@@ -1030,6 +1043,53 @@ func (s *StateStore) ClaimScopeRelease(repo, scopeKey string) (bool, error) {
 		return false, err
 	}
 	return n == 1, nil
+}
+
+// ClaimSpawnedFix atomically records that a fix issue is about to be created
+// for (repo, dedupKey). Returns claimed=true only when THIS call performed
+// the insert (single-winner discipline, mirrors ClaimScopeRelease above) — a
+// re-tick, a release-scan re-discovery, or a second daemon observing the same
+// failure signal all lose the claim and must skip creating a duplicate fix
+// issue (GH-4307).
+func (s *StateStore) ClaimSpawnedFix(repo, dedupKey string) (bool, error) {
+	result, err := s.db.Exec(`
+		INSERT OR IGNORE INTO autopilot_spawned_fixes (repo, dedup_key)
+		VALUES (?, ?)
+	`, repo, dedupKey)
+	if err != nil {
+		return false, err
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return n == 1, nil
+}
+
+// RecordSpawnedFixIssue backfills the created issue number onto an
+// already-claimed dedup row once CreatePilotIssue succeeds.
+func (s *StateStore) RecordSpawnedFixIssue(repo, dedupKey string, issueNumber int) error {
+	_, err := s.db.Exec(`
+		UPDATE autopilot_spawned_fixes SET issue_number = ? WHERE repo = ? AND dedup_key = ?
+	`, issueNumber, repo, dedupKey)
+	return err
+}
+
+// GetSpawnedFixIssue returns the issue number recorded for (repo, dedupKey),
+// or 0 if the claim row exists but RecordSpawnedFixIssue hasn't landed yet
+// (a create is still in flight) or the row doesn't exist.
+func (s *StateStore) GetSpawnedFixIssue(repo, dedupKey string) (int, error) {
+	var issueNumber int
+	err := s.db.QueryRow(`
+		SELECT issue_number FROM autopilot_spawned_fixes WHERE repo = ? AND dedup_key = ?
+	`, repo, dedupKey).Scan(&issueNumber)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return issueNumber, nil
 }
 
 // GetScopeRelease returns one scope-release row by repo+scopeKey, or nil, nil


### PR DESCRIPTION
## Summary

- Closes GH-4307 (subtask 1/4 of the decomposed epic).
- Root cause (documented in `.agent/system/incident-duplicate-cifix-2026-07-14.md`): `FeedbackLoop.CreateFailureIssue` had zero idempotency, so a re-tick, a release-scan re-discovery, or a second daemon observing the same failure signal each minted a fresh `fix(ci): resolve post-merge CI failure...` issue. This was the primary cause behind duplicate issues #4301/#4302/#4304/#4305/#4307 — all triggered by a false-positive scheduled canary check (`epic-lifecycle / run`) misattributed to PR #4299's post-merge CI.
- Adds a durable dedup claim in the shared SQLite store: new `autopilot_spawned_fixes` table (`internal/autopilot/state_store.go`), keyed on `(repo, dedup_key)` where `dedup_key` = PR number + failure type + sorted failed-check names. `StateStore.ClaimSpawnedFix` uses the same single-winner `INSERT OR IGNORE` + `RowsAffected` discipline as `ClaimScopeRelease`.
- `FeedbackLoop.CreateFailureIssue` (`internal/autopilot/feedback_loop.go`) now claims the dedup key before creating an issue; on a lost claim it returns the already-recorded issue number instead of creating a duplicate. `Controller.SetStateStore` forwards the store to the feedback loop (`internal/autopilot/controller.go`), same pattern as `SetLearningLoop`.
- Guard is opt-in via the store being set — callers/tests that don't wire a `StateStore` keep the pre-existing always-create behavior.

Out of scope for this subtask (left for the other 3 subtasks per the incident report's fix plan): suppressing scheduled-canary check-runs from post-merge CI attribution, an adapter-agnostic single-instance daemon lock, and closing the release-scan respawn loop by setting `StageFailed` before `removePR` on post-merge CI failure.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/autopilot/...` (full package, including new tests)
- [x] `go vet ./internal/autopilot/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] New tests added in `internal/autopilot/spawned_fix_test.go`:
  - `StateStore.ClaimSpawnedFix` exactly-one-winner under concurrency, and distinct-key independence
  - `StateStore.RecordSpawnedFixIssue` / `GetSpawnedFixIssue` round-trip
  - `FeedbackLoop.CreateFailureIssue` end-to-end: identical failure signal called twice creates exactly one GitHub issue; a genuinely different failed-checks signature is NOT deduped; no-store callers keep always-create behavior
  - `Controller.SetStateStore` forwards the store to `feedbackLoop`