### PR TITLE
feat(autopilot): test-evidence guard for auto-merge

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-15 (v2.151.0)
+**Last Updated:** 2026-07-09 (v2.151.0)
 
 ## Legend
 
@@ -409,6 +409,7 @@
 | Board sync tests | ✅ | adapters/github | - | - | ProjectBoardSync and ExecuteGraphQL unit tests (v2.30.0, PR #1865) |
 | CI context wiring | ✅ | autopilot | - | - | Wire proper CI context from autopilot controller (v2.52.0, PR #1981) |
 | PR stage execution-event audit trail | ✅ | autopilot | - | - | `Controller` writes `execution_events` rows (ci_passed/ci_failed/awaiting_approval/merged/released/failed) via `memory.Store.InsertExecutionEvent`; survives PR-state-row cleanup after merge since it keys off `executions.id` (GH-3847) |
+| Test-evidence gate | ✅ | autopilot | - | `autopilot.test_evidence` | Escalate-only guard at `handleCIPassed` (same pattern as scope_guard.go): holds auto-merge, comments on the PR, and journals a `test_evidence_hold` execution event when the CI job log shows zero/skipped tests on a PR touching production source. Default off, per-project opt-in (GH-4329) |
 
 ## Epic Management
 
@@ -424,7 +425,6 @@
 | Sub-issue dedup guard | ✅ | executor | - | - | CreateSubIssues skips if open children referencing parent already exist (GH-2494) |
 | createPilotIssue chokepoint | ✅ | adapters/github, autopilot | - | - | All Pilot-internal issue creation validated through CreatePilotIssue CC gate (GH-2494) |
 | Epic-lifecycle synthetic canary | ✅ | .github/workflows, scripts | `workflow_dispatch` (scenario `epic-lifecycle`) | - | GH Actions scenario files a deliberately decomposable epic on the sandbox and asserts 5 invariants (≥2 children, no duplicate merged PR per child, parent auto-close, no stale `pilot-needs-clarification`, no cascade beyond direct children) via `canary-poll.sh --assert n-children-merged` (TASK-403 A3, GH-4242) |
-| Sub-issue creation retry + coverage gate | ✅ | executor | - | - | Bounded retry (TLS timeout/5xx/rate-limit) around each `gh issue create`; if fewer sub-issues exist than planned (creation or recovery path), parent stays open + labeled `pilot-needs-clarification` + ledger event instead of closing (v2.239.0, GH-4300) |
 
 ## Test Coverage
 

--- a/.agent/tasks/gh-4329.md
+++ b/.agent/tasks/gh-4329.md
@@ -1,0 +1,43 @@
+# GH-4329
+
+**Created:** 2026-07-15
+
+## Problem
+
+GitHub Issue GH-4329: feat(autopilot): test-evidence guard — hold auto-merge when green CI ran zero/skipped tests (default off, per-project)
+
+## Context
+
+2026-07-15, qf-studio/pilot-console PR #13: autopilot auto-merged on green CI, but the `test` job had **skipped the entire `internal/fleet` store suite** (tests gated on a `DATABASE_URL` the workflow never provided). Green CI verified nothing; three mutation-verified store defects would have passed. The repo-level hole was fixed (pilot-console#16), but the orchestrator-level gap remains: **autopilot treats "CI concluded success" as "code was tested" — those are not the same statement.**
+
+## Problem
+
+The auto-merge decision (autopilot controller, CI-passed handling around the `handleCIPassed` chokepoint) consumes only the check-run conclusion. A test job that runs 0 tests, or skips a large fraction, is indistinguishable from a rigorous pass.
+
+## Fix
+
+Add a **test-evidence heuristic** to the CI-passed path, escalate-only (same pattern as scope_guard):
+
+1. After CI passes and before auto-merge, fetch the test job log for the head SHA (`gh run view --log` equivalent via the existing GH client).
+2. Parse for the common evidence patterns, Go first (`ok \s+<pkg>` / `--- PASS` / `--- SKIP` counts; `[no test files]`; for JS runners: vitest/jest summary lines). Compute: tests_run, tests_skipped.
+3. Escalate (hold auto-merge, comment on the PR, mark needs-attention — do NOT close) when: tests_run == 0, or skip ratio exceeds a configurable threshold (default 0.5), **and** the PR's diff touches source files with a corresponding test-file change or existing test coverage expectation.
+4. Config: `autopilot.test_evidence: {enabled: false, min_tests: 1, max_skip_ratio: 0.5}` — ship **default OFF**, enable per-project (canary the pilot repo + pilot-console first).
+5. Journal an execution event (`test_evidence_hold`) so the dashboard/history shows why a PR is held.
+
+## Non-goals
+
+- No coverage measurement, no failing CI re-runs, no blocking on parse failure (unparseable log ⇒ pass-through with a logged warning — fail-open).
+
+## Acceptance
+
+- Table-driven parser tests: Go `ok/PASS/SKIP/no test files` fixtures, vitest summary fixture, garbage log ⇒ fail-open.
+- Controller test: green CI + zero-test log + enabled config ⇒ PR held with comment + event; disabled config ⇒ current behavior byte-identical.
+- `make test` / `make lint` green.
+
+## Refs
+
+- Incident: pilot-console PR #13 (merged 2026-07-15T13:38Z with fully-skipped suite); repo-level fix pilot-console#16 (merged).
+- Pattern precedent: escalate-only guards at the `handleCIPassed` chokepoint (`internal/autopilot/scope_guard.go`).
+
+## Acceptance Criteria
+

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -683,6 +683,19 @@ autopilot:
     #                              # same SHA instead of enumerating them in `exclude`.
     discovery_grace_period: 60s   # Wait for CI to start
 
+  # Test-evidence gate (GH-4329): escalate-only, same pattern as the
+  # scope-drift/size-floor gates above. Green CI proves a check concluded
+  # "success" — it does NOT prove tests actually ran. When enabled, autopilot
+  # fetches the completed test job's log for the merge SHA and holds
+  # auto-merge (requiring human approval + posts a PR comment) if it looks
+  # like CI verified nothing: zero tests ran, or the skip ratio exceeds
+  # max_skip_ratio, on a PR that touches production source.
+  # Default off — enable per-project once canaried (pilot repo + pilot-console first).
+  test_evidence:
+    enabled: false
+    min_tests: 1        # escalate if fewer than this many tests ran
+    max_skip_ratio: 0.5  # escalate if skipped/(run+skipped) exceeds this
+
 # Dashboard settings
 dashboard:
   refresh_interval: 1000     # ms

--- a/internal/autopilot/ci_monitor.go
+++ b/internal/autopilot/ci_monitor.go
@@ -540,6 +540,55 @@ func (m *CIMonitor) GetFailedCheckLogs(ctx context.Context, sha string, maxLen i
 	return result
 }
 
+// GetCheckLogs fetches logs for all completed, in-scope check runs for sha and
+// returns them combined, each prefixed with the check name. Unlike
+// GetFailedCheckLogs, this includes successful/skipped runs too — the
+// test-evidence gate (GH-4329) needs to see the test job's own passing output
+// to tell a rigorous run from one that silently skipped everything.
+func (m *CIMonitor) GetCheckLogs(ctx context.Context, sha string, maxLen int) string {
+	checkRuns, err := m.ghClient.ListCheckRuns(ctx, m.owner, m.repo, sha)
+	if err != nil {
+		m.log.Warn("failed to list check runs for log fetch", "sha", ShortSHA(sha), "error", err)
+		return ""
+	}
+
+	var combined strings.Builder
+	for _, run := range checkRuns.CheckRuns {
+		if run.Status != github.CheckRunCompleted {
+			continue
+		}
+		if !m.isScopedCheck(run.Name) {
+			continue
+		}
+
+		logs, err := m.ghClient.GetJobLogs(ctx, m.owner, m.repo, run.ID)
+		if err != nil {
+			m.log.Warn("failed to fetch logs for check run",
+				"check", run.Name,
+				"id", run.ID,
+				"error", err,
+			)
+			continue
+		}
+
+		if combined.Len() > 0 {
+			combined.WriteString("\n\n")
+		}
+		combined.WriteString(fmt.Sprintf("=== %s ===\n", run.Name))
+		combined.WriteString(logs)
+
+		if combined.Len() >= maxLen {
+			break
+		}
+	}
+
+	result := combined.String()
+	if len(result) > maxLen {
+		result = result[:maxLen]
+	}
+	return result
+}
+
 // GetCheckStatus returns the current status of a specific check by name.
 func (m *CIMonitor) GetCheckStatus(ctx context.Context, sha, checkName string) (CIStatus, error) {
 	checkRuns, err := m.ghClient.ListCheckRuns(ctx, m.owner, m.repo, sha)

--- a/internal/autopilot/ci_monitor_test.go
+++ b/internal/autopilot/ci_monitor_test.go
@@ -1446,6 +1446,49 @@ func TestCIMonitor_GetFailedCheckLogs(t *testing.T) {
 	})
 }
 
+// TestCIMonitor_GetCheckLogs verifies GetCheckLogs (GH-4329) fetches logs for
+// completed check runs regardless of conclusion — unlike GetFailedCheckLogs,
+// a successful (or skipped) run's output must be included so the test-evidence
+// gate can inspect what a *passing* test job actually did.
+func TestCIMonitor_GetCheckLogs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/commits/abc123/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 2,
+				CheckRuns: []github.CheckRun{
+					{ID: 100, Name: "test", Status: "completed", Conclusion: "success"},
+					{ID: 101, Name: "build", Status: "in_progress"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/repos/owner/repo/actions/jobs/100/logs":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok  \tgithub.com/qf-studio/pilot/internal/fleet\t0.010s"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	monitor := NewCIMonitor(ghClient, "owner", "repo", cfg)
+
+	logs := monitor.GetCheckLogs(context.Background(), "abc123", 2000)
+
+	if !contains(logs, "=== test ===") {
+		t.Errorf("logs should contain the successful check's header, got %q", logs)
+	}
+	if !contains(logs, "ok") {
+		t.Errorf("logs should contain the successful check's output, got %q", logs)
+	}
+	if contains(logs, "=== build ===") {
+		t.Errorf("logs should not include the still-running check, got %q", logs)
+	}
+}
+
 // TestCIMonitor_CommitStatusFallback tests the fallback to the GitHub commit-status
 // API when check-runs returns empty. Providers like CircleCI, Jenkins, and Travis
 // use the statuses API exclusively, so empty check-runs must not auto-approve.

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1443,6 +1443,19 @@ func (c *Controller) handleCIPassed(ctx context.Context, prState *PRState) error
 		}
 	}
 
