### PR TITLE
fix(cli): funnel ErrClaimLost into a clean 'task already active' message

### DIFF
--- a/cmd/pilot/cli_task_execution_test.go
+++ b/cmd/pilot/cli_task_execution_test.go
@@ -148,6 +148,52 @@ func TestRecordCLITaskFinish_ExecutionError(t *testing.T) {
 	}
 }
 
+// TestClaimLostCLIError_ErrClaimLost covers GH-4360: recordCLITaskStart
+// racing another dispatch channel for the same (task, project, generation 0)
+// claim must fail with executor.ErrClaimLost (proven directly here, mirroring
+// dispatch_claim_test.go's TestDispatchClaim_EntryPointInventory), and
+// claimLostCLIError must turn that into the clean "task already active"
+// message the `pilot task` CLI surfaces instead of falling through to
+// runner.Execute() and starting a duplicate run.
+func TestClaimLostCLIError_ErrClaimLost(t *testing.T) {
+	store := newCLITaskTestStore(t)
+
+	taskID, projectPath := "TASK-claim-race", "/tmp/project-claim-race"
+
+	winner := &executor.Task{ID: taskID, ProjectPath: projectPath}
+	if _, err := recordCLITaskStart(store, winner); err != nil {
+		t.Fatalf("first recordCLITaskStart should win the claim, got: %v", err)
+	}
+
+	loser := &executor.Task{ID: taskID, ProjectPath: projectPath}
+	_, saveErr := recordCLITaskStart(store, loser)
+	if !errors.Is(saveErr, executor.ErrClaimLost) {
+		t.Fatalf("expected second recordCLITaskStart for the same claim to return ErrClaimLost, got: %v", saveErr)
+	}
+
+	claimErr := claimLostCLIError(loser.ID, saveErr)
+	if claimErr == nil {
+		t.Fatal("expected claimLostCLIError to return a non-nil error for ErrClaimLost")
+	}
+	want := "task already active: TASK-claim-race is already being executed by another Pilot process"
+	if claimErr.Error() != want {
+		t.Errorf("expected message %q, got %q", want, claimErr.Error())
+	}
+}
+
+// TestClaimLostCLIError_OtherErrorsPassThrough ensures claimLostCLIError only
+// special-cases ErrClaimLost — any other recordCLITaskStart failure (e.g. a
+// store write error) must return nil so the caller keeps its existing
+// Warn-and-continue behavior rather than aborting the task.
+func TestClaimLostCLIError_OtherErrorsPassThrough(t *testing.T) {
+	if got := claimLostCLIError("TASK-x", errors.New("disk full")); got != nil {
+		t.Errorf("expected nil for a non-ErrClaimLost error, got: %v", got)
+	}
+	if got := claimLostCLIError("TASK-x", nil); got != nil {
+		t.Errorf("expected nil for a nil error, got: %v", got)
+	}
+}
+
 func TestRecordCLITaskFinish_UnsuccessfulResult(t *testing.T) {
 	store := newCLITaskTestStore(t)
 

--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -805,6 +805,14 @@ Examples:
 					// human-readable task ID with no matching executions.id. Mirrors
 					// the dispatcher's queueSingleTask (internal/executor/dispatcher.go:547).
 					if id, saveErr := recordCLITaskStart(learningStore, task); saveErr != nil {
+						// GH-4360: Begin's contract requires aborting BEFORE
+						// invoking the backend on ErrClaimLost (lifecycle.go:
+						// 86-92), so this must stop the command here rather
+						// than fall through to runner.Execute() and start a
+						// duplicate run.
+						if claimErr := claimLostCLIError(task.ID, saveErr); claimErr != nil {
+							return claimErr
+						}
 						logging.WithComponent("execute").Warn("Failed to save execution row for CLI task, status/logs/metrics will not reflect this run", slog.Any("error", saveErr))
 					} else {
 						execID = id
@@ -1029,6 +1037,26 @@ Examples:
 // hand-rolling a memory.Execution{} literal here.
 func recordCLITaskStart(store *memory.Store, task *executor.Task) (execID string, err error) {
 	return executor.NewExecutionLifecycle(store).Begin(task, executor.ExecStatusRunning)
+}
+
+// claimLostCLIError converts a recordCLITaskStart failure into a clean,
+// user-visible "task already active" error when the failure is
+// errors.Is(err, executor.ErrClaimLost) — i.e. another dispatch channel
+// (poller, epic sub-issue loop, a racing `pilot task` invocation) already
+// won the claim for this task (GH-4360). Returns nil for every other error,
+// leaving those to the existing Warn-and-continue handling (a failed
+// executions-row write shouldn't block the CLI from running the task).
+//
+// The returned error is deliberately a plain fmt.Errorf with no %w wrapping
+// of saveErr: newTaskCmd's RunE returns it as-is, and main.go's top-level
+// handler does `fmt.Fprintln(os.Stderr, err); os.Exit(1)` — a bare message
+// here means that prints as one clean stderr line, not a wrapped chain or a
+// stack trace.
+func claimLostCLIError(taskID string, saveErr error) error {
+	if !errors.Is(saveErr, executor.ErrClaimLost) {
+		return nil
+	}
+	return fmt.Errorf("task already active: %s is already being executed by another Pilot process", taskID)
 }
 
 // recordCLITaskFinish marks the executions row created by recordCLITaskStart

--- a/internal/executor/dispatch_claim_test.go
+++ b/internal/executor/dispatch_claim_test.go
@@ -47,7 +47,7 @@ func TestDispatchClaim_EntryPointInventory(t *testing.T) {
 			projectPath: "/tmp/project-epic",
 		},
 		{
-			name:        "CLI recordCLITaskStart (cmd/pilot/commands.go:1031)",
+			name:        "CLI recordCLITaskStart (cmd/pilot/commands.go:1039)",
 			taskID:      "GH-entry-cli",
 			projectPath: "/tmp/project-cli",
 		},


### PR DESCRIPTION
## Summary
- `recordCLITaskStart`'s `ErrClaimLost` (from `ExecutionLifecycle.Begin`) was only logged as a `Warn`, and `pilot task` fell through to `runner.Execute()` regardless — so a CLI invocation racing another dispatch channel (poller, epic sub-issue loop, another CLI process) for the same `(task.ID, task.ProjectPath, generation)` claim would silently start a duplicate execution, violating `Begin`'s "abort before backend invocation" contract for `ErrClaimLost`.
- Added `claimLostCLIError` (cmd/pilot/commands.go) to detect `errors.Is(err, executor.ErrClaimLost)` and return a single clean `"task already active: <task-id> is already being executed by another Pilot process"` error instead. `newTaskCmd`'s `RunE` returns it as-is, so cobra's default `main.go` error path (`fmt.Fprintln(os.Stderr, err); os.Exit(1)`) prints one clean stderr line, non-zero exit, no stack trace.
- Kept the existing Warn-and-continue behavior for any other `recordCLITaskStart` failure (e.g. a store write error) — those still shouldn't block a CLI task from running.
- Updated the line-number reference in `internal/executor/dispatch_claim_test.go`'s entry-point-inventory table (a comment only) since `recordCLITaskStart` shifted a few lines.

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/pilot/... ./internal/executor/...` — added `TestClaimLostCLIError_ErrClaimLost` and `TestClaimLostCLIError_OtherErrorsPassThrough` in `cmd/pilot/cli_task_execution_test.go`; existing `TestDispatchClaim_EntryPointInventory` still passes.
- [x] `make test` — full suite green.
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues (the `make lint` failure on `internal/dashboard/grom_chrome.go:50` is pre-existing/unrelated to this change).
- [x] Manual `pilot task` run against an isolated temp config/store: pre-claimed `(task_id, project_path, generation=0)` in `execution_claims`, then ran `pilot task` for that same task/project — confirmed stderr shows exactly `Error: task already active: TASK-64404 is already being executed by another Pilot process`, exit code 1, and no `executions` row or backend invocation occurred for that run.