### PR TITLE
fix(daemon): recover panics in adapter goroutines (GH-4314)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -321,6 +321,7 @@
 | Docker support | ✅ | - | - | - | Dockerfile + deployment guide (v1.46.0) |
 | Helm chart | ✅ | - | - | - | Kubernetes Helm chart for production deployment (v1.46.0) |
 | PowerShell installer | ✅ | install | - | - | Windows PowerShell install script (`install.ps1`) |
+| Adapter goroutine panic recovery | ✅ | adapterhealth | - | - | Every adapter poller goroutine runs via `SafeAdapterGo`: panics are recovered, logged, restarted with backoff up to 5 attempts, then the adapter is marked disabled — one adapter's panic can't crash the daemon. Surfaced on `/api/v1/status` `adapters` + a `service_unhealthy` WARN alert (GH-4314) |
 | Gateway in polling mode | ✅ | gateway | - | - | HTTP server starts in background during polling for desktop/web (v1.62.0, GH-1662) |
 | Gateway budget nil fix | ✅ | gateway | - | - | Fix nil dereference when budget disabled in gateway mode (v2.43.0, GH-1935) |
 | Gateway learning loop | ✅ | gateway | - | - | Learning system init in gateway mode, mirrors polling mode (v2.43.0, GH-1935) |

--- a/cmd/pilot/adapters.go
+++ b/cmd/pilot/adapters.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/qf-studio/pilot/internal/adapterhealth"
 	"github.com/qf-studio/pilot/internal/adapters/slack"
 	"github.com/qf-studio/pilot/internal/adapters/telegram"
 	"github.com/qf-studio/pilot/internal/alerts"
@@ -325,6 +326,28 @@ func (a *autopilotProviderAdapter) GetFailureCount() int {
 func (a *autopilotProviderAdapter) IsAutoReleaseEnabled() bool {
 	cfg := a.controller.Config()
 	return cfg.Release != nil && cfg.Release.Enabled
+}
+
+// adapterHealthProviderAdapter wraps adapterhealth.Registry to satisfy
+// gateway.AdapterHealthSource (GH-4314), so /api/v1/status can surface which
+// adapters have panicked/restarted/been disabled.
+type adapterHealthProviderAdapter struct {
+	registry *adapterhealth.Registry
+}
+
+func (a *adapterHealthProviderAdapter) AdapterHealthSnapshot() []gateway.AdapterHealthStatus {
+	statuses := a.registry.Snapshot()
+	result := make([]gateway.AdapterHealthStatus, len(statuses))
+	for i, st := range statuses {
+		result[i] = gateway.AdapterHealthStatus{
+			Name:         st.Name,
+			Healthy:      st.Healthy,
+			Disabled:     st.Disabled,
+			LastError:    st.LastError,
+			RestartCount: st.RestartCount,
+		}
+	}
+	return result
 }
 
 // resolveOwnerRepo determines the GitHub owner and repo from config or git remote.

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -18,6 +18,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 
+	"github.com/qf-studio/pilot/internal/adapterhealth"
 	"github.com/qf-studio/pilot/internal/adapters/discord"
 	"github.com/qf-studio/pilot/internal/adapters/github"
 	"github.com/qf-studio/pilot/internal/adapters/linear"
@@ -875,6 +876,10 @@ Examples:
 			// (via githubPollerRegistration) owns default-repo GitHub polling.
 
 			// GH-1847: Start adapter pollers via registry pattern (gateway mode)
+			// GH-4314: adapterHealthRegistry tracks per-adapter panic/restart/disable
+			// state so one adapter's panic can't crash the daemon; wired into the
+			// gateway status endpoint once p.Gateway() exists below.
+			adapterHealthRegistry := adapterhealth.NewRegistry()
 			gwPollerDeps := &PollerDeps{
 				Cfg:                 cfg,
 				ProjectPath:         projectPath,
@@ -886,6 +891,7 @@ Examples:
 				Enforcer:            gwEnforcer,
 				AutopilotController: gwAutopilotController,
 				AutopilotStateStore: gwAutopilotStateStore,
+				AdapterHealth:       adapterHealthRegistry,
 			}
 			StartAdapterPollers(context.Background(), gwPollerDeps, adapterPollerRegistrations())
 
@@ -934,6 +940,9 @@ Examples:
 			// config, then auto-detection.
 			p.SetQualityCheckerFactory(newProjectQualityCheckerFactory(cfg))
 			logging.WithComponent("start").Info("quality gates enabled for webhook mode")
+
+			// GH-4314: surface adapter goroutine health on /api/v1/status.
+			p.Gateway().SetAdapterHealthSource(&adapterHealthProviderAdapter{registry: adapterHealthRegistry})
 
 			// GH-1585: Wire autopilot provider to gateway so /api/v1/autopilot returns live PR data
 			if gwAutopilotController != nil {
@@ -1804,6 +1813,11 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		}
 	}
 