+	// GH-4329: test-evidence gate. Default off (c.config.TestEvidence == nil or
+	// Enabled == false) — enable per-project once canaried. Fetches the CI job
+	// logs for the head SHA and escalates when they show CI passed without
+	// meaningfully exercising tests (see TestEvidenceReason).
+	testEvidenceHeld := false
+	if escalateReason == "" && c.config.TestEvidence != nil && c.config.TestEvidence.Enabled {
+		logs := c.ciMonitor.GetCheckLogs(ctx, prState.HeadSHA, testEvidenceLogMaxLen)
+		if reason := TestEvidenceReason(c.log, c.config.TestEvidence, files, logs); reason != "" {
+			escalateReason = reason
+			testEvidenceHeld = true
+		}
+	}
+
 	if escalateReason != "" {
 		c.log.Warn("merge gate escalated: requiring human approval",
 			"pr", prState.PRNumber, "reason", escalateReason)
@@ -1455,6 +1468,11 @@ func (c *Controller) handleCIPassed(ctx context.Context, prState *PRState) error
 			if err := c.notifier.NotifyApprovalRequired(ctx, prState); err != nil {
 				c.log.Warn("failed to send approval notification", "error", err)
 			}
+		}
+		if testEvidenceHeld {
+			c.postTestEvidenceHoldComment(ctx, prState, escalateReason)
+			c.recordExecutionEvent(prState, memory.StageAwaitingApproval,
+				fmt.Sprintf("test_evidence_hold: %s", escalateReason))
 		}
 		return nil
 	}
