### PR TITLE
fix(executor): recognize no_op as terminal to stop canary sandbox re-dispatch loop

### DIFF
--- a/.agent/knowledge/memories/pitfalls/pitfall_noop_terminal_state_invisible_to_dispatch_guards.md
+++ b/.agent/knowledge/memories/pitfalls/pitfall_noop_terminal_state_invisible_to_dispatch_guards.md
@@ -1,0 +1,24 @@
+# Pitfall: no_op is a legitimate terminal outcome but was invisible to every "is this task done" dispatch guard
+
+## Summary
+GH-4347: the canary sandbox's `duplicate-pr` assertion failed 3 scheduled runs in a row (#4265) — ledger showed GH-82 (a decomposed epic sub-issue) dispatched 6x in one cycle, all six runs terminating `no_op`. Root cause was NOT a tight concurrency race (rows were minutes apart, matching poll-interval + subprocess runtime) — it was that `no_op` ("nothing to change" — a legitimate, common epic sub-issue outcome) never satisfied `Store.HasCompletedExecution` (requires `status='completed'` + a commit/PR deliverable), so every re-dispatch guard that consulted it stayed blind forever: the SDK poller's own pre-dispatch `ExecutionChecker.HasCompletedExecution` check (poll time) and `dispatcher.go`'s `hasTerminalSuccessLedger` pickup guard (dispatch time) both re-treated the same no_op'd issue as a fresh candidate on every tick.
+
+## Context
+`internal/executor/dispatcher.go`'s `childCompletionEvidence` already encoded the correct domain knowledge ("no_op with no error is a legitimate completion") for the TASK-401 decomposed-parent guard, but that definition was never propagated to the two admission-time guards above, which both called `Store.HasCompletedExecution` directly. A comment on `hasTerminalSuccessLedger` even claimed it and the poller's `ExecutionChecker` were "the same guard" — true when both wrapped `internal/adapters/github/poller.go` (removed in the M7 4d.6 SDK-poller cutover, GH-4171), but the invariant silently broke when the poller migrated to `sdkcore.ExecutionChecker` backed directly by `*memory.Store`.
+
+## Details
+Fix: `Store.HasTerminalCompletion(taskID, projectPath)` (new, `internal/memory/store.go`) — an ANY-row check (not "latest row only", see below) OR'ing the existing deliverable-completion definition with a no_op-with-no-error clause. `executor.HasTerminalCompletion` wraps it; `dispatcher.go`'s `hasTerminalSuccessLedger` and a new `cmd/pilot` adapter `terminalCompletionChecker` (wired at `poller_github.go`'s `pollerDeps.ExecutionChecker`) both delegate to it, so poll-time and pickup-time guards agree.
+
+**Trap discovered while testing the fix:** `childCompletionEvidence`'s own no_op fallback checks only `GetLatestExecutionByTaskID`'s *most recent* row — correct for its call site (a decomposed child's one prior attempt) but WRONG for a general "should this admission be refused" check, because the scenario being guarded against is exactly "a fresh `queued` duplicate row already exists alongside the earlier no_op row" — the fresh row sorts as "latest" and hides the terminal no_op. `Store.HasTerminalCompletion` scans every row for the task_id instead of trusting recency ordering.
+
+Separately hardened `Dispatcher.QueueTask`'s check-then-act (IsTaskQueued SELECT, then insert) with a `dispatchMu sync.Mutex` — a genuine but narrower TOCTOU race, not what produced this incident's 6x, but explicitly requested by the task spec and cheap to close.
+
+`Store.HasCompletedExecution` itself was deliberately left untouched — TASK-359 established its strict "has a deliverable" contract is load-bearing elsewhere (`TestTaskCompletionInvariant`); broadening it directly was already refuted history (see `learn_task359_layer1_shipped.md`).
+
+## Recommended Approach
+When adding a new "is task X done" admission/re-arm gate, use `executor.HasTerminalCompletion` (or `Store.HasTerminalCompletion`), not `Store.HasCompletedExecution` directly, unless you specifically need the strict "has a deliverable" definition (e.g. release/PR-surfacing logic). When a comment claims two guards "share a definition", verify both call sites still call the SAME function — a re-wiring (like the SDK poller cutover) can silently split them without either call site's own tests catching it, since each side still compiles and passes in isolation.
+
+## Related
+- Tasks: TASK-401 (decomposed-parent cross-task-id guard), TASK-404 (ExecutionLifecycle), TASK-359 (HasCompletedExecution invariant)
+- Files: internal/executor/dispatcher.go, internal/memory/store.go, cmd/pilot/main.go, cmd/pilot/poller_github.go
+- Issue: GH-4347

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -3081,6 +3081,37 @@ func (s storeTaskChecker) IsTaskQueued(taskID string) bool {
 	return queued
 }
 
+// terminalCompletionChecker adapts *memory.Store to the SDK's
+// sdkcore.ExecutionChecker interface (HasCompletedExecution(taskID,
+// projectPath) (bool, error)) via executor.HasTerminalCompletion instead of
+// Store.HasCompletedExecution directly.
+//
+// GH-4347: Store.HasCompletedExecution only recognizes a "completed" row with
+// a commit/PR deliverable — a no_op outcome ("nothing to change", a common
+// legitimate epic sub-issue result) never satisfies it, so the poller's
+// pre-dispatch admission check kept treating an already-no_op'd issue as a
+// fresh candidate on every poll tick, re-dispatching it indefinitely
+// (confirmed via ledger: GH-82 on pilot-canary-sandbox, six no_op rows).
+// executor.HasTerminalCompletion is the same broadened "done" definition
+// dispatcher.go's own pickup guard (hasTerminalSuccessLedger) uses, so both
+// re-arm points agree.
+type terminalCompletionChecker struct {
+	store *memory.Store
+}
+
+func (c terminalCompletionChecker) HasCompletedExecution(taskID, projectPath string) (bool, error) {
+	return executor.HasTerminalCompletion(c.store, taskID, projectPath)
+}
+
+// InvalidateCompletion delegates to the store unchanged — GH-4347 only
+// broadens what counts as "done" for the pre-dispatch check above; deleting a
+// stale completed record for an explicit retry keeps its existing, stricter
+// "genuine completed row" semantics (a no_op row is legitimately terminal and
+// disappearing labels/relisting the issue should not delete it).
+func (c terminalCompletionChecker) InvalidateCompletion(taskID, projectPath string) error {
+	return c.store.InvalidateCompletion(taskID, projectPath)
+}
+
 // storeExecutionSaver adapts *memory.Store to the github.ExecutionSaver interface.
 // GH-2802: Persists pre-flight rejection records for observability.
 type storeExecutionSaver struct {

--- a/cmd/pilot/main_test.go
+++ b/cmd/pilot/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/qf-studio/pilot/internal/adapters/github"
 	"github.com/qf-studio/pilot/internal/config"
 	"github.com/qf-studio/pilot/internal/executor"
+	"github.com/qf-studio/pilot/internal/memory"
 	"github.com/qf-studio/pilot/internal/teams"
 )
 
@@ -1062,5 +1064,62 @@ func TestResolveExecutionMode(t *testing.T) {
 				t.Errorf("resolveExecutionMode(%q) = %q, want %q", tt.modeStr, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestTerminalCompletionChecker_RecognizesNoOp is the GH-4347 regression at
+// the SDK poller wiring layer: the ExecutionChecker passed to the SDK poller
+// (poller_github.go) used to be *memory.Store directly, whose
+// HasCompletedExecution only recognizes a "completed" row with a
+// commit/PR deliverable — never a no_op outcome. That left the poller's own
+// pre-dispatch admission check blind to a task that legitimately resolved
+// to "nothing to change", so it kept treating the issue as a fresh
+// candidate on every poll tick (six live executions for GH-82 on
+// pilot-canary-sandbox in one canary cycle). terminalCompletionChecker wraps
+// the store so the poller sees the same broadened "done" definition
+// dispatcher.go's own pickup guard uses.
+func TestTerminalCompletionChecker_RecognizesNoOp(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pilot-test-terminal-checker-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp failed: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	const projectPath = "/Users/pilot-op/Projects/startups/pilot-canary-sandbox"
+	const taskID = "GH-82"
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-terminal-checker-noop",
+		TaskID:      taskID,
+		ProjectPath: projectPath,
+		Status:      "no_op",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	checker := terminalCompletionChecker{store: store}
+
+	got, err := checker.HasCompletedExecution(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("HasCompletedExecution: %v", err)
+	}
+	if !got {
+		t.Error("expected terminalCompletionChecker to recognize a no_op row as a completed execution, got false")
+	}
+
+	// A raw *memory.Store, by contrast, must NOT — this pins the exact gap
+	// terminalCompletionChecker closes.
+	rawCompleted, err := store.HasCompletedExecution(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("store.HasCompletedExecution: %v", err)
+	}
+	if rawCompleted {
+		t.Error("expected raw Store.HasCompletedExecution to stay strict (no_op has no deliverable) — if this now passes, the invariant this test pins has changed")
 	}
 }

--- a/cmd/pilot/poller_github.go
+++ b/cmd/pilot/poller_github.go
@@ -327,9 +327,12 @@ func startGithubSDKPollerForRepo(ctx context.Context, deps *PollerDeps, log *slo
 	// GH-2201/GH-2242: task-queued gate + completed-execution guard.
 	// GH-4276: storeTaskChecker is scoped to this poller's own project so a
 	// same-numbered task_id active in a different project never counts here.
+	// GH-4347: terminalCompletionChecker wraps deps.Store rather than passing
+	// it directly — see its doc comment for why the raw Store.HasCompletedExecution
+	// method under-recognizes a no_op outcome as "done".
 	if deps.Store != nil {
 		pollerDeps.TaskChecker = storeTaskChecker{store: deps.Store, projectPath: target.projectPath}
-		pollerDeps.ExecutionChecker = deps.Store
+		pollerDeps.ExecutionChecker = terminalCompletionChecker{store: deps.Store}
 	}
 
 	// GH-2802: pre-flight judge (CC subprocess, no API key) — mirrors the

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -80,6 +80,19 @@ type Dispatcher struct {
 	ctx        context.Context
 	cancel     context.CancelFunc
 	wg         sync.WaitGroup
+
+	// dispatchMu serializes QueueTask's duplicate-task check + executions-row
+	// insert (GH-4347). The two steps were separate, unlocked store calls
+	// (IsTaskQueued SELECT, then queueSingleTask/queueDecomposedTask's INSERT
+	// via ExecutionLifecycle.Begin) — two goroutines racing QueueTask for the
+	// same task_id/project_path (e.g. the SDK poller's concurrent per-issue
+	// goroutines, or a poll tick overlapping epic sub-issue creation) could
+	// both observe "not queued" before either row landed, producing two
+	// executions rows and two live dispatches for one task. Held for the
+	// whole check-then-act region below; cheap (a couple of SQLite queries),
+	// so serializing it dispatcher-wide does not bottleneck actual task
+	// execution, which is unaffected by this lock.
+	dispatchMu sync.Mutex
 }
 
 // NewDispatcher creates a new task dispatcher.
@@ -562,6 +575,12 @@ func (d *Dispatcher) IsActive(taskID, projectPath string) bool {
 // If a decomposer is configured and the task is complex, it will be split
 // into subtasks that are queued instead of the parent task.
 func (d *Dispatcher) QueueTask(ctx context.Context, task *Task) (string, error) {
+	// GH-4347: serialize the duplicate check below with its own insert so two
+	// concurrent QueueTask calls for the same task_id/project_path can't both
+	// pass IsTaskQueued before either row lands. See dispatchMu's doc comment.
+	d.dispatchMu.Lock()
+	defer d.dispatchMu.Unlock()
+
 	// Check for duplicate tasks (GH-4276: scoped to this task's project)
 	exists, err := d.store.IsTaskQueued(task.ID, task.ProjectPath)
 	if err != nil {
@@ -1198,15 +1217,58 @@ func (w *ProjectWorker) recordExecutionEvent(executionID string, stage memory.St
 }
 
 // hasTerminalSuccessLedger reports whether the TASK-394 execution ledger
-// already holds a genuine completed row for taskID in this worker's project.
-// It is the single guard shared by both re-arm points: the poller's re-arm
-// path consults the identical ledger via ExecutionChecker.HasCompletedExecution
-// (internal/adapters/github/poller.go) at poll time, and processQueue calls
-// this method again immediately before pickup (GH-4184) — closing the window
+// already holds terminal-completion evidence for taskID in this worker's
+// project. It is the single guard shared by both re-arm points: the poller's
+// re-arm path consults the identical ledger via ExecutionChecker (M7 4d.6:
+// the SDK poller's ExecutionChecker.HasCompletedExecution, wired in
+// cmd/pilot/poller_github.go) at poll time, and processQueue calls this
+// method again immediately before pickup (GH-4184) — closing the window
 // where a completion lands between the poller's decision and the dispatcher
 // actually starting the backend.
+//
+// GH-4347: delegates to HasTerminalCompletion rather than the stricter
+// Store.HasCompletedExecution directly — a no_op outcome ("nothing to
+// change") never satisfies HasCompletedExecution (no commit/PR), so a task
+// whose correct terminal state is no_op was invisible to both re-arm points
+// forever, and got re-dispatched on every poll tick.
 func (w *ProjectWorker) hasTerminalSuccessLedger(taskID string) (bool, error) {
-	return w.store.HasCompletedExecution(taskID, w.projectPath)
+	return HasTerminalCompletion(w.store, taskID, w.projectPath)
+}
+
+// HasTerminalCompletion reports whether taskID has ledger evidence in
+// projectPath that no further dispatch is warranted: either a genuine
+// Store.HasCompletedExecution row (completed with a commit/PR deliverable),
+// or ANY row that terminated no_op with no error (Store.HasTerminalCompletion's
+// "nothing to change is itself a legitimate completion" definition, matching
+// childCompletionEvidence's no_op reason).
+//
+// GH-4347: exported so every re-arm/admission gate shares one definition of
+// "done" instead of drifting. Before this, Store.HasCompletedExecution's
+// stricter deliverable-only definition was consulted directly in two places
+// that both needed the broader one — the SDK poller's pre-dispatch
+// ExecutionChecker check (poll time) and this package's processQueue pickup
+// guard (hasTerminalSuccessLedger) — so a no_op task_id (a legitimate,
+// common epic sub-issue outcome: "already covered by a sibling", "nothing
+// to change") was re-dispatched on every poll tick indefinitely. Confirmed
+// via ledger (GH-82 on pilot-canary-sandbox: six no_op rows, ~minutes
+// apart, matching the poll interval plus per-run subprocess time — not a
+// tight race).
+//
+// Delegates to Store.HasTerminalCompletion rather than childCompletionEvidence:
+// the latter's no_op fallback only inspects GetLatestExecutionByTaskID's most
+// recent row, which is correct for its own call site (a decomposed child's
+// one prior attempt) but wrong here, where the caller is re-checking
+// admission for a task_id that may already have a fresh "queued" duplicate
+// row racing alongside the earlier no_op row — the fresh row would sort as
+// "latest" and hide the terminal no_op. Store.HasTerminalCompletion scans
+// every row for the task_id instead.
+//
+// Store.HasCompletedExecution itself is intentionally left untouched: TASK-359
+// established its strict "has a deliverable" contract is load-bearing
+// elsewhere (TestTaskCompletionInvariant); this wraps it rather than
+// broadening it.
+func HasTerminalCompletion(store *memory.Store, taskID, projectPath string) (bool, error) {
+	return store.HasTerminalCompletion(taskID, projectPath)
 }
 
 // decomposedChildrenAllComplete reports whether taskID has a recorded

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1420,6 +1421,234 @@ func TestDecomposedChildrenAllComplete(t *testing.T) {
 			t.Errorf("expected a warning log about the unparseable decomposed detail, got: %s", logBuf.String())
 		}
 	})
+}
+
+// TestHasTerminalCompletion is the GH-4347 table test for the exported
+// "is this task done" definition shared by the SDK poller's
+// ExecutionChecker (cmd/pilot/main.go's terminalCompletionChecker) and
+// dispatcher.go's own pickup guard (hasTerminalSuccessLedger). A no_op
+// outcome with no error must count as terminal (matching
+// childCompletionEvidence's existing "nothing to change is itself a
+// legitimate completion" definition) even though it never satisfies the
+// stricter Store.HasCompletedExecution.
+func TestHasTerminalCompletion(t *testing.T) {
+	const projectPath = "/project-terminal-completion"
+
+	tests := []struct {
+		name string
+		exec *memory.Execution
+		want bool
+	}{
+		{
+			name: "genuine completed row with deliverable",
+			exec: &memory.Execution{ID: "exec-htc-completed", TaskID: "GH-100", ProjectPath: projectPath, Status: "completed", PRUrl: "https://github.com/qf-studio/pilot/pull/100"},
+			want: true,
+		},
+		{
+			name: "no_op with no error is terminal",
+			exec: &memory.Execution{ID: "exec-htc-noop", TaskID: "GH-101", ProjectPath: projectPath, Status: "no_op"},
+			want: true,
+		},
+		{
+			name: "no_op with an error is NOT terminal",
+			exec: &memory.Execution{ID: "exec-htc-noop-err", TaskID: "GH-102", ProjectPath: projectPath, Status: "no_op", Error: "claude subprocess crashed"},
+			want: false,
+		},
+		{
+			name: "still running is not terminal",
+			exec: &memory.Execution{ID: "exec-htc-running", TaskID: "GH-103", ProjectPath: projectPath, Status: "running"},
+			want: false,
+		},
+		{
+			name: "infra failure is not terminal (should still retry)",
+			exec: &memory.Execution{ID: "exec-htc-infra", TaskID: "GH-104", ProjectPath: projectPath, Status: "infra"},
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store, cleanup := setupTestStore(t)
+			defer cleanup()
+
+			if err := store.SaveExecution(tc.exec); err != nil {
+				t.Fatalf("SaveExecution: %v", err)
+			}
+
+			got, err := HasTerminalCompletion(store, tc.exec.TaskID, projectPath)
+			if err != nil {
+				t.Fatalf("HasTerminalCompletion: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("HasTerminalCompletion(%q, %q) = %v, want %v", tc.exec.TaskID, projectPath, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestProcessQueue_NoOpTerminalLedger_SkipsBackend is the GH-4347 regression
+// for the pilot-canary-sandbox incident: GH-82 (a decomposed epic sub-issue)
+// legitimately resolved to no_op ("nothing to change") and was re-dispatched
+// on every subsequent poll tick — six live executions in one canary cycle —
+// because neither the dispatcher's pickup guard nor the SDK poller's
+// pre-dispatch check recognized a no_op row as terminal. Table-driven across
+// a pilot-repo-style path and a canary-sandbox-style path (the task's
+// acceptance criterion (a)) since the defect was reported as sandbox-only.
+func TestProcessQueue_NoOpTerminalLedger_SkipsBackend(t *testing.T) {
+	tests := []struct {
+		name        string
+		projectPath string
+	}{
+		{"pilot-repo-style path", "/Users/pilot-op/Projects/startups/pilot"},
+		{"canary-sandbox-style path", "/Users/pilot-op/Projects/startups/pilot-canary-sandbox"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store, cleanup := setupTestStore(t)
+			defer cleanup()
+
+			const taskID = "GH-82"
+
+			// Seed the ledger with the prior no_op outcome — GH-82's actual
+			// terminal state on the canary sandbox ("greeter farewell; no
+			// surviving PR").
+			priorExec := &memory.Execution{
+				ID:          "exec-noop-prior",
+				TaskID:      taskID,
+				ProjectPath: tc.projectPath,
+				Status:      "no_op",
+			}
+			if err := store.SaveExecution(priorExec); err != nil {
+				t.Fatalf("failed to save prior no_op execution: %v", err)
+			}
+
+			// A second, freshly queued row for the SAME task — the
+			// re-dispatch that must be refused now that no_op is recognized
+			// as terminal.
+			dupExec := &memory.Execution{
+				ID:          "exec-noop-dup",
+				TaskID:      taskID,
+				ProjectPath: tc.projectPath,
+				Status:      "queued",
+				TaskBranch:  "pilot/GH-82",
+			}
+			if err := store.SaveExecution(dupExec); err != nil {
+				t.Fatalf("failed to save duplicate execution: %v", err)
+			}
+
+			origCheck := mergedPRPreflightCheck
+			mergedPRPreflightCheck = func(_ context.Context, _, _ string) (string, error) { return "", nil }
+			defer func() { mergedPRPreflightCheck = origCheck }()
+
+			backend := &mockFixedBackend{result: &BackendResult{Success: true, Output: "should never run"}}
+			runner := NewRunnerWithBackend(backend)
+			worker := NewProjectWorker(tc.projectPath, store, runner, slog.Default())
+
+			worker.processQueue(context.Background())
+
+			backend.mu.Lock()
+			count := backend.execCount
+			backend.mu.Unlock()
+			if count != 0 {
+				t.Errorf("expected zero backend invocations (no_op terminal-ledger guard), got %d", count)
+			}
+
+			got, err := store.GetExecution(dupExec.ID)
+			if err != nil {
+				t.Fatalf("GetExecution: %v", err)
+			}
+			if got.Status != "completed" {
+				t.Errorf("expected duplicate row status 'completed' (ledger-guarded), got %q", got.Status)
+			}
+		})
+	}
+}
+
+// TestQueueTask_ConcurrentDuplicate_DispatchesOnce is the GH-4347 race test
+// for the dispatchMu fix: QueueTask's duplicate check (IsTaskQueued) and its
+// executions-row insert used to be two unlocked store calls, so concurrent
+// callers racing the same task_id/project_path — e.g. the SDK poller's
+// per-issue goroutines, or a poll tick landing while an epic is still
+// creating sub-issues — could both observe "not queued" before either row
+// landed. Table-driven across a pilot-repo-style and a sandbox-style project
+// path reusing the SAME small issue number (acceptance criteria (b) and (c):
+// concurrent poll ticks still dispatch once, and small-issue-number reuse
+// across projects/cycles never cross-collides).
+func TestQueueTask_ConcurrentDuplicate_DispatchesOnce(t *testing.T) {
+	const concurrency = 8
+
+	tests := []struct {
+		name        string
+		projectPath string
+	}{
+		{"pilot-repo-style path", "/Users/pilot-op/Projects/startups/pilot"},
+		{"canary-sandbox-style path", "/Users/pilot-op/Projects/startups/pilot-canary-sandbox"},
+	}
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runner := NewRunner()
+	dispatcher := NewDispatcher(store, runner, nil)
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			const taskID = "GH-60"
+
+			var wg sync.WaitGroup
+			var mu sync.Mutex
+			var successes int
+			var alreadyActive int
+			var otherErrs []error
+
+			for i := 0; i < concurrency; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					task := &Task{
+						ID:          taskID,
+						Title:       "Concurrent dispatch race",
+						Description: "GH-4347 regression",
+						ProjectPath: tc.projectPath,
+					}
+					_, err := dispatcher.QueueTask(context.Background(), task)
+					mu.Lock()
+					defer mu.Unlock()
+					switch {
+					case err == nil:
+						successes++
+					case errors.Is(err, ErrTaskAlreadyActive):
+						alreadyActive++
+					default:
+						otherErrs = append(otherErrs, err)
+					}
+				}()
+			}
+			wg.Wait()
+
+			if len(otherErrs) != 0 {
+				t.Fatalf("unexpected QueueTask errors: %v", otherErrs)
+			}
+			if successes != 1 {
+				t.Errorf("expected exactly 1 successful dispatch out of %d concurrent QueueTask calls, got %d (already-active: %d)", concurrency, successes, alreadyActive)
+			}
+			if alreadyActive != concurrency-1 {
+				t.Errorf("expected %d ErrTaskAlreadyActive rejections, got %d", concurrency-1, alreadyActive)
+			}
+
+			queued, err := store.IsTaskQueued(taskID, tc.projectPath)
+			if err != nil {
+				t.Fatalf("IsTaskQueued: %v", err)
+			}
+			if !queued {
+				t.Error("expected the single successful dispatch to leave the task queued")
+			}
+		})
+	}
 }
 
 // TestProcessQueue_CrossTaskIDGuard_MalformedDetailFallsThrough covers the

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -943,6 +943,42 @@ func (s *Store) HasCompletedExecution(taskID, projectPath string) (bool, error) 
 	return count > 0, nil
 }
 
+// HasTerminalCompletion reports whether taskID has ANY row in projectPath
+// that is terminal in the sense that no further dispatch is warranted:
+// either a genuine HasCompletedExecution row (completed with a commit/PR
+// deliverable), or a no_op row with no error ("nothing to change" is itself
+// a legitimate completion — the same definition childCompletionEvidence
+// uses in internal/executor/dispatcher.go for decomposed-child evidence).
+//
+// GH-4347: deliberately an ANY-row check, unlike childCompletionEvidence's
+// no_op fallback (which inspects only GetLatestExecutionByTaskID's most
+// recent row — correct for that call site, where "latest" is the child's
+// only prior attempt). Here the caller is specifically re-checking
+// admission for a task_id that may already have a fresh "queued" duplicate
+// row alongside an earlier no_op row — the fresh row would be "latest" and
+// would wrongly hide the terminal no_op if this used the same latest-only
+// definition. Scanning every row for the task avoids that ordering trap.
+func (s *Store) HasTerminalCompletion(taskID, projectPath string) (bool, error) {
+	completed, err := s.HasCompletedExecution(taskID, projectPath)
+	if err != nil {
+		return false, err
+	}
+	if completed {
+		return true, nil
+	}
+
+	var count int
+	err = s.db.QueryRow(`
+		SELECT COUNT(*) FROM executions
+		WHERE task_id = ? AND project_path = ? AND status = 'no_op'
+			AND (error IS NULL OR error = '')
+	`, taskID, projectPath).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
 // decomposedChildRefRegex extracts "#123"-style issue references from a
 // StageDecomposed execution_events detail string, e.g. "decomposed into 2
 // children: #4212, #4213" (see executor.formatDecomposedChildrenSummary).


### PR DESCRIPTION
## Summary

Fixes GH-4347: the epic-lifecycle canary's `duplicate-pr` assertion failed 3 consecutive scheduled runs (#4265). Ledger evidence (`~/.pilot/data/pilot.db`) on `pilot-canary-sandbox` showed GH-82 (a decomposed epic sub-issue) dispatched 6x in one cycle — all six executions terminated `no_op`, minutes apart, matching poll interval + subprocess runtime, **not** a tight concurrency race.

**Root cause**: `no_op` ("nothing to change" — a legitimate, common epic sub-issue outcome) never satisfies `Store.HasCompletedExecution` (requires `status='completed'` + a commit/PR deliverable). Both re-dispatch guards that gate on it stayed blind forever:
- The SDK poller's pre-dispatch `ExecutionChecker.HasCompletedExecution` check (poll time, wired in `cmd/pilot/poller_github.go`)
- `dispatcher.go`'s own pickup guard `hasTerminalSuccessLedger` (dispatch time)

A stale doc comment even claimed these two were "the same guard" — true before the M7 4d.6 SDK-poller cutover (GH-4171 removed the in-tree poller they both used to share), but the invariant silently broke when the SDK poller started consulting `*memory.Store` directly.

**Fix**:
- `Store.HasTerminalCompletion` (new) — an any-row check OR'ing the existing deliverable-completion definition with a no_op-with-no-error clause. Deliberately *not* "latest row only" like `childCompletionEvidence`'s fallback — that trap hides the terminal no_op row once a fresh duplicate `queued` row exists alongside it (exactly the scenario being guarded against).
- `executor.HasTerminalCompletion` wraps it; `hasTerminalSuccessLedger` and a new `terminalCompletionChecker` adapter (wired at the SDK poller's `ExecutionChecker`) both delegate to it, so poll-time and pickup-time admission agree.
- `Store.HasCompletedExecution` itself is untouched — TASK-359 established its strict "has a deliverable" contract is load-bearing elsewhere.
- `Dispatcher.QueueTask`'s check-then-act (IsTaskQueued SELECT, then insert) is also now serialized under a `dispatchMu` mutex, closing a real but narrower TOCTOU race per the task's explicit race-safe-dedup ask.

## Test plan

- [x] `TestHasTerminalCompletion` — table test for the new terminal-completion definition (completed w/ deliverable, no_op w/o error, no_op w/ error, running, infra)
- [x] `TestProcessQueue_NoOpTerminalLedger_SkipsBackend` — GH-82 repro at the pickup-guard layer, table-driven across pilot-repo-style and canary-sandbox-style project paths
- [x] `TestQueueTask_ConcurrentDuplicate_DispatchesOnce` — 8 concurrent `QueueTask` calls for the same task_id/project_path dispatch exactly once (`-race` clean), across both project-path styles reusing the same small issue number
- [x] `TestTerminalCompletionChecker_RecognizesNoOp` — pins the SDK poller wiring adapter's behavior vs. the raw store
- [x] `make test` — full suite green
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 new issues
- [ ] Next scheduled epic-lifecycle canary cycle green on `duplicate-pr` (observable post-merge + daemon restart)