### PR TITLE
fix(memory): persist exec.CreatedAt and fix sqlite time-bind format (GH-4332)

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -2719,6 +2719,19 @@
         ],
         "confidence": 0.95,
         "created": "2026-07-13"
+      },
+      "mem-153": {
+        "type": "pitfall",
+        "summary": "modernc.org/sqlite writes bound time.Time params using Go's time.Time.String() format by default, which SQLite's date()/datetime() can't parse (returns NULL) and sorts inconsistently against DEFAULT CURRENT_TIMESTAMP columns; fix by opening the DB with ?_time_format=sqlite. Also: SaveExecution's INSERT omitted created_at, letting the DB default silently override caller-supplied timestamps — root cause of internal/briefs's flaky TestGeneratorGenerate.",
+        "file": ".agent/knowledge/memories/pitfalls/pitfall_sqlite_time_bind_default_format.md",
+        "concepts": [
+          "sqlite",
+          "database",
+          "testing",
+          "flaky-test"
+        ],
+        "confidence": 0.9,
+        "created": "2026-07-15"
       }
     }
   },

--- a/.agent/knowledge/memories/pitfalls/pitfall_sqlite_time_bind_default_format.md
+++ b/.agent/knowledge/memories/pitfalls/pitfall_sqlite_time_bind_default_format.md
@@ -1,0 +1,22 @@
+# Pitfall: modernc.org/sqlite silently mis-formats bound time.Time params, breaking date()/created_at filters
+
+## Summary
+Binding a Go `time.Time` value directly as a `database/sql` query parameter against `modernc.org/sqlite` writes it using Go's `time.Time.String()` format (`"2006-01-02 15:04:05.999999999 -0700 MST"`) by default — a format SQLite's own `date()`/`datetime()`/`strftime()` don't recognize (they return NULL) and that sorts inconsistently against `DEFAULT CURRENT_TIMESTAMP`-populated columns in plain `>=`/`<` string comparisons. Fix: open the DB with `?_time_format=sqlite` in the DSN so the driver writes one of SQLite's own recognized date formats instead.
+
+## Context
+GH-4332: issue text claimed `internal/briefs` flaked with `FAIL ... sql: database is closed` (run 29378523581). Pulling the actual CI log (`gh run view <id> --log-failed`) showed that string came from an unrelated package's block in the same monorepo `go test ./...` run (a dispatcher test, output happens to land near the briefs block since `go test` flushes each package's buffered output as a unit, not chronologically); the real `internal/briefs` failure in that run was `TestGeneratorGenerate: generator_test.go:100: expected 1 blocked task, got 0`. **Always pull the actual CI log for the cited run before trusting a symptom string quoted in an issue** — see [[review-before-approval-ordering]] for the sibling "verify before acting on the stated premise" lesson.
+
+## Details
+`internal/memory/store.go`'s `SaveExecution` INSERT never listed the `created_at` column, so every row got `DEFAULT CURRENT_TIMESTAMP` (SQLite-native format, `date()`-parseable) regardless of what the caller set on `exec.CreatedAt` — silently discarding test-seeded timestamps. `GetExecutionsInPeriod`/`GetBriefMetrics` filter `WHERE created_at >= ? AND created_at < ?` against Go `time.Time` bounds (e.g. a test's `now`); under CI load, insertion could cross a wall-clock second after the test captured `now`, dropping the row from the window — a load-dependent flake, not a crash.
+
+Fixing just the omitted column (bind `exec.CreatedAt` directly) traded one bug for a worse one: `modernc.org/sqlite`'s default write format for a bound `time.Time` is Go's own `.String()` output, not ISO-8601 — `date(created_at)` on those rows returns NULL, which broke `GetDailyMetrics`'s `GROUP BY date(created_at)` (`internal/memory/store_test.go` `TestGetDailyMetrics_Excludes*`). The driver supports a DSN param, `_time_format=sqlite`, that switches its write format to one of the 7 formats `https://www.sqlite.org/lang_datefunc.html` recognizes (`conn.go:118-131`, `parseTimeFormats[0]` in `sqlite.go:65`) — verified empirically: without it, `SELECT date(?)` on a bound `time.Time` param returns NULL; with it, a correct date string.
+
+## Recommended Approach
+When SQLite date/time query results look wrong (NULL groupings, off-by-load-dependent-amount row filtering) in a Go codebase using `modernc.org/sqlite` with hand-bound `time.Time` params:
+1. Check the DSN for `_time_format=sqlite`. If absent, every bound `time.Time` param is written in Go's default `.String()` format, not SQLite's.
+2. Don't assume `INSERT`ing a Go `time.Time` and letting a column's `DEFAULT CURRENT_TIMESTAMP` fire produce comparable formats — they don't, until the DSN param is set.
+3. Fix at the `sql.Open()` DSN, not by hand-formatting individual bind calls — one fix covers every future INSERT/UPDATE in the store.
+
+## Related
+- Files: internal/memory/store.go (`NewStore`, `SaveExecution`)
+- Issue: GH-4332

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -39,7 +39,15 @@ func NewStore(dataPath string) (*Store, error) {
 	}
 
 	dbPath := filepath.Join(dataPath, "pilot.db")
