### PR TITLE
fix(autopilot): mark post-merge-CI-failed PR StageFailed + port cascade/size guards (GH-4312)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2627,27 +2627,83 @@ func (c *Controller) handlePostMergeCI(ctx context.Context, prState *PRState) er
 		failedChecks, _ := c.ciMonitor.GetFailedChecks(ctx, mainSHA)
 		// GH-1567: Fetch CI error logs for post-merge failures too.
 		ciLogs := c.ciMonitor.GetFailedCheckLogs(ctx, mainSHA, 2000)
-		// Post-merge failures start a new lineage (iteration 1), not part of pre-merge cascade.
-		issueNum, issueErr := c.feedbackLoop.CreateFailureIssue(ctx, prState, FailureCIPostMerge, failedChecks, ciLogs, 1)
-		if issueErr != nil {
-			c.log.Error("failed to create post-merge fix issue", "error", issueErr)
-		} else {
-			c.log.Info("created fix issue for post-merge CI failure", "pr", prState.PRNumber, "issue", issueNum)
-		}
-		// GH-1964/GH-1979: Learn from post-merge CI failure patterns (self-improvement).
-		// Guard: skip learning when CI logs are empty/whitespace (nothing to extract).
-		if c.learningLoop != nil && strings.TrimSpace(ciLogs) != "" {
-			projectPath := c.repoKey()
-			if learnErr := c.learningLoop.LearnFromCIFailure(ctx, projectPath, ciLogs, failedChecks); learnErr != nil {
-				c.log.Warn("Failed to learn from post-merge CI failure", slog.Any("error", learnErr))
+
+		// GH-4312: port the pre-merge cascade/size guards (~:1502-1593) to the
+		// post-merge path. Post-merge failures normally start a new lineage
+		// (iteration 1), but when prState.IssueNumber is itself a spawned fix
+		// issue carrying a higher counter in its body, the depth cap must still
+		// apply; an oversized merged PR must not spawn yet another fix either way.
+		iteration := 0
+		skipSpawn := false
+		if prState.IssueNumber > 0 && c.config.MaxCIFixIterations > 0 {
+			issue, err := c.ghClient.GetIssue(ctx, c.owner, c.repo, prState.IssueNumber)
+			if err != nil {
+				c.log.Warn("failed to fetch issue for post-merge iteration check", "issue", prState.IssueNumber, "error", err)
+				// Continue with iteration=0 (safe: won't block on transient error)
+			} else {
+				iteration = parseAutopilotIteration(issue.Body)
+			}
+			if iteration >= c.config.MaxCIFixIterations {
+				c.log.Warn("CI fix iteration limit reached, stopping post-merge cascade",
+					"pr", prState.PRNumber,
+					"issue", prState.IssueNumber,
+					"iteration", iteration,
+					"max", c.config.MaxCIFixIterations,
+				)
+				skipSpawn = true
 			}
 		}
-		// GH-3990: the fix-issue flow above is unchanged — additionally re-queue
-		// the scope release for a fresh carrier attempt.
-		if prState.ScopeKey != "" {
-			c.handleScopeReleaseFailure(ctx, prState, fmt.Sprintf("post-merge CI failed at %s", ShortSHA(mainSHA)))
+		if !skipSpawn && c.config.MaxCIFixPRSize > 0 {
+			files, err := c.ghClient.ListPullRequestFiles(ctx, c.owner, c.repo, prState.PRNumber)
+			if err != nil {
+				c.log.Warn("post-merge CI fix size guard: ListPullRequestFiles failed, skipping guard (fail-open)",
+					"pr", prState.PRNumber, "error", err)
+			} else {
+				production, bookkeeping, test := productionAdditions(files)
+				if production > c.config.MaxCIFixPRSize {
+					c.log.Warn("post-merge CI fix size guard fired — refusing to spawn fix issue",
+						"pr", prState.PRNumber, "production_additions", production, "test_additions", test,
+						"bookkeeping_additions", bookkeeping, "limit", c.config.MaxCIFixPRSize)
+					skipSpawn = true
+				}
+			}
 		}
-		c.removePR(prState.PRNumber)
+
+		if !skipSpawn {
+			issueNum, issueErr := c.feedbackLoop.CreateFailureIssue(ctx, prState, FailureCIPostMerge, failedChecks, ciLogs, iteration+1)
+			if issueErr != nil {
+				c.log.Error("failed to create post-merge fix issue", "error", issueErr)
+			} else {
+				c.log.Info("created fix issue for post-merge CI failure", "pr", prState.PRNumber, "issue", issueNum)
+			}
+			// GH-1964/GH-1979: Learn from post-merge CI failure patterns (self-improvement).
+			// Guard: skip learning when CI logs are empty/whitespace (nothing to extract).
+			if c.learningLoop != nil && strings.TrimSpace(ciLogs) != "" {
+				projectPath := c.repoKey()
+				if learnErr := c.learningLoop.LearnFromCIFailure(ctx, projectPath, ciLogs, failedChecks); learnErr != nil {
+					c.log.Warn("Failed to learn from post-merge CI failure", slog.Any("error", learnErr))
+				}
+			}
+		}
+
+		if prState.ScopeKey != "" {
+			// GH-3990: re-queue the scope for a fresh carrier attempt instead of
+			// leaving this one wedged at StageFailed forever — drain it now so the
+			// anchor PR slot frees for the retry. Re-discovery of the drained PR is
+			// guarded separately by ScopeMemberPending (controller.go ScanRecentlyMergedPRs).
+			c.handleScopeReleaseFailure(ctx, prState, fmt.Sprintf("post-merge CI failed at %s", ShortSHA(mainSHA)))
+			c.removePR(prState.PRNumber)
+			return nil
+		}
+		// GH-4312: mark StageFailed (mirrors the timeout branch above at :2587)
+		// instead of removePR. removePR issues a DELETE against the state store,
+		// so this merged-but-CI-failed PR — which has no release tag, since CI
+		// never passed — would otherwise vanish from persisted state entirely and
+		// get re-registered at StagePostMergeCI by the merged-PR release scan on
+		// its very next tick, re-entering this branch and respawning a fix issue
+		// forever.
+		prState.Stage = StageFailed
+		prState.Error = fmt.Sprintf("post-merge CI failed at %s", ShortSHA(mainSHA))
 
 	default:
 		// CIPending or CIRunning — stay in StagePostMergeCI and wait for next tick.
@@ -4206,6 +4262,26 @@ func (c *Controller) ScanRecentlyMergedPRsWithWindow(ctx context.Context, scanWi
 		c.mu.RUnlock()
 		if alreadyTracked {
 			continue
+		}
+
+		// GH-4312: skip a PR whose persisted row is already terminal 'failed' —
+		// e.g. a post-merge CI failure (handlePostMergeCI's CIFailure branch
+		// marks StageFailed before draining). RestoreState intentionally does
+		// NOT reload 'failed' rows into activePRs, so the in-memory gate above
+		// cannot catch this after a daemon restart. Without this check the scan
+		// would re-register the PR at StagePostMergeCI (no release tag exists —
+		// CI never passed) and re-enter CIFailure on the very next tick,
+		// respawning a fix issue forever.
+		if c.stateStore != nil {
+			if persisted, err := c.stateStore.GetPRState(c.repoKey(), pr.Number); err != nil {
+				c.log.Warn("failed to check persisted PR state for terminal-failed guard, will track to be safe",
+					"pr", pr.Number,
+					"error", err,
+				)
+			} else if persisted != nil && persisted.Stage == StageFailed {
+				c.log.Debug("skipping PR: persisted state is terminal failed", "pr", pr.Number)
+				continue
+			}
 		}
 
 		// B3 (TASK-309): activePRs is in-memory only. After a daemon restart a PR

--- a/internal/autopilot/controller_release_cycles_test.go
+++ b/internal/autopilot/controller_release_cycles_test.go
@@ -754,6 +754,83 @@ func TestScanRecentlyMergedPRs_RequireCI_RoutesToPostMergeCI(t *testing.T) {
 	}
 }
 
+// TestScanRecentlyMergedPRs_SkipsPersistedFailed verifies GH-4312: a merged PR
+// persisted at StageFailed (e.g. a prior post-merge CI failure) must not be
+// re-registered by the scan. RestoreState intentionally excludes StageFailed
+// rows from activePRs (controller.go:945), so after a simulated daemon
+// restart (row persisted, activePRs empty) the scan's in-memory
+// "already tracked" gate alone cannot catch it — only the state-store lookup
+// added alongside this test can.
+func TestScanRecentlyMergedPRs_SkipsPersistedFailed(t *testing.T) {
+	recentMergedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+
+	var gitRefPosts, issueGets int64
+	base := releaseCyclesServer(t, map[int]scopeMembershipFakeIssue{}, &gitRefPosts, &issueGets)
+	defer base.Close()
+
+	prs := []github.PullRequest{
+		{
+			Number:         70,
+			Head:           github.PRRef{Ref: "pilot/GH-500", SHA: "sha70"},
+			Base:           github.PRRef{Ref: "main"},
+			HTMLURL:        "https://github.com/owner/repo/pull/70",
+			Title:          "fix: previously failed post-merge CI",
+			Merged:         true,
+			MergedAt:       recentMergedAt,
+			MergeCommitSHA: "merge-sha-70",
+		},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls") && !strings.Contains(r.URL.Path, "/commits") {
+			out := make([]*github.PullRequest, len(prs))
+			for i := range prs {
+				out[i] = &prs[i]
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(out)
+			return
+		}
+		base.Config.Handler.ServeHTTP(w, r)
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge", RequireCI: true, TagPrefix: "v"}
+	cfg.MergedPRScanWindow = 30 * time.Minute
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	store, err := NewStateStoreFromPath(":memory:")
+	if err != nil {
+		t.Fatalf("NewStateStoreFromPath: %v", err)
+	}
+	c.SetStateStore(store)
+
+	// Simulate a daemon restart: the PR was previously driven to StageFailed by
+	// handlePostMergeCI's CIFailure branch and persisted, but RestoreState does
+	// not reload 'failed' rows into activePRs.
+	if err := store.SavePRState("owner/repo", &PRState{
+		PRNumber: 70,
+		PRURL:    "https://github.com/owner/repo/pull/70",
+		Stage:    StageFailed,
+		Error:    "post-merge CI failed at merge-sh",
+	}); err != nil {
+		t.Fatalf("SavePRState: %v", err)
+	}
+
+	if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+		t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+	}
+
+	if _, ok := c.GetPRState(70); ok {
+		t.Error("PR 70 is persisted at StageFailed and must not be re-registered by the scan")
+	}
+	if got := atomic.LoadInt64(&gitRefPosts); got != 0 {
+		t.Errorf("git/refs POST count = %d, want 0 (a failed PR must never be tagged)", got)
+	}
+}
+
 // TestCheckExternalMergeOrClose_StageGuards is a table-driven pin of every
 // early-return guard in checkExternalMergeOrClose: a scope-release carrier,
 // a PostMergeCI-stage PR (GH-3994), and a Releasing-stage PR (GH-4124) must

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -4611,6 +4611,201 @@ func TestHandlePostMergeCI_Timeout(t *testing.T) {
 	}
 }
 
+// TestHandlePostMergeCI_CIFailure_MarksStageFailedNotRemoved verifies GH-4312:
+// a post-merge CI failure (no scope release in play) marks the PR StageFailed
+// and leaves it in activePRs — mirroring the timeout branch above — instead of
+// calling removePR. removePR issues a DELETE against the state store; since no
+// release tag exists for this merge commit (CI never passed), evicting the row
+// would let the merged-PR release scan re-register the PR at StagePostMergeCI
+// on its very next tick, re-entering this branch and respawning a fix issue
+// forever.
+func TestHandlePostMergeCI_CIFailure_MarksStageFailedNotRemoved(t *testing.T) {
+	issueCreated := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/failsha1/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "ci", Status: "completed", Conclusion: "failure"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			issueCreated = true
+			resp := github.Issue{Number: 500}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, resp))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:             123,
+		Stage:                StagePostMergeCI,
+		PostMergeSHA:         "failsha1",
+		PostMergeCIStartedAt: time.Now(),
+	}
+	c.mu.Lock()
+	c.activePRs[123] = prState
+	c.mu.Unlock()
+
+	if err := c.handlePostMergeCI(context.Background(), prState); err != nil {
+		t.Fatalf("handlePostMergeCI returned unexpected error: %v", err)
+	}
+
+	if !issueCreated {
+		t.Error("expected post-merge fix issue to be created")
+	}
+	if prState.Stage != StageFailed {
+		t.Errorf("stage = %s, want %s", prState.Stage, StageFailed)
+	}
+	if prState.Error == "" {
+		t.Error("expected Error to be set on post-merge CI failure")
+	}
+
+	c.mu.RLock()
+	_, stillTracked := c.activePRs[123]
+	c.mu.RUnlock()
+	if !stillTracked {
+		t.Error("PR should remain tracked at StageFailed (terminal, no-op in main loop) — removePR would delete the persisted row and let the release scan re-discover it")
+	}
+}
+
+// TestHandlePostMergeCI_CIFailure_MaxCIFixIterationsGuard verifies GH-4312:
+// the pre-merge iteration-depth guard (controller.go handleCIFailed, ~:1502)
+// is ported to the post-merge path — when the merged PR's issue is itself a
+// spawned fix issue whose autopilot-meta iteration counter has already
+// reached MaxCIFixIterations, handlePostMergeCI must not spawn another fix
+// issue.
+func TestHandlePostMergeCI_CIFailure_MaxCIFixIterationsGuard(t *testing.T) {
+	issueCreated := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/failsha2/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "ci", Status: "completed", Conclusion: "failure"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/issues/77" && r.Method == http.MethodGet:
+			resp := github.Issue{Number: 77, Body: "<!-- autopilot-meta branch:pilot/GH-77 pr:200 iteration:2 -->"}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			issueCreated = true
+			resp := github.Issue{Number: 999}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, resp))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.MaxCIFixIterations = 2
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:             200,
+		IssueNumber:          77,
+		Stage:                StagePostMergeCI,
+		PostMergeSHA:         "failsha2",
+		PostMergeCIStartedAt: time.Now(),
+	}
+	c.mu.Lock()
+	c.activePRs[200] = prState
+	c.mu.Unlock()
+
+	if err := c.handlePostMergeCI(context.Background(), prState); err != nil {
+		t.Fatalf("handlePostMergeCI returned unexpected error: %v", err)
+	}
+
+	if issueCreated {
+		t.Error("fix issue must NOT be created when post-merge iteration limit is reached")
+	}
+	if prState.Stage != StageFailed {
+		t.Errorf("stage = %s, want %s", prState.Stage, StageFailed)
+	}
+}
+
+// TestHandlePostMergeCI_CIFailure_MaxCIFixPRSizeGuard verifies GH-4312: the
+// pre-merge cascade size guard (controller.go handleCIFailed, ~:1555) is
+// ported to the post-merge path — a merged PR that already exceeds
+// MaxCIFixPRSize must not spawn another fix issue on post-merge CI failure.
+func TestHandlePostMergeCI_CIFailure_MaxCIFixPRSizeGuard(t *testing.T) {
+	issueCreated := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/failsha3/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "ci", Status: "completed", Conclusion: "failure"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/pulls/300/files" && r.Method == http.MethodGet:
+			files := []*github.PRFile{
+				{Filename: "internal/foo.go", Status: "added", Additions: 500},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, files))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			issueCreated = true
+			resp := github.Issue{Number: 998}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, resp))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.MaxCIFixPRSize = 200
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:             300,
+		Stage:                StagePostMergeCI,
+		PostMergeSHA:         "failsha3",
+		PostMergeCIStartedAt: time.Now(),
+	}
+	c.mu.Lock()
+	c.activePRs[300] = prState
+	c.mu.Unlock()
+
+	if err := c.handlePostMergeCI(context.Background(), prState); err != nil {
+		t.Fatalf("handlePostMergeCI returned unexpected error: %v", err)
+	}
+
+	if issueCreated {
+		t.Error("fix issue must NOT be created when merged PR exceeds size floor")
+	}
+	if prState.Stage != StageFailed {
+		t.Errorf("stage = %s, want %s", prState.Stage, StageFailed)
+	}
+}
+
 // TestHandleCIFailed_EmptyLogs_SkipsLearning verifies that handleCIFailed skips
 // LearnFromCIFailure when CI logs are empty or whitespace-only (GH-1979).
 // TestHandleCIFailed_EmptyLogs_SkipsLearning verifies that handleCIFailed skips


