### PR TITLE
fix(executor): thread planned subtask title into monitor at decomposition create site (GH-4339)

### DIFF
--- a/internal/executor/runner_decompose.go
+++ b/internal/executor/runner_decompose.go
@@ -110,11 +110,30 @@ func (r *Runner) executeDecomposedTask(ctx context.Context, parentTask *Task, su
 		// GH-1235: Execute subtasks in the worktree when worktree mode is active
 		subtask.ProjectPath = executionPath
 
+		// GH-4339: register this subtask's planned title with the monitor
+		// before it starts executing. subtask.ID (e.g. "GH-4328-1") has no
+		// monitor entry yet at this point — without a Register call here, the
+		// first progress callback for that ID (from executeWithOptions below)
+		// hits Monitor.UpdateProgress's unknown-taskID fallback, which creates
+		// the entry with Title == ID. The dashboard then renders the bare
+		// sub-issue ID as its own title instead of the planned subtask
+		// summary.
+		if r.monitor != nil {
+			r.monitor.Register(subtask.ID, subtask.Title, "")
+		}
+
 		// Temporarily disable decomposer to prevent recursive decomposition
 		savedDecomposer := r.decomposer
 		r.decomposer = nil
 
-		subtaskResult, err := r.executeWithOptions(ctx, subtask, false)
+		var subtaskResult *ExecutionResult
+		var err error
+		if r.executeFunc != nil {
+			// Internal override for testing (mirrors epic.go's sub-issue loop).
+			subtaskResult, err = r.executeFunc(ctx, subtask)
+		} else {
+			subtaskResult, err = r.executeWithOptions(ctx, subtask, false)
+		}
 
 		// Restore decomposer
 		r.decomposer = savedDecomposer

--- a/internal/executor/runner_decompose_monitor_test.go
+++ b/internal/executor/runner_decompose_monitor_test.go
@@ -1,0 +1,54 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+)
+
+// TestExecuteDecomposedTask_RegistersPlannedSubtaskTitle is the GH-4339
+// regression test for the decomposition create site: when
+// executeDecomposedTask materializes a sub-issue execution (e.g.
+// "GH-4328-1"), the monitor entry for that task ID must carry the planned
+// subtask's title, not fall back to the bare sub-issue ID.
+//
+// Before the fix, subtask.ID had no monitor entry when its first progress
+// callback arrived, so Monitor.UpdateProgress's unknown-taskID fallback
+// (monitor.go) created one with Title == ID.
+func TestExecuteDecomposedTask_RegistersPlannedSubtaskTitle(t *testing.T) {
+	r := &Runner{
+		log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		monitor: NewMonitor(),
+		executeFunc: func(ctx context.Context, task *Task) (*ExecutionResult, error) {
+			return &ExecutionResult{
+				TaskID:    task.ID,
+				Success:   true,
+				CommitSHA: "deadbeef",
+			}, nil
+		},
+	}
+
+	parent := &Task{ID: "GH-4328", Title: "Epic: ship the thing", ProjectPath: "/tmp/does-not-matter"}
+	subtasks := []*Task{
+		{ID: "GH-4328-1", Title: "feat(api): add rate limiting middleware", ProjectPath: parent.ProjectPath},
+		{ID: "GH-4328-2", Title: "test(api): cover rate limiting edge cases", ProjectPath: parent.ProjectPath},
+	}
+
+	if _, err := r.executeDecomposedTask(context.Background(), parent, subtasks, parent.ProjectPath); err != nil {
+		t.Fatalf("executeDecomposedTask() error = %v", err)
+	}
+
+	for _, st := range subtasks {
+		state, ok := r.monitor.Get(st.ID)
+		if !ok {
+			t.Fatalf("monitor has no entry for subtask %s", st.ID)
+		}
+		if state.Title != st.Title {
+			t.Errorf("subtask %s: monitor Title = %q, want planned subtask title %q", st.ID, state.Title, st.Title)
+		}
+		if state.Title == st.ID {
+			t.Errorf("subtask %s: monitor Title fell back to the bare sub-issue ID", st.ID)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `executeDecomposedTask` (`internal/executor/runner_decompose.go`) never registered a monitor entry for a materialized sub-issue execution (e.g. `GH-4328-1`) before dispatching it to `executeWithOptions`.
- The first progress callback for that task ID then hit `Monitor.UpdateProgress`'s unknown-taskID fallback (`internal/executor/monitor.go:171`), which creates the entry with `Title == ID` — the dashboard then rendered the bare sub-issue ID as its own title instead of the planned subtask summary.
- Fix: call `r.monitor.Register(subtask.ID, subtask.Title, "")` at the point each subtask is materialized, before it starts executing.
- Also wires `r.executeFunc` (the existing "internal override for testing" already used by `epic.go`'s sub-issue loop) into `executeDecomposedTask`'s subtask dispatch, so this path is unit-testable without a real backend/git/worktree.

## Root cause trace
- `epic.go`'s real-GitHub-issue decomposition path (`executeSubIssuesTracked`) already threads titles correctly through `ExecutionLifecycle.Begin` (prior art #4283/#4285).
- The in-process `TaskDecomposer` path (`decompose.go` → `runner_decompose.go`, live in production via `decompose.enabled: true`) generates subtask IDs like `GH-4328-1` but never gave those IDs a monitor entry, since these subtasks intentionally never get their own `executions` DB row (they share the parent's row via `ParentExecutionID`, GH-4032). The TUI dashboard sources its QUEUE rows from the in-memory `Monitor` (`cmd/pilot/commands.go`'s `collectTasks`/`convertTaskStatesToDisplay`), not the DB — so the monitor is the actual "row" that needed the title threaded at creation time.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/executor/... -v` (new `TestExecuteDecomposedTask_RegistersPlannedSubtaskTitle` added; confirmed it fails without the fix)
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/executor/...`