-	db, err := sql.Open("sqlite", dbPath)
+	// _time_format=sqlite makes modernc.org/sqlite write bound time.Time
+	// parameters using a format SQLite's own date()/datetime()/strftime()
+	// recognize (one of https://www.sqlite.org/lang_datefunc.html's formats).
+	// Without it the driver falls back to Go's time.Time.String() ("2006-01-02
+	// 15:04:05.999999999 -0700 MST"), which those functions can't parse (they
+	// silently return NULL) and which also sorts inconsistently against
+	// CURRENT_TIMESTAMP-populated columns in plain string comparisons
+	// (GH-4332).
+	db, err := sql.Open("sqlite", dbPath+"?_time_format=sqlite")
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
@@ -565,16 +573,27 @@ func (s *Store) SaveExecution(exec *Execution) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal task labels: %w", err)
 	}
+	// createdAt is stamped in Go (rather than left to the column's
+	// DEFAULT CURRENT_TIMESTAMP) so callers that pre-set exec.CreatedAt
+	// (tests seeding a fixed time window) get exactly that value persisted,
+	// instead of the real insertion wall-clock time silently overriding it.
+	// The period queries (GetExecutionsInPeriod, GetBriefMetrics) filter on
+	// this column against Go time.Time bounds — letting SQLite pick the
+	// timestamp raced the caller's bounds under load (GH-4332).
+	createdAt := exec.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now()
+	}
 	return s.withRetry("SaveExecution", func() error {
 		_, err := s.db.Exec(`
-			INSERT INTO executions (id, task_id, project_path, status, output, error, duration_ms, pr_url, commit_sha, completed_at,
+			INSERT INTO executions (id, task_id, project_path, status, output, error, duration_ms, pr_url, commit_sha, created_at, completed_at,
 				tokens_input, tokens_output, tokens_total, tokens_cache_read, tokens_cache_write,
 				estimated_cost_usd, files_changed, lines_added, lines_removed, model_name,
 				task_title, task_description, task_branch, task_base_branch, task_create_pr, task_verbose,
 				task_source_adapter, task_source_issue_id, task_labels,
 				approval_request_id, effort_level, complexity_level, is_canary)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		`, exec.ID, exec.TaskID, exec.ProjectPath, exec.Status, exec.Output, exec.Error, exec.DurationMs, exec.PRUrl, exec.CommitSHA, exec.CompletedAt,
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`, exec.ID, exec.TaskID, exec.ProjectPath, exec.Status, exec.Output, exec.Error, exec.DurationMs, exec.PRUrl, exec.CommitSHA, createdAt, exec.CompletedAt,
 			exec.TokensInput, exec.TokensOutput, exec.TokensTotal, exec.TokensCacheRead, exec.TokensCacheWrite,
 			exec.EstimatedCostUSD, exec.FilesChanged, exec.LinesAdded, exec.LinesRemoved, exec.ModelName,
 			exec.TaskTitle, exec.TaskDescription, exec.TaskBranch, exec.TaskBaseBranch, exec.TaskCreatePR, exec.TaskVerbose,


### PR DESCRIPTION
## Summary

- Fixes the actual bug behind the internal/briefs CI flake cited in GH-4332 (run 29378523581). The issue text quotes `sql: database is closed`, but pulling the real CI log shows that string belongs to an unrelated package's output block in the same `go test ./...` run — `internal/briefs`'s actual failure in that run was `TestGeneratorGenerate: generator_test.go:100: expected 1 blocked task, got 0`.
- Root cause: `SaveExecution`'s INSERT never listed `created_at`, so SQLite's `DEFAULT CURRENT_TIMESTAMP` silently overrode any test-supplied `Execution.CreatedAt`. The period queries (`GetExecutionsInPeriod`, `GetBriefMetrics`) filter `created_at` against a Go-captured `time.Time` window — under CI load, real insertion time could cross a wall-clock second after the test captured its window, dropping the row. Fixed by binding `exec.CreatedAt` (falling back to `time.Now()` when unset, matching prior behavior for production callers that never set it).
- That fix surfaced a second, deeper bug: `modernc.org/sqlite` writes a bound `time.Time` param using Go's `time.Time.String()` format by default, which SQLite's `date()`/`datetime()` can't parse (returns NULL) and which sorts inconsistently against `CURRENT_TIMESTAMP`-populated rows in plain string comparison. Fixed by opening the DB with `_time_format=sqlite` in the DSN, switching the driver to one of SQLite's own recognized date formats for every future bound `time.Time`.
- Added a Navigator pitfall memory (`.agent/knowledge/memories/pitfalls/pitfall_sqlite_time_bind_default_format.md`) documenting both the CI-log-misattribution lesson and the driver gotcha.

## Retry note (supersedes closed PR #4343)

PR #4343 carried this same code fix but was closed without merging because it failed the **Knowledge Graph Drift Gate**: the new pitfall memory file was never registered in `.agent/knowledge/graph.json` (`.agent/knowledge/memories/pitfalls/pitfall_sqlite_time_bind_default_format.md` had no `mem-NNN` node pointing at it). Follow-up issue #4344 was auto-filed for that CI failure. This PR adds the missing `mem-153` node so `python3 scripts/check-graph.py` passes clean, closing out both #4332 and #4344.

## Test plan

- [x] `go test -race -count=20 ./internal/briefs/...` — green (137.7s)
- [x] `make test` — green
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 new issues (plain `make lint` surfaces one pre-existing unrelated `unused` finding in `internal/dashboard/grom_chrome.go`, unchanged by this PR)
- [x] `python3 scripts/check-graph.py` — clean (verified against tracked files only; the drift gate operates on git-tracked content, not local scratch files)

Closes #4332
Closes #4344