### PR TITLE
fix(autopilot): honor required-checks allowlist in auto CI-discovery mode (GH-4307)

### DIFF
--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -676,7 +676,11 @@ autopilot:
     exclude:                      # Check names to ignore in auto mode
       - "codecov/*"              # Glob patterns supported
       - "*-optional"
-    # required: []                # Only used in manual mode
+    # required: []                # Allowlist; when non-empty, scopes status/failure
+    #                              # attribution to exactly these checks even in auto
+    #                              # mode (GH-4307) — use this to shield against
+    #                              # unrelated scheduled/canary checks landing on the
+    #                              # same SHA instead of enumerating them in `exclude`.
     discovery_grace_period: 60s   # Wait for CI to start
 
 # Dashboard settings

--- a/internal/autopilot/ci_monitor.go
+++ b/internal/autopilot/ci_monitor.go
@@ -49,8 +49,13 @@ func NewCIMonitor(ghClient *github.Client, owner, repo string, cfg *Config) *CIM
 
 	if cfg.CIChecks != nil {
 		ciChecks = cfg.CIChecks
-		// If manual mode, use the Required list
-		if ciChecks.Mode == "manual" && len(ciChecks.Required) > 0 {
+		// GH-4307: honor a non-empty Required allowlist regardless of Mode.
+		// Previously this was gated on Mode == "manual", so an operator running
+		// auto-discovery with an explicit Required list (e.g. to shield against
+		// unrelated scheduled/canary checks landing on the same SHA) had that
+		// list silently ignored — checkStatus fell through to
+		// checkAutoDiscoveredRuns, which aggregates every non-excluded check.
+		if len(ciChecks.Required) > 0 {
 			requiredChecks = ciChecks.Required
 		}
 	} else if len(cfg.RequiredChecks) > 0 {
@@ -155,31 +160,41 @@ func (m *CIMonitor) checkStatus(ctx context.Context, sha string, skipGrace bool)
 		}
 	}
 
+	// GH-4307: a non-empty required-checks allowlist always wins, even in auto
+	// mode. Auto-discovery aggregates every check run on the SHA (minus
+	// Exclude patterns), so an always-on scheduled workflow (e.g. a canary)
+	// that happens to attach a check run to the same merge SHA can flip status
+	// to CIFailure despite being unrelated to the PR. An explicit Required
+	// list scopes status to exactly those checks, sidestepping that class of
+	// false positive without requiring every such workflow to be Exclude-d.
+	if len(m.requiredChecks) > 0 {
+		return m.checkRequiredChecks(checkRuns), nil
+	}
+
 	// Auto mode: use discovered checks with exclusions and grace period
 	if m.ciChecks != nil && m.ciChecks.Mode == "auto" {
 		return m.checkAutoDiscoveredRuns(ctx, sha, checkRuns, skipGrace)
 	}
 
-	// Manual mode: If no required checks configured, check all runs
-	if len(m.requiredChecks) == 0 {
-		return m.checkAllRuns(checkRuns), nil
-	}
+	// Manual mode with no required checks configured: check all runs
+	return m.checkAllRuns(checkRuns), nil
+}
 
-	// Track required checks
+// checkRequiredChecks aggregates status from only the checks named in
+// m.requiredChecks, ignoring every other check run on the SHA.
+func (m *CIMonitor) checkRequiredChecks(checkRuns *github.CheckRunsResponse) CIStatus {
 	requiredStatus := make(map[string]CIStatus)
 	for _, name := range m.requiredChecks {
 		requiredStatus[name] = CIPending
 	}
 
-	// Map check runs to status
 	for _, run := range checkRuns.CheckRuns {
 		if _, ok := requiredStatus[run.Name]; ok {
 			requiredStatus[run.Name] = m.mapCheckStatus(run.Status, run.Conclusion)
 		}
 	}
 
-	// Determine overall status
-	return m.aggregateStatus(requiredStatus), nil
+	return m.aggregateStatus(requiredStatus)
 }
 
 // checkAllRuns returns aggregate status when no required checks are configured.
@@ -435,7 +450,11 @@ func (m *CIMonitor) GetCIStatus(ctx context.Context, sha string) (CIStatus, erro
 	return m.checkStatus(ctx, sha, true)
 }
 
