### PR TITLE
fix(executor): poller re-pick claims generation+1 after a failed task (GH-4372)

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -73,7 +73,7 @@
       },
       "git-operations": {
         "label": "Git Operations",
-        "description": "Git command wrappers in executor \u2014 clone, fetch, push, sync, worktree management. Source of data-loss risk if destructive ops (reset --hard, push --force) are used without divergence checks.",
+        "description": "Git command wrappers in executor — clone, fetch, push, sync, worktree management. Source of data-loss risk if destructive ops (reset --hard, push --force) are used without divergence checks.",
         "related": [
           "executor"
         ],
@@ -133,7 +133,7 @@
       },
       "anthropic-api": {
         "label": "Anthropic API",
-        "description": "Direct Anthropic Messages API calls (x-api-key, max_tokens required) used by the bot module's llm.Client \u2014 distinct from the Claude Code subprocess the executor uses",
+        "description": "Direct Anthropic Messages API calls (x-api-key, max_tokens required) used by the bot module's llm.Client — distinct from the Claude Code subprocess the executor uses",
         "related": [
           "llm-integration",
           "claude-code-integration"
@@ -167,7 +167,7 @@
       },
       "doctor": {
         "label": "doctor",
-        "description": "pilot doctor health checks (internal/health) \u2014 presence-only today, target: live auth probes via Verifiable interface"
+        "description": "pilot doctor health checks (internal/health) — presence-only today, target: live auth probes via Verifiable interface"
       },
       "canary": {
         "label": "canary",
@@ -433,7 +433,7 @@
         "released": "v2.166.10-11"
       },
       "TASK-359": {
-        "title": "Daemon finalization hardening \u2014 Shapes A/B/C closure",
+        "title": "Daemon finalization hardening — Shapes A/B/C closure",
         "status": "planned",
         "priority": "P1",
         "file": ".agent/tasks/TASK-359-daemon-finalization-hardening.md",
@@ -478,7 +478,7 @@
         ],
         "created": "2026-07-05",
         "file": ".agent/tasks/archive/TASK-385-studio-sdk-v0260-github-surface.md",
-        "label": "studio-sdk v0.26.0 github poll/board/PR surface (studio-sdk#71) \u2014 unblocks M7 4b-4d",
+        "label": "studio-sdk v0.26.0 github poll/board/PR surface (studio-sdk#71) — unblocks M7 4b-4d",
         "priority": "P1",
         "status": "completed"
       },
@@ -523,7 +523,7 @@
       },
       "TASK-368": {
         "path": ".agent/tasks/TASK-368-m7-github-cutover-phase4.md",
-        "title": "M7 Phase 4 \u2014 GitHub adapter \u2192 studio-sdk cutover (MANUAL)",
+        "title": "M7 Phase 4 — GitHub adapter → studio-sdk cutover (MANUAL)",
         "status": "unknown",
         "concepts": [
           "frontend",
@@ -540,7 +540,7 @@
       },
       "TASK-390": {
         "path": "/Users/aleks.petrov/Projects/startups/pilot/.claude/worktrees/grot-dashboard-redesign/.agent/tasks/TASK-390-grot-dashboard-redesign.md",
-        "title": "Dashboard TUI redesign \u2014 grot design system",
+        "title": "Dashboard TUI redesign — grot design system",
         "status": "unknown",
         "concepts": [
           "testing",
@@ -567,7 +567,7 @@
       },
       "TASK-394": {
         "path": "/Users/aleks.petrov/Projects/startups/pilot/.agent/tasks/TASK-394-epic-subissue-execution-ledger.md",
-        "title": "Epic Sub-Issue Execution Ledger \u2014 kill double-intake, FK failures, starved success metrics",
+        "title": "Epic Sub-Issue Execution Ledger — kill double-intake, FK failures, starved success metrics",
         "status": "completed",
         "concepts": [
           "testing",
@@ -582,7 +582,7 @@
       },
       "TASK-395": {
         "path": "/Users/aleks.petrov/Projects/startups/pilot/.agent/tasks/TASK-395-epic-reconcile-false-positives.md",
-        "title": "Epic reconcile shipped-check false positives \u2014 parent in own child set, post-close escalation, stale needs-clarification",
+        "title": "Epic reconcile shipped-check false positives — parent in own child set, post-close escalation, stale needs-clarification",
         "status": "in-progress",
         "concepts": [
           "markers",
@@ -596,7 +596,7 @@
       },
       "TASK-396": {
         "path": "/Users/aleks.petrov/Projects/startups/pilot/.agent/tasks/TASK-396-release-sha-propagation.md",
-        "title": "Release SHA propagation \u2014 unconditional HeadSHA\u2190PostMergeSHA copy-back in handleReleasing",
+        "title": "Release SHA propagation — unconditional HeadSHA←PostMergeSHA copy-back in handleReleasing",
         "status": "completed",
         "concepts": [
           "workflow",
@@ -610,7 +610,7 @@
       },
       "TASK-397": {
         "path": "/Users/aleks.petrov/Projects/startups/pilot/.agent/tasks/TASK-397-m7-close-out.md",
-        "title": "M7 close-out \u2014 final dead-code deletion + #3423 milestone closure",
+        "title": "M7 close-out — final dead-code deletion + #3423 milestone closure",
         "status": "unknown",
         "concepts": [
           "database",
@@ -623,7 +623,7 @@
       },
       "TASK-398": {
         "path": "/Users/aleks.petrov/Projects/startups/pilot/.agent/tasks/TASK-398-dashboard-grom-panel-navigation.md",
-        "title": "Dashboard grom-style panel navigation \u2014 spatial focus, zoom, fluid layout",
+        "title": "Dashboard grom-style panel navigation — spatial focus, zoom, fluid layout",
         "status": "completed",
         "concepts": [
           "api",
@@ -636,7 +636,7 @@
       },
       "TASK-399": {
         "path": "/Users/aleks.petrov/Projects/startups/pilot/.agent/tasks/TASK-399-dashboard-status-truthfulness.md",
-        "title": "Dashboard history shows shipped issues as running/failed \u2014 reconcile persisted execution status against terminal truth",
+        "title": "Dashboard history shows shipped issues as running/failed — reconcile persisted execution status against terminal truth",
         "status": "dispatched",
         "concepts": [
           "deployment",
@@ -685,7 +685,7 @@
       },
       "TASK-403": {
         "path": "/Users/aleks.petrov/Projects/startups/pilot/.agent/tasks/TASK-403-canary-lifecycle-scenarios.md",
-        "title": "Canary lifecycle scenarios \u2014 scenario abstraction, epic-flow canary, canary metrics isolation",
+        "title": "Canary lifecycle scenarios — scenario abstraction, epic-flow canary, canary metrics isolation",
         "status": "completed",
         "concepts": [
           "deployment",
@@ -699,7 +699,7 @@
       },
       "TASK-404": {
         "path": "/Users/aleks.petrov/Projects/startups/pilot/.agent/tasks/TASK-404-execution-lifecycle-chokepoint.md",
-        "title": "Execution lifecycle chokepoint \u2014 one API for create/transition, kill the FK-787 class permanently",
+        "title": "Execution lifecycle chokepoint — one API for create/transition, kill the FK-787 class permanently",
         "status": "completed",
         "concepts": [
           "context",
@@ -767,7 +767,7 @@
       },
       "mem-006": {
         "type": "pattern",
-        "summary": "Navigator prompt should use 'Run until done' to trigger Loop Mode. Navigator then handles WORKFLOW CHECK, phase transitions (RESEARCH\u2192PLAN\u2192IMPL\u2192VERIFY\u2192COMPLETE), and EXIT_SIGNAL for completion.",
+        "summary": "Navigator prompt should use 'Run until done' to trigger Loop Mode. Navigator then handles WORKFLOW CHECK, phase transitions (RESEARCH→PLAN→IMPL→VERIFY→COMPLETE), and EXIT_SIGNAL for completion.",
         "concepts": [
           "executor",
           "navigator-integration"
@@ -819,7 +819,7 @@
       },
       "mem-011": {
         "type": "pitfall",
-        "summary": "CRITICAL: syncMainBranch() uses git reset --hard origin/main after every task. When GitHub push propagation lags behind the immediately-following fetch+reset, local commits are silently destroyed (only reflog-recoverable, 90d window). Race is in remote propagation, not push failure \u2014 reordering does NOT fix it. Fix: replace with merge --ff-only. Two call sites: runner.go:3258 (config-gated) and epic.go:1498 (NOT gated).",
+        "summary": "CRITICAL: syncMainBranch() uses git reset --hard origin/main after every task. When GitHub push propagation lags behind the immediately-following fetch+reset, local commits are silently destroyed (only reflog-recoverable, 90d window). Race is in remote propagation, not push failure — reordering does NOT fix it. Fix: replace with merge --ff-only. Two call sites: runner.go:3258 (config-gated) and epic.go:1498 (NOT gated).",
         "concepts": [
           "executor",
           "git-operations"
@@ -905,7 +905,7 @@
       },
       "mem-018": {
         "type": "learning",
-        "summary": "AUP/cyber-safeguard kills security-audit model output mid-run, but Workflow tool persists findings to /tmp/claude-501/.../<wfId>.output \u2014 recover via jq, never re-summarize via the model. File: learning_audit_safeguard_bypass.md (TASK-322).",
+        "summary": "AUP/cyber-safeguard kills security-audit model output mid-run, but Workflow tool persists findings to /tmp/claude-501/.../<wfId>.output — recover via jq, never re-summarize via the model. File: learning_audit_safeguard_bypass.md (TASK-322).",
         "concepts": [
           "claude-code-integration",
           "workflow-discipline"
@@ -928,7 +928,7 @@
       },
       "mem-020": {
         "type": "learning",
-        "summary": "Releasing Pilot: autopilot auto-cuts releases only on pilot/GH-* merges, so a manual fix/* PR sits on main unreleased. Manual release = push a v* tag (release.yml GoReleaser \u2192 Homebrew); do NOT also `make release`. Daemon runs ~/.local/bin/pilot (not make-install ~/go/bin, not brew) \u2014 update via `pilot upgrade`. Version string lags the commit; check `go version -m <bin> | grep vcs.revision`. File: learning_pilot_release_and_binary_path.md.",
+        "summary": "Releasing Pilot: autopilot auto-cuts releases only on pilot/GH-* merges, so a manual fix/* PR sits on main unreleased. Manual release = push a v* tag (release.yml GoReleaser → Homebrew); do NOT also `make release`. Daemon runs ~/.local/bin/pilot (not make-install ~/go/bin, not brew) — update via `pilot upgrade`. Version string lags the commit; check `go version -m <bin> | grep vcs.revision`. File: learning_pilot_release_and_binary_path.md.",
         "concepts": [
           "release",
           "autopilot"
@@ -939,7 +939,7 @@
       },
       "mem-021": {
         "type": "learning",
-        "summary": "Making a client method paginate (per_page+page until short page) silently breaks fixed-list httptest mocks that return the full list per request \u2014 they loop to maxPages (N\u00d7pages items) and starve callers, hanging tests to the 600s package timeout. C6/#3369 did this to the stress mocks. Fix: mocks return [] for page>=2, and ALWAYS bound test busy-waits with a deadline. A 600s 'FAIL <pkg>' with no '--- FAIL: Test' = a hang, not an assertion. File: learning_paginated_client_breaks_fixedlist_mocks.md (TASK-353).",
+        "summary": "Making a client method paginate (per_page+page until short page) silently breaks fixed-list httptest mocks that return the full list per request — they loop to maxPages (N×pages items) and starve callers, hanging tests to the 600s package timeout. C6/#3369 did this to the stress mocks. Fix: mocks return [] for page>=2, and ALWAYS bound test busy-waits with a deadline. A 600s 'FAIL <pkg>' with no '--- FAIL: Test' = a hang, not an assertion. File: learning_paginated_client_breaks_fixedlist_mocks.md (TASK-353).",
         "concepts": [
           "github-adapter",
           "testing"
@@ -950,7 +950,7 @@
       },
       "mem-022": {
         "type": "decision",
-        "summary": "Release pipeline is tag-only \u2014 goreleaser (release.yml) is the SOLE publisher. As of #3377 (after v2.166.6) `make release` only pushes the version tag; it no longer does a local `gh release create`, which had 422-collided with goreleaser and made it skip the Homebrew formula publish (bit v2.149.4 and v2.166.6). Never publish assets before goreleaser. File: decision_release_pipeline_tag_only.md.",
+        "summary": "Release pipeline is tag-only — goreleaser (release.yml) is the SOLE publisher. As of #3377 (after v2.166.6) `make release` only pushes the version tag; it no longer does a local `gh release create`, which had 422-collided with goreleaser and made it skip the Homebrew formula publish (bit v2.149.4 and v2.166.6). Never publish assets before goreleaser. File: decision_release_pipeline_tag_only.md.",
         "concepts": [
           "release"
         ],
@@ -997,7 +997,7 @@
       },
       "mem-026": {
         "type": "learning",
-        "summary": "The Pilot daemon's *finalization* path (push -> PR-create -> label) is the active reliability bottleneck \u2014 the *execution* path (Claude Code subprocess) is reliable. Studio-sdk extraction (PRs #28-#56, 2026-06-02/-03): 9/10 connectors shipped, but ~7/12 finalization runs needed manual recovery (Shape A stall-before-push), 2 hit a retry-race vs human recovery PRs (Shape B), 1 late-duplicate-PR (Shape C). The harness + review gates carried the outcome, not daemon finalization reliability. `no-decompose` label routes through the direct path (fatal error handling) instead of the epic path (warn-only) and was empirically reliable. Canonical fix: TASK-359 (3-layer plan: unified finalizeExecution MANUAL + 4 no-decompose Pilot issues for boundary fixes). RESOLUTION (2026-06-04): Shape A + C CLOSED & live-verified via TASK-359 Layer 1 (v2.166.16, studio-sdk #63/PR#64); Shape B (Layer 2b) + negative token-revoke shipped/unit-covered but not yet live-verified.",
+        "summary": "The Pilot daemon's *finalization* path (push -> PR-create -> label) is the active reliability bottleneck — the *execution* path (Claude Code subprocess) is reliable. Studio-sdk extraction (PRs #28-#56, 2026-06-02/-03): 9/10 connectors shipped, but ~7/12 finalization runs needed manual recovery (Shape A stall-before-push), 2 hit a retry-race vs human recovery PRs (Shape B), 1 late-duplicate-PR (Shape C). The harness + review gates carried the outcome, not daemon finalization reliability. `no-decompose` label routes through the direct path (fatal error handling) instead of the epic path (warn-only) and was empirically reliable. Canonical fix: TASK-359 (3-layer plan: unified finalizeExecution MANUAL + 4 no-decompose Pilot issues for boundary fixes). RESOLUTION (2026-06-04): Shape A + C CLOSED & live-verified via TASK-359 Layer 1 (v2.166.16, studio-sdk #63/PR#64); Shape B (Layer 2b) + negative token-revoke shipped/unit-covered but not yet live-verified.",
         "concepts": [
           "executor",
           "autopilot",
@@ -1022,7 +1022,7 @@
       },
       "mem-028": {
         "type": "learning",
-        "summary": "When grep for an alleged write API in internal/ returns zero, the root cause is external (config/another bot/GitHub workflow) \u2014 don't draft a Pilot fix",
+        "summary": "When grep for an alleged write API in internal/ returns zero, the root cause is external (config/another bot/GitHub workflow) — don't draft a Pilot fix",
         "concepts": [
           "workflow-discipline",
           "github-adapter"
@@ -1034,7 +1034,7 @@
       },
       "mem-029": {
         "type": "learning",
-        "summary": "For ad-hoc gh CLI writes to qf-studio (project board edits, etc.) use Pilot's PAT from ~/.pilot/config.yaml via GH_TOKEN env \u2014 OAuth refresh is silently blocked by SAML SSO",
+        "summary": "For ad-hoc gh CLI writes to qf-studio (project board edits, etc.) use Pilot's PAT from ~/.pilot/config.yaml via GH_TOKEN env — OAuth refresh is silently blocked by SAML SSO",
         "concepts": [
           "github-adapter",
           "doctor",
@@ -1047,7 +1047,7 @@
       },
       "mem-030": {
         "type": "pitfall",
-        "summary": "maybeCloseParentIssue trusted native sub-issue open-count alone; partial LinkSubIssue coverage makes count hit 0 while unlinked siblings are open \u2014 parent closes pilot-done with no PR-merge verification (GH-3513). Fixed PR #3527: native 0 must be confirmed by text search.",
+        "summary": "maybeCloseParentIssue trusted native sub-issue open-count alone; partial LinkSubIssue coverage makes count hit 0 while unlinked siblings are open — parent closes pilot-done with no PR-merge verification (GH-3513). Fixed PR #3527: native 0 must be confirmed by text search.",
         "concepts": [
           "autopilot",
           "epic-decomposition"
@@ -1059,7 +1059,7 @@
       },
       "mem-031": {
         "type": "pitfall",
-        "summary": "skipSupersededByParent superseded live children off parent.State==closed && pilot-done label \u2014 no merge verification; orphaned complete green PRs in GH-3513. Fixed PR #3527: open pilot/GH-N PR vetoes supersession.",
+        "summary": "skipSupersededByParent superseded live children off parent.State==closed && pilot-done label — no merge verification; orphaned complete green PRs in GH-3513. Fixed PR #3527: open pilot/GH-N PR vetoes supersession.",
         "concepts": [
           "autopilot",
           "poller",
@@ -1073,7 +1073,7 @@
       },
       "mem-032": {
         "type": "pitfall",
-        "summary": "inherited-spec:true children fetch the parent issue as their spec and re-implement the FULL feature \u2014 N redundant colliding PRs per epic (GH-3513). Fixed PR #3527 with a scope fence in subIssueBody(); sibling-branch PR base routing still unfixed.",
+        "summary": "inherited-spec:true children fetch the parent issue as their spec and re-implement the FULL feature — N redundant colliding PRs per epic (GH-3513). Fixed PR #3527 with a scope fence in subIssueBody(); sibling-branch PR base routing still unfixed.",
         "concepts": [
           "epic-decomposition",
           "executor"
@@ -1099,7 +1099,7 @@
       },
       "mem-034": {
         "type": "pitfall",
-        "summary": "Subprocess without cmd.Dir: getPostExecutionSummary ran git in the daemon's CWD and reported the wrong repo's HEAD as the commit SHA \u2014 ghost guard then killed real worker commits (TASK-320 false no-ops) or recorded wrong-repo completed SHAs (TASK-355). One bug, both incident families. Fix v2.186.2: worktree git harvest first, summary pinned to executionPath. Lesson: every executor exec.Command must set cmd.Dir; never ask an LLM for what git answers deterministically.",
+        "summary": "Subprocess without cmd.Dir: getPostExecutionSummary ran git in the daemon's CWD and reported the wrong repo's HEAD as the commit SHA — ghost guard then killed real worker commits (TASK-320 false no-ops) or recorded wrong-repo completed SHAs (TASK-355). One bug, both incident families. Fix v2.186.2: worktree git harvest first, summary pinned to executionPath. Lesson: every executor exec.Command must set cmd.Dir; never ask an LLM for what git answers deterministically.",
         "concepts": [
           "executor",
           "git-operations"
@@ -1111,7 +1111,7 @@
       },
       "mem-035": {
         "type": "learning",
-        "summary": "GH-201 'OAuth loop' ghost issues (#3562-64, #3576) were created by the TEST SUITE: TestCreateSubIssues_ProceedsWhenNoChildren drives CreateSubIssues past the dedup guard with fixture parent GH-201 and executionPath='' \u2014 createSubIssuesViaGitHub has no dryRun guard, so authed gh creates real issues; sibling tests spawn the real claude binary. Teammate/shared-PAT attribution was wrong: tests stamp the same autopilot-meta markers and bypass the DB (zero rows proves test path, not remote actor). Lessons: stub the exec boundary in tests; dryRun must guard every side-effecting path; verify the spawner not the signature. Fix: #3579.",
+        "summary": "GH-201 'OAuth loop' ghost issues (#3562-64, #3576) were created by the TEST SUITE: TestCreateSubIssues_ProceedsWhenNoChildren drives CreateSubIssues past the dedup guard with fixture parent GH-201 and executionPath='' — createSubIssuesViaGitHub has no dryRun guard, so authed gh creates real issues; sibling tests spawn the real claude binary. Teammate/shared-PAT attribution was wrong: tests stamp the same autopilot-meta markers and bypass the DB (zero rows proves test path, not remote actor). Lessons: stub the exec boundary in tests; dryRun must guard every side-effecting path; verify the spawner not the signature. Fix: #3579.",
         "concepts": [
           "executor",
           "testing",
@@ -1141,7 +1141,7 @@
       },
       "mem-037": {
         "type": "pitfall",
-        "summary": "Autopilot orphans the LAST epic child PRs: the epic's execution run owns child-PR merging, so children whose PRs are created late are left created-but-unmerged when the run ends. The standalone auto-merge loop won't reclaim them because their tracking issues are already CLOSED (it thinks the work is done) \u2014 so green/CLEAN child PRs sit with ZERO autopilot review/comment even under stage's require_approval:false + auto_merge:true + green test/lint. Epic stays OPEN+pilot-in-progress; any 'Blocked by: #<epic>' dependent is gated forever via poller hasPendingDependencies. Recover: merge the orphans in order yourself, then close the epic to release dependents. Late siblings often CONFLICT once one merges (same wiring) \u2014 close the conflicted PR and re-dispatch only its UNIQUE remainder vs updated main, don't hand-resolve in root. Observed 2026-06-26 epic #3665 (bot module): merged #3670/#3674 mid-run, orphaned #3678/#3679. TASK-359 finalization shape.",
+        "summary": "Autopilot orphans the LAST epic child PRs: the epic's execution run owns child-PR merging, so children whose PRs are created late are left created-but-unmerged when the run ends. The standalone auto-merge loop won't reclaim them because their tracking issues are already CLOSED (it thinks the work is done) — so green/CLEAN child PRs sit with ZERO autopilot review/comment even under stage's require_approval:false + auto_merge:true + green test/lint. Epic stays OPEN+pilot-in-progress; any 'Blocked by: #<epic>' dependent is gated forever via poller hasPendingDependencies. Recover: merge the orphans in order yourself, then close the epic to release dependents. Late siblings often CONFLICT once one merges (same wiring) — close the conflicted PR and re-dispatch only its UNIQUE remainder vs updated main, don't hand-resolve in root. Observed 2026-06-26 epic #3665 (bot module): merged #3670/#3674 mid-run, orphaned #3678/#3679. TASK-359 finalization shape.",
         "concepts": [
           "autopilot",
           "epic-decomposition",
@@ -1156,7 +1156,7 @@
       },
       "mem-038": {
         "type": "pattern",
-        "summary": "Bot module dual-path: fast conversational path (~1-2s, direct LLM via Responder) vs executor path (~15-30s, Claude Code worktree). Intents: greeting/chat/question/issue-intake \u2192 Responder; task/research/planning \u2192 executor. Fallback guarantee: Responder nil (bot disabled) \u2192 identical-to-before executor path. Rate limit via AllowMessage() before all dispatch. Voice seam: VoiceText merged into text when Text empty. Test-at-the-seam lesson: tests must cross adapter\u2192comms boundary (ref mem-036).",
+        "summary": "Bot module dual-path: fast conversational path (~1-2s, direct LLM via Responder) vs executor path (~15-30s, Claude Code worktree). Intents: greeting/chat/question/issue-intake → Responder; task/research/planning → executor. Fallback guarantee: Responder nil (bot disabled) → identical-to-before executor path. Rate limit via AllowMessage() before all dispatch. Voice seam: VoiceText merged into text when Text empty. Test-at-the-seam lesson: tests must cross adapter→comms boundary (ref mem-036).",
         "concepts": [
           "intent-routing",
           "executor",
@@ -1169,7 +1169,7 @@
       },
       "mem-039": {
         "type": "pitfall",
-        "summary": "Bot's direct LLM client (internal/llm/client.go) omitted required max_tokens and sent non-standard output_config{effort:low}, so every Anthropic Messages call 400'd ('max_tokens: Field required') and the bot replied 'Sorry, I couldn't process that.' Shipped GREEN because TestAnswer_RequestShape asserted output_config present and never checked max_tokens \u2014 the test encoded the bug. Diagnose request-shape bugs with curl (real key): code's request \u2192 400, +max_tokens/-output_config \u2192 200, in 2 calls. Fixed v2.200.1 (#3700): add max_tokens(2048), drop output_config, tests assert both. Lesson (again, see mem-036): assert the REQUIRED fields, not the optional ones.",
+        "summary": "Bot's direct LLM client (internal/llm/client.go) omitted required max_tokens and sent non-standard output_config{effort:low}, so every Anthropic Messages call 400'd ('max_tokens: Field required') and the bot replied 'Sorry, I couldn't process that.' Shipped GREEN because TestAnswer_RequestShape asserted output_config present and never checked max_tokens — the test encoded the bug. Diagnose request-shape bugs with curl (real key): code's request → 400, +max_tokens/-output_config → 200, in 2 calls. Fixed v2.200.1 (#3700): add max_tokens(2048), drop output_config, tests assert both. Lesson (again, see mem-036): assert the REQUIRED fields, not the optional ones.",
         "concepts": [
           "anthropic-api",
           "testing",
@@ -1184,7 +1184,7 @@
       },
       "mem-040": {
         "type": "pitfall",
-        "summary": "Daemon hot-upgrades to the latest GitHub RELEASE and re-execs (pid preserved \u2192 ps lstart looks unchanged while the on-disk binary swaps). A dev binary cp'd to ~/.local/bin/pilot reverts within ~20min to the last release. A fix merged to main is NOT in the running daemon until a release containing it is cut (autopilot shouldTriggerRelease gap). Observed 2026-06-26: 29MB dev fix at 12:32 reverted to 20.6MB v2.200.0 release by 12:52, bot kept failing. Durable fix: tag-driven release (mem-022) with the fix \u2192 pilot upgrade (prompts y/N) \u2192 restart. v2.200.1 held because it's the latest release. Confirm running binary via lsof txt + stat size + pilot version, not lstart alone.",
+        "summary": "Daemon hot-upgrades to the latest GitHub RELEASE and re-execs (pid preserved → ps lstart looks unchanged while the on-disk binary swaps). A dev binary cp'd to ~/.local/bin/pilot reverts within ~20min to the last release. A fix merged to main is NOT in the running daemon until a release containing it is cut (autopilot shouldTriggerRelease gap). Observed 2026-06-26: 29MB dev fix at 12:32 reverted to 20.6MB v2.200.0 release by 12:52, bot kept failing. Durable fix: tag-driven release (mem-022) with the fix → pilot upgrade (prompts y/N) → restart. v2.200.1 held because it's the latest release. Confirm running binary via lsof txt + stat size + pilot version, not lstart alone.",
         "concepts": [
           "hot-upgrade",
           "release",
@@ -1194,13 +1194,13 @@
         "confidence": 0.9,
         "severity": "medium",
         "created": "2026-06-26",
-        "incident": "2026-06-26: shipping the bot max_tokens fix \u2014 dev binary installs (12:32) auto-reverted to pre-fix v2.200.0 release (12:52); only cutting v2.200.1 and pilot-upgrading made the fix stick in the live daemon.",
+        "incident": "2026-06-26: shipping the bot max_tokens fix — dev binary installs (12:32) auto-reverted to pre-fix v2.200.0 release (12:52); only cutting v2.200.1 and pilot-upgrading made the fix stick in the live daemon.",
         "file": ".agent/knowledge/memories/pitfalls/bug_daemon_autoupgrade_reverts_dev_binary.md",
         "origin_task": "TASK-374"
       },
       "mem-041": {
         "type": "pitfall",
-        "summary": "LLM intent classifier was doubly broken so the bot misrouted open-ended input. (1) classifier.go sent output_config{effort} \u2192 Haiku 400 'does not support the effort parameter' \u2192 every Classify failed \u2192 silent regex fallback (same class as mem-039; a test asserted output_config present). (2) Prompt routed 'draw/outline/show' as code TASK \u2192 heavy executor + dangling tasks. Fixed v2.200.2 (#3703): drop output_config; add DELIVERABLE TEST (answer/diagram\u2192question/chat, change-code\u2192task, file-ticket\u2192issue_intake). Haiku now primary NL router, regex only guards /-commands. Validate classifier prompts via curl (TUI logs ungreppable). 8/8 live.",
+        "summary": "LLM intent classifier was doubly broken so the bot misrouted open-ended input. (1) classifier.go sent output_config{effort} → Haiku 400 'does not support the effort parameter' → every Classify failed → silent regex fallback (same class as mem-039; a test asserted output_config present). (2) Prompt routed 'draw/outline/show' as code TASK → heavy executor + dangling tasks. Fixed v2.200.2 (#3703): drop output_config; add DELIVERABLE TEST (answer/diagram→question/chat, change-code→task, file-ticket→issue_intake). Haiku now primary NL router, regex only guards /-commands. Validate classifier prompts via curl (TUI logs ungreppable). 8/8 live.",
         "concepts": [
           "intent-routing",
           "anthropic-api",
@@ -1215,7 +1215,7 @@
       },
       "mem-042": {
         "type": "pitfall",
-        "summary": "Bot answers/issues hit the WRONG repo via two traps. (1) Intake (comms.IssueCreator) resolves owner/repo from a SINGLE hardwired NewIssueCreator entry = cfg.Adapters.GitHub.Repo; resolveRepo falls to repos[0] for unmatched paths, so intake ALWAYS targets adapters.github.repo and /switch doesn't change it. (2) The per-context active project is in-memory and RESETS to default_project on every daemon restart, so Q&A answers about the wrong repo until re-/switch'd. Demo fix: point default_project AND adapters.github.repo at the same repo (+ project_board.enabled:false for label polling). Proper fix: NewIssueCreator entry per cfg.Projects + persist active project across restarts. Board-source repos also need intake\u2192board or label polling.",
+        "summary": "Bot answers/issues hit the WRONG repo via two traps. (1) Intake (comms.IssueCreator) resolves owner/repo from a SINGLE hardwired NewIssueCreator entry = cfg.Adapters.GitHub.Repo; resolveRepo falls to repos[0] for unmatched paths, so intake ALWAYS targets adapters.github.repo and /switch doesn't change it. (2) The per-context active project is in-memory and RESETS to default_project on every daemon restart, so Q&A answers about the wrong repo until re-/switch'd. Demo fix: point default_project AND adapters.github.repo at the same repo (+ project_board.enabled:false for label polling). Proper fix: NewIssueCreator entry per cfg.Projects + persist active project across restarts. Board-source repos also need intake→board or label polling.",
         "concepts": [
           "conversational-bot",
           "intent-routing",
@@ -1255,7 +1255,7 @@
         "confidence": 0.95,
         "severity": "high",
         "created": "2026-07-04",
-        "incident": "2026-07-03: daemon hot-upgraded to v2.201.2 at 12:50:23+02:00, then sat 7+ hours through v2.202.0-v2.207.0 with zero upgrade attempts (not failures \u2014 total silence) until a manual restart at 20:01.",
+        "incident": "2026-07-03: daemon hot-upgraded to v2.201.2 at 12:50:23+02:00, then sat 7+ hours through v2.202.0-v2.207.0 with zero upgrade attempts (not failures — total silence) until a manual restart at 20:01.",
         "file": ".agent/knowledge/memories/pitfalls/pitfall_self_upgrade_requires_manual_keypress.md",
         "origin_task": "GH-3790-1"
       },
@@ -1275,7 +1275,7 @@
       },
       "mem-046": {
         "type": "pitfall",
-        "summary": "Autopilot's direct PR-close call sites (handleCIFailed iteration-limit/size-guard/main, handleReviewRequested iteration-limit/main) never posted a PR/issue comment or corrected issue labels \u2014 the only convergence point that could have was notifyExternalClose, whose pilot-done skip-guard (GH-2340) returned with zero comments when the issue already had pilot-done from an earlier, unrelated PR. Result: PR #3802 (fix for #3789) closed CI-red with zero explanation and #3789 kept pilot-done, making discarded work look shipped (TASK-382 D9). Fix (GH-3806): notifyExternalClose now always posts a PR comment (AddPRComment hits /issues/{prNumber}/comments, not /pulls/.../comments) + issue comment from prState.Error on every branch including both skip guards; close sites set prState.Error (specific reason) and new in-memory PRState.TerminalLabel (forces pilot-failed instead of pilot-retry-ready when terminal or superseded by a follow-up issue) instead of commenting inline.",
+        "summary": "Autopilot's direct PR-close call sites (handleCIFailed iteration-limit/size-guard/main, handleReviewRequested iteration-limit/main) never posted a PR/issue comment or corrected issue labels — the only convergence point that could have was notifyExternalClose, whose pilot-done skip-guard (GH-2340) returned with zero comments when the issue already had pilot-done from an earlier, unrelated PR. Result: PR #3802 (fix for #3789) closed CI-red with zero explanation and #3789 kept pilot-done, making discarded work look shipped (TASK-382 D9). Fix (GH-3806): notifyExternalClose now always posts a PR comment (AddPRComment hits /issues/{prNumber}/comments, not /pulls/.../comments) + issue comment from prState.Error on every branch including both skip guards; close sites set prState.Error (specific reason) and new in-memory PRState.TerminalLabel (forces pilot-failed instead of pilot-retry-ready when terminal or superseded by a follow-up issue) instead of commenting inline.",
         "concepts": [
           "autopilot"
         ],
@@ -1326,7 +1326,7 @@
       },
       "mem-050": {
         "type": "pattern",
-        "summary": "autopilot_pr_state rows are deleted on success; absence is not a wiring bug \u2014 executions table is the history",
+        "summary": "autopilot_pr_state rows are deleted on success; absence is not a wiring bug — executions table is the history",
         "file": ".agent/knowledge/memories/patterns/pattern_autopilot_pr_state_ephemeral.md",
         "concepts": [
           "autopilot"
@@ -1540,7 +1540,7 @@
       },
       "mem-066": {
         "type": "pitfall",
-        "summary": "Approval button taps silently dropped \u2014 send path worked, inbound dispatch never wired; partial-wiring class recurs",
+        "summary": "Approval button taps silently dropped — send path worked, inbound dispatch never wired; partial-wiring class recurs",
         "file": ".agent/knowledge/memories/pitfalls/bug_telegram_approval_callback_unwired.md",
         "concepts": [
           "autopilot",
@@ -1579,7 +1579,7 @@
       },
       "mem-069": {
         "type": "learning",
-        "summary": "Verify remote file state via gh api before authoring Pilot issues \u2014 stale local clone causes redundant issues",
+        "summary": "Verify remote file state via gh api before authoring Pilot issues — stale local clone causes redundant issues",
         "file": ".agent/knowledge/memories/learnings/feedback_check_remote_state.md",
         "concepts": [
           "workflow-discipline",
@@ -1617,7 +1617,7 @@
       },
       "mem-072": {
         "type": "learning",
-        "summary": "Org-level setting blocks Actions PR creation; GITHUB_TOKEN pushes do not chain workflows \u2014 diagnosis recipe",
+        "summary": "Org-level setting blocks Actions PR creation; GITHUB_TOKEN pushes do not chain workflows — diagnosis recipe",
         "file": ".agent/knowledge/memories/learnings/feedback_gh_actions_pr_create_perm.md",
         "concepts": [
           "release",
@@ -1668,7 +1668,7 @@
       },
       "mem-076": {
         "type": "learning",
-        "summary": "Stop hook requires StructuredOutput call with branch, commit, files, summary \u2014 binds every pilot-executor session",
+        "summary": "Stop hook requires StructuredOutput call with branch, commit, files, summary — binds every pilot-executor session",
         "file": ".agent/knowledge/memories/learnings/feedback_structured_output_hook.md",
         "concepts": [
           "executor",
@@ -1723,7 +1723,7 @@
       },
       "mem-080": {
         "type": "decision",
-        "summary": "Pilot is a Claude Code orchestration layer, not a replacement \u2014 infrastructure play for the Anthropic ecosystem",
+        "summary": "Pilot is a Claude Code orchestration layer, not a replacement — infrastructure play for the Anthropic ecosystem",
         "file": ".agent/knowledge/memories/decisions/strategy_pilot_positioning.md",
         "concepts": [
           "product-positioning",
@@ -1751,7 +1751,7 @@
       },
       "mem-082": {
         "type": "pitfall",
-        "summary": "Autopilot can be silently disabled at startup when a gate check fails without a log line \u2014 operators unaware execution is off",
+        "summary": "Autopilot can be silently disabled at startup when a gate check fails without a log line — operators unaware execution is off",
         "file": ".agent/knowledge/memories/pitfalls/pitfall_silent_autopilot_gate_disable.md",
         "concepts": [
           "autopilot",
@@ -1779,7 +1779,7 @@
       },
       "mem-084": {
         "type": "pitfall",
-        "summary": "allChildrenDone() returned true for empty child set \u2014 vacuous truth tripped epic-complete exit with zero work done; require >=1 child",
+        "summary": "allChildrenDone() returned true for empty child set — vacuous truth tripped epic-complete exit with zero work done; require >=1 child",
         "file": ".agent/knowledge/memories/pitfalls/pitfall_allchildrendone_vacuous_truth.md",
         "concepts": [
           "epic-decomposition",
@@ -1813,13 +1813,13 @@
         "confidence": 0.9,
         "created": "2026-07-06",
         "severity": "high",
-        "summary": "Extraction-era SDK ports go stale vs evolving in-tree code: SDK GetTagForSHA shipped bounded (20 tags) while in-tree moved to exhaustive pagination \u2014 would have stalled release draining. Caught by running the consumer test suite against the SDK client (TestHandleReleasing_ExhaustiveTagDrain). Before cutover: diff SDK methods against CURRENT in-tree source; typed-error/pagination/retry drift compiles fine and fails only behaviorally.",
+        "summary": "Extraction-era SDK ports go stale vs evolving in-tree code: SDK GetTagForSHA shipped bounded (20 tags) while in-tree moved to exhaustive pagination — would have stalled release draining. Caught by running the consumer test suite against the SDK client (TestHandleReleasing_ExhaustiveTagDrain). Before cutover: diff SDK methods against CURRENT in-tree source; typed-error/pagination/retry drift compiles fine and fails only behaviorally.",
         "type": "pitfall",
         "file": ".agent/knowledge/memories/pitfalls/pitfall_sdk_ports_go_stale_vs_intree.md"
       },
       "mem-089": {
         "type": "pitfall",
-        "summary": "Epic parent's stuck-monitor entry freezes once sub-issue execution starts \u2014 false eviction on long sequential epics. executeSubIssuesTracked posted per-child progress to GitHub via UpdateIssueProgress, which never reaches the alerts engine, so the parent's taskLastProgress entry was touched once before the loop then frozen for the whole run. GH-4021: evicted with stuck_for=41m0s while sub-issue 2 was actively running. Fixed by calling r.reportProgress(parent.ID, ...) inside the loop per child (GH-4033, merged via 51fd3348).",
+        "summary": "Epic parent's stuck-monitor entry freezes once sub-issue execution starts — false eviction on long sequential epics. executeSubIssuesTracked posted per-child progress to GitHub via UpdateIssueProgress, which never reaches the alerts engine, so the parent's taskLastProgress entry was touched once before the loop then frozen for the whole run. GH-4021: evicted with stuck_for=41m0s while sub-issue 2 was actively running. Fixed by calling r.reportProgress(parent.ID, ...) inside the loop per child (GH-4033, merged via 51fd3348).",
         "path": "memories/pitfalls/mem-089.md",
         "confidence": 0.9,
         "concepts": [
@@ -1832,7 +1832,7 @@
       },
       "mem-090": {
         "type": "decision",
-        "summary": "Dashboard chrome delegates to grot pkg/tui (github.com/qf-studio/grot render + theme.Pilot) \u2014 one shared design system, imported not vendored (public v0.1.0, MIT, lipgloss-only). Glyph vocabulary replaces emoji on the TUI/daemon surface only; chat adapters + CLI subcommands untouched. Requires go >= 1.25. TASK-390.",
+        "summary": "Dashboard chrome delegates to grot pkg/tui (github.com/qf-studio/grot render + theme.Pilot) — one shared design system, imported not vendored (public v0.1.0, MIT, lipgloss-only). Glyph vocabulary replaces emoji on the TUI/daemon surface only; chat adapters + CLI subcommands untouched. Requires go >= 1.25. TASK-390.",
         "path": "memories/decisions/decision_grot_design_system.md",
         "confidence": 0.95,
         "concepts": [
@@ -1843,7 +1843,7 @@
       },
       "mem-091": {
         "type": "pattern",
-        "summary": "Duplicate 'completed' execution rows sharing one pr_url are SelfHealExecutionAfterMerge by design: on PR merge it flips EVERY non-success row (failed/no_op/stalled/rate_limited/infra/skipped) for the task_id to completed. Distinguish benign CI-retry (full events ending in failure, retry ~90s later) from restart-orphan (events just stop, hours-long lifespan). Dedup guard IsTaskQueued is innocent \u2014 first row was already terminal.",
+        "summary": "Duplicate 'completed' execution rows sharing one pr_url are SelfHealExecutionAfterMerge by design: on PR merge it flips EVERY non-success row (failed/no_op/stalled/rate_limited/infra/skipped) for the task_id to completed. Distinguish benign CI-retry (full events ending in failure, retry ~90s later) from restart-orphan (events just stop, hours-long lifespan). Dedup guard IsTaskQueued is innocent — first row was already terminal.",
         "path": "memories/patterns/pattern_selfheal_duplicate_completed_rows.md",
         "confidence": 0.9,
         "concepts": [
@@ -1902,7 +1902,7 @@
       },
       "mem-096": {
         "type": "decision",
-        "summary": "Lanes mechanism: extend `Complexity` \u2192 `Lane` - Tier routing already threaded end-to-end; lanes = bundling scattered knobs",
+        "summary": "Lanes mechanism: extend `Complexity` → `Lane` - Tier routing already threaded end-to-end; lanes = bundling scattered knobs",
         "path": "memories/decisions/mem-096.md",
         "confidence": 0.95,
         "concepts": [
@@ -1989,7 +1989,7 @@
       },
       "mem-101": {
         "type": "pitfall",
-        "summary": "ProjectWorker (dispatcher.go:843-899) is the sole per-repo serialization point; orchestrator.max_concurrent is neutralized (poller goroutines park in WaitForExecution). CI already decoupled \u2014 fixing ProjectWorker delivers concurrency + pipeline overlap. TASK-393 P3.",
+        "summary": "ProjectWorker (dispatcher.go:843-899) is the sole per-repo serialization point; orchestrator.max_concurrent is neutralized (poller goroutines park in WaitForExecution). CI already decoupled — fixing ProjectWorker delivers concurrency + pipeline overlap. TASK-393 P3.",
         "path": "memories/pitfalls/mem-101.md",
         "confidence": 0.9,
         "concepts": [
@@ -2003,7 +2003,7 @@
       },
       "mem-102": {
         "type": "pitfall",
-        "summary": "CreateWorktreeWithBranch (worktree.go:768-775) builds a fresh WorktreeManager (unshared createMu) per call \u2014 concurrent same-repo execution silently reintroduces the GH-1312 git worktree race. Shared-manager routing is TASK-393 P3.1 prerequisite.",
+        "summary": "CreateWorktreeWithBranch (worktree.go:768-775) builds a fresh WorktreeManager (unshared createMu) per call — concurrent same-repo execution silently reintroduces the GH-1312 git worktree race. Shared-manager routing is TASK-393 P3.1 prerequisite.",
         "path": "memories/pitfalls/mem-102.md",
         "confidence": 0.85,
         "concepts": [
@@ -2016,7 +2016,7 @@
       },
       "mem-103": {
         "type": "learning",
-        "summary": "Merge gate = handleCIPassed (controller.go:1212) + escalate-only scope_guard.go reasons (SizeFloor, ScopeDrift). require_ci (ReleaseConfig.RequireCI) gates the post-merge release train only \u2014 NOT the merge decision. Risk-score (TASK-393 P5) must extend scope_guard escalate-only.",
+        "summary": "Merge gate = handleCIPassed (controller.go:1212) + escalate-only scope_guard.go reasons (SizeFloor, ScopeDrift). require_ci (ReleaseConfig.RequireCI) gates the post-merge release train only — NOT the merge decision. Risk-score (TASK-393 P5) must extend scope_guard escalate-only.",
         "path": "memories/learnings/mem-103.md",
         "confidence": 0.85,
         "concepts": [
@@ -2063,7 +2063,7 @@
       },
       "mem-106": {
         "type": "decision",
-        "summary": "Lanes mechanism: extend `Complexity` \u2192 `Lane` - Tier routing already threaded end-to-end; lanes = bundling scattered knobs",
+        "summary": "Lanes mechanism: extend `Complexity` → `Lane` - Tier routing already threaded end-to-end; lanes = bundling scattered knobs",
         "path": "memories/decisions/mem-106.md",
         "confidence": 0.95,
         "concepts": [
@@ -2153,7 +2153,7 @@
       },
       "mem-112": {
         "type": "decision",
-        "summary": "Lanes mechanism: extend `Complexity` \u2192 `Lane` - Tier routing already threaded end-to-end; lanes = bundling scattered knobs",
+        "summary": "Lanes mechanism: extend `Complexity` → `Lane` - Tier routing already threaded end-to-end; lanes = bundling scattered knobs",
         "path": "memories/decisions/mem-112.md",
         "confidence": 0.95,
         "concepts": [
@@ -2348,7 +2348,7 @@
       },
       "mem-123": {
         "type": "pitfall",
-        "summary": "Release train (on_schedule) member resolution requires (#N) squash-title suffix \u2014 autopilot's auto-merger omits it, so trains over autopilot-merged commits skip forever ('no resolvable member PRs'). Cutover order: ship GH-4150 (#N suffix fix) FIRST, then flip trigger on_merge \u2192 on_schedule (schedule '0 16 * * 1-5', schedule_timezone Europe/Berlin); flipping first silently halts releases (merges held, train skips daily). Evidence: 8/9 commits in v2.236.4 lack (#N); v2.236.4 cut on-merge at 22:14 because config never followed the mem-104 train decision. Refs: internal/autopilot/scope_schedule.go resolveTrainMemberPRs, auto_merger.go commitTitle.",
+        "summary": "Release train (on_schedule) member resolution requires (#N) squash-title suffix — autopilot's auto-merger omits it, so trains over autopilot-merged commits skip forever ('no resolvable member PRs'). Cutover order: ship GH-4150 (#N suffix fix) FIRST, then flip trigger on_merge → on_schedule (schedule '0 16 * * 1-5', schedule_timezone Europe/Berlin); flipping first silently halts releases (merges held, train skips daily). Evidence: 8/9 commits in v2.236.4 lack (#N); v2.236.4 cut on-merge at 22:14 because config never followed the mem-104 train decision. Refs: internal/autopilot/scope_schedule.go resolveTrainMemberPRs, auto_merger.go commitTitle.",
         "path": "memories/pitfalls/mem-123.md",
         "confidence": 0.9,
         "concepts": [
@@ -2372,7 +2372,7 @@
       },
       "mem-125": {
         "type": "learning",
-        "summary": "Social-engineering campaign: fake 'patch .zip' comments on freshly-filed Pilot bugs \u2014 Pilot immune (executor never reads comments)",
+        "summary": "Social-engineering campaign: fake 'patch .zip' comments on freshly-filed Pilot bugs — Pilot immune (executor never reads comments)",
         "path": "memories/learnings/mem-090.md",
         "confidence": 0.95,
         "concepts": [
@@ -2570,7 +2570,7 @@
       },
       "mem-142": {
         "type": "pitfall",
-        "summary": "Dashboard/ledger stage strip can mark SHIPPED work as failed (\u2717 pr_created) \u2014 verify execution_events + GitHub before trusting it",
+        "summary": "Dashboard/ledger stage strip can mark SHIPPED work as failed (✗ pr_created) — verify execution_events + GitHub before trusting it",
         "path": "memories/pitfalls/mem-088.md",
         "confidence": 0.95,
         "concepts": [
@@ -2648,7 +2648,7 @@
       },
       "mem-148": {
         "type": "decision",
-        "summary": "Dashboard nav rework (TASK-398/#4199): port grom focusMove/Rect/zoom (~200 lines) into internal/dashboard/grid.go with attribution \u2014 don't promote to grot pkg (Widget iface is Prometheus-shaped; promote only at >=3 consumers). Ported source embedded in the issue spec because executor worktrees can't reach ../startups/grot.",
+        "summary": "Dashboard nav rework (TASK-398/#4199): port grom focusMove/Rect/zoom (~200 lines) into internal/dashboard/grid.go with attribution — don't promote to grot pkg (Widget iface is Prometheus-shaped; promote only at >=3 consumers). Ported source embedded in the issue spec because executor worktrees can't reach ../startups/grot.",
         "path": "memories/decisions/mem-148.md",
         "confidence": 0.9,
         "concepts": [
@@ -2678,7 +2678,7 @@
       },
       "mem-150": {
         "type": "pitfall",
-        "summary": "Dead-code audit: verify caller LIVENESS not just existence. SOP GH-4169 kept internal/adapters/github/poller.go as 'live' because callers existed \u2014 but all were test files; project_board.go had zero callers. Classify each caller production vs test-only before deciding a file is live.",
+        "summary": "Dead-code audit: verify caller LIVENESS not just existence. SOP GH-4169 kept internal/adapters/github/poller.go as 'live' because callers existed — but all were test files; project_board.go had zero callers. Classify each caller production vs test-only before deciding a file is live.",
         "path": "memories/pitfalls/mem-150.md",
         "confidence": 0.9,
         "concepts": [
@@ -2694,7 +2694,7 @@
       },
       "mem-151": {
         "type": "pitfall",
-        "summary": "Epic collapse to one sub-issue \u2192 scaffold-only under-delivery that passes CI green (TASK-398/#4199). Multi-phase epic auto-decomposed to a SINGLE inherited-spec sub-issue; executor built 3 helper files + tests (PR #4201 merged green) but never wired them into tui.go \u2014 helpers uncalled, zero reqs shipped, parent auto-closed (false completion). Detect via +N/-0 diff that never edits the target file; guard with Update/View integration-test ACs (fixed by TASK-399/#4203 \u2192 PR #4204).",
+        "summary": "Epic collapse to one sub-issue → scaffold-only under-delivery that passes CI green (TASK-398/#4199). Multi-phase epic auto-decomposed to a SINGLE inherited-spec sub-issue; executor built 3 helper files + tests (PR #4201 merged green) but never wired them into tui.go — helpers uncalled, zero reqs shipped, parent auto-closed (false completion). Detect via +N/-0 diff that never edits the target file; guard with Update/View integration-test ACs (fixed by TASK-399/#4203 → PR #4204).",
         "path": "memories/pitfalls/mem-151.md",
         "confidence": 0.9,
         "concepts": [
@@ -2709,7 +2709,7 @@
       },
       "mem-152": {
         "type": "learning",
-        "summary": "Status reports to user must be scannable grouped lists (done / failed+reset / needs-attention / watch), one line per item \u2014 never narrative prose. Direct user feedback 2026-07-13.",
+        "summary": "Status reports to user must be scannable grouped lists (done / failed+reset / needs-attention / watch), one line per item — never narrative prose. Direct user feedback 2026-07-13.",
         "path": "memories/learnings/mem-152.md",
         "concepts": [
           "user-preference",
@@ -2722,7 +2722,7 @@
       },
       "mem-153": {
         "type": "pitfall",
-        "summary": "modernc.org/sqlite writes bound time.Time params using Go's time.Time.String() format by default, which SQLite's date()/datetime() can't parse (returns NULL) and sorts inconsistently against DEFAULT CURRENT_TIMESTAMP columns; fix by opening the DB with ?_time_format=sqlite. Also: SaveExecution's INSERT omitted created_at, letting the DB default silently override caller-supplied timestamps \u2014 root cause of internal/briefs's flaky TestGeneratorGenerate.",
+        "summary": "modernc.org/sqlite writes bound time.Time params using Go's time.Time.String() format by default, which SQLite's date()/datetime() can't parse (returns NULL) and sorts inconsistently against DEFAULT CURRENT_TIMESTAMP columns; fix by opening the DB with ?_time_format=sqlite. Also: SaveExecution's INSERT omitted created_at, letting the DB default silently override caller-supplied timestamps — root cause of internal/briefs's flaky TestGeneratorGenerate.",
         "file": ".agent/knowledge/memories/pitfalls/pitfall_sqlite_time_bind_default_format.md",
         "concepts": [
           "sqlite",
@@ -2735,7 +2735,7 @@
       },
       "mem-154": {
         "type": "pitfall",
-        "summary": "no_op is a legitimate terminal outcome (common for epic sub-issues) but was invisible to every 'is this task done' dispatch guard \u2014 Store.HasCompletedExecution requires status='completed' plus a deliverable, so the SDK poller's ExecutionChecker and dispatcher.go's hasTerminalSuccessLedger both re-treated no_op'd issues as fresh candidates forever (GH-4347: GH-82 dispatched 6x in one cycle). Fix: Store.HasTerminalCompletion ANY-row check ORing deliverable-completion with no_op-with-no-error; new admission gates must use executor.HasTerminalCompletion, not HasCompletedExecution directly.",
+        "summary": "no_op is a legitimate terminal outcome (common for epic sub-issues) but was invisible to every 'is this task done' dispatch guard — Store.HasCompletedExecution requires status='completed' plus a deliverable, so the SDK poller's ExecutionChecker and dispatcher.go's hasTerminalSuccessLedger both re-treated no_op'd issues as fresh candidates forever (GH-4347: GH-82 dispatched 6x in one cycle). Fix: Store.HasTerminalCompletion ANY-row check ORing deliverable-completion with no_op-with-no-error; new admission gates must use executor.HasTerminalCompletion, not HasCompletedExecution directly.",
         "file": ".agent/knowledge/memories/pitfalls/pitfall_noop_terminal_state_invisible_to_dispatch_guards.md",
         "concepts": [
           "dispatcher",
@@ -2745,6 +2745,21 @@
         ],
         "confidence": 0.9,
         "created": "2026-07-15"
+      },
+      "mem-158": {
+        "type": "pitfall",
+        "summary": "An atomic claim's ErrClaimLost drop is only correct if callers distinguish a LIVE owner from a DEAD one — TASK-407 call sites all claimed at hardcoded generation 0 and dropped ANY ErrClaimLost, so a failed task's claim permanently blocked retry (GH-4372: poller dropped the same task every ~30s). Fix: Dispatcher.nextRetryGeneration classifies the occupied generation via Store.LatestClaimGeneration + execution status — live → drop, terminal-not-done → claim generation+1, terminal-done → drop (GH-4350 no_op invariant). Also: handleIssueGeneric only matched the wrapped ErrTaskAlreadyActive, missing QueueTask's nil-error+empty-execID silent-drop contract → WaitForExecution(\"\") sql.ErrNoRows error every poll tick.",
+        "file": ".agent/knowledge/memories/pitfalls/mem-158.md",
+        "concepts": [
+          "dispatcher",
+          "sdk-poller",
+          "atomic-claim",
+          "retry",
+          "ledger",
+          "execution-lifecycle"
+        ],
+        "confidence": 0.9,
+        "created": "2026-07-16"
       }
     }
   },

--- a/.agent/knowledge/memories/pitfalls/mem-158.md
+++ b/.agent/knowledge/memories/pitfalls/mem-158.md
@@ -1,0 +1,28 @@
+# Pitfall: An atomic claim's ErrClaimLost drop is only correct if callers distinguish a LIVE owner from a DEAD one — otherwise a failed task is permanently unretryable
+
+## Summary
+TASK-407 (#4361-#4363) shipped `ExecutionLifecycle.Begin`'s atomic claim and threaded `ErrClaimLost` through every entry point, but every production call site still called `Begin` at a hardcoded generation 0 and treated ANY `ErrClaimLost` identically — "another channel owns it, drop the pickup silently." That's correct for a LIVE owner (the duplicate-pickup race the claim exists to prevent) but wrong for a DEAD owner (a claim held by a *terminal* execution, e.g. one that failed): generation 0 is permanently occupied, so every future re-pick loses to itself forever and the task can never retry (GH-4372, GH-4370's repro — a DNS outage killed a session, and the poller then dropped the same task every ~30s cycle). The "retry deciders thread generation+1" checkbox in TASK-407 was left unchecked — this is exactly the gap it flagged.
+
+Compounding bug found in the same investigation: `handleIssueGeneric` (cmd/pilot/handler_common.go) only special-cased the *wrapped* `ErrTaskAlreadyActive` error. `QueueTask`'s OTHER silent-drop contract — nil error + empty execID, used by `queueSingleTask`/`queueDecomposedTask` on `ErrClaimLost` — fell through to the success branch and called `WaitForExecution(ctx, "", ...)`, which hit `sql.ErrNoRows` on its very first poll and surfaced as an ERROR ("failed to get execution: sql: no rows in result set") that the SDK poller logged on every tick.
+
+## Context
+2026-07-16, same session as mem-156/mem-157 (TASK-407 dispatch-admission-claim). GH-4372 filed hours after TASK-407 shipped, once a live task actually failed and hit the retry path in production.
+
+## Details
+Fix (GH-4372): `Dispatcher.nextRetryGeneration` reads the highest `execution_claims` generation for (task, project) via `Store.LatestClaimGeneration`, fetches that generation's execution status, and classifies it: live (queued/running) → drop as before; terminal but the task is NOT `HasTerminalCompletion`-done (e.g. failed, stalled) → claim generation+1; terminal AND done (completed, or no_op-with-no-error) → drop, preserving the GH-4350 no_op invariant. `beginWithGenerationRetry` wraps this around `Begin` so both `queueSingleTask` and `queueDecomposedTask`'s parent claim get it for free. Separately, `handleIssueGeneric` now checks `execID == ""` (not just the wrapped error) before calling `WaitForExecution`.
+
+## Recommended Approach
+When a "return nil error, drop silently" sentinel exists (empty string, nil pointer, etc.), grep every caller of the function that returns it — a caller that only pattern-matches on one *named* error variant (`errors.Is(err, ErrX)`) will miss the sentinel-only case. And: any atomic-claim primitive with a generation/attempt column needs its retry decision to be *computed from the claim's own history* (what generation is occupied, what happened to it) — accepting a pre-supplied generation (as `Begin(task, status, gen)` does) is necessary but not sufficient; something has to decide gen+1 versus "still live, don't retry," and if nothing does, the claim becomes a one-shot lock instead of a claim.
+
+## Related
+- [[mem-156]] (the duplicate-execution class this claim fixes)
+- [[mem-157]] (the atomic-claim idiom this generalizes)
+- TASK-407
+- `internal/executor/dispatcher.go` (`nextRetryGeneration`, `beginWithGenerationRetry`)
+- `internal/memory/store.go` (`LatestClaimGeneration`)
+- `cmd/pilot/handler_common.go`
+
+---
+**Captured**: 2026-07-16
+**Confidence**: 0.9
+**Concepts**: dispatcher, sdk-poller, atomic-claim, retry, ledger, execution-lifecycle

--- a/cmd/pilot/handler_common.go
+++ b/cmd/pilot/handler_common.go
@@ -180,6 +180,19 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 			} else {
 				execErr = fmt.Errorf("failed to queue task: %w", qErr)
 			}
+		} else if execID == "" {
+			// GH-4372: QueueTask returns a nil error AND an empty execID when
+			// it drops a duplicate/terminal pickup silently (ErrClaimLost to a
+			// live owner, or a dead owner whose task is already
+			// HasTerminalCompletion-done and must not be re-armed, GH-4350) —
+			// no executions row exists here to wait on. Previously this fell
+			// into the branch below and called WaitForExecution(ctx, "", ...),
+			// which hit sql.ErrNoRows on its very first poll (an empty execID
+			// never matches a row) and surfaced as "failed to get execution:
+			// sql: no rows in result set" — an ERROR the SDK poller logged on
+			// every tick for a task that was never actually a failure.
+			logging.WithComponent("dispatch").Debug("dispatch dropped duplicate/terminal pickup, nothing to wait for",
+				slog.String("task_id", taskID))
 		} else {
 			if deps.Monitor != nil {
 				deps.Monitor.Queue(taskID)

--- a/cmd/pilot/handler_common_test.go
+++ b/cmd/pilot/handler_common_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/qf-studio/pilot/internal/adapters/azuredevops"
 	"github.com/qf-studio/pilot/internal/adapters/github"
@@ -233,6 +234,77 @@ func TestHandleIssueGeneric_GenuineQueueFailure_StillErrors(t *testing.T) {
 	}
 	if errors.Is(err, executor.ErrTaskAlreadyActive) {
 		t.Errorf("expected a genuine failure, not the already-active dedup rejection: %v", err)
+	}
+}
+
+// TestHandleIssueGeneric_DroppedTerminalPickup_NoPhantomWaitError is the
+// GH-4372 regression test for the poller-visible half of the bug: before the
+// fix, QueueTask's silent-drop contract (nil error, empty execID) fell
+// through to the WaitForExecution(ctx, "", ...) branch, which hit
+// sql.ErrNoRows on its very first poll (an empty execID never matches a
+// row) and surfaced as "failed to get execution: sql: no rows in result
+// set" — an ERROR the SDK poller logged on every tick ("Failed to process
+// issue ...") for a task that was never actually a failure.
+//
+// A no_op'd task at generation 0 reproduces the drop deterministically
+// without needing a live owner (which the IsActive pre-check would catch
+// before QueueTask is even reached) or a real backend execution (which a
+// generation+1 retry would need to run to completion).
+func TestHandleIssueGeneric_DroppedTerminalPickup_NoPhantomWaitError(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pilot-test-handler-noop-drop-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp failed: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	dispatcher := executor.NewDispatcher(store, executor.NewRunner(), nil)
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	t.Cleanup(dispatcher.Stop)
+
+	taskID := "GH-4372-NOOP-DROP"
+	projectPath := "/tmp/pilot-gh-4372-noop-does-not-exist"
+
+	seed := &executor.Task{ID: taskID, ProjectPath: projectPath}
+	seedExecID, err := executor.NewExecutionLifecycle(store).Begin(seed, executor.ExecStatusRunning, 0)
+	if err != nil {
+		t.Fatalf("setup: generation 0 Begin failed: %v", err)
+	}
+	if err := store.UpdateExecutionStatus(seedExecID, "no_op"); err != nil {
+		t.Fatalf("setup: failed to mark generation 0 as no_op: %v", err)
+	}
+
+	monitor := executor.NewMonitor()
+	deps := HandlerDeps{Dispatcher: dispatcher, Monitor: monitor, ProjectPath: projectPath}
+	info := IssueInfo{TaskID: taskID, Title: "already no_op'd", Adapter: "github", LogMark: "▸"}
+	task := &executor.Task{ID: taskID, Title: "already no_op'd", Branch: "pilot/" + taskID, ProjectPath: projectPath}
+
+	done := make(chan struct{})
+	var hr *HandlerResult
+	var hErr error
+	go func() {
+		hr, hErr = handleIssueGeneric(context.Background(), deps, info, task)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleIssueGeneric hung — likely stuck polling a phantom empty execID (GH-4372)")
+	}
+
+	if hErr != nil {
+		t.Fatalf("expected nil error for a dropped duplicate/terminal pickup, got: %v (this reproduces GH-4372's poller ERROR log)", hErr)
+	}
+	if hr.Success {
+		t.Error("expected Success=false for a dropped duplicate/terminal pickup")
 	}
 }
 

--- a/internal/executor/dispatch_claim_test.go
+++ b/internal/executor/dispatch_claim_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"context"
 	"errors"
 	"os"
 	"sync"
@@ -171,6 +172,80 @@ func TestDispatchClaim_RetryGenerationPlusOne(t *testing.T) {
 	}
 	if losses != n-1 {
 		t.Errorf("expected %d losses among concurrent generation 2 retries, got %d", n-1, losses)
+	}
+}
+
+// TestDispatchClaim_PollerRetryPath is the GH-4372 extension of the #4363
+// entry-point inventory: the poller's re-pick path (queueSingleTask) must
+// itself be the caller that decides and claims generation+1 after a prior
+// generation's execution went terminal — not merely capable of accepting a
+// pre-computed generation, as TestDispatchClaim_RetryGenerationPlusOne
+// proves for the Begin primitive alone. Races N goroutines calling
+// queueSingleTask concurrently against a task whose generation 0 already
+// failed: exactly one must win a generation-1 claim, the rest must observe
+// the duplicate-pickup drop (empty execID, nil error) rather than a second
+// generation-1 row.
+func TestDispatchClaim_PollerRetryPath(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	taskID, projectPath := "GH-entry-poller-retry", "/tmp/project-poller-retry"
+
+	failedExecID, err := NewExecutionLifecycle(store).Begin(&Task{ID: taskID, ProjectPath: projectPath}, ExecStatusRunning, 0)
+	if err != nil {
+		t.Fatalf("setup: generation 0 Begin failed: %v", err)
+	}
+	if err := store.UpdateExecutionStatus(failedExecID, "failed", "boom"); err != nil {
+		t.Fatalf("setup: failed to mark generation 0 as failed: %v", err)
+	}
+
+	dispatcher := NewDispatcher(store, NewRunner(), nil)
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	const n = 8
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var wins, drops int
+	barrier := make(chan struct{})
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-barrier
+			execID, err := dispatcher.queueSingleTask(context.Background(), &Task{ID: taskID, ProjectPath: projectPath})
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				t.Errorf("queueSingleTask: unexpected error: %v", err)
+				return
+			}
+			if execID == "" {
+				drops++
+			} else {
+				wins++
+			}
+		}()
+	}
+	close(barrier)
+	wg.Wait()
+
+	if wins != 1 {
+		t.Errorf("expected exactly 1 winner claiming generation 1, got %d", wins)
+	}
+	if drops != n-1 {
+		t.Errorf("expected %d dropped duplicate pickups, got %d", n-1, drops)
+	}
+
+	gen, _, found, err := store.LatestClaimGeneration(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("LatestClaimGeneration failed: %v", err)
+	}
+	if !found || gen != 1 {
+		t.Errorf("expected exactly one generation-1 claim to have landed, got generation=%d found=%v", gen, found)
 	}
 }
 

--- a/internal/executor/dispatch_retry_test.go
+++ b/internal/executor/dispatch_retry_test.go
@@ -1,0 +1,168 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestDispatcher_QueueSingleTask_RetriesGenerationAfterTerminalFailure is the
+// GH-4372 regression test: a task whose generation-0 execution terminated
+// "failed" must not be permanently stuck. Before this fix, queueSingleTask
+// always called Begin at generation 0 — since that generation's claim was
+// already permanently occupied by the dead (failed) execution, every re-pick
+// lost with ErrClaimLost and was dropped silently forever, identical to the
+// live-owner duplicate-pickup case it was meant to guard against.
+func TestDispatcher_QueueSingleTask_RetriesGenerationAfterTerminalFailure(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	taskID, projectPath := "GH-4370", "/project-gh-4370"
+
+	// Generation 0 ran and failed — mirrors GH-4370's repro (a machine-wide
+	// DNS outage killed the session mid-run).
+	failedTask := &Task{ID: taskID, ProjectPath: projectPath}
+	failedExecID, err := NewExecutionLifecycle(store).Begin(failedTask, ExecStatusRunning, 0)
+	if err != nil {
+		t.Fatalf("setup: generation 0 Begin failed: %v", err)
+	}
+	if err := store.UpdateExecutionStatus(failedExecID, "failed", "dial tcp: lookup api.github.com: no such host"); err != nil {
+		t.Fatalf("setup: failed to mark generation 0 as failed: %v", err)
+	}
+
+	runner := NewRunner()
+	dispatcher := NewDispatcher(store, runner, nil)
+
+	var buf bytes.Buffer
+	dispatcher.log = slog.New(slog.NewTextHandler(&buf, nil))
+
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	// The next poll tick re-picks the same task_id.
+	retryTask := &Task{ID: taskID, ProjectPath: projectPath}
+	execID, err := dispatcher.queueSingleTask(context.Background(), retryTask)
+	if err != nil {
+		t.Fatalf("expected the re-pick to claim generation+1 and queue successfully, got error: %v", err)
+	}
+	if execID == "" {
+		t.Fatal("expected a fresh execution ID for the generation+1 retry, got empty string (still stuck dropping the pickup)")
+	}
+	if execID == failedExecID {
+		t.Errorf("expected a distinct execution ID from the failed generation 0 attempt, got the same ID %q", execID)
+	}
+
+	gen, claimedExecID, found, err := store.LatestClaimGeneration(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("LatestClaimGeneration failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected a claim row after the retry")
+	}
+	if gen != 1 {
+		t.Errorf("expected the retry to claim generation 1, got generation %d", gen)
+	}
+	if claimedExecID != execID {
+		t.Errorf("expected the generation 1 claim to reference %q, got %q", execID, claimedExecID)
+	}
+
+	if strings.Contains(buf.String(), "dispatch claim lost — task already owned") {
+		t.Errorf("did not expect the duplicate-pickup drop message for a successful retry, got: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "claiming next generation for retry") {
+		t.Errorf("expected a log noting the generation+1 retry, got: %s", buf.String())
+	}
+}
+
+// TestDispatcher_QueueSingleTask_LiveOwnerStillDropsSilently proves GH-4372's
+// fix preserves the original ErrClaimLost duplicate-prevention: a claim held
+// by a still-LIVE execution (queued/running) must keep dropping the
+// duplicate pickup silently rather than being (mis)treated as a dead claim
+// eligible for a generation+1 retry.
+func TestDispatcher_QueueSingleTask_LiveOwnerStillDropsSilently(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	taskID, projectPath := "GH-4372-LIVE", "/project-gh-4372-live"
+
+	liveTask := &Task{ID: taskID, ProjectPath: projectPath}
+	liveExecID, err := NewExecutionLifecycle(store).Begin(liveTask, ExecStatusRunning, 0)
+	if err != nil {
+		t.Fatalf("setup: winning Begin failed: %v", err)
+	}
+
+	runner := NewRunner()
+	dispatcher := NewDispatcher(store, runner, nil)
+
+	var buf bytes.Buffer
+	dispatcher.log = slog.New(slog.NewTextHandler(&buf, nil))
+
+	dupTask := &Task{ID: taskID, ProjectPath: projectPath}
+	execID, err := dispatcher.queueSingleTask(context.Background(), dupTask)
+	if err != nil {
+		t.Fatalf("expected the duplicate pickup against a live owner to drop silently, got error: %v", err)
+	}
+	if execID != "" {
+		t.Errorf("expected empty execID for a live-owner duplicate pickup, got %q", execID)
+	}
+
+	gen, claimedExecID, found, err := store.LatestClaimGeneration(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("LatestClaimGeneration failed: %v", err)
+	}
+	if !found || gen != 0 || claimedExecID != liveExecID {
+		t.Errorf("expected the claim to remain at generation 0 owned by %q, got generation=%d execID=%q found=%v", liveExecID, gen, claimedExecID, found)
+	}
+
+	if !strings.Contains(buf.String(), "dispatch claim lost") {
+		t.Errorf("expected an info log noting the dropped claim, got: %s", buf.String())
+	}
+}
+
+// TestDispatcher_QueueSingleTask_NoOpDoesNotReArm preserves the GH-4350
+// invariant through the new retry path: a task whose generation-0 execution
+// terminated "no_op" with no error (a legitimate "nothing to change"
+// completion) must NOT be re-armed by the generation+1 retry decider, even
+// though no_op is a terminal-for-claim status like failed.
+func TestDispatcher_QueueSingleTask_NoOpDoesNotReArm(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	taskID, projectPath := "GH-4350-NOOP", "/project-gh-4350-noop"
+
+	noOpTask := &Task{ID: taskID, ProjectPath: projectPath}
+	noOpExecID, err := NewExecutionLifecycle(store).Begin(noOpTask, ExecStatusRunning, 0)
+	if err != nil {
+		t.Fatalf("setup: generation 0 Begin failed: %v", err)
+	}
+	if err := store.UpdateExecutionStatus(noOpExecID, "no_op"); err != nil {
+		t.Fatalf("setup: failed to mark generation 0 as no_op: %v", err)
+	}
+
+	runner := NewRunner()
+	dispatcher := NewDispatcher(store, runner, nil)
+
+	var buf bytes.Buffer
+	dispatcher.log = slog.New(slog.NewTextHandler(&buf, nil))
+
+	rePick := &Task{ID: taskID, ProjectPath: projectPath}
+	execID, err := dispatcher.queueSingleTask(context.Background(), rePick)
+	if err != nil {
+		t.Fatalf("expected a no_op task to drop the re-pick silently (nil error), got: %v", err)
+	}
+	if execID != "" {
+		t.Errorf("expected empty execID — a no_op'd task must not be re-armed, got %q", execID)
+	}
+
+	gen, _, found, err := store.LatestClaimGeneration(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("LatestClaimGeneration failed: %v", err)
+	}
+	if !found || gen != 0 {
+		t.Errorf("expected the claim to remain at generation 0 (no retry claimed), got generation=%d found=%v", gen, found)
+	}
+}

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -23,6 +23,21 @@ import (
 // error text (GH-4008).
 var ErrTaskAlreadyActive = errors.New("task already queued or running")
 
+// terminalExecutionStatuses is every execution status WaitForExecution and
+// the GH-4372 retry decider both treat as "finished" — the execution is no
+// longer in flight, regardless of whether it succeeded. Kept as the single
+// definition both consult so they can't drift apart.
+var terminalExecutionStatuses = map[string]bool{
+	"completed": true, "failed": true, "cancelled": true, "declined": true,
+	"no_op": true, "rate_limited": true, "skipped": true, "stalled": true, "infra": true,
+}
+
+// isTerminalExecutionStatus reports whether status is one of
+// terminalExecutionStatuses.
+func isTerminalExecutionStatus(status string) bool {
+	return terminalExecutionStatuses[status]
+}
+
 // DispatcherConfig configures the task dispatcher behavior.
 type DispatcherConfig struct {
 	// StaleTaskDuration is a backwards-compat alias for StaleRunningThreshold.
@@ -623,31 +638,131 @@ func (d *Dispatcher) QueueTask(ctx context.Context, task *Task) (string, error) 
 	return d.queueSingleTask(ctx, task)
 }
 
+// nextRetryGeneration inspects the highest execution_claims generation
+// currently held for (taskID, projectPath) and reports whether a fresh
+// Begin(..., generation+1) is warranted (GH-4372). Three outcomes:
+//   - no claim row at all, or the claimed execution is still LIVE
+//     (queued/running): retry=false — this is the ordinary duplicate-pickup
+//     race ErrClaimLost exists to catch; the caller must keep dropping it
+//     silently.
+//   - the claimed execution is terminal (dead — the owning run finished) AND
+//     the task is already "done" per HasTerminalCompletion (a genuine
+//     deliverable, or a no_op with no error): retry=false — preserves
+//     GH-4350's invariant that a no_op'd task must never be re-armed.
+//   - the claimed execution is terminal but the task is NOT yet done (e.g.
+//     failed, stalled): retry=true, generation = claimed generation + 1.
+func (d *Dispatcher) nextRetryGeneration(taskID, projectPath string) (generation int, retry bool, err error) {
+	gen, execID, found, err := d.store.LatestClaimGeneration(taskID, projectPath)
+	if err != nil || !found {
+		return 0, false, err
+	}
+
+	claimedExec, err := d.store.GetExecution(execID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// Claim row landed but its executions row never did (Begin's
+			// save-failure case) — treat conservatively as still owned
+			// rather than guessing a retry is safe.
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	if !isTerminalExecutionStatus(claimedExec.Status) {
+		return 0, false, nil // live owner — today's ErrClaimLost drop path
+	}
+
+	done, err := HasTerminalCompletion(d.store, taskID, projectPath)
+	if err != nil {
+		return 0, false, err
+	}
+	if done {
+		return 0, false, nil // GH-4350: already "done" — must not re-arm
+	}
+
+	return gen + 1, true, nil
+}
+
+// beginWithGenerationRetry wraps ExecutionLifecycle.Begin(task, initial) so a
+// claim loss caused by a DEAD prior claim (the owning execution finished, but
+// the task isn't done yet — e.g. it failed) automatically retries at
+// generation+1 instead of retrying generation 0 forever. GH-4372: a task
+// that failed once was permanently unable to re-pick, since its claim on
+// generation 0 was already permanently occupied by the terminal failure and
+// every re-pick attempt kept retrying that same occupied generation.
+//
+// Returns ("", nil) for the two "drop this pickup silently" outcomes callers
+// already handle identically: a live owner (today's ErrClaimLost duplicate-
+// pickup case) or a dead owner whose task is already done and must not be
+// re-armed (GH-4350's no_op invariant). A genuine store error still
+// surfaces.
+func (d *Dispatcher) beginWithGenerationRetry(task *Task, initial Status) (string, error) {
+	lifecycle := NewExecutionLifecycle(d.store)
+	execID, err := lifecycle.Begin(task, initial)
+	if err == nil {
+		return execID, nil
+	}
+	if !errors.Is(err, ErrClaimLost) {
+		return "", err
+	}
+
+	gen, retry, decErr := d.nextRetryGeneration(task.ID, task.ProjectPath)
+	if decErr != nil {
+		d.log.Warn("failed to evaluate retry generation after claim loss — dropping pickup",
+			slog.String("task_id", task.ID),
+			slog.String("project", task.ProjectPath),
+			slog.Any("error", decErr))
+		return "", nil
+	}
+	if !retry {
+		return "", nil
+	}
+
+	retryExecID, retryErr := lifecycle.Begin(task, initial, gen)
+	if retryErr == nil {
+		d.log.Info("dispatch re-pick: prior claim was terminal but task is not done — claiming next generation for retry",
+			slog.String("task_id", task.ID),
+			slog.String("project", task.ProjectPath),
+			slog.Int("generation", gen),
+		)
+		return retryExecID, nil
+	}
+	if errors.Is(retryErr, ErrClaimLost) {
+		// Race: another channel claimed generation gen between our decision
+		// and this Begin call — drop it, same as any other duplicate pickup.
+		return "", nil
+	}
+	return "", fmt.Errorf("failed to save retry execution: %w", retryErr)
+}
+
 // queueDecomposedTask handles queuing a decomposed task and its subtasks.
 // The parent task is marked as "decomposed" and subtasks are queued in order.
 func (d *Dispatcher) queueDecomposedTask(ctx context.Context, parent *Task, result *DecomposeResult) (string, error) {
 	// GH-4243: single chokepoint for the row create + ExecutionID threading
-	// that used to be hand-rolled here.
-	parentExecID, err := NewExecutionLifecycle(d.store).Begin(parent, ExecStatusDecomposed)
-	if errors.Is(err, ErrClaimLost) {
-		// TASK-407/GH-4359: another dispatch channel (e.g. the epic sub-issue
-		// loop or a racing poller pass) already claimed
-		// (parent.ID, parent.ProjectPath, generation 0) before this
-		// dispatchMu-serialized call reached Begin. Unlike epic.go's
+	// that used to be hand-rolled here. GH-4372: beginWithGenerationRetry
+	// additionally claims generation+1 when the prior claim belongs to a
+	// dead (terminal, not-yet-done) execution instead of retrying generation
+	// 0 forever.
+	parentExecID, err := d.beginWithGenerationRetry(parent, ExecStatusDecomposed)
+	if err != nil {
+		return "", fmt.Errorf("failed to save decomposed parent: %w", err)
+	}
+	if parentExecID == "" {
+		// TASK-407/GH-4359, GH-4372: dropped duplicate pickup — either
+		// another dispatch channel (e.g. the epic sub-issue loop or a
+		// racing poller pass) already owns a LIVE execution for
+		// (parent.ID, parent.ProjectPath), or the parent task is already
+		// terminal-done (GH-4350: must not re-arm a no_op). Unlike epic.go's
 		// sub-issue loop, this call site has no wrapping execution row of
 		// its own to poll or attach a ledger event to — the parent task IS
 		// the top-level dispatch. Drop the duplicate pickup silently: the
 		// execution is already owned elsewhere, so re-queuing here would
 		// either FK-787 (no executions row to reference) or start a
 		// genuine duplicate run.
-		d.log.Info("dispatch claim lost — decomposed parent already owned by another dispatch channel, dropping duplicate pickup",
+		d.log.Info("dispatch claim lost — decomposed parent already owned by another dispatch channel or already terminal, dropping duplicate pickup",
 			slog.String("task_id", parent.ID),
 			slog.String("project", parent.ProjectPath),
 		)
 		return "", nil
-	}
-	if err != nil {
-		return "", fmt.Errorf("failed to save decomposed parent: %w", err)
 	}
 
 	d.log.Info("Task decomposed",
@@ -685,28 +800,34 @@ func (d *Dispatcher) queueDecomposedTask(ctx context.Context, parent *Task, resu
 // queueSingleTask queues a single task (no decomposition).
 func (d *Dispatcher) queueSingleTask(ctx context.Context, task *Task) (string, error) {
 	// GH-4243: single chokepoint for the row create + ExecutionID threading
-	// that used to be hand-rolled here.
-	execID, err := NewExecutionLifecycle(d.store).Begin(task, ExecStatusQueued)
-	if errors.Is(err, ErrClaimLost) {
-		// TASK-407/GH-4359: another dispatch channel already claimed
-		// (task.ID, task.ProjectPath, generation 0) — most likely a
-		// concurrently-racing epic sub-issue loop or CLI stub picking up the
-		// same task_id outside this dispatcher's dispatchMu-serialized path.
-		// Drop this pickup silently (idempotent pickup): the execution is
-		// already owned elsewhere, and proceeding here would either FK-787
-		// (no executions row for this call to reference) or start a genuine
-		// duplicate run. Returning a nil error — rather than wrapping
-		// ErrClaimLost like ErrTaskAlreadyActive — means callers (including
-		// the decomposed-subtask loop below) treat this exactly like an
-		// already-handled task, not a failure to log or retry.
-		d.log.Info("dispatch claim lost — task already owned by another dispatch channel, dropping duplicate pickup",
+	// that used to be hand-rolled here. GH-4372: beginWithGenerationRetry
+	// additionally claims generation+1 when the prior claim belongs to a
+	// dead (terminal, not-yet-done) execution instead of retrying generation
+	// 0 forever — this is the poller's primary re-pick path.
+	execID, err := d.beginWithGenerationRetry(task, ExecStatusQueued)
+	if err != nil {
+		return "", fmt.Errorf("failed to save execution: %w", err)
+	}
+	if execID == "" {
+		// TASK-407/GH-4359, GH-4372: dropped duplicate pickup — either
+		// another dispatch channel already claimed a LIVE execution for
+		// (task.ID, task.ProjectPath) — most likely a concurrently-racing
+		// epic sub-issue loop or CLI stub picking up the same task_id
+		// outside this dispatcher's dispatchMu-serialized path — or the
+		// task is already terminal-done (GH-4350: must not re-arm a
+		// no_op). Drop this pickup silently (idempotent pickup): the
+		// execution is already owned elsewhere, and proceeding here would
+		// either FK-787 (no executions row for this call to reference) or
+		// start a genuine duplicate run. Returning a nil error — rather
+		// than wrapping ErrClaimLost like ErrTaskAlreadyActive — means
+		// callers (including the decomposed-subtask loop below) treat this
+		// exactly like an already-handled task, not a failure to log or
+		// retry.
+		d.log.Info("dispatch claim lost — task already owned by another dispatch channel or already terminal, dropping duplicate pickup",
 			slog.String("task_id", task.ID),
 			slog.String("project", task.ProjectPath),
 		)
 		return "", nil
-	}
-	if err != nil {
-		return "", fmt.Errorf("failed to save execution: %w", err)
 	}
 
 	// GH-3732: surface per-project serialization instead of leaving a queued
@@ -887,9 +1008,7 @@ func (d *Dispatcher) WaitForExecution(ctx context.Context, execID string, pollIn
 			// else mutated the row — in the GH-3513/GH-3530 incidents a child PR
 			// merge self-healed the PARENT's row to completed with the child's PR
 			// URL, and the woken handler reported a false "✅ Pilot completed!".
-			switch exec.Status {
-			case "completed", "failed", "cancelled",
-				"declined", "no_op", "rate_limited", "skipped", "stalled", "infra":
+			if isTerminalExecutionStatus(exec.Status) {
 				return exec, nil
 			}
 		}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -2411,6 +2411,32 @@ func (s *Store) ClaimExecution(taskID, projectPath string, generation int, execu
 	return n == 1, nil
 }
 
+// LatestClaimGeneration returns the highest generation currently claimed for
+// (taskID, projectPath) in execution_claims, and the execution_id that
+// generation claimed. found is false when no claim row exists at all — the
+// normal state for a task that has never been dispatched.
+//
+// GH-4372: the poller's re-pick path uses this to distinguish a claim held by
+// a still-live execution (queued/running — the ErrClaimLost duplicate-pickup
+// case, must keep dropping silently) from one held by a dead, terminal
+// execution (failed/stalled/etc. — a legitimate retry candidate that should
+// claim generation+1) instead of retrying generation 0 forever.
+func (s *Store) LatestClaimGeneration(taskID, projectPath string) (generation int, executionID string, found bool, err error) {
+	err = s.db.QueryRow(`
+		SELECT generation, execution_id FROM execution_claims
+		WHERE task_id = ? AND project_path = ?
+		ORDER BY generation DESC
+		LIMIT 1
+	`, taskID, canonicalizeProjectPath(projectPath)).Scan(&generation, &executionID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, "", false, nil
+		}
+		return 0, "", false, err
+	}
+	return generation, executionID, true, nil
+}
+
 // CrossPattern represents a pattern that applies across multiple projects.
 // It enables knowledge sharing between projects within an organization,
 // tracking confidence based on usage outcomes.


### PR DESCRIPTION
## Summary
- Fixes GH-4372: a task that failed once was permanently unable to retry, because the poller/dispatcher re-pick path always called `ExecutionLifecycle.Begin` at claim generation 0 — since that generation was already permanently held by the terminal (failed) execution, every re-pick lost `ErrClaimLost` forever and was silently dropped, identical to the live-duplicate-pickup case the claim is meant to guard against.
- `Dispatcher.nextRetryGeneration` now inspects the current claim's execution status: a **live** owner (queued/running) still drops silently (duplicate-pickup prevention intact); a **dead-but-not-done** owner (e.g. failed, stalled) claims generation+1 via `beginWithGenerationRetry`; a **dead-and-done** owner (completed, or no_op with no error) still drops, preserving the GH-4350 no_op invariant.
- Also fixes a related bug in `handleIssueGeneric`: when `QueueTask` drops a duplicate/terminal pickup silently (nil error + empty execID), the code fell through to `WaitForExecution(ctx, "", ...)`, which hit `sql.ErrNoRows` immediately and surfaced as `"failed to get execution: sql: no rows in result set"` — the exact ERROR the SDK poller logged on every poll tick per the issue's live evidence.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/executor/... ./internal/memory/... ./cmd/pilot/...` (incl. `-race`)
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] New regression tests: generation+1 retry after a failed execution, live-owner still drops silently, no_op'd task does not re-arm (GH-4350), entry-point-inventory extension for the poller-retry path, and a `handleIssueGeneric`-level test proving no phantom `WaitForExecution("", ...)` error/hang.