### PR TITLE
test(adapterhealth): deflake TestRegistry_Go_DisablesAfterMaxRestarts

### DIFF
--- a/internal/adapterhealth/adapterhealth_test.go
+++ b/internal/adapterhealth/adapterhealth_test.go
@@ -110,9 +110,14 @@ func TestRegistry_Go_DisablesAfterMaxRestarts(t *testing.T) {
 		panic("always boom")
 	})
 
+	// Registry.Go sets st.Disabled=true and then invokes onPanic (adapterhealth.go
+	// runWithRestart) — the two aren't atomic w.r.t. a concurrent Snapshot(), so
+	// waiting on Disabled alone can observe it before the final onPanic call lands.
+	// Wait on all three so the exact-count assertions below are deterministic.
 	waitFor(t, 2*time.Second, func() bool {
 		snap := r.Snapshot()
-		return len(snap) == 1 && snap[0].Disabled
+		return len(snap) == 1 && snap[0].Disabled &&
+			calls.Load() == MaxRestarts && panicCount.Load() == MaxRestarts
 	})
 
 	if got := calls.Load(); got != MaxRestarts {


### PR DESCRIPTION
## Summary
- `TestRegistry_Go_DisablesAfterMaxRestarts` polled only `snap[0].Disabled`, but `Registry.Go` sets `st.Disabled = true` and *then* invokes the final `onPanic` callback (`internal/adapterhealth/adapterhealth.go` `runWithRestart`). A concurrent `Snapshot()` could observe `Disabled=true` before the 5th `onPanic` call landed, so `panicCount.Load()` sometimes read 4 instead of `MaxRestarts=5`.
- Failed twice within 30 minutes holding CI red: main run 29460531120 (commit bd750650) and PR #4351's run — same code, timing-dependent.
- Fix is test-side per the issue's recommendation: `waitFor` now also requires `calls.Load() == MaxRestarts && panicCount.Load() == MaxRestarts`, keeping the existing exact-count `Fatalf`s as the real assertions. No registry-side ordering guarantee was added since `onPanic` is only wired to alert dispatch (`cmd/pilot/poller_registry.go` → `alertAdapterPanic`) — no caller relies on Disabled-after-onPanic ordering.

Closes #4358.

## Test plan
- [x] `go build ./internal/adapterhealth/...`
- [x] `go vet ./internal/adapterhealth/...`
- [x] `go test -race -count=100 -run TestRegistry_Go_DisablesAfterMaxRestarts ./internal/adapterhealth/...` — pass
- [x] `go test -race -count=10 ./internal/adapterhealth/...` — full package pass
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/adapterhealth/...` — 0 issues