-// GetFailedChecks returns names of failed checks for a SHA.
+// GetFailedChecks returns names of failed checks for a SHA. It applies the
+// same scoping as checkStatus (GH-4307): with a required-checks allowlist,
+// only failures among those names are reported; otherwise, in auto mode,
+// Exclude-matched checks (e.g. an always-on scheduled canary) are dropped so
+// fix-issue bodies don't attribute an unrelated failure to this SHA's CI.
 func (m *CIMonitor) GetFailedChecks(ctx context.Context, sha string) ([]string, error) {
 	checkRuns, err := m.ghClient.ListCheckRuns(ctx, m.owner, m.repo, sha)
 	if err != nil {
@@ -444,11 +463,33 @@ func (m *CIMonitor) GetFailedChecks(ctx context.Context, sha string) ([]string, 
 
 	var failed []string
 	for _, run := range checkRuns.CheckRuns {
-		if run.Conclusion == github.ConclusionFailure {
-			failed = append(failed, run.Name)
+		if run.Conclusion != github.ConclusionFailure {
+			continue
 		}
+		if !m.isScopedCheck(run.Name) {
+			continue
+		}
+		failed = append(failed, run.Name)
 	}
 	return failed, nil
+}
+
+// isScopedCheck reports whether a check name is in scope for CI status/failure
+// attribution: within the required-checks allowlist when one is configured,
+// otherwise not matching an auto-mode Exclude pattern.
+func (m *CIMonitor) isScopedCheck(name string) bool {
+	if len(m.requiredChecks) > 0 {
+		for _, required := range m.requiredChecks {
+			if required == name {
+				return true
+			}
+		}
+		return false
+	}
+	if m.ciChecks != nil && m.ciChecks.Mode == "auto" && m.matchesExclude(name) {
+		return false
+	}
+	return true
 }
 
 // GetFailedCheckLogs fetches logs for all failed check runs and returns them
@@ -465,6 +506,9 @@ func (m *CIMonitor) GetFailedCheckLogs(ctx context.Context, sha string, maxLen i
 	var combined strings.Builder
 	for _, run := range checkRuns.CheckRuns {
 		if run.Conclusion != github.ConclusionFailure {
+			continue
+		}
+		if !m.isScopedCheck(run.Name) {
 			continue
 		}
 

--- a/internal/autopilot/ci_monitor_test.go
+++ b/internal/autopilot/ci_monitor_test.go
@@ -919,6 +919,58 @@ func TestCIMonitor_AutoDiscovery_WithExclusions(t *testing.T) {
 	}
 }
 
+// TestCIMonitor_AutoMode_RequiredChecksOverrideDiscovery is the GH-4307
+// regression guard: a scheduled canary check (e.g. "epic-lifecycle / run")
+// can attach a failing check run to the same merge SHA a post-merge monitor
+// is watching. Before this fix, an explicit Required allowlist was only
+// honored in manual mode, so auto-discovery aggregated every check —
+// including the unrelated canary — and a single always-red scheduled check
+// flipped status to CIFailure. With Required set, auto mode must scope
+// status to exactly those checks and ignore the rest.
+func TestCIMonitor_AutoMode_RequiredChecksOverrideDiscovery(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := github.CheckRunsResponse{
+			TotalCount: 3,
+			CheckRuns: []github.CheckRun{
+				{Name: "test", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+				{Name: "lint", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+				{Name: "epic-lifecycle / run", Status: github.CheckRunCompleted, Conclusion: github.ConclusionFailure}, // unrelated scheduled canary
+			},
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.CIPollInterval = 10 * time.Millisecond
+	cfg.CIWaitTimeout = 1 * time.Second
+	cfg.CIChecks = &CIChecksConfig{
+		Mode:                 "auto",
+		Required:             []string{"test", "lint"},
+		DiscoveryGracePeriod: 10 * time.Millisecond,
+	}
+
+	monitor := NewCIMonitor(ghClient, "owner", "repo", cfg)
+
+	status, err := monitor.CheckCI(context.Background(), "abc1234")
+	if err != nil {
+		t.Fatalf("CheckCI() error = %v", err)
+	}
+	if status != CISuccess {
+		t.Errorf("CheckCI() status = %s, want %s (unrelated canary check should be ignored)", status, CISuccess)
+	}
+
+	failed, err := monitor.GetFailedChecks(context.Background(), "abc1234")
+	if err != nil {
+		t.Fatalf("GetFailedChecks() error = %v", err)
+	}
+	if len(failed) != 0 {
+		t.Errorf("GetFailedChecks() = %v, want none (canary is out of the required-checks scope)", failed)
+	}
+}
+
 func TestCIMonitor_matchesExclude_GlobPatterns(t *testing.T) {
 	ghClient := github.NewClient(testutil.FakeGitHubToken)
 	cfg := DefaultConfig()

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -196,7 +196,11 @@ type CIChecksConfig struct {
 	// Exclude lists check names to ignore in auto mode (supports glob patterns).
 	Exclude []string `yaml:"exclude"`
 
-	// Required lists check names for manual mode.
+	// Required lists check names for manual mode. When non-empty, this
+	// allowlist takes precedence over Mode: status/failure attribution scopes
+	// to exactly these checks even in auto mode, so an always-on scheduled
+	// workflow (e.g. a canary) landing a check run on the same SHA cannot
+	// flip CI status or contaminate a fix-issue's failure logs (GH-4307).
 	Required []string `yaml:"required"`
 
 	// DiscoveryGracePeriod: how long to wait for checks to appear (default 60s).


### PR DESCRIPTION
## Summary
- `NewCIMonitor` only populated `requiredChecks` when `ci_checks.mode == "manual"`, so an operator-configured `Required` allowlist was silently dropped in the default auto-discovery mode — `checkStatus` always fell through to `checkAutoDiscoveredRuns`, which aggregates every non-excluded check run on the SHA.
- This let an always-on scheduled workflow (e.g. the `epic-lifecycle` canary) attach a permanently-failing check run to a PR's merge SHA and flip post-merge CI status to failure, misattributing the canary's own brokenness to unrelated merged PRs. This is root cause #2 in the incident report for #4301/#4302/#4304/#4305/#4307 — #1 (missing fix-issue dedup) was already fixed via #4319.
- `Required` now takes precedence over `Mode`: when non-empty, `checkStatus`, `GetFailedChecks`, and `GetFailedCheckLogs` all scope to exactly that allowlist regardless of auto/manual mode, so fix-issue bodies no longer carry logs from checks the allowlist excludes.

Part 2 of GH-4307 (part 1: #4319, the fix-issue dedup guard).

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/autopilot/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/autopilot/...`
- [x] New test `TestCIMonitor_AutoMode_RequiredChecksOverrideDiscovery` — reproduces the exact scenario (auto mode, `Required: [test, lint]`, an unrelated `epic-lifecycle / run` failure present) and asserts `CheckCI` returns `CISuccess` and `GetFailedChecks` reports no failures.