### PR TITLE
fix(executor): retry transient sub-issue creation + gate epic close on full coverage

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -321,7 +321,6 @@
 | Docker support | ✅ | - | - | - | Dockerfile + deployment guide (v1.46.0) |
 | Helm chart | ✅ | - | - | - | Kubernetes Helm chart for production deployment (v1.46.0) |
 | PowerShell installer | ✅ | install | - | - | Windows PowerShell install script (`install.ps1`) |
-| Adapter goroutine panic recovery | ✅ | adapterhealth | - | - | Every adapter poller goroutine runs via `SafeAdapterGo`: panics are recovered, logged, restarted with backoff up to 5 attempts, then the adapter is marked disabled — one adapter's panic can't crash the daemon. Surfaced on `/api/v1/status` `adapters` + a `service_unhealthy` WARN alert (GH-4314) |
 | Gateway in polling mode | ✅ | gateway | - | - | HTTP server starts in background during polling for desktop/web (v1.62.0, GH-1662) |
 | Gateway budget nil fix | ✅ | gateway | - | - | Fix nil dereference when budget disabled in gateway mode (v2.43.0, GH-1935) |
 | Gateway learning loop | ✅ | gateway | - | - | Learning system init in gateway mode, mirrors polling mode (v2.43.0, GH-1935) |