@@ -1478,6 +1496,26 @@ func (c *Controller) handleCIPassed(ctx context.Context, prState *PRState) error
 		prState.Stage = StageMerging
 	}
 	return nil
+}
+
+// testEvidenceLogMaxLen bounds how much combined CI job log text the
+// test-evidence gate (GH-4329) reads per PR — generous enough to see a full
+// `go test`/vitest summary without risking unbounded memory on a pathological
+// log.
+const testEvidenceLogMaxLen = 50_000
+
+// postTestEvidenceHoldComment posts a PR comment explaining why the
+// test-evidence gate (GH-4329) held auto-merge. Best-effort: a comment failure
+// is logged and swallowed, matching the fail-open posture of the gate itself —
+// the PR is already safely parked in StageAwaitApproval regardless.
+func (c *Controller) postTestEvidenceHoldComment(ctx context.Context, prState *PRState, reason string) {
+	body := fmt.Sprintf("🛑 **Auto-merge held: test-evidence gate**\n\n%s\n\n"+
+		"CI reported success, but the test-evidence heuristic (GH-4329) could not "+
+		"confirm this PR was actually exercised by tests. Merge requires human "+
+		"approval via the usual approve/reject flow.", reason)
+	if _, err := c.ghClient.AddComment(ctx, c.owner, c.repo, prState.PRNumber, body); err != nil {
+		c.log.Warn("test-evidence gate: failed to post PR comment", "pr", prState.PRNumber, "error", err)
+	}
 }
 
 // handleCIFailed creates fix issue via feedback loop.

