### PR TITLE
fix(memory): reuse canonicalizeProjectPath in IsTaskQueued

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -2283,23 +2283,33 @@ func (s *Store) IsTaskQueued(taskID, projectPath string) (bool, error) {
 	err := s.db.QueryRow(`
 		SELECT COUNT(*) FROM executions
 		WHERE task_id = ? AND project_path = ? AND status IN ('queued', 'pending', 'running')
-	`, taskID, projectPath).Scan(&count)
+	`, taskID, canonicalizeProjectPath(projectPath)).Scan(&count)
 	if err != nil {
 		return false, err
 	}
 	return count > 0, nil
 }
 
-// canonicalizeProjectPath normalizes projectPath for use as part of an
-// execution_claims key, trimming a trailing separator and collapsing "."/
-// ".." segments (filepath.Clean) so two textually-different-but-equivalent
-// paths for the same project (mem-019/GH-4297's discriminator-mismatch
-// class) claim the same row instead of silently splitting the key.
+// canonicalizeProjectPath normalizes projectPath for use as a discriminator
+// key (execution_claims, IsTaskQueued's active-task lookup), resolving
+// symlinks and collapsing a trailing separator / "."/".." segments so two
+// textually-different-but-equivalent paths for the same project
+// (mem-019/GH-4297's discriminator-mismatch class) resolve to the same key
+// instead of silently splitting it. filepath.Clean runs first so
+// EvalSymlinks sees a normalized input; if EvalSymlinks fails (path doesn't
+// exist yet, e.g. a project directory not yet checked out), it falls back to
+// the cleaned form rather than erroring, mirroring worktree.go's
+// resolvedRepoPath tolerance for the same OS-level symlink quirk (macOS
+// /var vs /private/var).
 func canonicalizeProjectPath(projectPath string) string {
 	if projectPath == "" {
 		return projectPath
 	}
-	return filepath.Clean(projectPath)
+	cleaned := filepath.Clean(projectPath)
+	if resolved, err := filepath.EvalSymlinks(cleaned); err == nil {
+		return resolved
+	}
+	return cleaned
 }
 
 // ClaimExecution atomically claims (task_id, project_path, generation) for

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -619,6 +619,43 @@ func TestIsTaskQueued_ProjectScoping(t *testing.T) {
 	}
 }
 
+// TestIsTaskQueued_CanonicalizesProjectPath is the mem-019/GH-4297
+// discriminator-mismatch regression for the read side: IsTaskQueued must
+// reuse canonicalizeProjectPath (as ClaimExecution already does at write
+// time) so a caller querying with a trailing separator or "./.." segments
+// still finds a row saved under the equivalent clean path, instead of
+// silently missing it and dispatching a duplicate.
+func TestIsTaskQueued_CanonicalizesProjectPath(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	_ = store.SaveExecution(&Execution{
+		ID:          "exec-canonical",
+		TaskID:      "GH-11",
+		ProjectPath: "/tmp/project-x",
+		Status:      "running",
+	})
+
+	queued, err := store.IsTaskQueued("GH-11", "/tmp/project-x/")
+	if err != nil {
+		t.Fatalf("IsTaskQueued failed: %v", err)
+	}
+	if !queued {
+		t.Error("expected trailing-slash query to match the row saved under the clean path")
+	}
+
+	queued, err = store.IsTaskQueued("GH-11", "/tmp/./project-x")
+	if err != nil {
+		t.Fatalf("IsTaskQueued failed: %v", err)
+	}
+	if !queued {
+		t.Error("expected a query with a '.' segment to match the row saved under the clean path")
+	}
+}
+
 // TestClaimExecution_SecondCallerLoses is the TASK-407/GH-4349 atomic-claim
 // idiom test (the INSERT OR IGNORE + RowsAffected()==1 pattern from
 // ClaimSpawnedFix, internal/autopilot/state_store.go:1062): a second


### PR DESCRIPTION
## Summary
- GH-4353 (child 1 of TASK-407/GH-4349, atomic dispatch-admission claim). The `execution_claims` migration, `Store.ClaimExecution`, and `ExecutionLifecycle.Begin`'s claim-then-save upgrade (this issue's other required pieces) were already shipped on `main` via sibling PRs #4361/#4362/#4363.
- The one remaining gap against the spec: `canonicalizeProjectPath` was applied at `ClaimExecution` write time but not reused by `IsTaskQueued`'s read-side lookup, so a caller querying with a trailing separator or unresolved symlink could silently miss an existing active-task row (mem-019/GH-4297's discriminator-mismatch class).
- Reuses `canonicalizeProjectPath` in `IsTaskQueued`'s query param, and extends the helper to resolve symlinks (previously only `filepath.Clean`), falling back to the cleaned path when the target doesn't exist yet (mirrors `worktree.go`'s `resolvedRepoPath` tolerance for the same macOS `/var` vs `/private/var` quirk).

## Test plan
- [x] `go build ./...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] `go test ./internal/memory/ ./internal/executor/ -race -count=5` — green
- [x] Added `TestIsTaskQueued_CanonicalizesProjectPath` covering trailing-slash and `"."`-segment query normalization against a row saved under the clean path