### PR TITLE
fix(executor): stall watchdog no longer kills sessions waiting on in-flight background tasks

### DIFF
--- a/.agent/tasks/archive/gh-4357.md
+++ b/.agent/tasks/archive/gh-4357.md
@@ -1,0 +1,60 @@
+# GH-4357
+
+**Created:** 2026-07-16
+
+## Problem
+
+GitHub Issue GH-4357: fix(executor): stall watchdog kills healthy sessions waiting on long-running background tasks
+
+## Problem
+
+The stall watchdog treats "no agent events for stall_timeout (default 3m)" as a dead session — but a session that launches a long-running background task (`task_started` / `local_bash`) and ends its turn to await the result legitimately emits **zero events** until the task completes.
+
+## Evidence (GH-4353, 2026-07-15 ~23:57Z)
+
+Recording `~/.pilot/recordings/TG-1784159243201`:
+- seq 258: assistant starts `go test ./internal/memory/ ./internal/executor/ -race -count=5` via Bash
+- seq 259 (01:54:30 local): `task_started` (task_type=local_bash) — **last event**
+- 01:57:53: `Stall watchdog: no event activity, terminating session` idle=3m22s → SIGKILL exit 137 after 10m53s of otherwise healthy execution
+
+The race-detector 5x suite exceeds 3m by design. The kill cascaded: parent GH-4349 marked stalled ("sub-issue 4353 failed"), both re-queued — burning a full execution and re-entering the queue. Any task whose spec demands thorough test verification will loop: stall → retry → stall.
+
+## Fix
+
+In the watchdog's idle computation, treat an in-flight background task (`task_started` without a matching completion event) as activity — e.g. reset/suspend the idle clock while `task_started` count > completed count, or emit synthetic heartbeat events while a local_bash task runs. Add a regression test: session that starts a background task and stays silent for > stall_timeout must NOT be terminated while the task process is alive.
+
+## Mitigation already applied (operator config)
+
+`executor.stall_timeout_ms: 600000` (10m) in `~/.pilot/config.yaml` — takes effect on next daemon restart. This is a blunt workaround; the watchdog logic fix should restore a tighter timeout.
+
+## Refs
+- `internal/executor/backend.go:351-399` (`EffectiveStallTimeout`)
+- `internal/executor/monitor.go:214` (Stall marking, TASK-308)
+- Incident context: TASK-407 (#4349/#4353) — this stall is currently blocking the atomic-claim implementation from shipping
+
+## Resolution (2026-07-16)
+
+Root cause confirmed against the actual recording (`~/.pilot/recordings/TG-1784159243201/stream.jsonl`
+seq 259): Claude Code emits a `{"type":"system","subtype":"task_started","task_type":"local_bash",...}`
+event when a Bash command backgrounds, and — for `local_bash` tasks specifically — no further stream
+events (no `task_progress` heartbeats, unlike `local_agent` sub-tasks) until a terminating
+`{"type":"system","subtype":"task_notification","status":"completed|failed|stopped",...}` arrives.
+That silence is by design, not a hang.
+
+Fix, in `internal/executor`:
+- `backend.go`: new `EventTypeTaskStarted` / `EventTypeTaskNotification` `BackendEventType`s + `BackgroundTaskID`/`BackgroundTaskStatus` fields on `BackendEvent`.
+- `runner.go` (`StreamEvent`): parse `task_id` / `status` fields.
+- `backend_claudecode.go` (`parseStreamEvent`): map `task_started`/`task_notification` subtypes to the new event types.
+- `runner.go` (`executeWithOptions`): track an `inFlightBackgroundTasks atomic.Int64` counter alongside the existing `lastEventAt`/`stallDetectedFlag`, incremented/decremented from the `EventHandler` closure.
+- `watchdog.go` (`runStallWatchdog`): new `inFlightBackgroundTasks *atomic.Int64` param; when > 0, the idle-clock check is skipped entirely for that tick (suspended, not reset), so time spent waiting on a background task never counts against `stall_timeout`.
+
+Regression tests added in `watchdog_test.go`:
+`TestStallWatchdog_SuspendsWhileBackgroundTaskInFlight` (stays alive across many ticks while a task is in flight) and `TestStallWatchdog_FiresAfterBackgroundTaskCompletes` (idle detection resumes once the count drops to zero). Plus `backend_claudecode_test.go::TestClaudeCodeBackendParseBackgroundTaskEvents` locks in the stream-event parsing.
+
+Operator mitigation (`stall_timeout_ms: 600000`) can be safely rolled back to the 3-minute default once this ships, since local_bash backgrounding no longer needs a blanket longer timeout to survive.
+
+## Acceptance Criteria
+
+- [x] Stall watchdog treats an in-flight `task_started` (no matching `task_notification`) as activity, not silence.
+- [x] Regression test: session that starts a background task and stays silent past `stall_timeout` is NOT terminated while the task is alive.
+- [x] Idle detection resumes normally once the background task completes.

--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -132,6 +132,14 @@ type BackendEvent struct {
 
 	// SessionID is the Claude Code session ID for resume support (GH-1265)
 	SessionID string
+
+	// BackgroundTaskID correlates task_started with its terminating
+	// task_notification for the same background task (GH-4357).
+	BackgroundTaskID string
+
+	// BackgroundTaskStatus carries the terminal status ("completed", "failed",
+	// or "stopped") on EventTypeTaskNotification events (GH-4357).
+	BackgroundTaskStatus string
 }
 
 // BackendError is implemented by all backend-specific error types (ClaudeCodeError,
@@ -170,6 +178,18 @@ const (
 
 	// EventTypeProgress indicates a progress update
 	EventTypeProgress BackendEventType = "progress"
+
+	// EventTypeTaskStarted indicates a background task (e.g. a long-running
+	// Bash command or sub-agent) started executing asynchronously. The agent
+	// legitimately emits zero further events until the task resolves, so the
+	// stall watchdog must treat an in-flight task as activity rather than
+	// silence (GH-4357).
+	EventTypeTaskStarted BackendEventType = "task_started"
+
+	// EventTypeTaskNotification indicates a previously started background
+	// task finished (BackgroundTaskStatus carries "completed"/"failed"/
+	// "stopped"). GH-4357.
+	EventTypeTaskNotification BackendEventType = "task_notification"
 )
 
 // BackendResult contains the outcome of a backend execution.

--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -798,10 +798,25 @@ func (b *ClaudeCodeBackend) parseStreamEvent(line string) BackendEvent {
 	// Map stream event type to backend event type
 	switch streamEvent.Type {
 	case "system":
-		if streamEvent.Subtype == "init" {
+		switch streamEvent.Subtype {
+		case "init":
 			event.Type = EventTypeInit
 			event.SessionID = streamEvent.SessionID // Capture session ID for resume (GH-1265)
 			event.Message = "Claude Code initialized"
+		case "task_started":
+			// GH-4357: a backgrounded task (e.g. long-running Bash command or
+			// sub-agent) started. Plain shell backgrounds (task_type=local_bash)
+			// emit no further events until completion, so the runner must track
+			// this as in-flight activity to keep the stall watchdog from
+			// killing an otherwise healthy session.
+			event.Type = EventTypeTaskStarted
+			event.BackgroundTaskID = streamEvent.TaskID
+			event.Message = "Background task started"
+		case "task_notification":
+			event.Type = EventTypeTaskNotification
+			event.BackgroundTaskID = streamEvent.TaskID
+			event.BackgroundTaskStatus = streamEvent.Status
+			event.Message = "Background task finished"
 		}
 
 	case "assistant":

--- a/internal/executor/backend_claudecode_test.go
+++ b/internal/executor/backend_claudecode_test.go
@@ -131,6 +131,43 @@ func TestClaudeCodeBackendParseStreamEvent(t *testing.T) {
 	}
 }
 
+// TestClaudeCodeBackendParseBackgroundTaskEvents verifies that Claude Code's
+// task_started/task_notification system events (emitted when a Bash command
+// or sub-agent runs in the background, e.g. task_type=local_bash) map to
+// EventTypeTaskStarted/EventTypeTaskNotification with the task ID and
+// terminal status preserved, so the runner can track in-flight background
+// tasks for the stall watchdog (GH-4357).
+func TestClaudeCodeBackendParseBackgroundTaskEvents(t *testing.T) {
+	backend := NewClaudeCodeBackend(nil)
+
+	t.Run("task_started", func(t *testing.T) {
+		line := `{"type":"system","subtype":"task_started","task_id":"bscl9ri3t","tool_use_id":"toolu_1","description":"Run tests","task_type":"local_bash","session_id":"sess-1"}`
+		event := backend.parseStreamEvent(line)
+
+		if event.Type != EventTypeTaskStarted {
+			t.Errorf("Type = %q, want %q", event.Type, EventTypeTaskStarted)
+		}
+		if event.BackgroundTaskID != "bscl9ri3t" {
+			t.Errorf("BackgroundTaskID = %q, want %q", event.BackgroundTaskID, "bscl9ri3t")
+		}
+	})
+
+	t.Run("task_notification completed", func(t *testing.T) {
+		line := `{"type":"system","subtype":"task_notification","task_id":"bscl9ri3t","tool_use_id":"toolu_1","status":"completed","summary":"tests passed"}`
+		event := backend.parseStreamEvent(line)
+
+		if event.Type != EventTypeTaskNotification {
+			t.Errorf("Type = %q, want %q", event.Type, EventTypeTaskNotification)
+		}
+		if event.BackgroundTaskID != "bscl9ri3t" {
+			t.Errorf("BackgroundTaskID = %q, want %q", event.BackgroundTaskID, "bscl9ri3t")
+		}
+		if event.BackgroundTaskStatus != "completed" {
+			t.Errorf("BackgroundTaskStatus = %q, want %q", event.BackgroundTaskStatus, "completed")
+		}
+	})
+}
+
 func TestClaudeCodeBackendParseUsageInfo(t *testing.T) {
 	backend := NewClaudeCodeBackend(nil)
 

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -276,6 +276,12 @@ type StreamEvent struct {
 	Model string     `json:"model,omitempty"`
 	// Session ID for resume support (GH-1265)
 	SessionID string `json:"session_id,omitempty"`
+	// TaskID identifies a background task on task_started/task_notification
+	// system events (GH-4357).
+	TaskID string `json:"task_id,omitempty"`
+	// Status carries the terminal status ("completed"/"failed"/"stopped") on
+	// task_notification system events (GH-4357).
+	Status string `json:"status,omitempty"`
 }
 
 // UsageInfo represents token usage in stream events
@@ -2606,10 +2612,14 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 	r.saveLogEntry(task.LogExecutionID(), "info", "Implementing changes...")
 
 	// TASK-308: Stall detection — track last event time and spawn a watchdog.
+	// GH-4357: also track in-flight background tasks (e.g. a backgrounded
+	// Bash command) so the watchdog doesn't kill a session that's legitimately
+	// silent while waiting on one.
 	var (
-		lastEventAt       atomic.Int64
-		stallDetectedFlag atomic.Bool
-		stallDone         = make(chan struct{})
+		lastEventAt             atomic.Int64
+		stallDetectedFlag       atomic.Bool
+		inFlightBackgroundTasks atomic.Int64
+		stallDone               = make(chan struct{})
 	)
 	lastEventAt.Store(time.Now().UnixNano())
 	stallTimeout := r.effectiveStallTimeout()
@@ -2617,7 +2627,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 	var stallCancel context.CancelFunc
 	if stallTimeout > 0 {
 		stallExecutionCtx, stallCancel = context.WithCancel(ctx)
-		go r.runStallWatchdog(task.ID, &lastEventAt, &stallDetectedFlag, stallTimeout, stallDone, stallCancel)
+		go r.runStallWatchdog(task.ID, &lastEventAt, &stallDetectedFlag, &inFlightBackgroundTasks, stallTimeout, stallDone, stallCancel)
 	} else {
 		stallExecutionCtx = ctx
 		stallCancel = func() {}
@@ -2678,6 +2688,17 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		EventHandler: func(event BackendEvent) {
 			// TASK-308: touch the last-event timestamp so the stall watchdog resets.
 			lastEventAt.Store(time.Now().UnixNano())
+
+			// GH-4357: track in-flight background tasks so the stall watchdog
+			// suspends its idle clock while one is running.
+			switch event.Type {
+			case EventTypeTaskStarted:
+				inFlightBackgroundTasks.Add(1)
+			case EventTypeTaskNotification:
+				if inFlightBackgroundTasks.Load() > 0 {
+					inFlightBackgroundTasks.Add(-1)
+				}
+			}
 
 			// Record the event
 			if recorder != nil {

--- a/internal/executor/watchdog.go
+++ b/internal/executor/watchdog.go
@@ -33,10 +33,17 @@ func watchdogTickInterval(stallTimeout time.Duration) time.Duration {
 // stallCancel if no backend event has been seen for longer than stallTimeout.
 // Sets stallDetected before canceling so callers can distinguish a stall from
 // other cancellations. Returns when done is closed (i.e., the execution has ended).
+//
+// inFlightBackgroundTasks counts backend task_started events without a
+// matching task_notification (e.g. a backgrounded Bash command still
+// running). While it is > 0, the idle clock is suspended entirely: a session
+// waiting on a legitimate long-running background task emits zero events by
+// design and must not be mistaken for a dead one (GH-4357).
 func (r *Runner) runStallWatchdog(
 	taskID string,
 	lastEventAt *atomic.Int64,
 	stallDetected *atomic.Bool,
+	inFlightBackgroundTasks *atomic.Int64,
 	stallTimeout time.Duration,
 	done <-chan struct{},
 	stallCancel context.CancelFunc,
@@ -48,6 +55,9 @@ func (r *Runner) runStallWatchdog(
 		case <-done:
 			return
 		case <-ticker.C:
+			if inFlightBackgroundTasks != nil && inFlightBackgroundTasks.Load() > 0 {
+				continue
+			}
 			lastAt := time.Unix(0, lastEventAt.Load())
 			idle := time.Since(lastAt)
 			if idle > stallTimeout {

--- a/internal/executor/watchdog_test.go
+++ b/internal/executor/watchdog_test.go
@@ -49,7 +49,8 @@ func TestStallWatchdog_FiresOnIdle(t *testing.T) {
 	// Use a very short stall timeout so the test doesn't wait 3 minutes.
 	stallTimeout := 5 * time.Second
 
-	go r.runStallWatchdog("test-task", &lastEventAt, &stallDetected, stallTimeout, done, cancel)
+	var inFlight atomic.Int64
+	go r.runStallWatchdog("test-task", &lastEventAt, &stallDetected, &inFlight, stallTimeout, done, cancel)
 
 	// The watchdog ticks every 30s by default — too slow for a unit test.
 	// Instead, simulate a stale lastEventAt (already set above) and wait for
@@ -99,7 +100,8 @@ func TestStallWatchdog_SurvivesLiveSession(t *testing.T) {
 
 	stallTimeout := 200 * time.Millisecond
 
-	go r.runStallWatchdog("test-task", &lastEventAt, &stallDetected, stallTimeout, done, cancel)
+	var inFlight atomic.Int64
+	go r.runStallWatchdog("test-task", &lastEventAt, &stallDetected, &inFlight, stallTimeout, done, cancel)
 
 	// Simulate periodic events keeping the watchdog alive.
 	// The watchdog interval is 30s in production; in the test we close done
@@ -122,6 +124,101 @@ func TestStallWatchdog_SurvivesLiveSession(t *testing.T) {
 	if stallDetected.Load() {
 		t.Fatal("stallDetected should be false for a live session")
 	}
+}
+
+// TestStallWatchdog_SuspendsWhileBackgroundTaskInFlight verifies the watchdog
+// does NOT terminate a session that is silent past stallTimeout while a
+// background task (e.g. a long-running backgrounded Bash command) is still
+// running. GH-4357: a session that starts such a task and awaits its result
+// legitimately emits zero events until it completes; the previous idle-only
+// check misclassified this as a dead session and killed a healthy execution
+// (observed: a `go test -race -count=5` run silently exceeding the 3m stall
+// timeout while otherwise healthy).
+func TestStallWatchdog_SuspendsWhileBackgroundTaskInFlight(t *testing.T) {
+	r := &Runner{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	var (
+		lastEventAt   atomic.Int64
+		stallDetected atomic.Bool
+		inFlight      atomic.Int64
+		done          = make(chan struct{})
+	)
+	// Simulate a task_started event long enough ago that, without the fix,
+	// the idle clock alone would exceed stallTimeout well before the ticker
+	// below stops.
+	lastEventAt.Store(time.Now().Add(-1 * time.Second).UnixNano())
+	inFlight.Store(1) // one background task in flight, no completion event yet
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stallTimeout := 50 * time.Millisecond
+
+	go r.runStallWatchdog("test-task", &lastEventAt, &stallDetected, &inFlight, stallTimeout, done, cancel)
+
+	// Let several ticks elapse — well past stallTimeout — while the
+	// background task remains in flight.
+	time.Sleep(10 * stallTimeout)
+	close(done)
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("stall watchdog terminated session while a background task was in flight")
+	default:
+		// expected: context still alive
+	}
+	if stallDetected.Load() {
+		t.Fatal("stallDetected should be false while a background task is in flight")
+	}
+}
+
+// TestStallWatchdog_FiresAfterBackgroundTaskCompletes verifies the watchdog
+// resumes normal idle detection once the in-flight background task count
+// drops back to zero (GH-4357).
+func TestStallWatchdog_FiresAfterBackgroundTaskCompletes(t *testing.T) {
+	r := &Runner{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	var (
+		lastEventAt   atomic.Int64
+		stallDetected atomic.Bool
+		inFlight      atomic.Int64
+		done          = make(chan struct{})
+	)
+	lastEventAt.Store(time.Now().Add(-1 * time.Second).UnixNano())
+	inFlight.Store(1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stallTimeout := 50 * time.Millisecond
+
+	go r.runStallWatchdog("test-task", &lastEventAt, &stallDetected, &inFlight, stallTimeout, done, cancel)
+
+	// Task is still running: watchdog must not fire yet.
+	time.Sleep(3 * stallTimeout)
+	select {
+	case <-ctx.Done():
+		t.Fatal("stall watchdog fired while background task was still in flight")
+	default:
+	}
+
+	// Background task completes (task_notification received) without any
+	// other event refreshing lastEventAt — idle clock resumes from a stale
+	// timestamp, so the very next tick should now detect a stall.
+	inFlight.Store(0)
+
+	select {
+	case <-ctx.Done():
+		// expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("stall watchdog did not resume idle detection after background task completed")
+	}
+
+	if !stallDetected.Load() {
+		t.Fatal("stallDetected should be true once idle detection resumes past stallTimeout")
+	}
+
+	close(done)
 }
 
 // TestEffectiveStallTimeout verifies default and custom values.


### PR DESCRIPTION
## Summary
- Fixes GH-4357: the stall watchdog was killing healthy sessions that legitimately went quiet while awaiting a backgrounded task (e.g. `go test -race -count=5` run via Bash `run_in_background`).
- Root cause confirmed against the actual incident recording (`~/.pilot/recordings/TG-1784159243201`): Claude Code emits a `system`/`task_started` event (`task_type=local_bash`) and then — unlike `local_agent` sub-tasks, which get periodic `task_progress` heartbeats — no further stream events until a terminating `system`/`task_notification` (`status: completed|failed|stopped`) arrives.
- New `EventTypeTaskStarted`/`EventTypeTaskNotification` backend event types (+ `BackgroundTaskID`/`BackgroundTaskStatus` fields) are parsed from Claude Code's stream-json in `backend_claudecode.go`.
- The runner now tracks an `inFlightBackgroundTasks` counter alongside the existing `lastEventAt`/`stallDetectedFlag`, and `runStallWatchdog` suspends its idle check entirely while the counter is > 0, resuming normal idle detection once the task completes.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/executor/...` (full package, includes new regression tests)
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/executor/...` — 0 issues
- [x] New tests: `TestStallWatchdog_SuspendsWhileBackgroundTaskInFlight`, `TestStallWatchdog_FiresAfterBackgroundTaskCompletes` (watchdog_test.go), `TestClaudeCodeBackendParseBackgroundTaskEvents` (backend_claudecode_test.go)

Once merged, the operator mitigation (`executor.stall_timeout_ms: 600000`) can be rolled back to the 3-minute default since local_bash backgrounding no longer needs a blanket longer timeout to survive.