+	// GH-4314: adapterHealthRegistry tracks per-adapter panic/restart/disable
+	// state so one adapter's panic can't crash the daemon; wired into
+	// pollingDeps below and, when the gateway runs, into /api/v1/status.
+	adapterHealthRegistry := adapterhealth.NewRegistry()
+
 	// GH-1662: Start gateway in background so desktop app can reach /health
 	var gwServer *gateway.Server // hoisted so TASK-332 alert-metrics wiring can run after alerts engine is created
 	// GH-4068: aggregate every controller's Metrics (default + one per
@@ -1820,6 +1834,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 	autopilotMetricsAggregate := autopilot.NewAggregateMetrics(fleetMetrics...)
 	if !noGateway && cfg.Gateway != nil {
 		gwServer = gateway.NewServer(cfg.Gateway)
+		gwServer.SetAdapterHealthSource(&adapterHealthProviderAdapter{registry: adapterHealthRegistry})
 
 		if autopilotController != nil {
 			gwServer.SetAutopilotProvider(&autopilotProviderAdapter{controller: autopilotController})
@@ -2552,6 +2567,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		AutopilotStateStore:  autopilotStateStore,
 		AutopilotControllers: autopilotControllers,
 		GitHubPollers:        ghPollerRegistry, // GH-4110: SDK poller registers itself here
+		AdapterHealth:        adapterHealthRegistry,
 	}
 	StartAdapterPollers(ctx, pollingDeps, adapterPollerRegistrations())
 

--- a/cmd/pilot/poller_asana.go
+++ b/cmd/pilot/poller_asana.go
@@ -68,13 +68,13 @@ func asanaPollerRegistration() PollerRegistration {
 				slog.String("tag", pilotTag),
 				slog.Duration("interval", interval),
 			)
-			go func() {
+			deps.SafeAdapterGo(ctx, "asana", func() {
 				if err := asanaPoller.Start(ctx); err != nil {
 					logging.WithComponent("asana").Error("Asana poller failed",
 						slog.Any("error", err),
 					)
 				}
-			}()
+			})
 		},
 	}
 }

--- a/cmd/pilot/poller_azuredevops.go
+++ b/cmd/pilot/poller_azuredevops.go
@@ -72,13 +72,13 @@ func azuredevopsPollerRegistration() PollerRegistration {
 				slog.String("project", deps.Cfg.Adapters.AzureDevOps.Project),
 				slog.Duration("interval", interval),
 			)
-			go func() {
+			deps.SafeAdapterGo(ctx, "azuredevops", func() {
 				if err := adoPoller.Start(ctx); err != nil {
 					logging.WithComponent("azuredevops").Error("Azure DevOps poller failed",
 						slog.Any("error", err),
 					)
 				}
-			}()
+			})
 		},
 	}
 }

--- a/cmd/pilot/poller_discord.go
+++ b/cmd/pilot/poller_discord.go
@@ -76,13 +76,13 @@ func discordPollerRegistration() PollerRegistration {
 			})
 			discordChatHandler.SetCommsHandler(discordCommsHandler)
 
-			go func() {
+			deps.SafeAdapterGo(ctx, "discord", func() {
 				if err := discordBridge.Start(ctx); err != nil {
 					logging.WithComponent("discord").Error("Discord listener error",
 						slog.Any("error", err),
 					)
 				}
-			}()
+			})
 			fmt.Println("● discord bot started")
 			logging.WithComponent("start").Info("Discord bot started")
 		},

--- a/cmd/pilot/poller_github.go
+++ b/cmd/pilot/poller_github.go
@@ -438,12 +438,12 @@ func startGithubSDKPollerForRepo(ctx context.Context, deps *PollerDeps, log *slo
 		slog.Bool("default_repo", target.isDefault),
 		slog.Bool("board_wired", sdkCfg.ProjectBoard != nil),
 	)
-	go func() {
+	deps.SafeAdapterGo(ctx, "github:"+target.repoFullName, func() {
 		if err := githubPoller.Start(ctx); err != nil {
 			repoLog.Error("GitHub SDK poller failed",
 				slog.Any("error", err),
 			)
 		}
-	}()
+	})
 	return true
 }