### PR DESCRIPTION
## Summary

- `handlePostMergeCI`'s `CIFailure` branch unconditionally called `removePR`, which issues a DELETE against the state store. Since no release tag exists for a merge whose post-merge CI failed, the merged-PR release scan (`ScanRecentlyMergedPRs`) would re-discover the PR on its very next tick and re-register it at `StagePostMergeCI`, re-entering `CIFailure` and respawning a fix issue forever — an amplifier of the duplicate-fix-issue bug independent of GH-4307's dedup.
- Fix mirrors the existing timeout branch (`controller.go:2587`): on a non-scope-release CI failure, set `prState.Stage = StageFailed` and leave the PR tracked (terminal, no-op in the tick loop) instead of calling `removePR`. The scope-release path (`ScopeKey != ""`) keeps calling `removePR`, since `ScopeMemberPending` already guards its re-discovery.
- Added a matching skip-gate to `ScanRecentlyMergedPRsWithWindow`: `RestoreState` intentionally excludes `StageFailed` rows when rebuilding `activePRs` after a daemon restart, so the in-memory "already tracked" gate alone can't catch a persisted-failed PR post-restart — the scan now also checks the state store directly.
- Ported the pre-merge `MaxCIFixIterations` / `MaxCIFixPRSize` cascade guards (`controller.go:~1502-1593`) to the post-merge spawn path, which previously hardcoded `iteration=1` with no depth or size cap.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/autopilot/...` (full package, including 4 new tests)
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] New tests cover: StageFailed set + PR stays tracked (not removed) on post-merge CI failure; iteration-depth guard suppresses fix-issue spawn; size guard suppresses fix-issue spawn; release scan skips a PR persisted at `StageFailed` after a simulated daemon restart.