@@ -410,7 +409,6 @@
 | Board sync tests | ✅ | adapters/github | - | - | ProjectBoardSync and ExecuteGraphQL unit tests (v2.30.0, PR #1865) |
 | CI context wiring | ✅ | autopilot | - | - | Wire proper CI context from autopilot controller (v2.52.0, PR #1981) |
 | PR stage execution-event audit trail | ✅ | autopilot | - | - | `Controller` writes `execution_events` rows (ci_passed/ci_failed/awaiting_approval/merged/released/failed) via `memory.Store.InsertExecutionEvent`; survives PR-state-row cleanup after merge since it keys off `executions.id` (GH-3847) |
-| Fix-issue creation idempotency guard | ✅ | autopilot | - | - | `autopilot_spawned_fixes` SQLite table (PK `repo, dedup_key`, `INSERT OR IGNORE` claim) checked before both pre-merge and post-merge `CreateFailureIssue` call sites; dedup key includes sorted failed-check signature so a new failure still spawns. Belt-and-suspenders: GitHub search for an open issue with the exact title + pilot labels catches a lost DB row (fresh clone/restored backup) that the SQLite claim can't see (GH-4307, GH-4309) |
 
 ## Epic Management
 
@@ -426,6 +424,7 @@
 | Sub-issue dedup guard | ✅ | executor | - | - | CreateSubIssues skips if open children referencing parent already exist (GH-2494) |
 | createPilotIssue chokepoint | ✅ | adapters/github, autopilot | - | - | All Pilot-internal issue creation validated through CreatePilotIssue CC gate (GH-2494) |
 | Epic-lifecycle synthetic canary | ✅ | .github/workflows, scripts | `workflow_dispatch` (scenario `epic-lifecycle`) | - | GH Actions scenario files a deliberately decomposable epic on the sandbox and asserts 5 invariants (≥2 children, no duplicate merged PR per child, parent auto-close, no stale `pilot-needs-clarification`, no cascade beyond direct children) via `canary-poll.sh --assert n-children-merged` (TASK-403 A3, GH-4242) |
+| Sub-issue creation retry + coverage gate | ✅ | executor | - | - | Bounded retry (TLS timeout/5xx/rate-limit) around each `gh issue create`; if fewer sub-issues exist than planned (creation or recovery path), parent stays open + labeled `pilot-needs-clarification` + ledger event instead of closing (v2.239.0, GH-4300) |
 
 ## Test Coverage
 

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -630,6 +630,139 @@ func IsParentDoneSkip(errStr string) bool {
 	return strings.Contains(errStr, ErrParentDone.Error())
 }
 
+// SubIssueCoverageGapError is returned when fewer sub-issues exist for a
+// decomposed epic than its plan called for, even after retrying transient
+// creation failures (GH-4300).
+//
+// Incident 2026-07-14 (pilot-console#1): a transient TLS handshake timeout
+// on the second of two planned subtasks' `gh issue create` call aborted
+// creation after only the first subtask's issue existed. A later run's
+// recovery pass (ErrSubIssuesAlreadyExist branch, runner.go) then found that
+// one issue, saw it was already closed, and treated the partial set as "the
+// epic" — closing the parent with the second subtask (db+log) never
+// dispatched. Any caller that receives this error must NOT execute-and-
+// finalize the partial set as if it were the whole plan. Both call sites
+// that can detect a gap (CreateSubIssues' own creation loop and the
+// recovery path in runner.go) route through handleSubIssueCoverageGap,
+// which — before returning this error — leaves the parent issue open, labels
+// it pilot-needs-clarification, posts a comment naming the missing
+// subtasks, and records a planned/created ledger event.
+type SubIssueCoverageGapError struct {
+	Planned int
+	Created int
+	Missing []string
+	Cause   error
+}
+
+func (e *SubIssueCoverageGapError) Error() string {
+	msg := fmt.Sprintf("sub-issue creation incomplete: planned=%d created=%d missing=%s",
+		e.Planned, e.Created, strings.Join(e.Missing, "; "))
+	if e.Cause != nil {
+		msg += fmt.Sprintf(" (cause: %v)", e.Cause)
+	}
+	return msg
+}
+
+func (e *SubIssueCoverageGapError) Unwrap() error { return e.Cause }
+
+// missingSubtaskTitles returns the titles of planned subtasks with no
+// corresponding entry in created, matched by Order — Title may have been
+// rewritten by validateSubtaskTitle's conventional-commit fallback before
+// the issue was actually created, so Order is the stable join key.
+func missingSubtaskTitles(planned []PlannedSubtask, created []CreatedIssue) []string {
+	haveOrder := make(map[int]bool, len(created))
+	for _, c := range created {
+		haveOrder[c.Subtask.Order] = true
+	}
+	var missing []string
+	for _, st := range planned {
+		if !haveOrder[st.Order] {
+			missing = append(missing, st.Title)
+		}
+	}
+	return missing
+}
+
+// bulletList renders items as a markdown bullet list for the coverage-gap
+// comment; "(none identifiable)" covers the degenerate case where every
+// planned subtask's Order collides with a created one despite the count
+// mismatch (should not happen in practice, but the comment must never come
+// back empty).
+func bulletList(items []string) string {
+	if len(items) == 0 {
+		return "_(none identifiable)_"
+	}
+	var b strings.Builder
+	for _, it := range items {
+		b.WriteString("- ")
+		b.WriteString(it)
+		b.WriteString("\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// handleSubIssueCoverageGap records and surfaces a sub-issue coverage gap
+// (GH-4300): len(created) < len(plan.Subtasks) for plan.ParentTask, either
+// because creation failed partway through (even after retries) or because a
+// recovery pass found fewer previously-created issues than this run
+// planned. Side effects (ledger event, label, comment) are best-effort and
+// logged on failure — the returned error is authoritative for the caller's
+// control flow regardless of whether they landed.
+func (r *Runner) handleSubIssueCoverageGap(ctx context.Context, plan *EpicPlan, created []CreatedIssue, executionPath string, cause error) *SubIssueCoverageGapError {
+	missing := missingSubtaskTitles(plan.Subtasks, created)
+	gap := &SubIssueCoverageGapError{
+		Planned: len(plan.Subtasks),
+		Created: len(created),
+		Missing: missing,
+		Cause:   cause,
+	}
+
+	parentID := ""
+	if plan.ParentTask != nil {
+		parentID = plan.ParentTask.ID
+	}
+	r.log.Error("sub-issue creation incomplete — refusing to finalize epic parent",
+		"parent_id", parentID,
+		"planned", gap.Planned,
+		"created", gap.Created,
+		"missing", missing,
+		"cause", cause,
+	)
+
+	if plan.ParentTask == nil {
+		return gap
+	}
+
+	detail := fmt.Sprintf("planned=%d created=%d missing=%s", gap.Planned, gap.Created, strings.Join(missing, "; "))
+	r.recordExecutionEvent(plan.ParentTask.LogExecutionID(), memory.StageSubIssuesIncomplete, truncateForLog(detail, 500))
+
+	// Label/comment use the gh CLI, so they only apply to GitHub-sourced
+	// parents — mirrors the useAdapterCreator condition in CreateSubIssues.
+	// Non-GitHub adapters (Linear, Jira, ...) still get the ledger event and
+	// log above; their own tracker's label/comment surface is out of scope
+	// here (no gh CLI equivalent for those trackers).
+	isGitHubParent := plan.ParentTask.SourceAdapter == "" || plan.ParentTask.SourceAdapter == "github"
+	if r.dryRun || !isGitHubParent {
+		return gap
+	}
+
+	if err := ghAddLabels(ctx, executionPath, parentID, []string{"pilot-needs-clarification"}); err != nil {
+		r.log.Warn("failed to label parent with pilot-needs-clarification after coverage gap",
+			"parent_id", parentID, "error", err)
+	}
+	comment := fmt.Sprintf(
+		"⚠️ **Epic decomposition incomplete: %d/%d planned sub-issues created**\n\n"+
+			"The following planned subtasks have no issue and were never dispatched:\n\n%s\n\n"+
+			"This issue stays open. Resolve the underlying failure and remove `pilot-needs-clarification` to retry decomposition.",
+		gap.Created, gap.Planned, bulletList(missing))
+	if err := ghIssueComment(ctx, executionPath, parentID, comment); err != nil {
+		r.log.Warn("failed to post coverage-gap comment on parent",
+			"parent_id", parentID, "error", err)
+	}
+
+	return gap
+}
+
 // isParentDone reports whether a task should be treated as done based on its
 // labels (pilot-done, pilot-skip) or its state (closed, merged).
 //
@@ -1093,46 +1226,79 @@ func (r *Runner) CreateSubIssues(ctx context.Context, plan *EpicPlan, executionP
 		}
 	}
 
-	// GH-3513 wave 2 (#3538/#3553): drop subtasks whose Description is empty —
-	// they produce junk sub-issues whose body is just the autopilot-meta marker
-	// and a scope fence wrapping nothing. Title validation already exists
-	// (validateSubtaskTitle); this is its Description counterpart, applied once
-	// here so both creator paths (adapter + gh CLI) are covered. Runs AFTER the
-	// dedup guard so recovery of already-created children is never blocked by
-	// plan quality. The plan is rebuilt rather than mutated so the caller's
-	// copy stays intact.
-	valid := make([]PlannedSubtask, 0, len(plan.Subtasks))
-	for _, st := range plan.Subtasks {
-		if strings.TrimSpace(st.Description) == "" {
-			parentID := ""
-			if plan.ParentTask != nil {
-				parentID = plan.ParentTask.ID
-			}
-			r.log.Warn("Skipping subtask with empty description",
-				"title", st.Title, "order", st.Order, "parent", parentID)
-			continue
-		}
-		valid = append(valid, st)
+	// GH-3513 wave 2 (#3538/#3553) / GH-4235/GH-4233: filter to the subtasks
+	// CreateSubIssues will actually attempt to create issues for — see
+	// creatableSubtasks. Runs AFTER the dedup guard so recovery of
+	// already-created children is never blocked by plan quality. The plan is
+	// rebuilt rather than mutated so the caller's copy stays intact.
+	parentID := ""
+	if plan.ParentTask != nil {
+		parentID = plan.ParentTask.ID
 	}
+	valid := creatableSubtasks(plan.Subtasks, parentID, r.log)
 	if len(valid) == 0 {
 		return nil, fmt.Errorf("decomposition produced %d subtasks but none had a description — refusing to create empty sub-issues", len(plan.Subtasks))
 	}
-
-	// GH-4235/GH-4233: fold any subtask that is pure verification of its
-	// immediate predecessor's work (verification-shape heuristic + no new
-	// file/symbol surface) into that predecessor, dropping the verify-only
-	// entry so it never becomes its own empty-work sub-issue.
-	valid = foldVerifyOnlySubtasks(valid)
-
 	if len(valid) < len(plan.Subtasks) {
 		plan = &EpicPlan{ParentTask: plan.ParentTask, Subtasks: valid, TotalEffort: plan.TotalEffort, PlanOutput: plan.PlanOutput}
 	}
 
+	var created []CreatedIssue
+	var createErr error
 	if useAdapterCreator {
-		return r.createSubIssuesViaAdapter(ctx, plan)
+		created, createErr = r.createSubIssuesViaAdapter(ctx, plan)
+	} else {
+		created, createErr = r.createSubIssuesViaGitHub(ctx, plan, executionPath)
+		if r.dryRun {
+			// dry-run intentionally creates nothing (createSubIssuesViaGitHub
+			// short-circuits above) — there is no coverage gap to gate on.
+			return created, createErr
+		}
 	}
 
-	return r.createSubIssuesViaGitHub(ctx, plan, executionPath)
+	// GH-4300: never let a caller (runner.go) treat a partial creation batch
+	// as a clean, fully-decomposed plan — whether that partial batch came
+	// from an outright creation error (transient retries exhausted, or a
+	// non-transient failure) or, in principle, a creator that silently
+	// under-delivered. handleSubIssueCoverageGap leaves the parent open,
+	// labels it, comments the gap, and records the ledger event before
+	// returning the sentinel error below.
+	if len(created) < len(plan.Subtasks) {
+		return created, r.handleSubIssueCoverageGap(ctx, plan, created, executionPath, createErr)
+	}
+
+	return created, createErr
+}
+
+// creatableSubtasks filters subtasks down to the set CreateSubIssues will
+// actually attempt to create issues for:
+//
+//   - GH-3513 wave 2 (#3538/#3553): drops subtasks whose Description is
+//     empty — they produce junk sub-issues whose body is just the
+//     autopilot-meta marker and a scope fence wrapping nothing.
+//   - GH-4235/GH-4233: folds any subtask that is pure verification of its
+//     immediate predecessor's work into that predecessor, dropping the
+//     verify-only entry so it never becomes its own empty-work sub-issue.
+//
+// log, when non-nil, records a warning for each dropped empty-description
+// subtask; pass nil to compute the filtered set without duplicate logging —
+// GH-4300's sub-issue recovery path (runner.go) needs the exact same
+// "planned" definition CreateSubIssues uses to detect a coverage gap, but
+// must not re-log what CreateSubIssues will already log on its own next
+// attempt.
+func creatableSubtasks(subtasks []PlannedSubtask, parentID string, log *slog.Logger) []PlannedSubtask {
+	valid := make([]PlannedSubtask, 0, len(subtasks))
+	for _, st := range subtasks {
+		if strings.TrimSpace(st.Description) == "" {
+			if log != nil {
+				log.Warn("Skipping subtask with empty description",
+					"title", st.Title, "order", st.Order, "parent", parentID)
+			}
+			continue
+		}
+		valid = append(valid, st)
+	}
+	return foldVerifyOnlySubtasks(valid)
 }
 
 // createSubIssuesViaAdapter creates sub-issues using the SubIssueCreator interface.
@@ -1305,6 +1471,123 @@ func sanitizeSubtaskDescription(description string) string {
 	return strings.TrimSpace(description)
 }
 
+// defaultSubIssueCreateRetryAttempts / defaultSubIssueCreateRetryDelay bound
+// the retry loop around each per-subtask `gh issue create` call (GH-4300).
+// Runner.subIssueCreateRetryAttempts/Delay override these per-instance (zero
+// uses the default); tests shrink the delay for fast runs. Exponential
+// backoff (delay * 2^(attempt-1)) mirrors the shape of the existing
+// gitPushRetryAttempts/prCreateRetryAttempts sibling retry loops in
+// runner.go.
+const (
+	defaultSubIssueCreateRetryAttempts = 3
+	defaultSubIssueCreateRetryDelay    = 500 * time.Millisecond
+)
+
+// subIssueCreateRetryConfig resolves the effective attempts/delay for the
+// sub-issue creation retry loop, falling back to the package defaults when
+// the Runner fields are unset (zero value).
+func (r *Runner) subIssueCreateRetryConfig() (attempts int, delay time.Duration) {
+	attempts = r.subIssueCreateRetryAttempts
+	if attempts <= 0 {
+		attempts = defaultSubIssueCreateRetryAttempts
+	}
+	delay = r.subIssueCreateRetryDelay
+	if delay <= 0 {
+		delay = defaultSubIssueCreateRetryDelay
+	}
+	return attempts, delay
+}
+
+// transientSubIssueCreateErrorSignatures are substrings (case-insensitive)
+// that identify a `gh issue create` failure as transient — worth retrying
+// rather than aborting the whole decomposition on the first blip. Covers
+// the raw incident signature ("net/http: TLS handshake timeout", GH-4300)
+// plus the network/5xx/rate-limit classes studio-sdk's github retry helper
+// (sdk/integrations/github/retry.go) already treats as retryable. That
+// helper isn't reusable as-is here: its classifier is unexported with no
+// injectable predicate, and — critically — it does not cover TLS handshake
+// timeouts, the exact signature from this incident. The equivalent list is
+// kept locally so it can include that pattern.
+var transientSubIssueCreateErrorSignatures = []string{
+	"tls handshake timeout",
+	"handshake timeout",
+	"connection reset",
+	"connection refused",
+	"i/o timeout",
+	"context deadline exceeded",
+	"dial tcp",
+	"no such host",
+	"network is unreachable",
+	"http 500", "http 502", "http 503", "http 504",
+	"status 500", "status 502", "status 503", "status 504",
+	"secondary rate limit",
+	"api rate limit exceeded",
+	"you have exceeded a secondary rate limit",
+}
+
+// isTransientSubIssueCreateError reports whether errText (a `gh issue
+// create` error combined with its stderr) matches a known-transient
+// failure signature. Non-transient errors (4xx auth/validation, malformed
+// input) return false so the caller fails fast instead of burning retry
+// attempts on a failure retrying can't fix.
+func isTransientSubIssueCreateError(errText string) bool {
+	lower := strings.ToLower(errText)
+	for _, sig := range transientSubIssueCreateErrorSignatures {
+		if strings.Contains(lower, sig) {
+			return true
+		}
+	}
+	return false
+}
+
+// runGHIssueCreateWithRetry runs `gh issue create` (args must already
+// include the full argument list) with bounded exponential-backoff retry
+// for transient failures (GH-4300). Returns the trimmed stdout (the created
+// issue's URL) on success. A non-transient error, or exhausting all
+// attempts, returns the last error unchanged — same shape callers already
+// handled before this helper existed.
+func (r *Runner) runGHIssueCreateWithRetry(ctx context.Context, args []string, executionPath string, subtaskOrder int) (string, error) {
+	attempts, delay := r.subIssueCreateRetryConfig()
+
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		cmd := exec.CommandContext(ctx, "gh", args...)
+		if executionPath != "" {
+			cmd.Dir = executionPath
+		}
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+
+		runErr := cmd.Run()
+		if runErr == nil {
+			return strings.TrimSpace(stdout.String()), nil
+		}
+
+		lastErr = fmt.Errorf("failed to create issue for subtask %d: %w (stderr: %s)",
+			subtaskOrder, runErr, stderr.String())
+
+		if !isTransientSubIssueCreateError(lastErr.Error()) || attempt == attempts {
+			return "", lastErr
+		}
+
+		backoff := delay * time.Duration(uint(1)<<uint(attempt-1))
+		r.log.Warn("gh issue create failed with transient error, retrying",
+			"subtask_order", subtaskOrder,
+			"attempt", attempt,
+			"max_attempts", attempts,
+			"backoff", backoff,
+			"error", runErr,
+		)
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(backoff):
+		}
+	}
+	return "", lastErr
+}
+
 // createSubIssuesViaGitHub creates sub-issues using the gh CLI.
 // This is the original implementation and fallback path.
 //
@@ -1403,36 +1686,27 @@ func (r *Runner) createSubIssuesViaGitHub(ctx context.Context, plan *EpicPlan, e
 			)[0].Title
 		}
 
-		// Create issue using gh CLI
+		// Create issue using gh CLI — GH-4300: retries transient failures
+		// (TLS handshake timeout, network errors, 5xx, rate-limit) with
+		// bounded exponential backoff instead of aborting the whole
+		// decomposition on the first blip. Non-transient errors (4xx auth/
+		// validation) fail fast, same as before.
 		subLabels := append([]string{"pilot"}, filterPropagatableLabels(plan.ParentTask.Labels)...)
 		args := []string{"issue", "create", "--title", title, "--body", body}
 		for _, l := range subLabels {
 			args = append(args, "--label", l)
 		}
 
-		cmd := exec.CommandContext(ctx, "gh", args...)
-
-		// Set working directory - use executionPath which respects worktree isolation
-		if executionPath != "" {
-			cmd.Dir = executionPath
-		}
-
-		var stdout, stderr bytes.Buffer
-		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
-
 		r.log.Debug("Creating GitHub issue",
 			"subtask_order", subtask.Order,
 			"title", subtask.Title,
 		)
 
-		if err := cmd.Run(); err != nil {
-			return created, fmt.Errorf("failed to create issue for subtask %d: %w (stderr: %s)",
-				subtask.Order, err, stderr.String())
+		issueURL, err := r.runGHIssueCreateWithRetry(ctx, args, executionPath, subtask.Order)
+		if err != nil {
+			return created, err
 		}
 
-		// gh issue create outputs the issue URL on success
-		issueURL := strings.TrimSpace(stdout.String())
 		issueNumber := parseIssueNumber(issueURL)
 
 		created = append(created, CreatedIssue{

--- a/internal/executor/gh4300_test.go
+++ b/internal/executor/gh4300_test.go
@@ -1,0 +1,387 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// gh4300TwoSubtasks returns two subtasks used across the GH-4300 coverage-gap
+// tests. Distinct directories keep isSinglePackageScope from consolidating
+// them into a single task for the r.Execute-driven recovery test.
+func gh4300TwoSubtasks() []PlannedSubtask {
+	return []PlannedSubtask{
+		{Order: 1, Title: "feat(gateway): add websocket handler", Description: "Implement upgrade handler in internal/gateway/server.go"},
+		{Order: 2, Title: "feat(adapters): add telegram bot", Description: "Wire bot client in internal/adapters/telegram/bot.go"},
+	}
+}
+
+// TestIsTransientSubIssueCreateError covers the classifier that decides
+// whether a `gh issue create` failure is worth retrying (GH-4300). The TLS
+// handshake timeout case is the exact signature from the 2026-07-14
+// pilot-console#1 incident.
+func TestIsTransientSubIssueCreateError(t *testing.T) {
+	tests := []struct {
+		name    string
+		errText string
+		want    bool
+	}{
+		{"TLS handshake timeout (incident signature)", `Post "https://api.github.com/graphql": net/http: TLS handshake timeout`, true},
+		{"generic handshake timeout", "remote error: handshake timeout", true},
+		{"connection reset", "read: connection reset by peer", true},
+		{"connection refused", "dial tcp: connection refused", true},
+		{"i/o timeout", "read tcp: i/o timeout", true},
+		{"context deadline exceeded", "context deadline exceeded", true},
+		{"dial tcp failure", "dial tcp 140.82.0.0:443: i/o timeout", true},
+		{"no such host", "dial tcp: lookup api.github.com: no such host", true},
+		{"network unreachable", "connect: network is unreachable", true},
+		{"http 502", "HTTP 502: Bad Gateway", true},
+		{"status 503", "gh: status 503", true},
+		{"secondary rate limit", "You have exceeded a secondary rate limit", true},
+		{"api rate limit exceeded", "API rate limit exceeded for user", true},
+		{"case-insensitive", "NET/HTTP: TLS HANDSHAKE TIMEOUT", true},
+		{"auth failure — not transient", "HTTP 401: Bad credentials", false},
+		{"not found — not transient", "HTTP 404: Not Found", false},
+		{"validation failed — not transient", "HTTP 422: Validation Failed", false},
+		{"empty string", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTransientSubIssueCreateError(tt.errText); got != tt.want {
+				t.Errorf("isTransientSubIssueCreateError(%q) = %v, want %v", tt.errText, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCreateSubIssues_HappyPathUnchanged asserts the no-failure case still
+// creates every planned issue in one pass with no retries and no coverage
+// gap — GH-4300 acceptance: "No behavior change on the happy path."
+func TestCreateSubIssues_HappyPathUnchanged(t *testing.T) {
+	fakeBin := t.TempDir()
+	countFile := filepath.Join(t.TempDir(), "count")
+	script := filepath.Join(fakeBin, "gh")
+	content := "#!/bin/sh\n" +
+		`if [ "$1" = "issue" ] && [ "$2" = "create" ]; then
+  COUNT_FILE="` + countFile + `"
+  if [ -f "$COUNT_FILE" ]; then N=$(cat "$COUNT_FILE"); else N=0; fi
+  N=$((N+1))
+  echo $N > "$COUNT_FILE"
+  echo "https://github.com/owner/repo/issues/$((200+N))"
+fi
+`
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	origPATH := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+origPATH)
+
+	runner := NewRunner()
+	plan := &EpicPlan{
+		ParentTask: &Task{ID: "GH-4300H"},
+		Subtasks:   gh4300TwoSubtasks(),
+	}
+
+	created, err := runner.CreateSubIssues(context.Background(), plan, t.TempDir())
+	if err != nil {
+		t.Fatalf("CreateSubIssues returned error, want nil: %v", err)
+	}
+	if len(created) != 2 {
+		t.Fatalf("created = %d, want 2", len(created))
+	}
+
+	data, _ := os.ReadFile(countFile)
+	if strings.TrimSpace(string(data)) != "2" {
+		t.Errorf("gh issue create invocation count = %s, want 2 (one per subtask, no retries)", data)
+	}
+}
+
+// TestCreateSubIssues_RetriesTransientCreateFailureThenSucceeds is the
+// GH-4300 acceptance case: a transient failure on the Kth sub-issue
+// creation retries and, once it succeeds, all N issues exist and
+// CreateSubIssues returns no error — reproducing the exact TLS handshake
+// timeout signature from the 2026-07-14 pilot-console#1 incident, except
+// this time the retry recovers instead of silently dropping the subtask.
+func TestCreateSubIssues_RetriesTransientCreateFailureThenSucceeds(t *testing.T) {
+	fakeBin := t.TempDir()
+	countFile := filepath.Join(t.TempDir(), "count")
+	script := filepath.Join(fakeBin, "gh")
+	// Invocation 1 (subtask 1): succeeds immediately.
+	// Invocation 2 (subtask 2, attempt 1): transient TLS handshake timeout.
+	// Invocation 3 (subtask 2, attempt 2 / retry): succeeds.
+	content := "#!/bin/sh\n" +
+		`if [ "$1" = "issue" ] && [ "$2" = "create" ]; then
+  COUNT_FILE="` + countFile + `"
+  if [ -f "$COUNT_FILE" ]; then N=$(cat "$COUNT_FILE"); else N=0; fi
+  N=$((N+1))
+  echo $N > "$COUNT_FILE"
+  if [ "$N" = "2" ]; then
+    echo 'Post "https://api.github.com/graphql": net/http: TLS handshake timeout' >&2
+    exit 1
+  fi
+  echo "https://github.com/owner/repo/issues/$((200+N))"
+fi
+`
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	origPATH := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+origPATH)
+
+	runner := NewRunner()
+	runner.subIssueCreateRetryDelay = time.Millisecond // keep the test fast
+
+	plan := &EpicPlan{
+		ParentTask: &Task{ID: "GH-4300B"},
+		Subtasks:   gh4300TwoSubtasks(),
+	}
+
+	created, err := runner.CreateSubIssues(context.Background(), plan, t.TempDir())
+	if err != nil {
+		t.Fatalf("CreateSubIssues returned error, want nil after retry recovers: %v", err)
+	}
+	if len(created) != 2 {
+		t.Fatalf("created = %d, want 2 (both subtasks, including the one that needed a retry)", len(created))
+	}
+
+	data, _ := os.ReadFile(countFile)
+	if strings.TrimSpace(string(data)) != "3" {
+		t.Errorf("gh issue create invocation count = %s, want 3 (subtask1 success + subtask2 fail + subtask2 retry success)", data)
+	}
+}
+
+// TestCreateSubIssues_PermanentFailureLeavesParentFlaggedNotClosed is the
+// GH-4300 acceptance case: when sub-issue creation exhausts its retries, the
+// parent must not be treated as done. CreateSubIssues must return a
+// *SubIssueCoverageGapError naming the uncreated subtask, label the parent
+// pilot-needs-clarification, comment the gap, and record a ledger event
+// with planned/created counts.
+func TestCreateSubIssues_PermanentFailureLeavesParentFlaggedNotClosed(t *testing.T) {
+	fakeBin := t.TempDir()
+	countFile := filepath.Join(t.TempDir(), "count")
+	logFile := filepath.Join(t.TempDir(), "gh-calls.log")
+	script := filepath.Join(fakeBin, "gh")
+	// Invocation 1 (subtask 1): succeeds. Every "issue create" invocation
+	// after that (subtask 2, every retry attempt) fails with a transient
+	// signature that never clears — simulating an outage that outlasts the
+	// bounded retry budget. Non-create subcommands (issue edit/comment, used
+	// by the coverage-gap label/comment) always succeed.
+	content := "#!/bin/sh\n" +
+		`echo "$@" >> "` + logFile + `"
+if [ "$1" = "issue" ] && [ "$2" = "create" ]; then
+  COUNT_FILE="` + countFile + `"
+  if [ -f "$COUNT_FILE" ]; then N=$(cat "$COUNT_FILE"); else N=0; fi
+  N=$((N+1))
+  echo $N > "$COUNT_FILE"
+  if [ "$N" = "1" ]; then
+    echo "https://github.com/owner/repo/issues/201"
+  else
+    echo 'Post "https://api.github.com/graphql": net/http: TLS handshake timeout' >&2
+    exit 1
+  fi
+fi
+`
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	origPATH := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+origPATH)
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runner := NewRunner()
+	runner.SetLogStore(store)
+	runner.subIssueCreateRetryAttempts = 2 // bound the outage-outlasts-retries loop
+	runner.subIssueCreateRetryDelay = time.Millisecond
+
+	parent := &Task{ID: "GH-4300P"}
+	if err := store.SaveExecution(&memory.Execution{ID: parent.LogExecutionID(), TaskID: parent.ID, Status: "running"}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	plan := &EpicPlan{ParentTask: parent, Subtasks: gh4300TwoSubtasks()}
+
+	created, err := runner.CreateSubIssues(context.Background(), plan, t.TempDir())
+	if err == nil {
+		t.Fatal("CreateSubIssues returned nil error, want a coverage-gap error")
+	}
+	if len(created) != 1 {
+		t.Fatalf("created = %d, want 1 (only the subtask that succeeded)", len(created))
+	}
+
+	var gapErr *SubIssueCoverageGapError
+	if !errors.As(err, &gapErr) {
+		t.Fatalf("error is not *SubIssueCoverageGapError: %v", err)
+	}
+	if gapErr.Planned != 2 {
+		t.Errorf("gapErr.Planned = %d, want 2", gapErr.Planned)
+	}
+	if gapErr.Created != 1 {
+		t.Errorf("gapErr.Created = %d, want 1", gapErr.Created)
+	}
+	if len(gapErr.Missing) != 1 || gapErr.Missing[0] != "feat(adapters): add telegram bot" {
+		t.Errorf("gapErr.Missing = %v, want the second subtask's title", gapErr.Missing)
+	}
+
+	// Parent must be labeled pilot-needs-clarification and commented — not closed.
+	logData, _ := os.ReadFile(logFile)
+	logStr := string(logData)
+	if !strings.Contains(logStr, "issue edit") || !strings.Contains(logStr, "pilot-needs-clarification") {
+		t.Errorf("expected a `gh issue edit ... --add-label pilot-needs-clarification` call, log:\n%s", logStr)
+	}
+	if !strings.Contains(logStr, "issue comment") {
+		t.Errorf("expected a `gh issue comment` call naming the gap, log:\n%s", logStr)
+	}
+	if strings.Contains(logStr, "issue close") {
+		t.Errorf("parent must NOT be closed on a coverage gap, log:\n%s", logStr)
+	}
+
+	// Ledger event: planned=2 created=1.
+	events, err := store.ListExecutionEvents(parent.LogExecutionID())
+	if err != nil {
+		t.Fatalf("ListExecutionEvents: %v", err)
+	}
+	found := false
+	for _, e := range events {
+		if e.Stage == memory.StageSubIssuesIncomplete {
+			found = true
+			if !strings.Contains(e.Detail, "planned=2 created=1") {
+				t.Errorf("event detail = %q, want it to contain %q", e.Detail, "planned=2 created=1")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected a StageSubIssuesIncomplete ledger event, got stages: %+v", events)
+	}
+}
+
+// TestCreateSubIssues_NonTransientErrorFailsFastWithoutRetry asserts a 4xx
+// auth/validation-style failure is not retried — GH-4300's retry loop must
+// only spend attempts on errors retrying can plausibly fix.
+func TestCreateSubIssues_NonTransientErrorFailsFastWithoutRetry(t *testing.T) {
+	fakeBin := t.TempDir()
+	countFile := filepath.Join(t.TempDir(), "count")
+	script := filepath.Join(fakeBin, "gh")
+	content := "#!/bin/sh\n" +
+		`if [ "$1" = "issue" ] && [ "$2" = "create" ]; then
+  COUNT_FILE="` + countFile + `"
+  if [ -f "$COUNT_FILE" ]; then N=$(cat "$COUNT_FILE"); else N=0; fi
+  N=$((N+1))
+  echo $N > "$COUNT_FILE"
+  if [ "$N" = "1" ]; then
+    echo "https://github.com/owner/repo/issues/201"
+  else
+    echo "HTTP 422: Validation Failed" >&2
+    exit 1
+  fi
+fi
+`
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	origPATH := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+origPATH)
+
+	runner := NewRunner()
+	runner.subIssueCreateRetryAttempts = 3
+	runner.subIssueCreateRetryDelay = time.Millisecond
+
+	plan := &EpicPlan{
+		ParentTask: &Task{ID: "GH-4300N"},
+		Subtasks:   gh4300TwoSubtasks(),
+	}
+
+	created, err := runner.CreateSubIssues(context.Background(), plan, t.TempDir())
+	if err == nil {
+		t.Fatal("CreateSubIssues returned nil error, want a coverage-gap error")
+	}
+	if len(created) != 1 {
+		t.Fatalf("created = %d, want 1", len(created))
+	}
+
+	data, _ := os.ReadFile(countFile)
+	if strings.TrimSpace(string(data)) != "2" {
+		t.Errorf("gh issue create invocation count = %s, want 2 (subtask1 success + subtask2's single, non-retried failure)", data)
+	}
+}
+
+// TestExecute_EpicRecoveryCoverageGap_ParentStaysOpen is the GH-4300
+// regression test for the actual 2026-07-14 pilot-console#1 incident
+// mechanism: a prior run's `gh issue create` failed partway through, leaving
+// only one of two planned subtasks with an issue. A later run's
+// ErrSubIssuesAlreadyExist recovery pass finds that one issue already
+// closed. Before this fix, allChildrenDone(recovered) short-circuited
+// straight to "epic complete" without ever comparing against the plan's
+// subtask count, so the parent closed with the second subtask never
+// dispatched. This test drives the real r.Execute entry point end-to-end.
+func TestExecute_EpicRecoveryCoverageGap_ParentStaysOpen(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	r := NewRunner()
+	r.skipPreflightChecks = true
+	r.dryRun = true // no real gh CLI needed: label/comment side effects are skipped in dry-run
+	r.SetLogStore(store)
+	r.openSubIssueCheck = func(_ context.Context, _, _ string) (bool, error) {
+		return true, nil // force the ErrSubIssuesAlreadyExist → recovery path
+	}
+	r.recoverSubIssuesFn = func(_ context.Context, _, _ string) ([]CreatedIssue, error) {
+		subs := gh4300TwoSubtasks()
+		// Only the first subtask's issue was ever created; it's already
+		// closed — the exact shape that previously fooled allChildrenDone.
+		return []CreatedIssue{{Number: 201, State: "closed", Subtask: subs[0]}}, nil
+	}
+	r.planEpicFn = func(_ context.Context, task *Task, _ string) (*EpicPlan, error) {
+		return &EpicPlan{ParentTask: task, Subtasks: gh4300TwoSubtasks()}, nil
+	}
+
+	task := &Task{ID: "GH-4300R", Title: "[epic] recovery coverage gap test"}
+	if err := store.SaveExecution(&memory.Execution{ID: task.LogExecutionID(), TaskID: task.ID, Status: "running"}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	result, err := r.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute returned unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Success {
+		t.Error("expected Success=false — the partial recovered set must not be treated as a complete epic")
+	}
+	if !result.Declined {
+		t.Error("expected Declined=true so callers add pilot-needs-clarification instead of pilot-failed")
+	}
+	if !strings.Contains(result.Error, "planned=2 created=1") {
+		t.Errorf("result.Error = %q, want it to mention planned=2 created=1", result.Error)
+	}
+
+	events, err := store.ListExecutionEvents(task.LogExecutionID())
+	if err != nil {
+		t.Fatalf("ListExecutionEvents: %v", err)
+	}
+	found := false
+	for _, e := range events {
+		if e.Stage == memory.StageSubIssuesIncomplete {
+			found = true
+			if !strings.Contains(e.Detail, "planned=2 created=1") {
+				t.Errorf("event detail = %q, want it to contain %q", e.Detail, "planned=2 created=1")
+			}
+		}
+		// The parent must never reach StageCompleted from this path.
+		if e.Stage == memory.StageCompleted {
+			t.Errorf("parent must not record StageCompleted on a coverage gap, got event: %+v", e)
+		}
+	}
+	if !found {
+		t.Error("expected a StageSubIssuesIncomplete ledger event")
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -704,6 +704,11 @@ type Runner struct {
 	// defaultChildOutcomeReconcileTimeout); tests shrink these for fast runs.
 	childOutcomeReconcilePollInterval time.Duration
 	childOutcomeReconcileTimeout      time.Duration
+	// GH-4300: bounds the retry loop around each per-subtask `gh issue create`
+	// call. Zero uses the package defaults (defaultSubIssueCreateRetryAttempts /
+	// defaultSubIssueCreateRetryDelay); tests shrink the delay for fast runs.
+	subIssueCreateRetryAttempts int
+	subIssueCreateRetryDelay    time.Duration
 }
 
 // SetRepoAllowlist injects the allowlist used by the sub-issue creation
@@ -2092,6 +2097,35 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 							recover = recoverExistingSubIssues
 						}
 						recovered, _ := recover(ctx, executionPath, plan.ParentTask.ID)
+
+						// GH-4300: a recovered set smaller than this run's plan means at
+						// least one planned subtask never got an issue created at all (the
+						// 2026-07-14 pilot-console#1 incident — a transient failure on
+						// subtask 2's `gh issue create` left only subtask 1's issue behind;
+						// a later recovery pass found that one issue already closed,
+						// treated it as "the epic," and closed the parent with subtask 2
+						// never dispatched). Gate BEFORE allChildrenDone: even when every
+						// recovered issue is done, or when the open subset would execute
+						// cleanly, finishing that partial set must never close the parent
+						// as if the plan were fully covered.
+						plannedNow := creatableSubtasks(plan.Subtasks, plan.ParentTask.ID, nil)
+						if len(recovered) < len(plannedNow) {
+							gapPlan := &EpicPlan{ParentTask: plan.ParentTask, Subtasks: plannedNow, TotalEffort: plan.TotalEffort, PlanOutput: plan.PlanOutput}
+							gapErr := r.handleSubIssueCoverageGap(ctx, gapPlan, recovered, executionPath, err)
+							r.reportProgress(task.ID, "Needs Clarification", 100, gapErr.Error())
+							return &ExecutionResult{
+								TaskID:         task.ID,
+								Success:        false,
+								Declined:       true,
+								DeclinedReason: gapErr.Error(),
+								Outcome:        "declined",
+								Error:          gapErr.Error(),
+								Duration:       time.Since(start),
+								IsEpic:         true,
+								EpicPlan:       plan,
+							}, nil
+						}
+
 						if allChildrenDone(recovered) {
 							r.log.Info("All recovered sub-issues are done, treating epic as complete",
 								slog.String("task_id", task.ID),
@@ -2124,6 +2158,27 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 						)
 						issues = open
 					} else {
+						// GH-4300: CreateSubIssues has already labeled the parent
+						// pilot-needs-clarification, posted a comment naming the
+						// uncreated subtasks, and recorded the planned/created ledger
+						// event before returning this sentinel — surface it as
+						// "declined" (parent stays open) instead of stamping a
+						// generic pilot-failed StageFailed event on top.
+						var gapErr *SubIssueCoverageGapError
+						if errors.As(err, &gapErr) {
+							r.reportProgress(task.ID, "Needs Clarification", 100, gapErr.Error())
+							return &ExecutionResult{
+								TaskID:         task.ID,
+								Success:        false,
+								Declined:       true,
+								DeclinedReason: gapErr.Error(),
+								Outcome:        "declined",
+								Error:          gapErr.Error(),
+								Duration:       time.Since(start),
+								IsEpic:         true,
+								EpicPlan:       plan,
+							}, nil
+						}
 						createErr := fmt.Sprintf("failed to create sub-issues: %v", err)
 						r.recordExecutionEvent(task.LogExecutionID(), memory.StageFailed, truncateForLog(createErr, 200))
 						return &ExecutionResult{

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -790,6 +790,16 @@ const (
 	// canary run (sandbox#6, 275 words vs min 300) indistinguishable from the
 	// TASK-401 defect class without hand-querying execution_events.
 	StageDecompositionSkipped Stage = "decomposition_skipped"
+	// StageSubIssuesIncomplete records a sub-issue creation coverage gap
+	// (GH-4300): fewer sub-issues exist for a decomposed epic than its plan
+	// called for, even after retrying transient creation failures. Detail
+	// carries "planned=N created=M missing=<titles>". A gap fires this stage
+	// instead of StageFailed because the epic parent is deliberately left
+	// open (labeled pilot-needs-clarification) rather than terminated —
+	// incident 2026-07-14 (pilot-console#1) closed a parent with 1 of 2
+	// planned subtasks never dispatched after a transient sub-issue-creation
+	// failure went unnoticed.
+	StageSubIssuesIncomplete Stage = "sub_issues_incomplete"
 )
 
 // Event represents a single stage-transition record for an execution.


### PR DESCRIPTION
## Summary
- Fixes GH-4300: a transient `gh issue create` failure (e.g. the TLS handshake timeout from the 2026-07-14 pilot-console#1 incident) could silently drop a planned subtask — only the earlier subtask's issue got created, and a later recovery pass then closed the epic parent as "complete" with the missing subtask never dispatched.
- `createSubIssuesViaGitHub` now retries transient `gh issue create` failures (TLS handshake timeout, network errors, HTTP 5xx, rate-limit) with bounded exponential backoff; non-transient errors (4xx auth/validation) still fail fast.
- `CreateSubIssues` and the `ErrSubIssuesAlreadyExist` recovery path in `runner.go` now compare created/recovered sub-issue counts against the plan before treating decomposition as complete. On a gap: the parent stays open, is labeled `pilot-needs-clarification`, gets a comment naming the missing subtasks, and a `StageSubIssuesIncomplete` ledger event (`planned=N created=M`) is recorded via `execution_events`.
- No behavior change on the happy path (all subtasks created on the first try).

## Test plan
- [x] `go build ./...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...` → 0 issues
- [x] `go test ./internal/executor/... ./internal/memory/...` → all pass
- [x] New table-driven tests in `internal/executor/gh4300_test.go`:
  - happy path unchanged (no retries, no gap)
  - transient failure retries then succeeds (all N created)
  - permanent failure: parent stays open, labeled, commented, ledger event recorded
  - non-transient error fails fast (no wasted retry attempts)
  - recovery-path coverage gap reproduces the actual incident mechanism end-to-end via `r.Execute`