--- a/cmd/pilot/poller_gitlab.go
+++ b/cmd/pilot/poller_gitlab.go
@@ -85,13 +85,13 @@ func gitlabPollerRegistration() PollerRegistration {
 				slog.String("label", pilotLabel),
 				slog.Duration("interval", interval),
 			)
-			go func() {
+			deps.SafeAdapterGo(ctx, "gitlab", func() {
 				if err := gitlabPoller.Start(ctx); err != nil {
 					logging.WithComponent("gitlab").Error("GitLab poller failed",
 						slog.Any("error", err),
 					)
 				}
-			}()
+			})
 		},
 	}
 }

--- a/cmd/pilot/poller_jira.go
+++ b/cmd/pilot/poller_jira.go
@@ -74,13 +74,13 @@ func jiraPollerRegistration() PollerRegistration {
 				slog.String("label", pilotLabel),
 				slog.Duration("interval", interval),
 			)
-			go func() {
+			deps.SafeAdapterGo(ctx, "jira", func() {
 				if err := jiraPoller.Start(ctx); err != nil {
 					logging.WithComponent("jira").Error("Jira poller failed",
 						slog.Any("error", err),
 					)
 				}
-			}()
+			})
 		},
 	}
 }

--- a/cmd/pilot/poller_linear.go
+++ b/cmd/pilot/poller_linear.go
@@ -84,13 +84,13 @@ func linearPollerRegistration() PollerRegistration {
 				slog.String("workspaces", fmt.Sprintf("%d workspace(s)", len(internalWss))),
 				slog.Duration("interval", interval),
 			)
-			go func() {
+			deps.SafeAdapterGo(ctx, "linear", func() {
 				if err := linearPoller.Start(ctx); err != nil {
 					logging.WithComponent("linear").Error("Linear poller failed",
 						slog.Any("error", err),
 					)
 				}
-			}()
+			})
 		},
 	}
 }

--- a/cmd/pilot/poller_plane.go
+++ b/cmd/pilot/poller_plane.go
@@ -98,13 +98,13 @@ func planePollerRegistration() PollerRegistration {
 				slog.Int("projects", len(deps.Cfg.Adapters.Plane.ProjectIDs)),
 				slog.Duration("interval", interval),
 			)
-			go func() {
+			deps.SafeAdapterGo(ctx, "plane", func() {
 				if err := planePoller.Start(ctx); err != nil {
 					logging.WithComponent("plane").Error("Plane poller failed",
 						slog.Any("error", err),
 					)
 				}
-			}()
+			})
 		},
 	}
 }

--- a/cmd/pilot/poller_registry.go
+++ b/cmd/pilot/poller_registry.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/qf-studio/pilot/internal/adapterhealth"
 	"github.com/qf-studio/pilot/internal/alerts"
 	"github.com/qf-studio/pilot/internal/autopilot"
 	"github.com/qf-studio/pilot/internal/budget"
@@ -37,6 +39,12 @@ type PollerDeps struct {
 	// handle otherwise never leaves githubPollerRegistration() (GH-4110). Nil when
 	// GitHub polling is off.
 	GitHubPollers *githubPollerRegistry
+
+	// AdapterHealth tracks panic/restart/disabled state for every adapter
+	// goroutine started via SafeAdapterGo (GH-4314). Nil is tolerated —
+	// SafeAdapterGo falls back to plain logging.SafeGo with no restart/health
+	// tracking so callers that don't wire it (e.g. tests) still work.
+	AdapterHealth *adapterhealth.Registry
 }
 
 // PollerRegistration describes a single adapter poller that can be conditionally started.
@@ -73,4 +81,35 @@ func StartAdapterPollers(ctx context.Context, deps *PollerDeps, registrations []
 			reg.CreateAndStart(ctx, deps)
 		}
 	}
+}
+
+// SafeAdapterGo is the single entry point every adapter poller goroutine
+// must use to launch its listen loop (GH-4314): a panic in one adapter
+// (e.g. the studio-sdk Discord gateway's nil-conn deref that took down the
+// whole daemon) is recovered, logged with the adapter name, and the
+// goroutine is restarted with backoff instead of crashing the process. Core
+// executor/dispatcher goroutines must NOT go through this path — their
+// panics indicate real corruption and should keep crashing loudly.
+func (d *PollerDeps) SafeAdapterGo(ctx context.Context, name string, fn func()) {
+	if d.AdapterHealth == nil {
+		logging.SafeGo(name, fn)
+		return
+	}
+	d.AdapterHealth.Go(ctx, name, d.alertAdapterPanic, fn)
+}
+
+// alertAdapterPanic raises a WARN-level service_unhealthy alert when an
+// adapter goroutine panics — an adapter going down is an ops signal, not a
+// silent degrade. Mirrors the config_error alerting pattern already used
+// for adapter credential failures in adapter_preflight.go.
+func (d *PollerDeps) alertAdapterPanic(name, message string) {
+	if d.AlertsEngine == nil {
+		return
+	}
+	d.AlertsEngine.ProcessEvent(alerts.Event{
+		Type:      alerts.EventTypeConfigError,
+		Error:     message,
+		Metadata:  map[string]string{"adapter": name},
+		Timestamp: time.Now(),
+	})
 }

