### PR TITLE
feat(cmd): adapter-agnostic single-instance flock lock + pilot stop/restart

### DIFF
--- a/.agent/sops/operations/safe-daemon-restart.md
+++ b/.agent/sops/operations/safe-daemon-restart.md
@@ -1,0 +1,74 @@
+# SOP: Safe Pilot Daemon Restart (no orphans, no double-daemon)
+
+**Category:** operations
+**Created:** 2026-07-14
+**Trigger:** Restarting the Pilot daemon after a config change, binary rebuild, or crash.
+
+## Why this exists
+
+2026-07-14 incident: restarting the `--dashboard` daemon from an assistant/background
+shell created an **invisible headless orphan** while the old TUI daemon kept running
+— two `pilot start` processes polled the same repos concurrently. Two autopilot
+controllers both scanning the same merged PR (#4299), plus a scheduled-canary false
+failure and zero fix-issue dedup, produced **4 duplicate CI-fix issues**
+(#4301/#4302/#4304/#4305). Root cause: **there is no adapter-agnostic single-instance
+lock** — the only guard is the Telegram 409 conflict, which is gated behind `--telegram`
+and absent for github-only/headless runs (`cmd/pilot/main.go:1885,1964`).
+
+Related: `.agent/system/incident-duplicate-cifix-2026-07-14.md` (full root cause);
+fix issues for the durable lock (A3) + spawn dedup (A1) tracked as `pilot` issues.
+
+## Hard rules
+
+- ❌ **NEVER start a second `pilot start` "just for github" or "just headless."** That is
+  exactly how the orphan controller arises. One process owns github + telegram + dashboard + tunnel.
+  As of GH-4311, a second `pilot start` against the same `Memory.Path` now refuses outright
+  (adapter-agnostic `flock` on `<Memory.Path>/pilot.lock`, naming the holder pid) — this is a
+  backstop, not a reason to skip the enumerate/confirm steps below.
+- ❌ **NEVER restart the user's `--dashboard` daemon from a non-interactive/background shell.**
+  `--dashboard` is a bubbletea TUI that needs a real TTY; backgrounding it (`nohup ... &`)
+  detaches the TUI (invisible orphan) and does not render. **The restart is the operator's
+  action in their own terminal.** An assistant may `make build` + install the binary, but
+  must not launch/relaunch the daemon.
+- ✅ `pilot start --replace` is now safe to use as the routine restart mechanism (GH-4311):
+  it SIGTERMs the pid recorded in the lock file and waits (bounded) for the lock to actually
+  release before acquiring it itself — no more coarse `pkill` with no confirmation the target
+  exited. `pilot stop` / `pilot restart` are also available for a clean single-command handoff.
+
+## Procedure (manual, serial)
+
+1. **Enumerate:** `pgrep -fa "pilot start"` — expect exactly one PID. Ignore transient
+   children (a PID that shows in `pgrep` but has no command under `ps -o command= -p <pid>`
+   has already exited — a subprocess flicker, not a daemon).
+2. **Stop all cleanly:** `pkill -f "pilot start"`, then re-run `pgrep -fa "pilot start"` and
+   confirm **zero** matches. Do not skip the confirm — SIGTERM is best-effort; the process
+   may still be draining a tick.
+3. **Kill strays:** verify no orphaned `--tunnel` cloudflared or headless dashboard child lingers.
+4. **Start exactly one**, in your terminal, with the full flag set for the whole session:
+   `GITHUB_TOKEN=$(gh auth token) pilot start --dashboard --github --telegram --tunnel --replace`
+   (drop `--dashboard`/`--tunnel` only if you genuinely don't want them — but still one process).
+5. **Verify:** `pgrep -f "pilot start" | wc -l` → `1`; TUI renders; `curl -s localhost:9091/metrics | grep pilot_queue_depth` responds; no Telegram 409 in `~/.pilot/logs/daemon.log`.
+
+## When a config change needs a restart
+
+Adding/removing a `projects:` entry, changing adapter credentials, or editing
+`ci_checks`/gates all require a restart — the config is read once at startup and pollers
+are wired then (`Config.Reload()` only fires after self-upgrade). Sequence: edit config →
+validate it parses (`python3 -c "import yaml,sys; yaml.safe_load(open('~/.pilot/config.yaml'))"`)
+→ follow the restart procedure above. Dispatched issues for the new repo sit unpolled until
+the restart activates its poller.
+
+## The durable fix (A3) — shipped GH-4311
+
+`internal/singleton` provides an OS-level `flock` on `<Memory.Path>/pilot.lock`
+(`LOCK_EX|LOCK_NB`, pid written in, held for process lifetime), acquired in `runPollingMode`
+before any adapter wires. A second `pilot start` against the same lock refuses and names the
+holder pid; `--replace` SIGTERMs the holder and waits for the lock to release before
+acquiring it. `pilot stop` (SIGTERM + wait for release) and `pilot restart` (stop, then
+exec into `pilot start` in the same terminal/TTY) round out the single-handoff story. The
+manual procedure above remains the belt-and-suspenders check — the lock stops a second
+daemon from *running*, but doesn't by itself verify strays like a leftover `--tunnel`
+cloudflared process.
+
+Independently, the fix-issue spawn dedup (A1) lives in the shared SQLite store so even a
+momentary lock gap during handoff cannot produce duplicates.

--- a/.agent/system/incident-duplicate-cifix-2026-07-14.md
+++ b/.agent/system/incident-duplicate-cifix-2026-07-14.md
@@ -1,0 +1,100 @@
+Evidence confirmed against the source. Writing the synthesis.
+
+---
+
+# Incident Report: Duplicate Autopilot CI-Fix Issues (#4301 / #4302 / #4304 / #4305)
+
+**Date:** 2026-07-14 · **Repo:** qf-studio/pilot · **Severity:** Medium (noise + wasted executor cycles, no data loss)
+
+Autopilot filed four identical issues — `fix(ci): resolve post-merge CI failure from PR #4299` — for a PR that merged cleanly and introduced no regression. The "failure" was a perpetually-red scheduled canary check (`epic-lifecycle / run`, issue #4265), not a real post-merge code check. This is the third occurrence of this class of bug (prior: #4258 as 1×; #4261/#4262/#4263 as 3×).
+
+---
+
+## 1. Root Cause
+
+Three independent defects stacked. Each is necessary to reach the observed outcome; only one is truly *primary*.
+
+### Ranked contributing causes
+
+**#1 — PRIMARY: No idempotency on fix-issue creation (the "count multiplier" *and* the reason a retry is ever a duplicate).**
+`FeedbackLoop.CreateFailureIssue` (`internal/autopilot/feedback_loop.go:137-189`) performs zero existence checking. It builds a title (`feedback_loop.go:198`) and body (`feedback_loop.go:214`) and unconditionally calls `ghissue.CreatePilotIssue`, which itself only validates the repo allowlist and conventional-commit title format before POSTing (`internal/ghissue/create.go:60-72`). There is no search for an existing open fix-issue, no label check, no persisted dedup key. The only respawn suppression anywhere is `removePR` (`controller.go:2613/2640`) evicting the PR from the in-memory `activePRs` map and its SQLite row (`persistRemovePR`, `controller.go:3532-3563`) — per-process bookkeeping, not an issue-level guard. A grep across `internal/autopilot` finds idempotency machinery for merges, releases, alerts, and scopes, but **none for fix-issue creation**. This is why *any* re-entry into the `CIFailure` branch produces a brand-new issue rather than a no-op.
+
+**#2 — Canary attribution: post-merge monitor equates "any failing check on the merge SHA" with "this PR's CI failed" (the reason there was a "failure" at all).**
+`handlePostMergeCI` captures the default-branch HEAD (the merge commit) as `PostMergeSHA` and calls `CheckCI(mainSHA)`. `checkStatus` (`ci_monitor.go:129`) lists **every** check-run on that SHA via `ListCheckRuns` with no event-type or workflow filter. GitHub pins a *scheduled* workflow's check-runs to the default-branch HEAD at trigger time — so when the "Pilot Synthetic Pipeline Canary" (`.github/workflows/pilot-canary.yml`, `on: schedule + workflow_dispatch`, **no push trigger**, cron `0 */6 * * *`) fired, its always-failing `epic-lifecycle / run` job attached a failing run to the exact SHA the #4299 monitor was watching. The configured `required_checks: [test, lint]` allowlist that would have filtered this is **dead config**: `NewCIMonitor` (`ci_monitor.go:50-69`) only honors `Required` when `ci_checks.mode == "manual"`; the pilot config sets `ci_checks: {mode: auto, exclude: []}`, so `requiredChecks` stays nil, `checkAutoDiscoveredRuns` aggregates *all* non-excluded runs, and a single canary failure ⇒ `CIFailure`.
+
+**#3 — Double-daemon + release-scan re-discovery (the amplifiers: 1 → 4).**
+Two mechanisms re-enter the `CIFailure` branch after `removePR` has "cleaned up":
+- *Concurrent controllers:* two `pilot start` daemons ran simultaneously (orphan + user's + an earlier stale one). Each holds its own in-memory `activePRs` and its own PRState for #4299 at `StagePostMergeCI`; `removePR`/`persistRemovePR` in one process cannot suppress the other's in-memory copy, and there is no cross-process guard in the shared store. Both tick, both see the same red canary, both spawn.
+- *Release-scan re-discovery:* the `CIFailure` branch does **not** set `prState.Stage = StageFailed` (contrast the timeout branch at `controller.go:2577`); it only `removePR`s. The merged-PR release scan (`controller.go:4193-4308`) then re-discovers #4299 on a later tick — merged, absent from `activePRs`, no release tag (CI never passed ⇒ no tag cut), and none of the skip-gates match a post-merge-CI-failed PR — so it re-registers the PR into `StagePostMergeCI` and the next tick spawns again.
+
+**How they compound:** #2 manufactures a false failure signal on the merge SHA. #1 means every observation of that signal mints a fresh issue instead of being idempotent. #3 causes the signal to be observed N times (controllers × re-scan cycles). The occurrence count tracks how many controller-instances × re-scan cycles overlapped the failing window — which is exactly why the prior clusters were 1× and 3×, and this one 4×.
+
+---
+
+## 2. Was It the Restarts?
+
+**Partly — the restarts/double-daemon are causal to reaching *four* (not to there being a bug at all).**
+
+- **What the restarts caused:** the count. Two (briefly three) concurrent controllers each rehydrated #4299 at `StagePostMergeCI` on startup (per commit `28e1ff9c`, "hydrate monitor from DB on restart") and independently re-drove `handlePostMergeCI`. With no cross-process spawn dedup, each daemon filed its own issue; release-scan re-discovery compounded within each. Concurrency × restart-rehydration × zero dedup = 4.
+- **What the restarts did NOT cause:** the existence of a spurious issue. Even a single, cleanly-running daemon files at least one bogus issue here, because #1 (no dedup) and #2 (canary attribution) are present regardless of process count. A dedup guard keyed on `(PR, failureType, SHA)` collapses all four to one even with two daemons live.
+- **Why concurrency was possible:** the only single-instance guard in the codebase is Telegram's 409-conflict check (`cmd/pilot/main.go:1964` → `telegram/client.go:166-194`), fully gated behind `if hasTelegram` (`main.go:1885`). A github-only or headless daemon has **zero** single-instance protection — no pidfile, flock, socket, or lockfile exists (grep confirms). `--replace` (`main.go:1152`) only acts when Telegram is enabled *and* a 409 is observed, and even then `killExistingTelegramBot` (`commands.go:913-946`) is a coarse `pgrep -f "pilot start"` + SIGTERM with no confirmation the target exited.
+
+**Verdict:** restarts amplified 1→4 but are not the root cause. The bug ships duplicates with a single daemon.
+
+---
+
+## 3. Fix Plan (prioritized, independently shippable)
+
+### A. Prevents recurrence
+
+**A1 — Idempotency guard on fix-issue creation (PRIMARY; ship first).**
+*Scope:* Add a durable dedup claim in the shared SQLite store, checked before every `CreateFailureIssue`, so a re-tick, a re-scan, or a second daemon cannot file a duplicate.
+*Files:* `internal/autopilot/state_store.go` (new `spawned_fix_issues` table + `RecordSpawnedFix`/`SpawnedFixExists`; PRIMARY KEY `(repo, dedup_key)`, `INSERT OR IGNORE` returning newly-inserted); `internal/autopilot/feedback_loop.go:137` (compute key, check-then-create-then-record); call sites `controller.go:2621` and `controller.go:1589`.
+*Key:* `fix:{owner}/{repo}:pr{PRNumber}:{failureType}[:{sorted failedChecks sig}]` — including the check signature lets a genuinely new failure spawn while blocking same-check repeats. Because the claim lives in the **shared** store, it holds even during transient double-daemon overlap.
+*Belt-and-suspenders:* before creating, GitHub-search open issues by exact title + pilot label to cover a lost DB row.
+
+**A2 — Suppress scheduled-canary check-runs in post-merge attribution.**
+*Scope:* Stop trusting all check-runs on the merge SHA. Filter to push/pull_request-triggered runs (drop schedule/workflow_dispatch-only workflows) and honor a required-checks allowlist. Fix the `NewCIMonitor` precedence so a non-empty `required_checks` is respected even when `ci_checks.mode == auto`.
+*Files:* `internal/autopilot/ci_monitor.go:50-69` (precedence), `ci_monitor.go:224-320` (`checkAutoDiscoveredRuns` event/workflow filter), `ci_monitor.go:438-452` (`GetFailedChecks` same filter).
+*Immediate mitigation (config-only, do now):* add `epic-lifecycle / run` and the canary workflow names to `ci_checks.exclude` in `~/.pilot/config.yaml:224-231`.
+
+**A3 — Adapter-agnostic single-instance lock + `pilot stop`/`restart`.**
+*Scope:* Acquire an exclusive OS lock (`flock` on `<Memory.Path>/pilot.lock`, `LOCK_EX|LOCK_NB`, held for process lifetime, pid written in) at `runPollingMode` before wiring adapters. Refuse to start if held; with `--replace`, read pid → SIGTERM → wait for release → acquire. Add `pilot stop` (read pid, SIGTERM, wait) and `pilot restart`.
+*Files:* `cmd/pilot/main.go:1341` (lock acquisition), `cmd/pilot/main.go:1885-2000` (replace the Telegram-409-only gate as primary), `cmd/pilot/commands.go` (new stop/restart). This works for github-only/headless daemons where the Telegram guard is absent.
+
+**A4 — Close the release-scan respawn loop.**
+*Scope:* In the `CIFailure` branch, set `prState.Stage = StageFailed` and persist before `removePR`, so a post-merge-CI-failed PR is not re-discoverable by the release scan.
+*Files:* `internal/autopilot/controller.go:2615-2640`; verify skip-gates in `controller.go:4193-4308` exclude `StageFailed`.
+
+### B. Cleanup
+
+**B1 — Close the four duplicates** #4301/#4302/#4304/#4305 as bogus (canary-attribution false positive).
+**B2 — Fix the canary scenario design** (issue #4265): the epic subtasks all live in one directory → `isSinglePackageScope` folds decomposition → `child-count:0`. Split into distinct package scopes so the canary reflects real behavior instead of being permanently red.
+**B3 — Port post-merge cascade/size guards** from the pre-merge path (the `MaxCIFixIterations` and `MaxCIFixPRSize` guards around `controller.go:1560-1581`); post-merge currently hardcodes `iteration=1` with no guard.
+
+---
+
+## 4. Safe-Restart SOP
+
+Until A3 lands there is **no** automatic single-instance protection for a github-only/headless daemon, so restarts must be done manually and serially.
+
+**Procedure:**
+1. **Enumerate every running daemon:** `pgrep -fa "pilot start"`. Expect exactly one PID. If you see more than one, you already have a double-daemon condition — proceed to kill all before starting a new one.
+2. **Stop cleanly, all of them:** `pkill -f "pilot start"`, then re-run `pgrep -fa "pilot start"` and confirm **zero** matches. Do not skip the confirmation — SIGTERM is best-effort and the process may still be draining a tick. Wait until the list is empty.
+3. **Verify no orphaned tunnel/dashboard child** lingers (a detached `--tunnel` cloudflared or a headless dashboard). Kill any strays.
+4. **Start exactly one** with the full flag set you intend to run for the whole session (`pilot start --telegram --github [--dashboard] [--tunnel]`). Do not start a second "just for github" or "just headless" — that is precisely how the orphan controller arose.
+5. **Single-telegram-bot constraint:** only one process may poll the Telegram bot (getUpdates 409s otherwise). This is your *incidental* single-instance signal today — but it only fires with `--telegram`, so never rely on it for a github-only run.
+6. **`--dashboard`/`--tunnel`:** run them as part of the single `pilot start`, not as a second invocation. One process owns the TUI, the tunnel, and the Telegram poll.
+7. **Do not use `--replace` as a routine restart** until A3 lands: today it only acts when Telegram 409s and coarsely SIGTERMs every `pilot start` match with no confirmation. Manual stop-verify-start is safer.
+
+**Should a single-instance lock be added? — Yes (A3).** The manual SOP is a stopgap. The durable fix is the adapter-agnostic `flock` lock plus `pilot stop`/`pilot restart` so one clean handoff replaces the race-prone `pkill`. Critically, the A1 spawn-dedup must live in the **shared SQLite store** regardless, so that even a momentary lock gap during handoff cannot produce duplicates.
+
+---
+
+## 5. Top 3 Actions Right Now
+
+1. **Config mitigation + close dupes (minutes):** add `epic-lifecycle / run` (and the canary workflow names) to `ci_checks.exclude` in `~/.pilot/config.yaml`, and close #4301/#4302/#4304/#4305 as bogus. Stops the bleeding immediately without a code deploy.
+2. **Confirm exactly one daemon is running** via the Safe-Restart SOP steps 1-2 (`pgrep -fa "pilot start"` → reduce to one). The double-daemon is what turned one false positive into four.
+3. **Dispatch A1 (idempotency guard)** as the first code issue — it is the primary root cause and the single change that makes every future re-tick/re-scan/double-daemon path a no-op instead of a duplicate.
+
+**Key evidence anchors:** `feedback_loop.go:137-189` (no dedup), `controller.go:2621` (unconditional spawn, `iteration=1`), `controller.go:2640` vs `2577` (no `StageFailed`), `controller.go:4193-4308` (release re-discovery), `ci_monitor.go:50-69` (dead `required_checks`), `ci_monitor.go:224-320` (all-runs aggregation), `pilot-canary.yml:22-25` (schedule-only trigger), `cmd/pilot/main.go:1885/1964` (Telegram-gated singleton), `commands.go:913-946` (coarse pkill).

--- a/.agent/tasks/gh-4311.md
+++ b/.agent/tasks/gh-4311.md
@@ -1,0 +1,44 @@
+# GH-4311
+
+**Created:** 2026-07-14
+
+## Problem
+
+GitHub Issue GH-4311: feat(cmd): adapter-agnostic single-instance flock lock + pilot stop/restart (prevents double-daemon)
+
+## Context
+
+There is NO adapter-agnostic single-instance guard on the daemon — the only one is the Telegram 409 check (`cmd/pilot/main.go:1885,1964`), absent for github-only/headless runs. On 2026-07-14 this let two `pilot start` processes poll the same repos concurrently → two autopilot controllers → duplicate work. `--replace` (`main.go:1152`) only acts on a Telegram 409 and coarsely `pkill`s (`commands.go:913-946`) with no confirmation the target exited.
+
+## Implementation
+
+1. Acquire an exclusive OS lock at `runPollingMode` (`cmd/pilot/main.go:1341`) BEFORE wiring adapters: `flock` on `<Memory.Path>/pilot.lock` (`LOCK_EX|LOCK_NB`), write pid, hold for process lifetime. Refuse to start if held (print the holding pid).
+2. Make the lock the PRIMARY `--replace` mechanism (not Telegram-gated, `main.go:1885-2000`): with `--replace`, read the lock's pid → SIGTERM → wait (bounded) for release → acquire.
+3. Add `pilot stop` (read pid, SIGTERM, wait for lock release) and `pilot restart` (stop + start) to `cmd/pilot/commands.go`.
+
+## Acceptance
+
+- [x] A second `pilot start` (github-only, no telegram) REFUSES to start while one holds the lock, naming the holder pid
+- [x] `pilot start --replace` cleanly supersedes the existing daemon (old exits, lock handed over, no overlap window that both poll)
+- [x] `pilot stop` terminates the daemon and releases the lock; `pilot restart` works
+- [x] Lock released on clean exit AND on crash (flock auto-releases on process death); existing startup tests green
+
+## Status: DONE (2026-07-14)
+
+Implemented via `internal/singleton` (new package: `Acquire`/`Release`/`ReadPID`,
+Unix `flock` backend + Windows no-op stub since the CLI daemon isn't shipped for
+Windows). Wired into `cmd/pilot/main.go` (`acquireDaemonLock`, called at the top of
+`runPollingMode`) and `cmd/pilot/commands.go` (`stopDaemon` shared by `pilot stop` and
+`pilot restart`; `pilot restart` execs into `pilot start` after a confirmed stop).
+Manually verified end-to-end: refuse-while-held (names holder pid), `--replace`
+handoff with zero overlap, `pilot stop` termination + lock release. Unit tests in
+`internal/singleton/lock_test.go` and `cmd/pilot/lock_cmd_test.go`; full `cmd/pilot`
++ `internal/singleton` suites green; `golangci-lint run --new-from-rev=origin/main`
+clean.
+
+## Refs
+
+- `.agent/system/incident-duplicate-cifix-2026-07-14.md` §3 A3 + §4 SOP · `.agent/sops/operations/safe-daemon-restart.md` · evidence: main.go:1341/1885/1964, commands.go:913-946
+
+## Acceptance Criteria
+

--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -4,11 +4,13 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -32,22 +34,155 @@ import (
 	"github.com/qf-studio/pilot/internal/memory"
 	"github.com/qf-studio/pilot/internal/pilot"
 	"github.com/qf-studio/pilot/internal/replay"
+	"github.com/qf-studio/pilot/internal/singleton"
 	"github.com/qf-studio/pilot/internal/upgrade"
 	githubSDK "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 )
 
+// stopDaemonTimeout bounds how long `pilot stop`/`pilot restart` wait for
+// the running daemon to release its single-instance lock (GH-4311) after
+// SIGTERM before giving up.
+const stopDaemonTimeout = 30 * time.Second
+
 func newStopCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "stop",
-		Short: "Stop the Pilot daemon",
+		Short: "Stop the running Pilot daemon",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Daemon process management is out of scope - users should use
-			// standard OS signals (Ctrl+C) or process managers (systemd, launchd)
-			fmt.Println("▸ Stopping Pilot daemon...")
-			fmt.Println("   Use Ctrl+C or send SIGTERM to stop the daemon")
-			return nil
+			configPath := cfgFile
+			if configPath == "" {
+				configPath = config.DefaultConfigPath()
+			}
+			cfg, err := config.Load(configPath)
+			if err != nil {
+				return fmt.Errorf("failed to load config: %w", err)
+			}
+			return stopDaemon(cfg, stopDaemonTimeout)
 		},
 	}
+}
+
+// stopDaemonLockDir mirrors main.go's daemonLockDir fallback so `pilot
+// stop`/`pilot restart` (a separate process from the daemon) resolve the
+// same lock file the daemon acquired in acquireDaemonLock.
+func stopDaemonLockDir(cfg *config.Config) string {
+	if cfg.Memory != nil && cfg.Memory.Path != "" {
+		return cfg.Memory.Path
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".pilot", "data")
+}
+
+// stopDaemon reads the pid recorded in the GH-4311 single-instance lock
+// file, SIGTERMs it, and polls (bounded by timeout) until the lock is
+// released — confirmed by successfully re-acquiring and immediately
+// releasing it, rather than just assuming SIGTERM landed.
+func stopDaemon(cfg *config.Config, timeout time.Duration) error {
+	dir := stopDaemonLockDir(cfg)
+
+	pid, err := singleton.ReadPID(dir)
+	if err != nil {
+		return fmt.Errorf("failed to read pilot daemon lock: %w", err)
+	}
+	if pid == 0 {
+		fmt.Println("○ Pilot daemon is not running (no lock held)")
+		return nil
+	}
+
+	fmt.Printf("▸ stopping Pilot daemon (pid %d)...\n", pid)
+	if proc, err := os.FindProcess(pid); err == nil {
+		if err := proc.Signal(syscall.SIGTERM); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			fmt.Printf("   ⚠ failed to signal pid %d: %v (continuing to wait for lock release)\n", pid, err)
+		}
+	}
+
+	fmt.Print("   Waiting for daemon to exit")
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		time.Sleep(300 * time.Millisecond)
+		fmt.Print(".")
+		lock, err := singleton.Acquire(dir)
+		if err == nil {
+			_ = lock.Release()
+			fmt.Println(" ✓")
+			fmt.Println("   ✓ daemon stopped, lock released")
+			return nil
+		}
+	}
+	fmt.Println(" ✗")
+	return fmt.Errorf("timed out after %s waiting for pilot daemon (pid %d) to release its lock", timeout, pid)
+}
+
+func newRestartCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "restart [-- start-flags...]",
+		Short: "Restart the Pilot daemon (stop the running instance, then start)",
+		Long: `Restart stops the running Pilot daemon (same as "pilot stop") and, once its
+single-instance lock is confirmed released, execs into "pilot start" in this
+process — taking over the current terminal exactly as a fresh "pilot start"
+would (see .agent/sops/operations/safe-daemon-restart.md: the daemon needs a
+real TTY, so restart must run in the operator's own terminal, not a
+background/assistant shell).
+
+Flags after "restart" (or after "--") are forwarded verbatim to "pilot start",
+e.g.:
+
+  pilot restart --dashboard --github --telegram --replace`,
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			startArgs := make([]string, 0, len(args))
+			for _, a := range args {
+				if a == "--" {
+					continue
+				}
+				startArgs = append(startArgs, a)
+			}
+
+			configPath := extractConfigFlag(startArgs)
+			if configPath == "" {
+				configPath = cfgFile
+			}
+			if configPath == "" {
+				configPath = config.DefaultConfigPath()
+			}
+			cfg, err := config.Load(configPath)
+			if err != nil {
+				return fmt.Errorf("failed to load config: %w", err)
+			}
+
+			if err := stopDaemon(cfg, stopDaemonTimeout); err != nil {
+				return err
+			}
+
+			binPath, err := os.Executable()
+			if err != nil {
+				return fmt.Errorf("failed to resolve pilot executable: %w", err)
+			}
+
+			fmt.Println("▸ starting Pilot...")
+			_ = os.Stdout.Sync()
+			_ = os.Stderr.Sync()
+
+			execArgs := append([]string{binPath, "start"}, startArgs...)
+			return syscall.Exec(binPath, execArgs, os.Environ())
+		},
+	}
+	return cmd
+}
+
+// extractConfigFlag scans forwarded "start" args for an explicit --config
+// value, so `pilot restart --config foo.yaml ...` resolves the same config
+// file for both the stop phase (reading the lock) and the exec'd start.
+func extractConfigFlag(args []string) string {
+	for i, a := range args {
+		if a == "--config" && i+1 < len(args) {
+			return args[i+1]
+		}
+		if strings.HasPrefix(a, "--config=") {
+			return strings.TrimPrefix(a, "--config=")
+		}
+	}
+	return ""
 }
 
 func newStatusCmd() *cobra.Command {

--- a/cmd/pilot/lock_cmd_test.go
+++ b/cmd/pilot/lock_cmd_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/config"
+)
+
+func TestExtractConfigFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"no config flag", []string{"--github", "--replace"}, ""},
+		{"space form", []string{"--config", "custom.yaml", "--github"}, "custom.yaml"},
+		{"equals form", []string{"--config=custom.yaml", "--github"}, "custom.yaml"},
+		{"space form at end, no value", []string{"--github", "--config"}, ""},
+		{"empty args", nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractConfigFlag(tt.args); got != tt.want {
+				t.Errorf("extractConfigFlag(%v) = %q, want %q", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStopDaemonLockDir(t *testing.T) {
+	t.Run("uses configured Memory.Path", func(t *testing.T) {
+		cfg := &config.Config{Memory: &config.MemoryConfig{Path: "/custom/memory/path"}}
+		if got := stopDaemonLockDir(cfg); got != "/custom/memory/path" {
+			t.Errorf("stopDaemonLockDir() = %q, want /custom/memory/path", got)
+		}
+	})
+
+	t.Run("falls back to ~/.pilot/data when Memory is nil", func(t *testing.T) {
+		// Pin HOME rather than reading the ambient os.UserHomeDir(): other
+		// tests in this package (e.g. TestAddProjectToConfig_NoDuplicate)
+		// mutate the process-wide HOME env var without fully restoring it,
+		// which otherwise makes this assertion order-dependent.
+		cfg := &config.Config{}
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		want := filepath.Join(home, ".pilot", "data")
+		if got := stopDaemonLockDir(cfg); got != want {
+			t.Errorf("stopDaemonLockDir() = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestStopDaemonNoLockFile(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{Memory: &config.MemoryConfig{Path: dir}}
+
+	if err := stopDaemon(cfg, time.Second); err != nil {
+		t.Fatalf("stopDaemon with no lock file should be a no-op, got: %v", err)
+	}
+}
+
+func TestStopDaemonStalePIDReleasesImmediately(t *testing.T) {
+	// A lock file with a pid recorded but not actually flock'd (e.g. left
+	// behind by a process that crashed before the OS reclaimed the file
+	// handle across a reboot/restore) should be treated as free: SIGTERM to
+	// the dead pid is a harmless no-op, and stopDaemon must not block for
+	// the full timeout waiting on a lock nobody holds.
+	dir := t.TempDir()
+	lockPath := dir + "/pilot.lock"
+	if err := os.WriteFile(lockPath, []byte("999999999"), 0o644); err != nil {
+		t.Fatalf("write stale lock file: %v", err)
+	}
+
+	cfg := &config.Config{Memory: &config.MemoryConfig{Path: dir}}
+
+	start := time.Now()
+	if err := stopDaemon(cfg, 5*time.Second); err != nil {
+		t.Fatalf("stopDaemon with stale pid should succeed, got: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 4*time.Second {
+		t.Fatalf("stopDaemon took %s, expected it to release almost immediately (lock wasn't actually held)", elapsed)
+	}
+}

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/qf-studio/pilot/internal/logging"
 	"github.com/qf-studio/pilot/internal/memory"
 	"github.com/qf-studio/pilot/internal/pilot"
+	"github.com/qf-studio/pilot/internal/singleton"
 	"github.com/qf-studio/pilot/internal/teams"
 	"github.com/qf-studio/pilot/internal/tunnel"
 	"github.com/qf-studio/pilot/internal/upgrade"
@@ -195,6 +196,7 @@ func main() {
 	rootCmd.AddCommand(
 		newStartCmd(),
 		newStopCmd(),
+		newRestartCmd(),
 		newStatusCmd(),
 		newInitCmd(),
 		newVersionCmd(),
@@ -1333,6 +1335,79 @@ func startApprovalExpirySweep(ctx context.Context, handler *approval.TelegramHan
 	})
 }
 
+// daemonLockDir resolves the directory that holds the single-instance lock
+// file, falling back to the same default memory.Path uses when config
+// somehow leaves Memory unset.
+func daemonLockDir(cfg *config.Config) string {
+	if cfg.Memory != nil && cfg.Memory.Path != "" {
+		return cfg.Memory.Path
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".pilot", "data")
+}
+
+// acquireDaemonLock takes the adapter-agnostic single-instance guard
+// (GH-4311): an OS-level flock on <Memory.Path>/pilot.lock, held for the
+// process lifetime and released automatically on exit or crash (flock
+// semantics — no cleanup code required for the crash case).
+//
+// With --replace, an existing holder is SIGTERM'd and we wait (bounded) for
+// it to release the lock before acquiring it ourselves. This is now the
+// primary --replace mechanism — it supersedes the old behavior where
+// --replace only fired on a Telegram 409 and pkilled every "pilot start"
+// match with no confirmation the target actually exited.
+func acquireDaemonLock(cfg *config.Config, replace bool) (*singleton.Lock, error) {
+	dir := daemonLockDir(cfg)
+
+	lock, err := singleton.Acquire(dir)
+	if err == nil {
+		return lock, nil
+	}
+
+	var held *singleton.ErrHeld
+	if !errors.As(err, &held) {
+		return nil, fmt.Errorf("failed to acquire single-instance lock: %w", err)
+	}
+
+	if !replace {
+		fmt.Println()
+		fmt.Printf("✗ Another pilot daemon is already running (pid %d)\n", held.PID)
+		fmt.Println()
+		fmt.Println("   Options:")
+		fmt.Println("   • Stop it:            pilot stop")
+		fmt.Println("   • Auto-replace:       pilot start --replace")
+		fmt.Println()
+		return nil, fmt.Errorf("conflict: pilot daemon already running (pid %d)", held.PID)
+	}
+
+	fmt.Printf("⟲ stopping existing pilot daemon (pid %d)...\n", held.PID)
+	if held.PID > 0 {
+		if proc, ferr := os.FindProcess(held.PID); ferr == nil {
+			_ = proc.Signal(syscall.SIGTERM)
+		}
+	}
+
+	fmt.Print("   Waiting for existing daemon to release its lock")
+	const maxRetries = 20
+	for i := 0; i < maxRetries; i++ {
+		time.Sleep(time.Duration(500+i*250) * time.Millisecond)
+		fmt.Print(".")
+		lock, err = singleton.Acquire(dir)
+		if err == nil {
+			fmt.Println(" ✓")
+			fmt.Println("   ✓ existing daemon stopped, lock acquired")
+			fmt.Println()
+			return lock, nil
+		}
+		if !errors.As(err, &held) {
+			fmt.Println(" ✗")
+			return nil, fmt.Errorf("failed to acquire single-instance lock: %w", err)
+		}
+	}
+	fmt.Println(" ✗")
+	return nil, fmt.Errorf("timeout waiting for existing pilot daemon (pid %d) to release lock", held.PID)
+}
+
 // runPollingMode runs lightweight polling-only mode.
 // When noGateway is false, the HTTP gateway starts in the background so the
 // desktop app (and any other client hitting /health) can reach the daemon.
@@ -1341,6 +1416,18 @@ func startApprovalExpirySweep(ctx context.Context, handler *approval.TelegramHan
 func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, replace, dashboardMode, noGateway bool, bootReconcile *upgrade.BootReconcileResult) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// GH-4311: adapter-agnostic single-instance guard. Must run before any
+	// adapter wiring below — two daemons concurrently wiring the same
+	// adapters (e.g. two autopilot controllers polling the same repo) is
+	// exactly the duplicate-work failure mode this closes. This supersedes
+	// the Telegram-only 409 check further down, which is blind to
+	// github-only/headless runs.
+	daemonLock, err := acquireDaemonLock(cfg, replace)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = daemonLock.Release() }()
 
 	// Check Telegram config if enabled
 	hasTelegram := cfg.Adapters.Telegram != nil && cfg.Adapters.Telegram.Enabled

--- a/internal/singleton/lock.go
+++ b/internal/singleton/lock.go
@@ -1,0 +1,143 @@
+// Package singleton provides an adapter-agnostic single-instance guard for
+// the Pilot daemon process, backed by an OS-level advisory file lock
+// (flock). Unlike the Telegram-only 409 conflict check it complements
+// (internal/adapters/telegram singleton check), this guard applies
+// regardless of which adapters are enabled — including github-only/headless
+// runs (GH-4311).
+package singleton
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// LockFileName is the name of the lock file created under the daemon's
+// memory directory (Config.Memory.Path).
+const LockFileName = "pilot.lock"
+
+// Lock is a held exclusive single-instance lock. The zero value is not
+// usable; obtain one via Acquire.
+type Lock struct {
+	file *os.File
+	path string
+}
+
+// ErrHeld is returned by Acquire when another live process already holds
+// the lock. PID is the process id recorded by the holder (best-effort; 0 if
+// it could not be read).
+type ErrHeld struct {
+	PID  int
+	Path string
+}
+
+func (e *ErrHeld) Error() string {
+	if e.PID > 0 {
+		return fmt.Sprintf("pilot daemon already running (pid %d, lock held at %s)", e.PID, e.Path)
+	}
+	return fmt.Sprintf("pilot daemon already running (lock held at %s)", e.Path)
+}
+
+// Acquire takes an exclusive, non-blocking lock on <dir>/pilot.lock,
+// creating the directory and file as needed, and stamps the file with the
+// current process's pid. The lock is released automatically by the OS if
+// this process dies or exits — including a crash — so callers do not need
+// to arrange crash cleanup; Release is only needed for a clean shutdown.
+//
+// Returns *ErrHeld if another process already holds the lock.
+func Acquire(dir string) (*Lock, error) {
+	if dir == "" {
+		return nil, fmt.Errorf("singleton: empty lock directory")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("singleton: create lock dir: %w", err)
+	}
+	path := filepath.Join(dir, LockFileName)
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("singleton: open lock file: %w", err)
+	}
+
+	if err := tryFlock(f.Fd()); err != nil {
+		defer func() { _ = f.Close() }()
+		if isLockHeldErr(err) {
+			pid, _ := readPID(f)
+			return nil, &ErrHeld{PID: pid, Path: path}
+		}
+		return nil, fmt.Errorf("singleton: lock %s: %w", path, err)
+	}
+
+	// We hold the lock — stamp our pid, replacing whatever the previous
+	// holder last wrote.
+	if err := f.Truncate(0); err != nil {
+		_ = unflock(f.Fd())
+		_ = f.Close()
+		return nil, fmt.Errorf("singleton: truncate lock file: %w", err)
+	}
+	if _, err := f.WriteAt([]byte(strconv.Itoa(os.Getpid())), 0); err != nil {
+		_ = unflock(f.Fd())
+		_ = f.Close()
+		return nil, fmt.Errorf("singleton: write pid: %w", err)
+	}
+	_ = f.Sync()
+
+	return &Lock{file: f, path: path}, nil
+}
+
+// Release unlocks and closes the lock file. Safe to call on a nil *Lock.
+// The lock file itself is left in place — the next Acquire truncates and
+// re-stamps it, and flock is keyed on the open file description, not file
+// content, so leaving it behind is harmless.
+func (l *Lock) Release() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+	_ = unflock(l.file.Fd())
+	err := l.file.Close()
+	l.file = nil
+	return err
+}
+
+// Path returns the filesystem path of the lock file, or "" for a nil Lock.
+func (l *Lock) Path() string {
+	if l == nil {
+		return ""
+	}
+	return l.path
+}
+
+// ReadPID reads the pid recorded in <dir>/pilot.lock without acquiring the
+// lock. Returns 0, nil if the lock file does not exist or has no readable
+// pid — callers should treat 0 as "no known holder", not an error.
+func ReadPID(dir string) (int, error) {
+	path := filepath.Join(dir, LockFileName)
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("singleton: open lock file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	pid, _ := readPID(f)
+	return pid, nil
+}
+
+func readPID(f *os.File) (int, error) {
+	buf := make([]byte, 32)
+	n, err := f.ReadAt(buf, 0)
+	if n == 0 {
+		if err != nil {
+			return 0, nil
+		}
+	}
+	s := strings.TrimSpace(string(buf[:n]))
+	pid, convErr := strconv.Atoi(s)
+	if convErr != nil {
+		return 0, nil
+	}
+	return pid, nil
+}

--- a/internal/singleton/lock_test.go
+++ b/internal/singleton/lock_test.go
@@ -1,0 +1,90 @@
+package singleton
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestAcquireRelease(t *testing.T) {
+	dir := t.TempDir()
+
+	lock, err := Acquire(dir)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if lock.Path() == "" {
+		t.Fatal("expected non-empty lock path")
+	}
+
+	pid, err := ReadPID(dir)
+	if err != nil {
+		t.Fatalf("ReadPID: %v", err)
+	}
+	if pid != os.Getpid() {
+		t.Fatalf("ReadPID = %d, want %d", pid, os.Getpid())
+	}
+
+	if err := lock.Release(); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+}
+
+func TestAcquireHeldByAnother(t *testing.T) {
+	dir := t.TempDir()
+
+	first, err := Acquire(dir)
+	if err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+	defer func() { _ = first.Release() }()
+
+	_, err = Acquire(dir)
+	if err == nil {
+		t.Fatal("expected second Acquire to fail while first holds the lock")
+	}
+	var held *ErrHeld
+	if !errors.As(err, &held) {
+		t.Fatalf("expected *ErrHeld, got %T: %v", err, err)
+	}
+	if held.PID != os.Getpid() {
+		t.Fatalf("ErrHeld.PID = %d, want %d", held.PID, os.Getpid())
+	}
+}
+
+func TestAcquireAfterRelease(t *testing.T) {
+	dir := t.TempDir()
+
+	first, err := Acquire(dir)
+	if err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+	if err := first.Release(); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+
+	second, err := Acquire(dir)
+	if err != nil {
+		t.Fatalf("second Acquire after release: %v", err)
+	}
+	defer func() { _ = second.Release() }()
+}
+
+func TestReadPIDNoLockFile(t *testing.T) {
+	dir := t.TempDir()
+
+	pid, err := ReadPID(dir)
+	if err != nil {
+		t.Fatalf("ReadPID: %v", err)
+	}
+	if pid != 0 {
+		t.Fatalf("ReadPID = %d, want 0 for missing lock file", pid)
+	}
+}
+
+func TestReleaseNilLock(t *testing.T) {
+	var l *Lock
+	if err := l.Release(); err != nil {
+		t.Fatalf("Release on nil *Lock should be a no-op, got %v", err)
+	}
+}

--- a/internal/singleton/lock_unix.go
+++ b/internal/singleton/lock_unix.go
@@ -1,0 +1,23 @@
+// Package singleton: Unix flock backend.
+
+//go:build !windows
+
+package singleton
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+func tryFlock(fd uintptr) error {
+	return unix.Flock(int(fd), unix.LOCK_EX|unix.LOCK_NB)
+}
+
+func unflock(fd uintptr) error {
+	return unix.Flock(int(fd), unix.LOCK_UN)
+}
+
+func isLockHeldErr(err error) bool {
+	return errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN)
+}

--- a/internal/singleton/lock_windows.go
+++ b/internal/singleton/lock_windows.go
@@ -1,0 +1,23 @@
+// Package singleton: Windows stub.
+//
+// The Pilot CLI daemon is not currently built or shipped for Windows (only
+// the desktop app is, via wails — see release-desktop.yml); this stub keeps
+// `go build ./...` working under GOOS=windows without pulling in
+// LockFileEx/golang.org/x/sys/windows. It intentionally does not enforce
+// single-instance semantics.
+
+//go:build windows
+
+package singleton
+
+func tryFlock(fd uintptr) error {
+	return nil
+}
+
+func unflock(fd uintptr) error {
+	return nil
+}
+
+func isLockHeldErr(err error) bool {
+	return false
+}


### PR DESCRIPTION
## Summary
- Adds `internal/singleton`: an OS-level `flock(LOCK_EX|LOCK_NB)` on `<Memory.Path>/pilot.lock`, acquired in `runPollingMode` before any adapter wires. A second `pilot start` against the same lock refuses and names the holder pid (no longer gated on Telegram being enabled).
- Makes the lock the primary `--replace` mechanism: SIGTERM the holder → wait (bounded) for lock release → acquire. Replaces the old Telegram-409-only trigger that coarsely `pkill`ed every `pilot start` match with no confirmation the target exited.
- Adds `pilot stop` (read pid from lock, SIGTERM, wait for release) and `pilot restart` (stop, then exec into `pilot start` in the same terminal/TTY, forwarding any flags passed after `restart`).

Fixes GH-4311. Root cause: `.agent/system/incident-duplicate-cifix-2026-07-14.md`; procedure updated in `.agent/sops/operations/safe-daemon-restart.md`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/pilot/... ./internal/singleton/...` (new unit tests for lock acquire/release/contention, `stopDaemon`, `extractConfigFlag`)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] Manual end-to-end smoke test with a built binary:
  - Second `pilot start --no-gateway` against a running instance refuses, naming the holder pid
  - `pilot start --no-gateway --replace` SIGTERMs the old daemon, waits for lock release, and takes over with zero overlap
  - `pilot stop` terminates the daemon and releases the lock