### PR TITLE
fix(dashboard): QUEUE row alignment for wide sub-issue IDs (GH-4338)

### DIFF
--- a/internal/dashboard/queue_width_test.go
+++ b/internal/dashboard/queue_width_test.go
@@ -27,7 +27,7 @@ func TestRenderTask_WidthAware(t *testing.T) {
 				Phase:    "build",
 				PRURL:    "https://github.com/o/r/pull/42",
 			}
-			row := m.renderTask(task, false, 0, iw)
+			row := m.renderTask(task, false, 0, iw, queueIDColumnWidth([]TaskDisplay{task}))
 			if w := lipgloss.Width(row); w > iw {
 				t.Errorf("iw=%d status=%s: row width %d exceeds iw", iw, status, w)
 			}
@@ -45,8 +45,9 @@ func TestRenderTask_TitleExpandsWithWidth(t *testing.T) {
 		return TaskDisplay{ID: "GH-1234", Title: longTitle, Status: "running", Progress: 42}
 	}
 
-	narrow := m.renderTask(task(), false, 0, 65)
-	wide := m.renderTask(task(), false, 0, 120)
+	idW := queueIDColumnWidth([]TaskDisplay{task()})
+	narrow := m.renderTask(task(), false, 0, 65, idW)
+	wide := m.renderTask(task(), false, 0, 120, idW)
 
 	titleLen := func(row string) int {
 		// Count visible chars of longTitle actually present in the row.
@@ -80,7 +81,7 @@ func TestRenderTask_NarrowRegressionPin(t *testing.T) {
 		PRURL:    "https://github.com/o/r/pull/42",
 	}
 
-	row := m.renderTask(task, false, 0, 65)
+	row := m.renderTask(task, false, 0, 65, queueIDColumnWidth([]TaskDisplay{task}))
 	const want = "  ✓ done    GH-1234 a very long title...  ■■■■■■■■■■■■■■■■   #42"
 	if row != want {
 		t.Errorf("narrow (iw=65) rendering changed:\ngot:  %q\nwant: %q", row, want)
@@ -99,7 +100,7 @@ func TestRenderTask_BarColumnsAligned(t *testing.T) {
 	for _, iw := range []int{65, 90, 120} {
 		for _, status := range statuses {
 			task := TaskDisplay{ID: "GH-1", Title: "t", Status: status, Progress: 50, Phase: "x"}
-			row := m.renderTask(task, false, 0, iw)
+			row := m.renderTask(task, false, 0, iw, queueIDColumnWidth([]TaskDisplay{task}))
 			if strings.ContainsAny(row, "[]") {
 				t.Errorf("iw=%d status=%s: bracket bar found in %q", iw, status, row)
 			}
@@ -107,5 +108,69 @@ func TestRenderTask_BarColumnsAligned(t *testing.T) {
 				t.Errorf("iw=%d status=%s: meter cell count = %d, want 16", iw, status, n)
 			}
 		}
+	}
+}
+
+// TestRenderTasks_MixedIDColumnAlignment covers GH-4338: sub-issue IDs like
+// "GH-4328-1" (9 chars) used to overflow the hardcoded 7-char ID column and
+// push every other column out of alignment. The ID column now widens to fit
+// the longest visible ID (capped at 12), so mixed-length ID rows keep their
+// progress bars aligned and stay within the panel's inner width.
+func TestRenderTasks_MixedIDColumnAlignment(t *testing.T) {
+	m := NewModel("test")
+	tasks := []TaskDisplay{
+		{ID: "GH-11", Title: "Short ID task", Status: "done", Progress: 100, PRURL: "https://github.com/o/r/pull/11"},
+		{ID: "GH-4328", Title: "Epic parent task", Status: "running", Progress: 50},
+		{ID: "GH-4328-1", Title: "Sub-issue task", Status: "queued"},
+	}
+
+	for _, iw := range []int{65, 90, 120} {
+		idW := queueIDColumnWidth(tasks)
+
+		var barStart int
+		for i, task := range tasks {
+			row := m.renderTask(task, false, i, iw, idW)
+
+			if w := lipgloss.Width(row); w > iw {
+				t.Errorf("iw=%d id=%s: row width %d exceeds inner width %d", iw, task.ID, w, iw)
+			}
+
+			start := strings.IndexRune(row, '■')
+			if start < 0 {
+				t.Fatalf("iw=%d id=%s: no progress-bar glyph found in row %q", iw, task.ID, row)
+			}
+			if i == 0 {
+				barStart = start
+			} else if start != barStart {
+				t.Errorf("iw=%d id=%s: bar starts at col %d, want %d (matching row 0)", iw, task.ID, start, barStart)
+			}
+		}
+	}
+}
+
+// TestRenderTask_ParentTitleFallback covers GH-4338: a sub-issue row whose
+// title is empty or echoes its own ID renders "<parent-title> · i/n" when
+// the parent linkage resolves from the sibling ID pattern (e.g. "GH-4328-1"
+// under sibling "GH-4328"), instead of duplicating the bare ID into the
+// title column. When no parent can be resolved, it falls back to the
+// (dimmed) ID without panicking or breaking row width.
+func TestRenderTask_ParentTitleFallback(t *testing.T) {
+	m := NewModel("test")
+	m.tasks = []TaskDisplay{
+		{ID: "GH-4328", Title: "Epic: ship the thing", Status: "running", Progress: 50},
+		{ID: "GH-4328-1", Title: "", Status: "queued"},
+	}
+	idW := queueIDColumnWidth(m.tasks)
+
+	sub := m.tasks[1]
+	row := m.renderTask(sub, false, 0, 90, idW)
+	if !strings.Contains(row, "Epic: ship the thing · 1/1") {
+		t.Errorf("expected parent-title fallback in row, got: %q", row)
+	}
+
+	orphan := TaskDisplay{ID: "GH-9999-1", Title: "GH-9999-1", Status: "queued"}
+	orphanRow := m.renderTask(orphan, false, 0, 90, idW)
+	if w := lipgloss.Width(orphanRow); w > 90 {
+		t.Errorf("orphan fallback row width %d exceeds inner width 90", w)
 	}
 }

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1910,6 +1911,7 @@ func (m Model) renderTasks() string {
 		content.WriteString("  No tasks in queue")
 	} else {
 		sorted := m.sortedTasks()
+		idW := queueIDColumnWidth(sorted)
 
 		queueIdx := 0 // position counter for queued items' "#N" label
 		for i, task := range sorted {
@@ -1921,7 +1923,7 @@ func (m Model) renderTasks() string {
 				offset = queueIdx
 				queueIdx++
 			}
-			content.WriteString(m.renderTask(task, i == m.selectedTask, offset, iw))
+			content.WriteString(m.renderTask(task, i == m.selectedTask, offset, iw, idW))
 		}
 	}
 
@@ -1965,19 +1967,97 @@ func (m Model) sortedTasks() []TaskDisplay {
 	return sorted
 }
 
+// queueIDColumnWidth computes the shared ID column width for a queue render
+// pass: wide enough for the longest visible ID, capped so a pathological ID
+// (e.g. a deep sub-issue chain like "GH-4328-12") can't blow out row
+// alignment. GH-4338.
+func queueIDColumnWidth(tasks []TaskDisplay) int {
+	longest := 0
+	for _, t := range tasks {
+		if w := lipgloss.Width(t.ID); w > longest {
+			longest = w
+		}
+	}
+	idW := longest
+	if idW < 7 {
+		idW = 7
+	}
+	if idW > 12 {
+		idW = 12
+	}
+	return idW
+}
+
+// resolveParentTitle resolves the parent title and i/n position for a
+// sub-issue ID like "GH-4328-1" (parent "GH-4328", position 1) from the
+// currently known tasks/completed tasks. Used by the queue row title
+// fallback (GH-4338) so sub-issue rows with an unhydrated title show parent
+// context instead of duplicating the bare ID into the title column.
+func (m Model) resolveParentTitle(id string) (title string, pos, total int, ok bool) {
+	idx := strings.LastIndex(id, "-")
+	if idx <= 0 || idx == len(id)-1 {
+		return "", 0, 0, false
+	}
+	p, err := strconv.Atoi(id[idx+1:])
+	if err != nil || p <= 0 {
+		return "", 0, 0, false
+	}
+	parentID := id[:idx]
+
+	for _, t := range m.tasks {
+		if t.ID == parentID && t.Title != "" && t.Title != t.ID {
+			title = t.Title
+			break
+		}
+	}
+	if title == "" {
+		for _, t := range m.completedTasks {
+			if t.ID == parentID && t.Title != "" && t.Title != t.ID {
+				title = t.Title
+				break
+			}
+		}
+	}
+	if title == "" {
+		return "", 0, 0, false
+	}
+
+	total = p
+	for _, t := range m.tasks {
+		if strings.HasPrefix(t.ID, parentID+"-") {
+			if n, err := strconv.Atoi(t.ID[len(parentID)+1:]); err == nil && n > total {
+				total = n
+			}
+		}
+	}
+	return title, p, total, true
+}
+
 // renderTask renders a single task row with state-aware icons, bars, and meta.
 //
 // Layout (width-aware, minimum 65 inner chars):
 //
-//	sel(2) + icon+state(9) + space(1) + id(7) + space(1) + title(flex, min 20) + gap(2) + bar(16) + gap(1) + meta(5)
+//	sel(2) + icon+state(9) + space(1) + id(flex, 7-12) + space(1) + title(flex, min 20) + gap(2) + bar(16) + gap(1) + meta(5)
 //
-// Everything but the title is fixed; the title expands to fill iw (GH-3970),
+// Everything but the title and id is fixed; the title expands to fill iw
+// (GH-3970) and the id column widens to fit the widest visible ID (GH-4338),
 // mirroring how renderStandaloneLine flexes titles in HISTORY.
-func (m Model) renderTask(task TaskDisplay, selected bool, queueOffset int, iw int) string {
-	const fixedCols = 45 // non-title columns (44) + 1 reserve so the row never exceeds iw
+func (m Model) renderTask(task TaskDisplay, selected bool, queueOffset int, iw int, idW int) string {
+	const nonFlexCols = 37             // fixed columns excluding id and title (see layout above)
+	fixedCols := nonFlexCols + idW + 1 // +1 reserve so the row never exceeds iw at the min title width
 	titleW := iw - fixedCols
 	if titleW < 20 {
 		titleW = 20
+	}
+	// Hard ceiling: a wide id column can make the 20-char title floor push
+	// the row past iw (mem-024 — width math must never let a row overflow
+	// its panel). When that happens, shrink the title below the floor
+	// rather than overflow.
+	if maxTitleW := iw - nonFlexCols - idW; titleW > maxTitleW {
+		titleW = maxTitleW
+	}
+	if titleW < 1 {
+		titleW = 1
 	}
 	var icon, stateLabel, meta string
 	var iconStyle lipgloss.Style
@@ -2044,13 +2124,25 @@ func (m Model) renderTask(task TaskDisplay, selected bool, queueOffset int, iw i
 	// Render meta with state-appropriate color
 	renderedMeta := iconStyle.Render(fmt.Sprintf("%5s", meta))
 
+	// Title fallback (GH-4338): sub-issue rows can hydrate with an empty
+	// title or one that just echoes the ID; render parent context instead of
+	// duplicating the bare ID into the title column.
+	displayTitle := task.Title
+	if displayTitle == "" || displayTitle == task.ID {
+		if parentTitle, pos, total, ok := m.resolveParentTitle(task.ID); ok {
+			displayTitle = fmt.Sprintf("%s · %d/%d", parentTitle, pos, total)
+		} else {
+			displayTitle = dimStyle.Render(task.ID)
+		}
+	}
+
 	// Left side: selector + icon+state + id + title
 	// Right side: bar + meta (right-aligned)
-	return fmt.Sprintf("%s%s %-7s %s  %s %s",
+	return fmt.Sprintf("%s%s %s %s  %s %s",
 		selector,
 		iconState,
-		task.ID,
-		padOrTruncate(truncateVisual(task.Title, titleW), titleW),
+		padOrTruncate(task.ID, idW),
+		padOrTruncate(truncateVisual(displayTitle, titleW), titleW),
 		progressBar,
 		renderedMeta,
 	)

--- a/internal/dashboard/zoom.go
+++ b/internal/dashboard/zoom.go
@@ -408,6 +408,7 @@ func (m Model) renderZoomed() string {
 // state-priority sort order as the grid QUEUE panel.
 func (m Model) renderZoomedQueue(w, h int) string {
 	sorted := m.sortedTasks()
+	idW := queueIDColumnWidth(sorted)
 	offsets := make([]int, len(sorted))
 	qi := 0
 	for i, t := range sorted {
@@ -428,7 +429,7 @@ func (m Model) renderZoomedQueue(w, h int) string {
 	} else {
 		end := minInt(scroll+visible, total)
 		for i := scroll; i < end; i++ {
-			lines = append(lines, m.renderTask(sorted[i], i == sel, offsets[i], iw))
+			lines = append(lines, m.renderTask(sorted[i], i == sel, offsets[i], iw, idW))
 		}
 	}
 	indicator := dimStyle.Render(zoomListIndicator(scroll, minInt(scroll+visible, total), total))


### PR DESCRIPTION
## Summary
- `renderTasks`/`renderZoomedQueue` now compute a shared `idW = max(7, min(12, longest visible ID))` per render pass via `queueIDColumnWidth` and thread it into `renderTask`, replacing the hardcoded `%-7s` ID padding that overflowed for sub-issue IDs like `GH-4328-1` and misaligned sibling rows.
- `fixedCols` derives from `idW` (min title width stays 20), with a hard ceiling so a wide ID column can never push a row past its panel's inner width (mem-024 guard). Over-cap IDs truncate via the existing `truncateVisual` ellipsis.
- Added a render-side title fallback: when a row's title is empty or echoes its own ID, render `<parent-title> · i/n` when parent linkage resolves from the sibling ID pattern (e.g. `GH-4328-1` under `GH-4328`), otherwise a dimmed ID instead of duplicating the bare ID into the title column.

## Test plan
- [x] `go test ./internal/dashboard/ -run 'TestRenderTask|Queue' -v` — all pass, including new `TestRenderTasks_MixedIDColumnAlignment` (GH-11/GH-4328/GH-4328-1 at widths 65/90/120, asserting equal progress-bar start column and `lipgloss.Width(row) <= iw`) and `TestRenderTask_ParentTitleFallback`.
- [x] `go build ./...`
- [x] `gofmt -l`, `go vet ./internal/dashboard/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/dashboard/...` — 0 issues