--- a/cmd/pilot/poller_registry_test.go
+++ b/cmd/pilot/poller_registry_test.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/qf-studio/pilot/internal/adapterhealth"
 	"github.com/qf-studio/pilot/internal/config"
 )
 
@@ -59,6 +62,114 @@ func TestAdapterPollerRegistrations_ReturnsAllFive(t *testing.T) {
 		if regs[i].Name != name {
 			t.Errorf("registration[%d]: expected name %q, got %q", i, name, regs[i].Name)
 		}
+	}
+}
+
+// TestSafeAdapterGo_PanicIsRecoveredAndOthersKeepRunning is the GH-4314
+// acceptance test: a panicking fake adapter must not crash the daemon, and
+// every other adapter goroutine started via SafeAdapterGo must keep running
+// unaffected — mirroring the 2026-07-14 incident where a nil-conn deref in
+// the Discord gateway's listen loop took down github + telegram execution
+// mid-flight.
+func TestSafeAdapterGo_PanicIsRecoveredAndOthersKeepRunning(t *testing.T) {
+	deps := &PollerDeps{
+		Cfg:           &config.Config{},
+		AdapterHealth: adapterhealth.NewRegistry(),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var healthyTicks atomic.Int32
+	deps.SafeAdapterGo(ctx, "healthy-adapter", func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				healthyTicks.Add(1)
+				time.Sleep(time.Millisecond)
+			}
+		}
+	})
+
+	deps.SafeAdapterGo(ctx, "panicking-adapter", func() {
+		panic("simulated nil-conn deref")
+	})
+
+	// If the panic weren't recovered, the whole test process would crash
+	// here rather than reaching this assertion.
+	deadline := time.After(2 * time.Second)
+	for {
+		snap := deps.AdapterHealth.Snapshot()
+		var panickingSeen bool
+		for _, st := range snap {
+			if st.Name == "panicking-adapter" && st.LastError != "" {
+				panickingSeen = true
+			}
+		}
+		if panickingSeen {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("expected panicking-adapter's panic to be recorded")
+		case <-time.After(time.Millisecond):
+		}
+	}
+
+	if healthyTicks.Load() == 0 {
+		t.Fatal("expected healthy-adapter to keep running after the other adapter panicked")
+	}
+}
+
+// TestSafeAdapterGo_FiresAlertOnPanic confirms a recovered adapter panic
+// raises a WARN service_unhealthy alert (GH-4314) — an adapter going down
+// is an ops signal, not a silent degrade.
+func TestSafeAdapterGo_FiresAlertOnPanic(t *testing.T) {
+	engine, ch := newTestAlertsEngine(t)
+	deps := &PollerDeps{
+		Cfg:           &config.Config{},
+		AlertsEngine:  engine,
+		AdapterHealth: adapterhealth.NewRegistry(),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	deps.SafeAdapterGo(ctx, "flaky", func() {
+		panic("boom")
+	})
+
+	deadline := time.After(2 * time.Second)
+	for ch.count() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("expected an alert to be fired when an adapter panics")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+// TestSafeAdapterGo_NilRegistryFallsBackSafely confirms SafeAdapterGo still
+// recovers panics (via logging.SafeGo) when AdapterHealth is nil, so callers
+// that don't wire it up (e.g. older tests) don't crash the process either.
+func TestSafeAdapterGo_NilRegistryFallsBackSafely(t *testing.T) {
+	deps := &PollerDeps{Cfg: &config.Config{}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	deps.SafeAdapterGo(ctx, "no-registry", func() {
+		defer close(done)
+		panic("boom")
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected fn to run (and its panic to be recovered) without crashing the test")
 	}
 }
 

--- a/internal/adapterhealth/adapterhealth.go
+++ b/internal/adapterhealth/adapterhealth.go
@@ -1,0 +1,168 @@
+// Package adapterhealth tracks the health of long-lived adapter goroutines
+// (poller listen loops, chat gateway listeners) and gives each one panic
+// recovery with bounded restart-with-backoff (GH-4314). A panic in one
+// adapter must never crash the daemon and take down every other adapter
+// with it.
+//
+// Scope: this package is for adapter I/O goroutines only. Core
+// executor/dispatcher panics indicate real corruption and must NOT be
+// routed through Registry.Go — they should keep crashing loudly.
+package adapterhealth
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime/debug"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/logging"
+)
+
+// MaxRestarts bounds how many times a panicking adapter goroutine is
+// restarted before it's marked Disabled and left stopped, so an adapter
+// that panics in a tight loop can't spin forever.
+const MaxRestarts = 5
+
+// baseBackoff/maxBackoff are vars (not consts) so tests can shrink them to
+// keep the MaxRestarts-exhaustion path fast; production code never mutates them.
+var (
+	baseBackoff = time.Second
+	maxBackoff  = time.Minute
+)
+
+// Status is a point-in-time health snapshot for one adapter goroutine.
+type Status struct {
+	Name         string
+	Healthy      bool
+	Disabled     bool
+	LastError    string
+	LastPanicAt  time.Time
+	RestartCount int
+}
+
+// OnPanic is invoked with the adapter name and a human-readable message each
+// time a panic is recovered, so the caller can wire it to alert dispatch.
+type OnPanic func(name, message string)
+
+// Registry tracks the health of every adapter goroutine started via Go.
+// Safe for concurrent use.
+type Registry struct {
+	mu       sync.RWMutex
+	statuses map[string]*Status
+}
+
+// NewRegistry creates an empty adapter health registry.
+func NewRegistry() *Registry {
+	return &Registry{statuses: make(map[string]*Status)}
+}
+
+// Snapshot returns a stable-ordered copy of every tracked adapter's status.
+func (r *Registry) Snapshot() []Status {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]Status, 0, len(r.statuses))
+	for _, st := range r.statuses {
+		out = append(out, *st)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func (r *Registry) register(name string) *Status {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	st, ok := r.statuses[name]
+	if !ok {
+		st = &Status{Name: name, Healthy: true}
+		r.statuses[name] = st
+	}
+	return st
+}
+
+// Go runs fn in a goroutine, recovering any panic so it can never crash the
+// process. A panicking adapter is restarted with exponential backoff (1s,
+// capped at 1m) up to MaxRestarts times; once exhausted the adapter is
+// marked Disabled and Go stops restarting it. onPanic (may be nil) is
+// called on every recovered panic so the caller can raise an alert.
+func (r *Registry) Go(ctx context.Context, name string, onPanic OnPanic, fn func()) {
+	st := r.register(name)
+	logging.SafeGo(name, func() {
+		r.runWithRestart(ctx, name, st, onPanic, fn)
+	})
+}
+
+func (r *Registry) runWithRestart(ctx context.Context, name string, st *Status, onPanic OnPanic, fn func()) {
+	backoff := baseBackoff
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		if !r.runOnce(name, st, fn) {
+			// Clean return (e.g. ctx cancelled during shutdown) — no restart needed.
+			return
+		}
+
+		r.mu.Lock()
+		st.RestartCount++
+		count := st.RestartCount
+		r.mu.Unlock()
+
+		if count >= MaxRestarts {
+			r.mu.Lock()
+			st.Disabled = true
+			st.Healthy = false
+			r.mu.Unlock()
+			msg := fmt.Sprintf("adapter %q disabled after %d panics — giving up restarts", name, count)
+			logging.WithComponent(name).Error(msg, slog.Int("restart_count", count))
+			if onPanic != nil {
+				onPanic(name, msg)
+			}
+			return
+		}
+
+		msg := fmt.Sprintf("adapter %q panicked and will be restarted (attempt %d/%d)", name, count, MaxRestarts)
+		logging.WithComponent(name).Warn(msg, slog.Int("restart_count", count), slog.Duration("backoff", backoff))
+		if onPanic != nil {
+			onPanic(name, msg)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+	}
+}
+
+// runOnce runs fn once, recovering a panic if it occurs. It reports whether
+// fn panicked (true) so the caller can decide whether to restart, or
+// returned cleanly (false).
+func (r *Registry) runOnce(name string, st *Status, fn func()) (panicked bool) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			stack := debug.Stack()
+			logging.WithComponent(name).Error("panic recovered in adapter goroutine",
+				slog.Any("panic", rec),
+				slog.String("stack", string(stack)),
+			)
+			r.mu.Lock()
+			st.Healthy = false
+			st.LastError = fmt.Sprintf("%v", rec)
+			st.LastPanicAt = time.Now()
+			r.mu.Unlock()
+			panicked = true
+		}
+	}()
+	fn()
+	r.mu.Lock()
+	st.Healthy = true
+	r.mu.Unlock()
+	return false
+}

--- a/internal/adapterhealth/adapterhealth_test.go
+++ b/internal/adapterhealth/adapterhealth_test.go
@@ -1,0 +1,215 @@
+package adapterhealth
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// waitFor polls cond until it's true or the timeout elapses, failing the test otherwise.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("condition not met within %s", timeout)
+}
+
+func TestRegistry_Go_CleanReturnDoesNotRestart(t *testing.T) {
+	r := NewRegistry()
+	var calls atomic.Int32
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	r.Go(ctx, "clean-adapter", nil, func() {
+		calls.Add(1)
+		close(done)
+	})
+
+	<-done
+	waitFor(t, time.Second, func() bool { return calls.Load() == 1 })
+	time.Sleep(20 * time.Millisecond) // ensure no spurious restart follows
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected fn called exactly once for a clean return, got %d", got)
+	}
+
+	snap := r.Snapshot()
+	if len(snap) != 1 || !snap[0].Healthy || snap[0].RestartCount != 0 {
+		t.Fatalf("unexpected status after clean return: %+v", snap)
+	}
+}
+
+func TestRegistry_Go_RecoversPanicAndRestarts(t *testing.T) {
+	orig := baseBackoff
+	baseBackoff = time.Millisecond
+	defer func() { baseBackoff = orig }()
+
+	r := NewRegistry()
+	var calls atomic.Int32
+	var panicMsgs []string
+	var mu sync.Mutex
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	onPanic := func(name, msg string) {
+		mu.Lock()
+		panicMsgs = append(panicMsgs, msg)
+		mu.Unlock()
+	}
+
+	r.Go(ctx, "flaky-adapter", onPanic, func() {
+		n := calls.Add(1)
+		if n <= 2 {
+			panic("boom")
+		}
+		// Third call succeeds cleanly — stop the goroutine.
+	})
+
+	waitFor(t, time.Second, func() bool { return calls.Load() == 3 })
+
+	mu.Lock()
+	gotMsgs := len(panicMsgs)
+	mu.Unlock()
+	if gotMsgs != 2 {
+		t.Fatalf("expected onPanic called twice, got %d (%v)", gotMsgs, panicMsgs)
+	}
+
+	waitFor(t, time.Second, func() bool {
+		snap := r.Snapshot()
+		return len(snap) == 1 && snap[0].Healthy && snap[0].RestartCount == 2 && !snap[0].Disabled
+	})
+}
+
+func TestRegistry_Go_DisablesAfterMaxRestarts(t *testing.T) {
+	origBase, origMax := baseBackoff, maxBackoff
+	baseBackoff = time.Millisecond
+	maxBackoff = time.Millisecond
+	defer func() { baseBackoff, maxBackoff = origBase, origMax }()
+
+	r := NewRegistry()
+	var calls atomic.Int32
+	var panicCount atomic.Int32
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r.Go(ctx, "always-panics", func(name, msg string) {
+		panicCount.Add(1)
+	}, func() {
+		calls.Add(1)
+		panic("always boom")
+	})
+
+	waitFor(t, 2*time.Second, func() bool {
+		snap := r.Snapshot()
+		return len(snap) == 1 && snap[0].Disabled
+	})
+
+	if got := calls.Load(); got != MaxRestarts {
+		t.Fatalf("expected fn called exactly MaxRestarts=%d times, got %d", MaxRestarts, got)
+	}
+	if got := panicCount.Load(); got != MaxRestarts {
+		t.Fatalf("expected onPanic called MaxRestarts=%d times, got %d", MaxRestarts, got)
+	}
+
+	snap := r.Snapshot()
+	st := snap[0]
+	if st.Healthy {
+		t.Error("expected Healthy=false once disabled")
+	}
+	if !st.Disabled {
+		t.Error("expected Disabled=true")
+	}
+	if st.LastError == "" {
+		t.Error("expected LastError to be recorded")
+	}
+	if st.LastPanicAt.IsZero() {
+		t.Error("expected LastPanicAt to be recorded")
+	}
+
+	// No further calls after disabling, even if we wait past another backoff window.
+	time.Sleep(20 * time.Millisecond)
+	if got := calls.Load(); got != MaxRestarts {
+		t.Fatalf("expected no further restarts after disabling, calls=%d", got)
+	}
+}
+
+func TestRegistry_Go_StopsRestartingWhenContextCancelled(t *testing.T) {
+	orig := baseBackoff
+	baseBackoff = 200 * time.Millisecond
+	defer func() { baseBackoff = orig }()
+
+	r := NewRegistry()
+	var calls atomic.Int32
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	r.Go(ctx, "cancel-me", nil, func() {
+		calls.Add(1)
+		panic("boom")
+	})
+
+	waitFor(t, time.Second, func() bool { return calls.Load() == 1 })
+	cancel() // cancel while the goroutine is sleeping in backoff
+
+	time.Sleep(400 * time.Millisecond) // well past the backoff window
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected no restart after context cancellation, calls=%d", got)
+	}
+}
+
+func TestRegistry_Snapshot_SortedAndIsolated(t *testing.T) {
+	r := NewRegistry()
+	r.register("zebra")
+	r.register("alpha")
+	r.register("mango")
+
+	snap := r.Snapshot()
+	if len(snap) != 3 {
+		t.Fatalf("expected 3 statuses, got %d", len(snap))
+	}
+	names := []string{snap[0].Name, snap[1].Name, snap[2].Name}
+	want := []string{"alpha", "mango", "zebra"}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("expected sorted names %v, got %v", want, names)
+		}
+	}
+
+	// Mutating the returned snapshot must not affect the registry's internal state.
+	snap[0].Healthy = false
+	if got := r.Snapshot()[0].Healthy; !got {
+		t.Fatal("Snapshot should return copies, not references into internal state")
+	}
+}
+
+func TestRegistry_Go_NilOnPanicIsSafe(t *testing.T) {
+	orig := baseBackoff
+	baseBackoff = time.Millisecond
+	defer func() { baseBackoff = orig }()
+
+	r := NewRegistry()
+	var calls atomic.Int32
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r.Go(ctx, "no-callback", nil, func() {
+		n := calls.Add(1)
+		if n == 1 {
+			panic("boom")
+		}
+	})
+
+	waitFor(t, time.Second, func() bool { return calls.Load() == 2 })
+}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -58,6 +58,23 @@ type AutopilotProvider interface {
 	IsAutoReleaseEnabled() bool
 }
 