--- a/internal/autopilot/controller_test_evidence_test.go
+++ b/internal/autopilot/controller_test_evidence_test.go
@@ -1,0 +1,171 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestController_TestEvidenceGate_HoldsOnZeroTests verifies the GH-4329
+// test-evidence gate: green CI whose job log shows zero tests run, on a PR
+// touching production source, holds auto-merge (StageAwaitApproval), posts a
+// PR comment, and journals a test_evidence_hold execution event. Disabled
+// config (the default) must behave byte-identically to pre-gate: proceed
+// straight to StageMerging with no comment and no test_evidence_hold event.
+func TestController_TestEvidenceGate_HoldsOnZeroTests(t *testing.T) {
+	const prNumber = 60
+	const issueNumber = 25
+	const headSHA = "shaTE1"
+
+	buildServer := func(t *testing.T, commentPosted *bool) *httptest.Server {
+		t.Helper()
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.URL.Path == "/repos/owner/repo/pulls/"+strconv.Itoa(prNumber)+"/files":
+				resp := []*github.PRFile{
+					{Filename: "internal/fleet/store.go", Status: "modified", Additions: 120},
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(resp)
+
+			case r.URL.Path == "/repos/owner/repo/commits/"+headSHA+"/check-runs":
+				resp := github.CheckRunsResponse{
+					TotalCount: 1,
+					CheckRuns: []github.CheckRun{
+						{ID: 200, Name: "test", Status: "completed", Conclusion: "success"},
+					},
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(resp)
+
+			case r.URL.Path == "/repos/owner/repo/actions/jobs/200/logs":
+				w.WriteHeader(http.StatusOK)
+				// The pilot-console PR #13 shape: package reports "ok" despite
+				// every subtest inside it having been skipped (DATABASE_URL unset).
+				_, _ = w.Write([]byte("?   \tgithub.com/qf-studio/pilot-console/internal/fleet\t[no test files]"))
+
+			case r.URL.Path == "/repos/owner/repo/issues/"+strconv.Itoa(prNumber)+"/comments" && r.Method == http.MethodPost:
+				if commentPosted != nil {
+					*commentPosted = true
+				}
+				w.WriteHeader(http.StatusCreated)
+				_ = json.NewEncoder(w).Encode(github.PRComment{ID: 1})
+
+			case r.URL.Path == "/repos/owner/repo/pulls/"+strconv.Itoa(prNumber)+"/merge":
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"sha":"merged","merged":true,"message":"merged"}`))
+
+			default:
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{}`))
+			}
+		}))
+	}
+
+	newPRState := func() *PRState {
+		return &PRState{
+			PRNumber:    prNumber,
+			PRURL:       "https://github.com/owner/repo/pull/60",
+			IssueNumber: issueNumber,
+			BranchName:  "pilot/GH-25",
+			HeadSHA:     headSHA,
+			Stage:       StageCIPassed,
+			CreatedAt:   time.Now(),
+		}
+	}
+
+	t.Run("enabled config holds the PR with comment + event", func(t *testing.T) {
+		var commentPosted bool
+		server := buildServer(t, &commentPosted)
+		defer server.Close()
+
+		ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+		cfg := DefaultConfig()
+		cfg.Environment = EnvDev
+		cfg.TestEvidence = &TestEvidenceConfig{Enabled: true}
+
+		c := NewController(cfg, ghClient, nil, "owner", "repo")
+		mock := &mockApprovalPersister{execByTask: map[string]string{"GH-25": "exec-gh-25"}}
+		c.memoryStore = mock
+
+		c.mu.Lock()
+		c.activePRs[prNumber] = newPRState()
+		c.mu.Unlock()
+
+		if err := c.ProcessPR(context.Background(), prNumber, nil); err != nil {
+			t.Fatalf("ProcessPR: %v", err)
+		}
+
+		pr, ok := c.GetPRState(prNumber)
+		if !ok {
+			t.Fatal("PR not found in activePRs")
+		}
+		if pr.Stage != StageAwaitApproval {
+			t.Errorf("Stage = %s, want %s (test-evidence gate should hold auto-merge)", pr.Stage, StageAwaitApproval)
+		}
+		if !strings.Contains(pr.EscalationReason, "test-evidence gate") {
+			t.Errorf("EscalationReason = %q, want it to name the test-evidence gate", pr.EscalationReason)
+		}
+		if !commentPosted {
+			t.Error("expected a PR comment explaining the hold")
+		}
+
+		var found bool
+		for _, ev := range mock.executionEvents {
+			if ev.executionID == "exec-gh-25" && ev.stage == memory.StageAwaitingApproval && strings.Contains(ev.detail, "test_evidence_hold") {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected a test_evidence_hold execution event, got %+v", mock.executionEvents)
+		}
+	})
+
+	t.Run("disabled config (default) proceeds to merge, byte-identical to pre-gate behavior", func(t *testing.T) {
+		var commentPosted bool
+		server := buildServer(t, &commentPosted)
+		defer server.Close()
+
+		ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+		cfg := DefaultConfig()
+		cfg.Environment = EnvDev
+		// cfg.TestEvidence left nil — the shipped default (GH-4329: off).
+
+		c := NewController(cfg, ghClient, nil, "owner", "repo")
+		mock := &mockApprovalPersister{execByTask: map[string]string{"GH-25": "exec-gh-25"}}
+		c.memoryStore = mock
+
+		c.mu.Lock()
+		c.activePRs[prNumber] = newPRState()
+		c.mu.Unlock()
+
+		if err := c.ProcessPR(context.Background(), prNumber, nil); err != nil {
+			t.Fatalf("ProcessPR: %v", err)
+		}
+
+		pr, ok := c.GetPRState(prNumber)
+		if !ok {
+			t.Fatal("PR not found in activePRs")
+		}
+		if pr.Stage != StageMerging {
+			t.Errorf("Stage = %s, want %s (disabled gate must not change existing behavior)", pr.Stage, StageMerging)
+		}
+		if commentPosted {
+			t.Error("disabled gate must not post a PR comment")
+		}
+		for _, ev := range mock.executionEvents {
+			if strings.Contains(ev.detail, "test_evidence_hold") {
+				t.Errorf("disabled gate must not journal a test_evidence_hold event, got %+v", mock.executionEvents)
+			}
+		}
+	})
+}

