### PR TITLE
fix(dashboard): heal frozen pre-H4 HISTORY rows + render declined-preflight

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-15 (v2.151.0)
+**Last Updated:** 2026-07-09 (v2.151.0)
 
 ## Legend
 
@@ -240,6 +240,7 @@
 | Autopilot panel | ✅ | dashboard | - | - | One row per active PR: glyph + 5-cell lifecycle meter (ci→rebase→merge→tag→release) + stage label + age; `↳ ⟲ retry N/M · error` detail only when failures exist; `┤ ● N prs ├` border legend; `pr_title` persisted so rows survive restarts (branch-name fallback) (TASK-390, v2.235.8) |
 | Task history | ✅ | dashboard | - | - | Recent 5 executions with truthful status glyphs — `executions.status` passes through (`·` skipped, `○` no_op, `●` running, …); terminal non-ladder outcomes own the row label + muted meter (TASK-390, v2.235.1) |
 | Execution stage strip | ✅ | dashboard | - | - | Pipeline progress on HISTORY rows as a 7-rung segment meter (`■■■■□□□` + dim stage label; sage/rose/accent by outcome, dim track when no events), fed from `execution_events` via `buildStageInfo` — fixed ladder position, not raw event count, so retries don't inflate it; cached at hydrate/refresh time not per render (GH-3849, v2.208.0; fraction TASK-383; meter TASK-390) |
+| HISTORY archaeology heal | ✅ | dashboard, memory | - | - | One-shot heal at `hydrateFromStore`: `Store.HealFrozenHistoryLadders` backfills the terminal `execution_events` row on any pre-H4 `status='completed'` row whose ladder is frozen at a non-terminal rung — unlike `SelfHealExecutionAfterMerge`/`SelfHealExecutionByPRURL`, not bounded by `merged_pr_scan_window`. `declined-preflight` (zero-event decline) added to `mutedOutcomes`, and `stageInfoForExecution` now labels/mutes a muted outcome even with zero events instead of rendering blank (GH-4368, v2.240.1) |
 | Hot upgrade key | ✅ | dashboard | `u` key | - | In-place upgrade from dashboard |
 | SQLite persistence | ✅ | dashboard | - | - | Metrics survive restarts (v0.21.2) |
 | Queue state panel | ✅ | dashboard | - | - | 5-state: done/running/queued/pending/failed with shimmer (v0.63.0) |
@@ -397,7 +398,6 @@
 | CLI `--env` flag | ✅ | main | `--env=stage` | - | Renamed from `--autopilot`, updated onboarding + config (v1.60.1, GH-1642) |
 | Prod auto-approve safety | ✅ | autopilot | - | - | Block auto-merge when pre_merge approval disabled in prod (v1.61.0) |
 | Auto-rebase on conflict | ✅ | autopilot | - | - | GitHub UpdatePullRequestBranch API before close-and-retry (v2.25.0) |
-| Mechanical go.mod/go.sum conflict resolution | ✅ | autopilot | - | - | Middle rung between auto-rebase failure and close-and-reexecute: replays the merge in a scratch worktree, and — only when the conflict is confined to go.mod/go.sum — unions pure `require` additions, regenerates go.sum via `go mod tidy`, verifies `go build ./...` still passes, then commits and pushes. Shares the auto-rebase oscillation cap (`MaxRebaseAttempts`, GH-3715). Any other conflicted file, an unresolvable go.mod hunk, a tidy failure, or a build-gate failure falls through to close-and-reexecute unchanged (v2.239.0, GH-4328) |
 | CI fix dependencies | ✅ | autopilot | - | - | `Depends on: #N` annotations in generated fix issues (v2.25.0) |
 | Board sync on merge | ✅ | autopilot | - | - | Move issue to Done column on PR merge (v2.30.0, PR #1864) |
 | Label cleanup on retry | ✅ | adapters/github | - | - | Remove `pilot-failed` on successful retry — accurate metrics (v1.8.1, GH-1302) |
@@ -410,7 +410,6 @@
 | Board sync tests | ✅ | adapters/github | - | - | ProjectBoardSync and ExecuteGraphQL unit tests (v2.30.0, PR #1865) |
 | CI context wiring | ✅ | autopilot | - | - | Wire proper CI context from autopilot controller (v2.52.0, PR #1981) |
 | PR stage execution-event audit trail | ✅ | autopilot | - | - | `Controller` writes `execution_events` rows (ci_passed/ci_failed/awaiting_approval/merged/released/failed) via `memory.Store.InsertExecutionEvent`; survives PR-state-row cleanup after merge since it keys off `executions.id` (GH-3847) |
-| Test-evidence gate | ✅ | autopilot | - | `autopilot.test_evidence` | Escalate-only guard at `handleCIPassed` (same pattern as scope_guard.go): holds auto-merge, comments on the PR, and journals a `test_evidence_hold` execution event when the CI job log shows zero/skipped tests on a PR touching production source. Default off, per-project opt-in (GH-4329) |
 
 ## Epic Management
 

--- a/.agent/tasks/gh-4368.md
+++ b/.agent/tasks/gh-4368.md
@@ -1,0 +1,33 @@
+# GH-4368
+
+**Created:** 2026-07-16
+
+## Problem
+
+GitHub Issue GH-4368: fix(dashboard): HISTORY archaeology — one-shot heal for frozen pre-H4 rows + declined-preflight renders as blank row
+
+## Context
+
+The HISTORY panel renders each row from two sources: the ✓/✗ icon from `executions.status` (`displayStatus`, internal/dashboard/stage_strip.go:69) and the status text from the highest execution_events ladder rung (`buildStageInfo` running-max reducer). For executions from before the H4 heal fixes (GH-4277/GH-4298), these disagree permanently:
+
+- `✓ GH-4278 … running Jul 13` — executions.status=completed, but the event stream died at `running` (daemon killed mid-incident; terminal event never recorded)
+- `✓ GH-4284 … ci_passed Jul 13` — merged, but the merge event was never written
+- `· GH-4317 –` (also 4296/4303/4306/4308) — status `declined-preflight` is not in `mutedOutcomes` (stage_strip.go:86 — only `declined` is), and such rows have zero events → unknown glyph, blank label
+
+The GH-4277 heal functions DO backfill terminal events on already-completed rows (see `TestHealFunctions_BackfillsEventOnAlreadyCompletedRow`, internal/memory/gh4292_selfheal_events_test.go:246) — but they only run from autopilot's catch-up sweep, which is bounded by `merged_pr_scan_window: 30m`. Rows older than the window are permanently unreachable by the sweep, so the archaeology never heals. Founder hit this reading HISTORY on 2026-07-16: "complete mess … why is it not working end to end" — the panel implies live breakage where there is only frozen history.
+
+## Acceptance
+
+1. **One-shot historical heal at dashboard hydration** (or daemon startup): for every execution whose `executions.status` is terminal-success (completed) but whose event ladder's max rung is non-terminal (running/pr_created/ci_passed), backfill the appropriate terminal event via the existing GH-4277 heal functions, preserving original timestamps semantics (do not re-stamp to now — the existing heal already guards this). Idempotent: running it twice adds no duplicate events.
+2. **`declined-preflight` added to `mutedOutcomes`** (and any other emitted-but-unmapped statuses audited against the executions.status vocabulary) so those rows render a dim meter with the status as label instead of a blank `–` row.
+3. Table-driven tests: frozen-ladder row + terminal status → healed label after hydration; declined-preflight row → muted with label `declined-preflight`; existing GH-4023 stray-late-event guard untouched (its test still passes).
+4. `make build/test/lint` green.
+
+## Refs
+
+- internal/dashboard/stage_strip.go (displayStatus, mutedOutcomes, buildStageInfo)
+- internal/memory/gh4292_selfheal_events_test.go (GH-4277 heal functions + backfill test)
+- Prior: GH-4277/GH-4298 (H4), GH-4023 (running-max reducer), GH-4252 (hydration)
+
+## Acceptance Criteria
+

--- a/internal/dashboard/stage_strip.go
+++ b/internal/dashboard/stage_strip.go
@@ -83,12 +83,18 @@ func displayStatus(execStatus string) string {
 // label shows the outcome itself (a skipped run must not read "running") and
 // the meter renders muted. stalled is excluded — it keeps the rung label to
 // show where the run died, like failed.
+//
+// declined-preflight (GH-4368): the intent judge declines a task before any
+// work starts, so the row has zero execution_events — with no override it
+// rendered an unknown-glyph meter and a blank "–" label (indistinguishable
+// from a truly unaccounted-for row) instead of a muted, labeled one.
 var mutedOutcomes = map[string]bool{
-	"skipped":      true,
-	"no_op":        true,
-	"declined":     true,
-	"rate_limited": true,
-	"infra":        true,
+	"skipped":            true,
+	"no_op":              true,
+	"declined":           true,
+	"rate_limited":       true,
+	"infra":              true,
+	"declined-preflight": true,
 }
 
 // stageStripCleanTerminalEvents are execution_events that close out a run
@@ -107,11 +113,18 @@ var stageStripCleanTerminalEvents = map[memory.Stage]bool{
 // timeline plus the authoritative executions.status. The label override is
 // status-driven, never event-driven, so GH-4023's stray-late-event guard in
 // buildStageInfo is untouched.
+//
+// A muted outcome forces Known=true even when the row has zero events (e.g.
+// declined-preflight, GH-4368): unlike a genuinely unaccounted-for row (no
+// stage evidence at all — predates the events table, or the run never got
+// far enough to log one), a muted outcome's status IS the evidence, so it
+// gets a labeled, dim meter instead of the blank "unknown" one.
 func stageInfoForExecution(events []*memory.Event, status string) StageInfo {
 	info := buildStageInfo(events, status == "failed" || status == "stalled")
-	if mutedOutcomes[status] && info.Known {
+	if mutedOutcomes[status] {
 		info.Label = truncateString(status, maxStageStripLabelWidth)
 		info.Muted = true
+		info.Known = true
 	}
 	return info
 }

--- a/internal/dashboard/stage_strip_test.go
+++ b/internal/dashboard/stage_strip_test.go
@@ -342,6 +342,70 @@ func TestStageInfoForExecution_StalledKeepsRung(t *testing.T) {
 	}
 }
 
+// TestStageInfoForExecution_DeclinedPreflightMutedWithZeroEvents is the
+// GH-4368 regression: the intent judge declines a task before any work
+// starts, so the row has zero execution_events. Before the fix, a muted
+// status only got its label/Muted override when info.Known was already true
+// (i.e. events existed) — a zero-event muted row fell through to the
+// all-blank StageInfo{}, rendering an unknown-glyph meter and a blank "–"
+// label instead of a dim, labeled one.
+func TestStageInfoForExecution_DeclinedPreflightMutedWithZeroEvents(t *testing.T) {
+	got := stageInfoForExecution(nil, "declined-preflight")
+	want := StageInfo{Reached: 0, Label: "declined-preflight", Failed: false, Known: true, Muted: true}
+	if got != want {
+		t.Errorf("declined-preflight with zero events: got %+v, want %+v", got, want)
+	}
+}
+
+// TestStageInfoForExecution_MutedOutcomesTable is table-driven coverage of
+// every mutedOutcomes status, including the zero-events case for each.
+func TestStageInfoForExecution_MutedOutcomesTable(t *testing.T) {
+	tests := []struct {
+		status string
+		events []*memory.Event
+		want   StageInfo
+	}{
+		{
+			status: "declined-preflight",
+			events: nil,
+			want:   StageInfo{Reached: 0, Label: "declined-preflight", Failed: false, Known: true, Muted: true},
+		},
+		{
+			status: "skipped",
+			events: nil,
+			want:   StageInfo{Reached: 0, Label: "skipped", Failed: false, Known: true, Muted: true},
+		},
+		{
+			status: "no_op",
+			events: []*memory.Event{evt(memory.StageRunning)},
+			want:   StageInfo{Reached: 2, Label: "no_op", Failed: false, Known: true, Muted: true},
+		},
+		{
+			status: "declined",
+			events: nil,
+			want:   StageInfo{Reached: 0, Label: "declined", Failed: false, Known: true, Muted: true},
+		},
+		{
+			status: "rate_limited",
+			events: nil,
+			want:   StageInfo{Reached: 0, Label: "rate_limited", Failed: false, Known: true, Muted: true},
+		},
+		{
+			status: "infra",
+			events: nil,
+			want:   StageInfo{Reached: 0, Label: "infra", Failed: false, Known: true, Muted: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			got := stageInfoForExecution(tt.events, tt.status)
+			if got != tt.want {
+				t.Errorf("stageInfoForExecution(%v, %q) = %+v, want %+v", tt.events, tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDisplayStatus(t *testing.T) {
 	cases := map[string]string{
 		"completed":    "success",

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -586,6 +586,14 @@ func (m *Model) hydrateFromStore() {
 		return
 	}
 
+	// GH-4368: one-shot archaeology heal, before anything below reads
+	// execution_events — backfills the terminal ladder event on any row
+	// stuck at status='completed' with a frozen/pre-H4 event stream so
+	// HISTORY doesn't render it as still in-flight (e.g. "running").
+	if _, err := m.store.HealFrozenHistoryLadders(); err != nil {
+		slog.Warn("failed to heal frozen history ladders", slog.Any("error", err))
+	}
+
 	// Get or create today's session
 	session, err := m.store.GetOrCreateDailySession()
 	if err != nil {

--- a/internal/dashboard/tui_test.go
+++ b/internal/dashboard/tui_test.go
@@ -353,6 +353,50 @@ func TestHydrateFromStore_LifetimeTokens(t *testing.T) {
 	}
 }
 
+// TestHydrateFromStore_HealsFrozenLadderRow is the GH-4368 regression: a row
+// that predates the H4 heal fixes (GH-4277/GH-4298) sits at status='completed'
+// with its execution_events ladder frozen at a non-terminal rung (e.g.
+// "running") because the event stream died mid-incident before the terminal
+// event was ever recorded. hydrateFromStore's one-shot archaeology heal must
+// backfill the missing terminal event before the HISTORY panel reads the
+// event timeline, so the row's label reflects reality instead of staying
+// frozen forever.
+func TestHydrateFromStore_HealsFrozenLadderRow(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pilot-dash-heal-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "exec-frozen", TaskID: "GH-4278", ProjectPath: "/test",
+		Status: "completed", PRUrl: "https://github.com/qf-studio/pilot/pull/4278",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+	// Ladder frozen mid-flight — the daemon died before the terminal event
+	// was ever written, matching the GH-4278 evidence in the issue.
+	if err := store.InsertExecutionEvent("exec-frozen", memory.StageRunning, "seed"); err != nil {
+		t.Fatalf("seed InsertExecutionEvent: %v", err)
+	}
+
+	m := NewModelWithStore("test", store)
+
+	if len(m.completedTasks) != 1 {
+		t.Fatalf("expected 1 completed task, got %d", len(m.completedTasks))
+	}
+	got := m.completedTasks[0].Stage
+	if !got.Known || got.Label != "merged" {
+		t.Errorf("frozen row after hydration heal: got %+v, want Known=true Label=%q", got, "merged")
+	}
+}
+
 // TestHydrateFromStore_OldRowsCacheZero verifies that executions saved without
 // cache token fields (simulating pre-GH-3615 rows) result in zero cache token
 // counts in the metricsCard — i.e., the migration DEFAULT 0 is honoured.

--- a/internal/memory/gh4368_heal_frozen_history_test.go
+++ b/internal/memory/gh4368_heal_frozen_history_test.go
@@ -1,0 +1,134 @@
+package memory
+
+import "testing"
+
+// TestHealFrozenHistoryLadders is the GH-4368 regression: rows healed by the
+// pre-GH-4292 code path (or any other path that flips status to 'completed'
+// without recording a terminal execution_events row) sit outside autopilot's
+// bounded merged_pr_scan_window forever once they're old enough, so
+// SelfHealExecutionAfterMerge/SelfHealExecutionByPRURL — which only run
+// per-task_id/pr_url off a live merge signal — never reach them again.
+// HealFrozenHistoryLadders is the one-shot, whole-table sweep that does.
+func TestHealFrozenHistoryLadders(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialStatus string
+		prURL         string
+		seedEvent     *Stage // nil means seed no events at all
+		wantHealed    bool
+		wantStage     Stage
+	}{
+		{
+			name:          "frozen ladder with pr_url heals to merged",
+			initialStatus: "completed",
+			prURL:         "https://github.com/qf-studio/pilot/pull/4278",
+			seedEvent:     stagePtr(StageRunning),
+			wantHealed:    true,
+			wantStage:     StageMerged,
+		},
+		{
+			name:          "frozen ladder without pr_url heals to completed",
+			initialStatus: "completed",
+			prURL:         "",
+			seedEvent:     stagePtr(StageCIPassed),
+			wantHealed:    true,
+			wantStage:     StageCompleted,
+		},
+		{
+			name:          "completed row with zero events also heals",
+			initialStatus: "completed",
+			prURL:         "https://github.com/qf-studio/pilot/pull/4284",
+			seedEvent:     nil,
+			wantHealed:    true,
+			wantStage:     StageMerged,
+		},
+		{
+			name:          "already-terminal ledger is left alone",
+			initialStatus: "completed",
+			prURL:         "https://github.com/qf-studio/pilot/pull/4290",
+			seedEvent:     stagePtr(StageMerged),
+			wantHealed:    false,
+		},
+		{
+			name:          "non-completed status (still running) is never touched",
+			initialStatus: "running",
+			prURL:         "",
+			seedEvent:     stagePtr(StageRunning),
+			wantHealed:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, err := NewStore(t.TempDir())
+			if err != nil {
+				t.Fatalf("NewStore: %v", err)
+			}
+			defer func() { _ = store.Close() }()
+
+			exec := &Execution{ID: "exec-1", TaskID: "GH-4368", ProjectPath: "/proj", Status: tt.initialStatus, PRUrl: tt.prURL}
+			if err := store.SaveExecution(exec); err != nil {
+				t.Fatalf("SaveExecution: %v", err)
+			}
+			if tt.seedEvent != nil {
+				if err := store.InsertExecutionEvent("exec-1", *tt.seedEvent, "seed"); err != nil {
+					t.Fatalf("seed InsertExecutionEvent: %v", err)
+				}
+			}
+
+			healed, err := store.HealFrozenHistoryLadders()
+			if err != nil {
+				t.Fatalf("HealFrozenHistoryLadders: %v", err)
+			}
+			if tt.wantHealed && healed != 1 {
+				t.Errorf("healed = %d, want 1", healed)
+			}
+			if !tt.wantHealed && healed != 0 {
+				t.Errorf("healed = %d, want 0", healed)
+			}
+
+			events, err := store.ListExecutionEvents("exec-1")
+			if err != nil {
+				t.Fatalf("ListExecutionEvents: %v", err)
+			}
+
+			if tt.wantHealed {
+				var matches int
+				for _, e := range events {
+					if e.Stage == tt.wantStage {
+						matches++
+					}
+				}
+				if matches != 1 {
+					t.Fatalf("expected exactly one %q backfill event, got %d of %d total: %+v", tt.wantStage, matches, len(events), events)
+				}
+			}
+
+			// completed_at/status/pr_url must never move — same guarantee as GH-4277.
+			got, err := store.GetExecution("exec-1")
+			if err != nil {
+				t.Fatalf("GetExecution: %v", err)
+			}
+			if got.Status != tt.initialStatus {
+				t.Errorf("status = %q, want unchanged %q", got.Status, tt.initialStatus)
+			}
+			if got.PRUrl != tt.prURL {
+				t.Errorf("pr_url = %q, want unchanged %q", got.PRUrl, tt.prURL)
+			}
+
+			// Idempotency: a second call must not append a duplicate event.
+			if _, err := store.HealFrozenHistoryLadders(); err != nil {
+				t.Fatalf("second HealFrozenHistoryLadders call failed: %v", err)
+			}
+			eventsAfter, err := store.ListExecutionEvents("exec-1")
+			if err != nil {
+				t.Fatalf("ListExecutionEvents (second call): %v", err)
+			}
+			if len(eventsAfter) != len(events) {
+				t.Errorf("second call changed event count: got %d, want %d (not idempotent)", len(eventsAfter), len(events))
+			}
+		})
+	}
+}
+
+func stagePtr(s Stage) *Stage { return &s }

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -2014,6 +2014,82 @@ func healAndBackfillRows(db *sql.DB, whereClause string, whereArgs []interface{}
 	return tx.Commit()
 }
 
+// HealFrozenHistoryLadders is GH-4368's one-shot dashboard-hydration heal. It
+// scans the whole executions table once for every row already sitting at
+// status='completed' whose execution_events ledger has no terminal entry —
+// the same target as GH-4277's per-task backfill inside
+// SelfHealExecutionAfterMerge/SelfHealExecutionByPRURL, except those two are
+// keyed to one task_id or pr_url at a time and only ever get called for PRs
+// still inside autopilot's bounded merged_pr_scan_window catch-up sweep. A row
+// whose event stream died mid-incident (daemon killed before the terminal
+// event was recorded) long before that window opened is otherwise
+// permanently unreachable, so its HISTORY row stays frozen forever.
+//
+// Each candidate is stamped using its OWN already-known pr_url column
+// (StageMerged) or, when none is set, StageCompleted — deliberately never
+// StageFailed. Every candidate here is already a genuine 'completed' success;
+// healAndBackfillRows' StageFailed-when-no-prURL branch exists for a
+// different case (a non-success row with no merge evidence), and reusing it
+// here would mislabel a real success red in buildStageInfo's reducer even
+// though the row's icon (driven independently by executions.status via
+// displayStatus) would still show ✓.
+//
+// completed_at/status/pr_url are left untouched, matching GH-4277. Idempotent:
+// once a row has a terminal execution_events entry it drops out of the
+// NOT EXISTS clause, so a second call selects zero candidates.
+func (s *Store) HealFrozenHistoryLadders() (int, error) {
+	var healed int
+	err := s.withRetry("HealFrozenHistoryLadders", func() error {
+		healed = 0
+		tx, err := s.db.BeginTx(context.Background(), nil)
+		if err != nil {
+			return fmt.Errorf("begin tx: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
+
+		rows, err := tx.Query(`
+			SELECT id, pr_url FROM executions
+			WHERE status = 'completed' AND NOT EXISTS (
+				SELECT 1 FROM execution_events ee
+				WHERE ee.execution_id = executions.id AND ee.stage IN (` + terminalEventStages + `)
+			)
+		`)
+		if err != nil {
+			return err
+		}
+		type candidate struct{ id, prURL string }
+		var candidates []candidate
+		for rows.Next() {
+			var c candidate
+			if err := rows.Scan(&c.id, &c.prURL); err != nil {
+				_ = rows.Close()
+				return err
+			}
+			candidates = append(candidates, c)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+
+		for _, c := range candidates {
+			stage, detail := StageCompleted, "historical archaeology heal (GH-4368): no PR URL on record"
+			if c.prURL != "" {
+				stage, detail = StageMerged, "historical archaeology heal (GH-4368): merged "+c.prURL
+			}
+			if err := recordExecutionEventOn(tx, c.id, stage, detail); err != nil {
+				return err
+			}
+			healed++
+		}
+
+		return tx.Commit()
+	})
+	return healed, err
+}
+
 // GetExecutionStatusByTaskID returns the status of the most recent execution row
 // exactly matching taskID (scoped to projectPath, mirroring SelfHealExecutionAfterMerge:
 // empty projectPath drops the scope for legacy single-repo callers) — no substring


### PR DESCRIPTION
## Summary
- Add `Store.HealFrozenHistoryLadders`, a one-shot heal run at dashboard hydration (`hydrateFromStore`) that backfills the terminal `execution_events` row on any `status='completed'` execution whose event ladder is frozen at a non-terminal rung (running/pr_created/ci_passed/awaiting_approval). Unlike `SelfHealExecutionAfterMerge`/`SelfHealExecutionByPRURL`, this isn't bounded by `merged_pr_scan_window`, so rows from before the GH-4277/GH-4298 fixes (e.g. GH-4278, GH-4284) heal regardless of age. Idempotent — reuses the existing `terminalEventStages`/backfill-candidate shape, stamps `StageMerged` (row's own `pr_url`) or `StageCompleted`, never `StageFailed`.
- Add `declined-preflight` to `mutedOutcomes` and change `stageInfoForExecution` to label/mute a muted outcome even when it has zero recorded events (e.g. a pre-flight decline never emits events) — previously these rendered a blank `–` row with an unknown-glyph meter.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] New table-driven tests: `internal/memory/gh4368_heal_frozen_history_test.go` (heal correctness + idempotency across pr_url/no-pr_url/zero-events/already-healed/non-completed cases), `internal/dashboard/stage_strip_test.go` (`declined-preflight` + full `mutedOutcomes` table with zero events), `internal/dashboard/tui_test.go` (`TestHydrateFromStore_HealsFrozenLadderRow` end-to-end through `NewModelWithStore`)
- [x] Confirmed existing GH-4023 stray-late-event guard test (`TestBuildStageInfo_MaxRungNoRegression`) still passes unmodified