### PR TITLE
fix(autopilot): scope-release train unrecoverable after terminal 'failed' state

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -945,6 +945,23 @@ func (c *Controller) RestoreState() (int, error) {
 		if pr.Stage == StageFailed {
 			continue
 		}
+		// GH-4331: a scope carrier whose scope-release row already resolved
+		// terminal (failed/done) between its last persist and this restart
+		// must not be rehydrated — re-ticking it would re-run
+		// handleScopeReleaseFailure against a row MarkScopeReleasePending's
+		// terminal guard now refuses to touch, bouncing forever without ever
+		// re-registering through startPendingScopeReleases (the zombie-carrier
+		// class identified in GH-4331's RCA).
+		if pr.ScopeKey != "" && c.stateStore != nil {
+			if row, err := c.stateStore.GetScopeRelease(c.repoKey(), pr.ScopeKey); err != nil {
+				c.log.Warn("RestoreState: failed to check scope release state, rehydrating carrier anyway",
+					"pr", pr.PRNumber, "scope", pr.ScopeKey, "error", err)
+			} else if row != nil && (row.State == "failed" || row.State == "done") {
+				c.log.Info("RestoreState: skipping rehydration of carrier for terminal scope release",
+					"pr", pr.PRNumber, "scope", pr.ScopeKey, "scope_state", row.State)
+				continue
+			}
+		}
 		c.activePRs[pr.PRNumber] = pr
 	}
 	c.mu.Unlock()

--- a/internal/autopilot/scope_release.go
+++ b/internal/autopilot/scope_release.go
@@ -89,11 +89,13 @@ func (c *Controller) startPendingScopeReleases(ctx context.Context) {
 			continue
 		}
 		c.log.Info("re-driving scope release with no live carrier", "scope", row.ScopeKey)
-		if err := c.stateStore.MarkScopeReleasePending(repo, row.ScopeKey, false); err != nil {
+		if err := c.stateStore.MarkScopeReleasePending(repo, row.ScopeKey, false, ""); err != nil {
 			c.log.Warn("startPendingScopeReleases: failed to re-queue stale releasing row",
 				"scope", row.ScopeKey, "error", err)
 		}
 	}
+
+	c.recoverFailedScopeReleases(ctx)
 
 	pending, err := c.stateStore.ListScopeReleases(repo, "pending")
 	if err != nil {
@@ -102,6 +104,42 @@ func (c *Controller) startPendingScopeReleases(ctx context.Context) {
 	}
 	for _, row := range pending {
 		c.tryStartScopeRelease(row)
+	}
+}
+
+// recoverFailedScopeReleases resurrects terminal 'failed' scope-release rows
+// once main has moved past the SHA they last failed against — turning a
+// same-day fix into a same-day release instead of leaving the train dead
+// until tomorrow's scope rolls it forward. Attempts reset to 0 so the fresh
+// carrier retries against the new commit with the full budget (GH-4331).
+// Rows with no recorded LastFailedSHA (pre-migration data) are left alone —
+// there is nothing to compare against, so leave the human-alerted terminal
+// state as-is rather than guess.
+func (c *Controller) recoverFailedScopeReleases(ctx context.Context) {
+	repo := c.repoKey()
+	failed, err := c.stateStore.ListScopeReleases(repo, "failed")
+	if err != nil {
+		c.log.Warn("recoverFailedScopeReleases: failed to list failed scope rows", "error", err)
+		return
+	}
+	if len(failed) == 0 {
+		return
+	}
+	mainSHA, err := c.getMainBranchSHA(ctx)
+	if err != nil {
+		c.log.Warn("recoverFailedScopeReleases: failed to get main branch SHA", "error", err)
+		return
+	}
+	for _, row := range failed {
+		if row.LastFailedSHA == "" || row.LastFailedSHA == mainSHA {
+			continue
+		}
+		if err := c.stateStore.ResetScopeReleaseForRetry(repo, row.ScopeKey); err != nil {
+			c.log.Warn("recoverFailedScopeReleases: failed to reset scope release", "scope", row.ScopeKey, "error", err)
+			continue
+		}
+		c.log.Info("recovered terminal scope release for retry against new main HEAD",
+			"scope", row.ScopeKey, "old_sha", ShortSHA(row.LastFailedSHA), "new_sha", ShortSHA(mainSHA))
 	}
 }
 