--- a/internal/autopilot/test_evidence.go
+++ b/internal/autopilot/test_evidence.go
@@ -1,0 +1,130 @@
+package autopilot
+
+import (
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strconv"
+
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GH-4329: escalate-only test-evidence gate at the handleCIPassed chokepoint.
+// Same defense-in-depth pattern as scope_guard.go — this only forces human
+// approval when green CI looks like it verified nothing; it never blocks CI,
+// never fails a check, and never relaxes an already-required approval.
+
+const (
+	defaultMinTests     = 1
+	defaultMaxSkipRatio = 0.5
+)
+
+var (
+	reGoPass        = regexp.MustCompile(`(?m)^\s*--- PASS: `)
+	reGoFail        = regexp.MustCompile(`(?m)^\s*--- FAIL: `)
+	reGoSkip        = regexp.MustCompile(`(?m)^\s*--- SKIP: `)
+	reGoOK          = regexp.MustCompile(`(?m)^ok\s+\S+`)
+	reGoNoTestFiles = regexp.MustCompile(`(?m)^\?\s+\S+\s+\[no test files\]`)
+
+	// vitest summary: "Tests  42 passed | 5 skipped (47)" (skip clause optional).
+	reVitestTests = regexp.MustCompile(`(?mi)^\s*Tests\s+(\d+)\s+passed(?:\s*\|\s*(\d+)\s+skipped)?\s*\(\d+\)`)
+	// jest summary: "Tests:       5 skipped, 40 passed, 45 total".
+	reJestTests = regexp.MustCompile(`(?mi)^\s*Tests:\s+(?:(\d+)\s+skipped,\s*)?(\d+)\s+passed,\s*\d+\s+total`)
+)
+
+// parseTestEvidence scans a combined CI job log for common test-runner summary
+// shapes and returns how many tests ran and how many were skipped. parsed is
+// false when none of the known shapes are found — an unparseable log must
+// fail open (abstain), never be treated as "zero tests ran".
+//
+// Go is checked first (per-test `--- PASS/FAIL/SKIP` lines, falling back to
+// per-package `ok` summary lines, falling back to `[no test files]`), then
+// vitest/jest summary lines.
+func parseTestEvidence(log string) (testsRun, testsSkipped int, parsed bool) {
+	if pass, fail, skip := len(reGoPass.FindAllString(log, -1)), len(reGoFail.FindAllString(log, -1)), len(reGoSkip.FindAllString(log, -1)); pass+fail+skip > 0 {
+		return pass + fail, skip, true
+	}
+
+	if m := reVitestTests.FindStringSubmatch(log); m != nil {
+		passed, _ := strconv.Atoi(m[1])
+		skipped := 0
+		if m[2] != "" {
+			skipped, _ = strconv.Atoi(m[2])
+		}
+		return passed, skipped, true
+	}
+
+	if m := reJestTests.FindStringSubmatch(log); m != nil {
+		skipped := 0
+		if m[1] != "" {
+			skipped, _ = strconv.Atoi(m[1])
+		}
+		passed, _ := strconv.Atoi(m[2])
+		return passed, skipped, true
+	}
+
+	// No per-test lines found — a non-verbose `go test ./...` run only prints
+	// one `ok`/`FAIL` line per package. Count `ok` lines as a coarse tests-ran
+	// proxy since individual test counts aren't recoverable from this shape.
+	if okLines := len(reGoOK.FindAllString(log, -1)); okLines > 0 {
+		return okLines, 0, true
+	}
+
+	// Only "[no test files]" markers and no ok/PASS/FAIL lines at all: the
+	// job ran but exercised zero test files.
+	if reGoNoTestFiles.MatchString(log) {
+		return 0, 0, true
+	}
+
+	return 0, 0, false
+}
+
+// TestEvidenceReason returns a non-empty escalation reason when the test-
+// evidence gate should hold auto-merge: the combined CI job log shows fewer
+// than cfg.MinTests executed tests, or a skip ratio above cfg.MaxSkipRatio,
+// on a PR that touches production source (files with a nonzero production
+// addition per productionAdditions — see scope_guard.go). Empty string means
+// no escalation: the gate is disabled, the log didn't parse (fail-open), or
+// the PR doesn't touch production code (nothing to expect test coverage for).
+func TestEvidenceReason(logger *slog.Logger, cfg *TestEvidenceConfig, files []*github.PRFile, log string) string {
+	if cfg == nil || !cfg.Enabled {
+		return ""
+	}
+
+	production, _, _ := productionAdditions(files)
+	if production == 0 {
+		return ""
+	}
+
+	testsRun, testsSkipped, parsed := parseTestEvidence(log)
+	if !parsed {
+		if logger != nil {
+			logger.Warn("test-evidence gate abstained: could not parse CI job log (fail-open)")
+		}
+		return ""
+	}
+
+	minTests := cfg.MinTests
+	if minTests <= 0 {
+		minTests = defaultMinTests
+	}
+	maxSkipRatio := cfg.MaxSkipRatio
+	if maxSkipRatio <= 0 {
+		maxSkipRatio = defaultMaxSkipRatio
+	}
+
+	if testsRun < minTests {
+		return fmt.Sprintf("test-evidence gate: CI log shows %d test(s) run (< min_tests=%d) on a PR with %d production-line additions — green CI did not verify this change",
+			testsRun, minTests, production)
+	}
+
+	if total := testsRun + testsSkipped; total > 0 {
+		skipRatio := float64(testsSkipped) / float64(total)
+		if skipRatio > maxSkipRatio {
+			return fmt.Sprintf("test-evidence gate: %d/%d tests skipped (%.0f%% > max_skip_ratio=%.0f%%)",
+				testsSkipped, total, skipRatio*100, maxSkipRatio*100)
+		}
+	}
+
+	return ""
+}

--- a/internal/autopilot/test_evidence_test.go
+++ b/internal/autopilot/test_evidence_test.go
@@ -1,0 +1,250 @@
+package autopilot
+
+import (
+	"strings"
+	"testing"
+
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+func TestParseTestEvidence(t *testing.T) {
+	cases := []struct {
+		name        string
+		log         string
+		wantRun     int
+		wantSkipped int
+		wantParsed  bool
+	}{
+		{
+			name: "go verbose PASS/SKIP",
+			log: strings.Join([]string{
+				"=== RUN   TestFoo",
+				"--- PASS: TestFoo (0.00s)",
+				"=== RUN   TestBar",
+				"--- SKIP: TestBar (0.00s)",
+				"=== RUN   TestBaz",
+				"--- PASS: TestBaz (0.00s)",
+				"PASS",
+				"ok  \tgithub.com/qf-studio/pilot-console/internal/fleet\t0.010s",
+			}, "\n"),
+			wantRun:     2,
+			wantSkipped: 1,
+			wantParsed:  true,
+		},
+		{
+			name: "go non-verbose ok summary",
+			log: strings.Join([]string{
+				"ok  \tgithub.com/qf-studio/pilot/internal/executor\t0.512s",
+				"ok  \tgithub.com/qf-studio/pilot/internal/memory\t0.223s",
+			}, "\n"),
+			wantRun:     2,
+			wantSkipped: 0,
+			wantParsed:  true,
+		},
+		{
+			name: "go no test files",
+			log: strings.Join([]string{
+				"?   \tgithub.com/qf-studio/pilot/internal/fleet\t[no test files]",
+			}, "\n"),
+			wantRun:     0,
+			wantSkipped: 0,
+			wantParsed:  true,
+		},
+		{
+			name: "go all skipped, still ok per package (the pilot-console PR #13 shape)",
+			log: strings.Join([]string{
+				"=== RUN   TestStore_Create",
+				"    store_test.go:12: skipping: DATABASE_URL not set",
+				"--- SKIP: TestStore_Create (0.00s)",
+				"=== RUN   TestStore_Update",
+				"    store_test.go:30: skipping: DATABASE_URL not set",
+				"--- SKIP: TestStore_Update (0.00s)",
+				"PASS",
+				"ok  \tgithub.com/qf-studio/pilot-console/internal/fleet\t0.005s",
+			}, "\n"),
+			wantRun:     0,
+			wantSkipped: 2,
+			wantParsed:  true,
+		},
+		{
+			name: "vitest summary with skips",
+			log: strings.Join([]string{
+				" Test Files  3 passed (3)",
+				"      Tests  42 passed | 5 skipped (47)",
+				"   Start at  10:00:00",
+				"   Duration  1.20s",
+			}, "\n"),
+			wantRun:     42,
+			wantSkipped: 5,
+			wantParsed:  true,
+		},
+		{
+			name: "vitest summary with no skips",
+			log: strings.Join([]string{
+				" Test Files  1 passed (1)",
+				"      Tests  12 passed (12)",
+			}, "\n"),
+			wantRun:     12,
+			wantSkipped: 0,
+			wantParsed:  true,
+		},
+		{
+			name: "jest summary with skips",
+			log: strings.Join([]string{
+				"Tests:       5 skipped, 40 passed, 45 total",
+				"Test Suites: 6 passed, 6 total",
+			}, "\n"),
+			wantRun:     40,
+			wantSkipped: 5,
+			wantParsed:  true,
+		},
+		{
+			name:        "garbage log fails open",
+			log:         "Building Docker image...\nPushing to registry...\ndone.",
+			wantRun:     0,
+			wantSkipped: 0,
+			wantParsed:  false,
+		},
+		{
+			name:        "empty log fails open",
+			log:         "",
+			wantRun:     0,
+			wantSkipped: 0,
+			wantParsed:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			run, skipped, parsed := parseTestEvidence(tc.log)
+			if parsed != tc.wantParsed {
+				t.Fatalf("parsed = %v, want %v", parsed, tc.wantParsed)
+			}
+			if run != tc.wantRun {
+				t.Errorf("testsRun = %d, want %d", run, tc.wantRun)
+			}
+			if skipped != tc.wantSkipped {
+				t.Errorf("testsSkipped = %d, want %d", skipped, tc.wantSkipped)
+			}
+		})
+	}
+}
+
+func TestTestEvidenceReason(t *testing.T) {
+	sourceFiles := []*github.PRFile{
+		{Filename: "internal/fleet/store.go", Status: "modified", Additions: 40},
+	}
+	docsOnlyFiles := []*github.PRFile{
+		{Filename: ".agent/tasks/TASK-1.md", Status: "modified", Additions: 40},
+	}
+
+	cases := []struct {
+		name         string
+		cfg          *TestEvidenceConfig
+		files        []*github.PRFile
+		log          string
+		wantContains string // empty = expect no escalation
+	}{
+		{
+			name:         "disabled config never escalates",
+			cfg:          &TestEvidenceConfig{Enabled: false},
+			files:        sourceFiles,
+			log:          "?   \tpkg\t[no test files]",
+			wantContains: "",
+		},
+		{
+			name:         "nil config never escalates",
+			cfg:          nil,
+			files:        sourceFiles,
+			log:          "?   \tpkg\t[no test files]",
+			wantContains: "",
+		},
+		{
+			name:         "zero tests run escalates",
+			cfg:          &TestEvidenceConfig{Enabled: true},
+			files:        sourceFiles,
+			log:          "?   \tpkg\t[no test files]",
+			wantContains: "0 test(s) run",
+		},
+		{
+			name:  "all-skipped escalates over max_skip_ratio",
+			cfg:   &TestEvidenceConfig{Enabled: true},
+			files: sourceFiles,
+			log: strings.Join([]string{
+				"--- SKIP: TestA (0.00s)",
+				"--- SKIP: TestB (0.00s)",
+				"--- SKIP: TestC (0.00s)",
+				"--- PASS: TestD (0.00s)",
+			}, "\n"),
+			wantContains: "3/4 tests skipped",
+		},
+		{
+			name:  "skip ratio under threshold does not escalate",
+			cfg:   &TestEvidenceConfig{Enabled: true},
+			files: sourceFiles,
+			log: strings.Join([]string{
+				"--- SKIP: TestA (0.00s)",
+				"--- PASS: TestB (0.00s)",
+				"--- PASS: TestC (0.00s)",
+				"--- PASS: TestD (0.00s)",
+			}, "\n"),
+			wantContains: "",
+		},
+		{
+			name:         "rigorous pass does not escalate",
+			cfg:          &TestEvidenceConfig{Enabled: true},
+			files:        sourceFiles,
+			log:          "--- PASS: TestA (0.00s)\n--- PASS: TestB (0.00s)\nok  \tpkg\t0.010s",
+			wantContains: "",
+		},
+		{
+			name:         "bookkeeping-only PR abstains even with zero tests",
+			cfg:          &TestEvidenceConfig{Enabled: true},
+			files:        docsOnlyFiles,
+			log:          "?   \tpkg\t[no test files]",
+			wantContains: "",
+		},
+		{
+			name:         "garbage log fails open even when enabled",
+			cfg:          &TestEvidenceConfig{Enabled: true},
+			files:        sourceFiles,
+			log:          "Building Docker image...\ndone.",
+			wantContains: "",
+		},
+		{
+			name:         "custom min_tests threshold",
+			cfg:          &TestEvidenceConfig{Enabled: true, MinTests: 5},
+			files:        sourceFiles,
+			log:          "--- PASS: TestA (0.00s)\n--- PASS: TestB (0.00s)",
+			wantContains: "< min_tests=5",
+		},
+		{
+			name:  "custom max_skip_ratio threshold",
+			cfg:   &TestEvidenceConfig{Enabled: true, MaxSkipRatio: 0.9},
+			files: sourceFiles,
+			log: strings.Join([]string{
+				"--- SKIP: TestA (0.00s)",
+				"--- SKIP: TestB (0.00s)",
+				"--- SKIP: TestC (0.00s)",
+				"--- PASS: TestD (0.00s)",
+			}, "\n"),
+			// 75% skipped is below the raised 90% threshold — no escalation.
+			wantContains: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := TestEvidenceReason(nil, tc.cfg, tc.files, tc.log)
+			if tc.wantContains == "" {
+				if got != "" {
+					t.Fatalf("TestEvidenceReason = %q, want no escalation", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.wantContains) {
+				t.Fatalf("TestEvidenceReason = %q, want substring %q", got, tc.wantContains)
+			}
+		})
+	}
+}

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -177,6 +177,33 @@ type Config struct {
 	// Name is a user-friendly label for this environment (e.g. "staging", "production").
 	// When empty, defaults to the Environment value.
 	Name string `yaml:"name"`
+
+	// TestEvidence configures the post-CI test-evidence gate (GH-4329): escalate
+	// to human approval when green CI ran zero/skipped tests on a PR that
+	// touches production source. nil (the DefaultConfig default) means the gate
+	// is off — enable per-project once canaried.
+	TestEvidence *TestEvidenceConfig `yaml:"test_evidence"`
+}
+
+// TestEvidenceConfig configures the test-evidence escalate-only gate at the
+// handleCIPassed chokepoint (GH-4329), same defense-in-depth pattern as
+// ScopeDriftReason/SizeFloorReason in scope_guard.go: it only forces human
+// approval, it never merges silently and never relaxes an already-required
+// approval.
+//
+// Born from qf-studio/pilot-console PR #13 (2026-07-15): autopilot auto-merged
+// on green CI while the `test` job silently skipped an entire suite (gated on
+// a DATABASE_URL the workflow never provided). "CI concluded success" and
+// "code was tested" are not the same statement.
+type TestEvidenceConfig struct {
+	// Enabled controls whether the gate is active. Default off.
+	Enabled bool `yaml:"enabled"`
+	// MinTests is the minimum number of tests that must have run for CI's
+	// signal to count as rigorous. Zero/unset falls back to 1.
+	MinTests int `yaml:"min_tests"`
+	// MaxSkipRatio is the skipped/(run+skipped) fraction above which the gate
+	// escalates even though some tests ran. Zero/unset falls back to 0.5.
+	MaxSkipRatio float64 `yaml:"max_skip_ratio"`
 }
 
 // ReviewFeedbackConfig holds configuration for handling PR review change requests.


### PR DESCRIPTION
## Summary

- Adds an escalate-only test-evidence gate at the `handleCIPassed` chokepoint (same defense-in-depth pattern as `scope_guard.go`'s scope-drift/size-floor gates): green CI proves a check concluded success, not that code was tested.
- Fetches completed check-run job logs for the head SHA (`CIMonitor.GetCheckLogs`, new — includes successful/skipped runs, unlike `GetFailedCheckLogs`), parses Go (`--- PASS/SKIP/FAIL`, `ok` package summaries, `[no test files]`) and vitest/jest summary lines for `tests_run`/`tests_skipped`.
- Holds auto-merge (`StageAwaitApproval`), posts a PR comment, and journals a `test_evidence_hold` execution event when zero tests ran or the skip ratio exceeds `max_skip_ratio`, on a PR that touches production source (bookkeeping/test-only diffs abstain).
- Unparseable logs fail open (logged warning, no escalation) — no coverage measurement, no CI re-runs, never blocks CI itself.
- New `autopilot.test_evidence: {enabled, min_tests, max_skip_ratio}` config block, default OFF — per-project opt-in once canaried (pilot repo + pilot-console first).

## Context

qf-studio/pilot-console PR #13 (2026-07-15) auto-merged on green CI while the `test` job silently skipped an entire suite (gated on a `DATABASE_URL` the workflow never provided) — three mutation-verified store defects would have passed. The repo-level hole was fixed in pilot-console#16; this closes the orchestrator-level gap.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/autopilot/...` (incl. new parser table tests, controller enabled/disabled gate test, `GetCheckLogs` test)
- [x] `go test -race ./internal/autopilot/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] `go test ./...` (full repo) — all green