+// AdapterHealthStatus is a point-in-time health snapshot for one adapter
+// goroutine, surfaced on /api/v1/status (GH-4314). Defined in gateway
+// (rather than importing internal/adapterhealth) to decouple this package
+// from the adapter wiring layer, mirroring AutopilotPRState above.
+type AdapterHealthStatus struct {
+	Name         string `json:"name"`
+	Healthy      bool   `json:"healthy"`
+	Disabled     bool   `json:"disabled"`
+	LastError    string `json:"last_error,omitempty"`
+	RestartCount int    `json:"restart_count"`
+}
+
+// AdapterHealthSource exposes adapter goroutine health to the gateway API.
+type AdapterHealthSource interface {
+	AdapterHealthSnapshot() []AdapterHealthStatus
+}
+
 // Server is the main gateway server handling WebSocket and HTTP connections.
 // It provides a control plane for managing Pilot via WebSocket, receives webhooks
 // from external services (Linear, GitHub, Jira, Asana), and exposes REST APIs for status
@@ -80,6 +97,7 @@ type Server struct {
 	prometheusExporter     *PrometheusExporter
 	alertsSource           AlertMetricsSource
 	autopilotProvider      AutopilotProvider
+	adapterHealthSource    AdapterHealthSource
 	dashboardStore         DashboardStore
 	dashboardProjectPath   string          // Project path filter for dashboard metrics/queue/history APIs ("" = all projects)
 	logStreamStore         LogStreamStore
@@ -308,6 +326,15 @@ func (s *Server) SetAutopilotProvider(p AutopilotProvider) {
 	s.autopilotProvider = p
 }
 
+// SetAdapterHealthSource wires adapter goroutine health into the
+// /api/v1/status endpoint (GH-4314), so an adapter panic/restart/disable is
+// an observable ops signal rather than a silent degrade.
+func (s *Server) SetAdapterHealthSource(source AdapterHealthSource) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.adapterHealthSource = source
+}
+
 // SetGitGraphPath sets the project path used by the /api/v1/gitgraph endpoint.
 // Defaults to "." if not set.
 func (s *Server) SetGitGraphPath(path string) {
@@ -497,11 +524,21 @@ func (s *Server) Heartbeat() {
 // handleStatus returns current Pilot status
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+
+	resp := map[string]interface{}{
 		"version":  "0.1.0",
 		"running":  s.running,
 		"sessions": s.sessions.Count(),
-	})
+	}
+
+	s.mu.RLock()
+	ahSource := s.adapterHealthSource
+	s.mu.RUnlock()
+	if ahSource != nil {
+		resp["adapters"] = ahSource.AdapterHealthSnapshot()
+	}
+
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // handleTasks returns current tasks

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -414,6 +414,54 @@ func TestStatusEndpoint(t *testing.T) {
 	if response["version"] != "0.1.0" {
 		t.Errorf("Expected version '0.1.0', got '%v'", response["version"])
 	}
+	if _, ok := response["adapters"]; ok {
+		t.Error("Expected no 'adapters' key when no AdapterHealthSource is wired")
+	}
+}
+
+// mockAdapterHealthSource implements AdapterHealthSource for tests.
+type mockAdapterHealthSource struct {
+	statuses []AdapterHealthStatus
+}
+
+func (m *mockAdapterHealthSource) AdapterHealthSnapshot() []AdapterHealthStatus {
+	return m.statuses
+}
+
+func TestStatusEndpoint_IncludesAdapterHealth(t *testing.T) {
+	config := &Config{Host: "127.0.0.1", Port: 9090}
+	server := NewServer(config)
+	server.SetAdapterHealthSource(&mockAdapterHealthSource{
+		statuses: []AdapterHealthStatus{
+			{Name: "discord", Healthy: false, Disabled: true, LastError: "nil-conn deref", RestartCount: 5},
+			{Name: "github", Healthy: true},
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	w := httptest.NewRecorder()
+	server.handleStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d", w.Code)
+	}
+
+	var response struct {
+		Adapters []AdapterHealthStatus `json:"adapters"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if len(response.Adapters) != 2 {
+		t.Fatalf("Expected 2 adapter statuses, got %d", len(response.Adapters))
+	}
+	if response.Adapters[0].Name != "discord" || !response.Adapters[0].Disabled || response.Adapters[0].LastError != "nil-conn deref" {
+		t.Errorf("Unexpected discord status: %+v", response.Adapters[0])
+	}
+	if response.Adapters[1].Name != "github" || !response.Adapters[1].Healthy {
+		t.Errorf("Unexpected github status: %+v", response.Adapters[1])
+	}
 }
 
 func TestLinearWebhook(t *testing.T) {


### PR DESCRIPTION
## Summary

- A nil-conn deref in the Discord gateway's `listen` goroutine (studio-sdk) crashed the entire Pilot daemon on 2026-07-14, killing github + telegram execution mid-flight. No adapter poller goroutine had panic recovery.
- Adds `internal/adapterhealth`, a `Registry.Go` that wraps an adapter goroutine with recover + logging + exponential-backoff restart (up to 5 attempts), then marks the adapter `Disabled` instead of restarting forever.
- Routes every adapter poller goroutine (linear, jira, asana, azuredevops, plane, discord, gitlab, github — one per repo) through a new `PollerDeps.SafeAdapterGo` helper instead of a raw `go func(){...}()`.
- Surfaces adapter health on `GET /api/v1/status` (`adapters` array: name/healthy/disabled/last_error/restart_count) via a new `gateway.AdapterHealthSource` interface, wired in both gateway-mode and polling-mode daemon startup.
- Fires a `service_unhealthy` alert event (WARN, via the existing `EventTypeConfigError` → `AlertTypeServiceUnhealthy` rule path) on every recovered panic, so an adapter going down is an ops signal, not a silent degrade.
- Core executor/dispatcher goroutines are untouched — this recovery path is scoped to adapter I/O goroutines only, per the issue's explicit requirement not to mask real corruption.

## Test plan

- [x] `internal/adapterhealth`: unit tests for clean return (no restart), panic-then-recover-then-restart, disable-after-5-panics, context-cancellation stopping restarts, and snapshot isolation/ordering — all pass with `-race`.
- [x] `cmd/pilot`: `TestSafeAdapterGo_PanicIsRecoveredAndOthersKeepRunning` reproduces the incident directly — a panicking fake adapter goroutine alongside a healthy one; the healthy adapter keeps ticking and the panic is recorded, with no process crash.
- [x] `cmd/pilot`: `TestSafeAdapterGo_FiresAlertOnPanic` confirms the WARN alert fires on panic.
- [x] `cmd/pilot`: `TestSafeAdapterGo_NilRegistryFallsBackSafely` confirms callers that don't wire `AdapterHealth` still get panic recovery (no regression for existing tests).
- [x] `internal/gateway`: `TestStatusEndpoint_IncludesAdapterHealth` confirms the new `/api/v1/status` field.
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run --new-from-rev=origin/main ./...` (0 issues), `go test ./...` (full suite green).