### PR TITLE
fix(autopilot): honor legacy required_checks when ci_checks.required is empty (GH-4333)

### DIFF
--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -681,6 +681,11 @@ autopilot:
     #                              # mode (GH-4307) — use this to shield against
     #                              # unrelated scheduled/canary checks landing on the
     #                              # same SHA instead of enumerating them in `exclude`.
+    #                              # Precedence (GH-4333): a non-empty `required` here
+    #                              # always wins. If empty, the deprecated top-level
+    #                              # `required_checks` is used as a fallback (with a
+    #                              # startup WARN). If both are empty, no allowlist is
+    #                              # active and ALL non-excluded checks gate CI status.
     discovery_grace_period: 60s   # Wait for CI to start
 
   # Test-evidence gate (GH-4329): escalate-only, same pattern as the

--- a/internal/autopilot/ci_monitor.go
+++ b/internal/autopilot/ci_monitor.go
@@ -46,31 +46,57 @@ func NewCIMonitor(ghClient *github.Client, owner, repo string, cfg *Config) *CIM
 	// Determine CI checks configuration
 	var ciChecks *CIChecksConfig
 	var requiredChecks []string
+	startupLog := slog.Default().With("component", "ci-monitor")
 
-	if cfg.CIChecks != nil {
-		ciChecks = cfg.CIChecks
+	switch {
+	case cfg.CIChecks != nil && len(cfg.CIChecks.Required) > 0:
 		// GH-4307: honor a non-empty Required allowlist regardless of Mode.
 		// Previously this was gated on Mode == "manual", so an operator running
 		// auto-discovery with an explicit Required list (e.g. to shield against
 		// unrelated scheduled/canary checks landing on the same SHA) had that
 		// list silently ignored — checkStatus fell through to
 		// checkAutoDiscoveredRuns, which aggregates every non-excluded check.
-		if len(ciChecks.Required) > 0 {
-			requiredChecks = ciChecks.Required
+		ciChecks = cfg.CIChecks
+		requiredChecks = ciChecks.Required
+	case len(cfg.RequiredChecks) > 0:
+		// GH-4333: ci_checks.required is empty (or ci_checks is unset) but the
+		// legacy required_checks allowlist is populated. Before this fix, any
+		// non-nil cfg.CIChecks (which DefaultConfig always sets) silently
+		// dropped the legacy list here with zero warning, leaving operators
+		// who believed required_checks was shielding them with no allowlist
+		// active at all (RCA of #4331).
+		mode := "manual"
+		var exclude []string
+		var grace time.Duration
+		if cfg.CIChecks != nil {
+			exclude = cfg.CIChecks.Exclude
+			grace = cfg.CIChecks.DiscoveryGracePeriod
 		}
-	} else if len(cfg.RequiredChecks) > 0 {
-		// Legacy: if RequiredChecks is set, use manual mode
 		ciChecks = &CIChecksConfig{
-			Mode:     "manual",
-			Required: cfg.RequiredChecks,
+			Mode:                 mode,
+			Exclude:              exclude,
+			Required:             cfg.RequiredChecks,
+			DiscoveryGracePeriod: grace,
 		}
 		requiredChecks = cfg.RequiredChecks
-	} else {
-		// Default: auto mode
-		ciChecks = &CIChecksConfig{
-			Mode:                 "auto",
-			DiscoveryGracePeriod: 60 * time.Second,
+		startupLog.Warn("falling back to deprecated required_checks allowlist because ci_checks.required is empty; migrate to ci_checks.required",
+			"required_checks", cfg.RequiredChecks)
+	default:
+		// Both ci_checks.required and the legacy required_checks are empty:
+		// no allowlist is active, so every non-excluded check on the SHA
+		// participates in the CI gate. This is valid (e.g. intentional
+		// auto-discovery), but it's also exactly the trap an operator hits
+		// when they believe an allowlist is shielding them and it silently
+		// isn't (RCA of #4331) — so make it visible at startup.
+		if cfg.CIChecks != nil {
+			ciChecks = cfg.CIChecks
+		} else {
+			ciChecks = &CIChecksConfig{
+				Mode:                 "auto",
+				DiscoveryGracePeriod: 60 * time.Second,
+			}
 		}
+		startupLog.Warn("no CI required-checks allowlist configured (ci_checks.required and required_checks are both empty); all non-excluded checks on the SHA will gate CI status")
 	}
 
 	// Ensure grace period has a default
@@ -88,7 +114,7 @@ func NewCIMonitor(ghClient *github.Client, owner, repo string, cfg *Config) *CIM
 		ciChecks:         ciChecks,
 		discoveredChecks: make(map[string][]string),
 		discoveryStart:   make(map[string]time.Time),
-		log:              slog.Default().With("component", "ci-monitor"),
+		log:              startupLog,
 	}
 }
 

--- a/internal/autopilot/ci_monitor_test.go
+++ b/internal/autopilot/ci_monitor_test.go
@@ -1,10 +1,13 @@
 package autopilot
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -1309,6 +1312,105 @@ func TestCIMonitor_NewConfigUsesManualMode(t *testing.T) {
 	}
 	if len(monitor.requiredChecks) != 2 {
 		t.Errorf("requiredChecks = %v, want [ci, deploy]", monitor.requiredChecks)
+	}
+}
+
+// TestNewCIMonitor_RequiredChecksPrecedence is the GH-4333 regression test:
+// RCA of #4331 found that with ci_checks.required empty, the legacy
+// required_checks allowlist was silently dropped whenever cfg.CIChecks was
+// non-nil (which DefaultConfig always sets) — the operator's believed
+// shield was inert with zero warning. Verifies the corrected precedence:
+// new key wins when non-empty, legacy is a warned fallback, and both-empty
+// logs a startup warning.
+func TestNewCIMonitor_RequiredChecksPrecedence(t *testing.T) {
+	tests := []struct {
+		name           string
+		ciChecks       *CIChecksConfig
+		requiredChecks []string
+		wantRequired   []string
+		wantMode       string
+		wantLogSubstr  string
+	}{
+		{
+			name:           "new key set, legacy unset",
+			ciChecks:       &CIChecksConfig{Mode: "manual", Required: []string{"ci"}},
+			requiredChecks: nil,
+			wantRequired:   []string{"ci"},
+			wantMode:       "manual",
+		},
+		{
+			name:           "legacy only, ci_checks.required empty but ci_checks non-nil",
+			ciChecks:       &CIChecksConfig{Mode: "auto", Required: []string{}},
+			requiredChecks: []string{"test", "lint"},
+			wantRequired:   []string{"test", "lint"},
+			wantMode:       "manual",
+			wantLogSubstr:  "deprecated required_checks allowlist",
+		},
+		{
+			name:           "legacy only, ci_checks nil",
+			ciChecks:       nil,
+			requiredChecks: []string{"test", "lint"},
+			wantRequired:   []string{"test", "lint"},
+			wantMode:       "manual",
+			wantLogSubstr:  "deprecated required_checks allowlist",
+		},
+		{
+			name:           "both set, new key wins",
+			ciChecks:       &CIChecksConfig{Mode: "manual", Required: []string{"ci"}},
+			requiredChecks: []string{"test", "lint"},
+			wantRequired:   []string{"ci"},
+			wantMode:       "manual",
+		},
+		{
+			name:           "both empty, warns that no allowlist is active",
+			ciChecks:       &CIChecksConfig{Mode: "auto", Required: []string{}},
+			requiredChecks: nil,
+			wantRequired:   nil,
+			wantMode:       "auto",
+			wantLogSubstr:  "no CI required-checks allowlist configured",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ghClient := github.NewClient(testutil.FakeGitHubToken)
+			cfg := DefaultConfig()
+			cfg.CIChecks = tt.ciChecks
+			cfg.RequiredChecks = tt.requiredChecks
+
+			var buf bytes.Buffer
+			h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+			prev := slog.Default()
+			slog.SetDefault(slog.New(h))
+			defer slog.SetDefault(prev)
+
+			monitor := NewCIMonitor(ghClient, "owner", "repo", cfg)
+
+			if len(monitor.requiredChecks) != len(tt.wantRequired) {
+				t.Errorf("requiredChecks = %v, want %v", monitor.requiredChecks, tt.wantRequired)
+			}
+			for i, want := range tt.wantRequired {
+				if monitor.requiredChecks[i] != want {
+					t.Errorf("requiredChecks = %v, want %v", monitor.requiredChecks, tt.wantRequired)
+					break
+				}
+			}
+			if monitor.ciChecks.Mode != tt.wantMode {
+				t.Errorf("ciChecks.Mode = %s, want %s", monitor.ciChecks.Mode, tt.wantMode)
+			}
+
+			out := buf.String()
+			if tt.wantLogSubstr != "" {
+				if !strings.Contains(out, "level=WARN") {
+					t.Errorf("expected WARN level log, got: %s", out)
+				}
+				if !strings.Contains(out, tt.wantLogSubstr) {
+					t.Errorf("expected log to contain %q, got: %s", tt.wantLogSubstr, out)
+				}
+			} else if strings.Contains(out, "level=WARN") {
+				t.Errorf("expected no WARN log, got: %s", out)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- RCA of missed releases (#4331) found a config trap: `DefaultConfig` always sets a non-nil `CIChecks`, so with `ci_checks.required: []` the `ciChecks != nil` branch in `NewCIMonitor` always won — silently dropping a populated legacy `required_checks` allowlist with zero warning.
- Fixes precedence in `internal/autopilot/ci_monitor.go`: non-empty `ci_checks.required` wins; falls back to the deprecated `required_checks` (logs WARN) when the new key is empty; logs a startup WARN when both are empty so operators know no allowlist is gating CI status.
- Adds a one-line precedence note to `configs/pilot.example.yaml`.

## Test plan
- [x] `TestNewCIMonitor_RequiredChecksPrecedence` — table-driven regression test covering: new-key-only, legacy-only (ci_checks non-nil), legacy-only (ci_checks nil), both-set (new wins), both-empty (warn path)
- [x] `make test`
- [x] `make lint`

Refs: #4333, #4331