@@ -117,7 +155,7 @@ func (c *Controller) tryStartScopeRelease(row *ScopeRelease) {
 		return
 	}
 	if c.memberPRsStillActive(row.MemberPRs) {
-		c.log.Debug("deferring scope release: a member PR is still mid-pipeline", "scope", row.ScopeKey)
+		c.log.Info("deferring scope release: a member PR is still mid-pipeline", "scope", row.ScopeKey)
 		return
 	}
 
@@ -128,7 +166,7 @@ func (c *Controller) tryStartScopeRelease(row *ScopeRelease) {
 	_, tracked := c.activePRs[anchorPR]
 	c.mu.RUnlock()
 	if tracked {
-		c.log.Debug("deferring scope release: anchor PR already tracked", "scope", row.ScopeKey, "anchor_pr", anchorPR)
+		c.log.Info("deferring scope release: anchor PR already tracked", "scope", row.ScopeKey, "anchor_pr", anchorPR)
 		return
 	}
 	if age, found, err := c.stateStore.PersistedReleasingAge(repo, anchorPR); err != nil {
@@ -136,7 +174,7 @@ func (c *Controller) tryStartScopeRelease(row *ScopeRelease) {
 			"scope", row.ScopeKey, "anchor_pr", anchorPR, "error", err)
 		return
 	} else if found && age < releasingStaleThreshold {
-		c.log.Debug("deferring scope release: anchor PR has a fresh persisted releasing row",
+		c.log.Info("deferring scope release: anchor PR has a fresh persisted releasing row",
 			"scope", row.ScopeKey, "anchor_pr", anchorPR)
 		return
 	}
@@ -329,7 +367,7 @@ func (c *Controller) handleScopeReleaseFailure(ctx context.Context, prState *PRS
 		return
 	}
 	repo := c.repoKey()
-	if err := c.stateStore.MarkScopeReleasePending(repo, prState.ScopeKey, true); err != nil {
+	if err := c.stateStore.MarkScopeReleasePending(repo, prState.ScopeKey, true, prState.PostMergeSHA); err != nil {
 		c.log.Warn("handleScopeReleaseFailure: failed to re-queue scope release", "scope", prState.ScopeKey, "error", err)
 		return
 	}

--- a/internal/autopilot/scope_release_state_store_test.go
+++ b/internal/autopilot/scope_release_state_store_test.go
@@ -130,7 +130,7 @@ func TestStateStore_MarkScopeReleasePending_AttemptsIncrement(t *testing.T) {
 	}
 
 	// incrementAttempts=false: crash-recovery re-drive, attempts unchanged.
-	if err := store.MarkScopeReleasePending("owner/repo", "epic:1", false); err != nil {
+	if err := store.MarkScopeReleasePending("owner/repo", "epic:1", false, ""); err != nil {
 		t.Fatalf("MarkScopeReleasePending(false) failed: %v", err)
 	}
 	row, err := store.GetScopeRelease("owner/repo", "epic:1")
@@ -141,8 +141,9 @@ func TestStateStore_MarkScopeReleasePending_AttemptsIncrement(t *testing.T) {
 		t.Errorf("state/attempts = %q/%d, want pending/0", row.State, row.Attempts)
 	}
 
-	// incrementAttempts=true: genuine carrier failure, attempts bumps.
-	if err := store.MarkScopeReleasePending("owner/repo", "epic:1", true); err != nil {
+	// incrementAttempts=true: genuine carrier failure, attempts bumps and
+	// last_failed_sha is recorded.
+	if err := store.MarkScopeReleasePending("owner/repo", "epic:1", true, "redsha1"); err != nil {
 		t.Fatalf("MarkScopeReleasePending(true) failed: %v", err)
 	}
 	row, err = store.GetScopeRelease("owner/repo", "epic:1")
@@ -151,6 +152,9 @@ func TestStateStore_MarkScopeReleasePending_AttemptsIncrement(t *testing.T) {
 	}
 	if row.Attempts != 1 {
 		t.Errorf("Attempts = %d, want 1", row.Attempts)
+	}
+	if row.LastFailedSHA != "redsha1" {
+		t.Errorf("LastFailedSHA = %q, want redsha1", row.LastFailedSHA)
 	}
 }
 

--- a/internal/autopilot/scope_release_test.go
+++ b/internal/autopilot/scope_release_test.go
@@ -300,7 +300,7 @@ func TestScopeCarrier_AttemptsCapEscalatesToFailedAlert(t *testing.T) {
 	}
 	// Pre-load the row to attempts=maxScopeReleaseAttempts so the next failure crosses the cap.
 	for i := 0; i < maxScopeReleaseAttempts; i++ {
-		if err := stateStore.MarkScopeReleasePending("owner/repo", "epic:1", true); err != nil {
+		if err := stateStore.MarkScopeReleasePending("owner/repo", "epic:1", true, "redsha"); err != nil {
 			t.Fatalf("MarkScopeReleasePending failed: %v", err)
 		}
 	}
@@ -666,5 +666,179 @@ func TestScopeCarrierAPIMode_ReleaseBodyContainsAllElements(t *testing.T) {
 		if !strings.Contains(createdBody, want) {
 			t.Errorf("release body missing %q\n--- got ---\n%s", want, createdBody)
 		}
+	}
+}
+
+// TestHandleScopeReleaseFailure_TerminalFailedRowIsNotResurrected is the
+// GH-4331 regression guard for the zombie-carrier bounce identified in the
+// RCA: a scope-release row that already reached terminal 'failed' (attempts
+// exhausted, human alerted) must never be flipped back to 'pending' by a
+// restart-rehydrated carrier still ticking against it. Before the fix,
+// MarkScopeReleasePending had no state guard, so each failure bounced the row
+// failed->pending->failed and kept inflating attempts forever (observed in
+// production: train:07-13 attempts=19, train:07-14 attempts=11).
+func TestHandleScopeReleaseFailure_TerminalFailedRowIsNotResurrected(t *testing.T) {
+	stateStore := newTestStateStore(t)
+	if err := stateStore.EnqueueScopeRelease("owner/repo", "epic:1", "epic", []int{9}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+	// Seed the row directly as already terminal-failed with attempts past the
+	// cap — simulates state left behind by a prior daemon run.
+	if _, err := stateStore.db.Exec(
+		`UPDATE autopilot_scope_release SET state = 'failed', attempts = 6, last_failed_sha = 'redsha' WHERE repo = ? AND scope_key = ?`,
+		"owner/repo", "epic:1",
+	); err != nil {
+		t.Fatalf("failed to seed terminal row: %v", err)
+	}
+
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_scope_close"}
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, "http://127.0.0.1:0")
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.SetStateStore(stateStore)
+	c.SetAlertsEngine(&fakeAlertSink{})
+
+	// Restart-rehydrated zombie carrier: still tracked at StagePostMergeCI
+	// even though its scope already resolved terminal.
+	prState := &PRState{PRNumber: 9, ScopeKey: "epic:1", IssueNumber: 1, Stage: StagePostMergeCI, PostMergeSHA: "redsha"}
+
+	c.handleScopeReleaseFailure(context.Background(), prState, "post-merge CI failed")
+	c.handleScopeReleaseFailure(context.Background(), prState, "post-merge CI failed")
+
+	row, err := stateStore.GetScopeRelease("owner/repo", "epic:1")
+	if err != nil || row == nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+	if row.State != "failed" {
+		t.Errorf("state = %q, want failed (terminal row must not be resurrected)", row.State)
+	}
+	if row.Attempts != 6 {
+		t.Errorf("attempts = %d, want 6 (unchanged)", row.Attempts)
+	}
+}
+
+// TestMarkScopeReleaseDone_EmptyTagDoesNotBlankRecordedTag is the GH-4331
+// regression guard: a restart replay that re-observes an already-'done' scope
+// as a no-op release (empty tag, e.g. CompareCommits finds nothing new past
+// the tag) must not blank the tag a prior pass already recorded.
+func TestMarkScopeReleaseDone_EmptyTagDoesNotBlankRecordedTag(t *testing.T) {
+	store := newTestStateStore(t)
+	if err := store.EnqueueScopeRelease("owner/repo", "epic:1", "epic", []int{1}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+	if _, err := store.ClaimScopeRelease("owner/repo", "epic:1"); err != nil {
+		t.Fatalf("ClaimScopeRelease failed: %v", err)
+	}
+	if err := store.MarkScopeReleaseDone("owner/repo", "epic:1", "v2.238.0", "sha1"); err != nil {
+		t.Fatalf("MarkScopeReleaseDone failed: %v", err)
+	}
+
+	// Restart replay re-observes the same scope as a no-op release.
+	if err := store.MarkScopeReleaseDone("owner/repo", "epic:1", "", "sha2"); err != nil {
+		t.Fatalf("MarkScopeReleaseDone (no-op replay) failed: %v", err)
+	}
+
+	row, err := store.GetScopeRelease("owner/repo", "epic:1")
+	if err != nil || row == nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+	if row.Tag != "v2.238.0" {
+		t.Errorf("Tag = %q, want v2.238.0 (must not be blanked by no-op replay)", row.Tag)
+	}
+	if row.FinalSHA != "sha2" {
+		t.Errorf("FinalSHA = %q, want sha2 (final_sha always updates)", row.FinalSHA)
+	}
+}
+
+// TestStartPendingScopeReleases_DoesNotClaimFailedRows is a characterization
+// pin (GH-4331): startPendingScopeReleases only ever lists 'releasing' and
+// 'pending' rows for claiming, so a terminal 'failed' row (with no
+// LastFailedSHA to compare against, i.e. nothing for recoverFailedScopeReleases
+// to act on) is left untouched by the sweep. Passes both before and after the
+// GH-4331 fix — guards against a naive "retry failed rows unconditionally"
+// implementation.
+func TestStartPendingScopeReleases_DoesNotClaimFailedRows(t *testing.T) {
+	stateStore := newTestStateStore(t)
+	if err := stateStore.EnqueueScopeRelease("owner/repo", "epic:1", "epic", []int{9}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+	if _, err := stateStore.db.Exec(
+		`UPDATE autopilot_scope_release SET state = 'failed', attempts = 6 WHERE repo = ? AND scope_key = ?`,
+		"owner/repo", "epic:1",
+	); err != nil {
+		t.Fatalf("failed to seed terminal row: %v", err)
+	}
+
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_scope_close"}
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, "http://127.0.0.1:0")
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.SetStateStore(stateStore)
+
+	c.startPendingScopeReleases(context.Background())
+
+	if _, ok := c.GetPRState(9); ok {
+		t.Error("expected no carrier registered for a terminal failed row")
+	}
+	row, err := stateStore.GetScopeRelease("owner/repo", "epic:1")
+	if err != nil || row == nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+	if row.State != "failed" {
+		t.Errorf("state = %q, want failed (unclaimed, unchanged)", row.State)
+	}
+}
+
+// TestRecoverFailedScopeReleases_ResetsAttemptsWhenMainAdvances verifies the
+// GH-4331 self-healing recovery path from the acceptance criteria: once main
+// moves past the SHA a terminal 'failed' scope last failed against, the next
+// startPendingScopeReleases sweep resurrects it as 'pending' with attempts
+// reset to 0, and the same sweep's tryStartScopeRelease claim registers a
+// fresh carrier — turning a same-day fix into a same-day release instead of
+// leaving the train dead until tomorrow's scope rolls it forward.
+func TestRecoverFailedScopeReleases_ResetsAttemptsWhenMainAdvances(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/branches/main":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"name": "main", "commit": map[string]string{"sha": "greensha"}})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	stateStore := newTestStateStore(t)
+	if err := stateStore.EnqueueScopeRelease("owner/repo", "epic:1", "epic", []int{9}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+	if _, err := stateStore.db.Exec(
+		`UPDATE autopilot_scope_release SET state = 'failed', attempts = 6, last_failed_sha = 'redsha' WHERE repo = ? AND scope_key = ?`,
+		"owner/repo", "epic:1",
+	); err != nil {
+		t.Fatalf("failed to seed terminal row: %v", err)
+	}
+
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_scope_close"}
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.SetStateStore(stateStore)
+
+	c.startPendingScopeReleases(context.Background())
+
+	if _, ok := c.GetPRState(9); !ok {
+		t.Fatal("expected a fresh carrier registered after self-recovery against the new main HEAD")
+	}
+	row, err := stateStore.GetScopeRelease("owner/repo", "epic:1")
+	if err != nil || row == nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+	if row.State != "releasing" {
+		t.Errorf("state = %q, want releasing (claimed by tryStartScopeRelease)", row.State)
+	}
+	if row.Attempts != 0 {
+		t.Errorf("attempts = %d, want 0 (reset on recovery)", row.Attempts)
 	}
 }

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -144,6 +144,11 @@ func (s *StateStore) migrate() error {
 		// each mint a fresh "fix(ci): resolve post-merge CI failure..." issue —
 		// this table is checked (via ClaimSpawnedFix) before every
 		// CreateFailureIssue call so only the first observation creates one.
+		// GH-4331: track the main-HEAD SHA a scope-release carrier last failed
+		// against, so a recovery sweep can distinguish "still the same red
+		// commit" (leave terminal) from "main moved, worth retrying" without
+		// re-running CI itself.
+		`ALTER TABLE autopilot_scope_release ADD COLUMN last_failed_sha TEXT NOT NULL DEFAULT ''`,
 		`CREATE TABLE IF NOT EXISTS autopilot_spawned_fixes (
 			repo TEXT NOT NULL,
 			dedup_key TEXT NOT NULL,
@@ -970,8 +975,11 @@ type ScopeRelease struct {
 	FinalSHA   string
 	Tag        string
 	Attempts   int
-	CreatedAt  time.Time
-	UpdatedAt  time.Time
+	// LastFailedSHA is the main-HEAD SHA this scope last failed a carrier
+	// against (GH-4331). Empty until the first genuine carrier failure.
+	LastFailedSHA string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
 }
 
 // encodeIntCSV renders a sorted []int as a comma-separated string for storage
@@ -1096,7 +1104,7 @@ func (s *StateStore) GetSpawnedFixIssue(repo, dedupKey string) (int, error) {
 // if not found.
 func (s *StateStore) GetScopeRelease(repo, scopeKey string) (*ScopeRelease, error) {
 	row := s.db.QueryRow(`
-		SELECT repo, scope_key, scope_title, member_prs, anchor_pr, state, final_sha, tag, attempts, created_at, updated_at
+		SELECT repo, scope_key, scope_title, member_prs, anchor_pr, state, final_sha, tag, attempts, last_failed_sha, created_at, updated_at
 		FROM autopilot_scope_release WHERE repo = ? AND scope_key = ?
 	`, repo, scopeKey)
 	sr, err := scanScopeRelease(row.Scan)
@@ -1123,7 +1131,7 @@ func (s *StateStore) ListScopeReleases(repo string, states ...string) ([]*ScopeR
 		args = append(args, st)
 	}
 	query := fmt.Sprintf(`
-		SELECT repo, scope_key, scope_title, member_prs, anchor_pr, state, final_sha, tag, attempts, created_at, updated_at
+		SELECT repo, scope_key, scope_title, member_prs, anchor_pr, state, final_sha, tag, attempts, last_failed_sha, created_at, updated_at
 		FROM autopilot_scope_release WHERE repo = ? AND state IN (%s)
 	`, strings.Join(placeholders, ", "))
 	rows, err := s.db.Query(query, args...)
@@ -1145,28 +1153,42 @@ func (s *StateStore) ListScopeReleases(repo string, states ...string) ([]*ScopeR
 
 // MarkScopeReleaseDone marks a scope-release row terminal-success. tag is ""
 // for a no-op release (BumpNone — the scope's commits carry no releasable
-// change), recorded so a no-op scope never retries.
+// change), recorded so a no-op scope never retries. GH-4331: an empty tag
+// here never blanks an already-recorded tag — a restart replay re-observing
+// the same completed scope as a no-op (e.g. after CompareCommits sees
+// nothing new post-tag) must not erase the tag a prior pass already wrote.
 func (s *StateStore) MarkScopeReleaseDone(repo, scopeKey, tag, finalSHA string) error {
 	_, err := s.db.Exec(`
 		UPDATE autopilot_scope_release
-		SET state = 'done', tag = ?, final_sha = ?, updated_at = CURRENT_TIMESTAMP
+		SET state = 'done', tag = CASE WHEN ? = '' THEN tag ELSE ? END, final_sha = ?, updated_at = CURRENT_TIMESTAMP
 		WHERE repo = ? AND scope_key = ?
-	`, tag, finalSHA, repo, scopeKey)
+	`, tag, tag, finalSHA, repo, scopeKey)
 	return err
 }
 
 // MarkScopeReleasePending re-queues a scope-release row as 'pending' so the
 // next startPendingScopeReleases sweep claims a fresh carrier for it.
 // incrementAttempts distinguishes a genuine carrier failure (true — bumps the
-// retry-cap counter handleScopeReleaseFailure checks) from crash recovery
-// (false — a 'releasing' row left with no live carrier after a restart, which
-// is not itself a failure of the release).
-func (s *StateStore) MarkScopeReleasePending(repo, scopeKey string, incrementAttempts bool) error {
-	q := `UPDATE autopilot_scope_release SET state = 'pending', updated_at = CURRENT_TIMESTAMP WHERE repo = ? AND scope_key = ?`
+// retry-cap counter handleScopeReleaseFailure checks, and records failedSHA as
+// the main-HEAD SHA that failed) from crash recovery (false — a 'releasing'
+// row left with no live carrier after a restart, which is not itself a
+// failure of the release; failedSHA is ignored in that case).
+//
+// GH-4331: rows already terminal ('failed' or 'done') are never matched —
+// without this guard, a zombie carrier rehydrated from a persisted PRState
+// whose scope already resolved terminal would bounce the row
+// failed->pending->failed forever every tick, inflating attempts far past
+// maxScopeReleaseAttempts. Recovery for a genuinely stuck 'failed' row is
+// ResetScopeReleaseForRetry, called only once main has moved past
+// LastFailedSHA.
+func (s *StateStore) MarkScopeReleasePending(repo, scopeKey string, incrementAttempts bool, failedSHA string) error {
+	q := `UPDATE autopilot_scope_release SET state = 'pending', updated_at = CURRENT_TIMESTAMP WHERE repo = ? AND scope_key = ? AND state NOT IN ('failed', 'done')`
+	args := []interface{}{repo, scopeKey}
 	if incrementAttempts {
-		q = `UPDATE autopilot_scope_release SET state = 'pending', attempts = attempts + 1, updated_at = CURRENT_TIMESTAMP WHERE repo = ? AND scope_key = ?`
+		q = `UPDATE autopilot_scope_release SET state = 'pending', attempts = attempts + 1, last_failed_sha = CASE WHEN ? = '' THEN last_failed_sha ELSE ? END, updated_at = CURRENT_TIMESTAMP WHERE repo = ? AND scope_key = ? AND state NOT IN ('failed', 'done')`
+		args = []interface{}{failedSHA, failedSHA, repo, scopeKey}
 	}
-	_, err := s.db.Exec(q, repo, scopeKey)
+	_, err := s.db.Exec(q, args...)
 	return err
 }
 
@@ -1176,6 +1198,21 @@ func (s *StateStore) MarkScopeReleaseFailed(repo, scopeKey string) error {
 	_, err := s.db.Exec(`
 		UPDATE autopilot_scope_release SET state = 'failed', updated_at = CURRENT_TIMESTAMP
 		WHERE repo = ? AND scope_key = ?
+	`, repo, scopeKey)
+	return err
+}
+
+// ResetScopeReleaseForRetry resurrects a terminal 'failed' scope-release row
+// for a fresh attempt, resetting attempts to 0 so the new carrier gets the
+// full retry budget. Callers (recoverFailedScopeReleases) must only invoke
+// this once main has moved past the SHA the row last failed against — this
+// method itself does not compare SHAs, it just performs the resurrection
+// (GH-4331).
+func (s *StateStore) ResetScopeReleaseForRetry(repo, scopeKey string) error {
+	_, err := s.db.Exec(`
+		UPDATE autopilot_scope_release
+		SET state = 'pending', attempts = 0, updated_at = CURRENT_TIMESTAMP
+		WHERE repo = ? AND scope_key = ? AND state = 'failed'
 	`, repo, scopeKey)
 	return err
 }
@@ -1219,7 +1256,7 @@ func scanScopeRelease(scan func(dest ...interface{}) error) (*ScopeRelease, erro
 	var createdAt, updatedAt sql.NullTime
 	err := scan(
 		&sr.Repo, &sr.ScopeKey, &sr.ScopeTitle, &memberCSV, &sr.AnchorPR,
-		&sr.State, &sr.FinalSHA, &sr.Tag, &sr.Attempts, &createdAt, &updatedAt,
+		&sr.State, &sr.FinalSHA, &sr.Tag, &sr.Attempts, &sr.LastFailedSHA, &createdAt, &updatedAt,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Closes #4331.

Implements against the issue's current (RCA-corrected 2026-07-15) body — the
scope-release train's terminal-failed recovery gap and zombie-carrier
resurrection, not the originally-filed `CheckCI`/`GetFailedChecks` exclusion
hypothesis, which the RCA refuted for both incident days (the exclusion
filtering already works correctly).

- `MarkScopeReleasePending` refuses to touch rows already `failed`/`done`,
  closing the bounce (`failed -> pending -> failed`, observed attempts=19/11
  in production) at the state-store layer.
- `MarkScopeReleaseDone` no longer blanks a previously-recorded tag when a
  restart replay re-observes the scope as a no-op release.
- `Controller.RestoreState` skips rehydrating a carrier `PRState` whose scope
  release row is already terminal, so the zombie carrier is never created.
- New `last_failed_sha` column + `recoverFailedScopeReleases` sweep
  resurrects a terminal `failed` row (attempts reset to 0) once main has
  moved past the SHA it last failed against — same-day fix -> same-day
  release instead of waiting for tomorrow's train.
- `tryStartScopeRelease`'s deferring logs raised Debug -> Info so a dying
  train is visible in the dashboard.

## Test plan

- [x] New regression tests: `TestHandleScopeReleaseFailure_TerminalFailedRowIsNotResurrected`, `TestMarkScopeReleaseDone_EmptyTagDoesNotBlankRecordedTag` (both verified to fail on pre-fix code), `TestStartPendingScopeReleases_DoesNotClaimFailedRows` (characterization pin, green before/after), `TestRecoverFailedScopeReleases_ResetsAttemptsWhenMainAdvances`.
- [x] `go test ./internal/autopilot/...` green.
- [x] `go test ./...` green.
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues.