### PR TITLE
fix(autopilot): backfill released stage from git tag ancestry (GH-4370)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -41,6 +41,10 @@ type approvalPersister interface {
 	// exists before inserting, so a stale/unknown execution ID can never
 	// surface as an execution_events foreign-key error.
 	RecordExecutionEvent(executionID string, stage memory.Stage, detail string) error
+	// HasExecutionEventStage backs the GH-4370 release-backfill sweep's
+	// idempotency check: whether executionID already carries a given stage
+	// (e.g. StageReleased), so a repeat pass never double-stamps the ladder.
+	HasExecutionEventStage(executionID string, stage memory.Stage) (bool, error)
 }
 
 // projectBoardSyncer abstracts GitHub Projects V2 board status updates.
@@ -4616,6 +4620,10 @@ func (c *Controller) Run(ctx context.Context) error {
 			// GH-3990: claim any scope releases now unblocked, and re-drive
 			// stale 'releasing' rows with no live carrier.
 			c.startPendingScopeReleases(ctx)
+			// GH-4370: heal autopilot_pr_state residue (failed/releasing rows
+			// orphaned by a manual tag push that bypassed the release train)
+			// whose PR is, in fact, already merged and tagged.
+			c.reconcileReleaseBackfill(ctx)
 		case <-ticker.C:
 			c.processAllPRs(ctx)
 

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -7863,6 +7863,15 @@ func (m *mockApprovalPersister) RecordExecutionEvent(executionID string, stage m
 	return nil
 }
 
+func (m *mockApprovalPersister) HasExecutionEventStage(executionID string, stage memory.Stage) (bool, error) {
+	for _, ev := range m.executionEvents {
+		if ev.executionID == executionID && ev.stage == stage {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // TestController_SetApprovalDecision_PersistsToMemoryStore verifies that
 // Controller.SetApprovalDecision updates in-memory PRState AND calls the
 // injected approvalPersister (executions table write path).
@@ -7927,6 +7936,10 @@ func (m *errApprovalPersister) GetLatestExecutionByTaskID(_, _ string) (*memory.
 
 func (m *errApprovalPersister) RecordExecutionEvent(_ string, _ memory.Stage, _ string) error {
 	return nil
+}
+
+func (m *errApprovalPersister) HasExecutionEventStage(_ string, _ memory.Stage) (bool, error) {
+	return false, nil
 }
 
 // TestController_ApprovalPersistMiss_RequestID verifies that a sql.ErrNoRows from

--- a/internal/autopilot/gh4130_test.go
+++ b/internal/autopilot/gh4130_test.go
@@ -27,6 +27,9 @@ func (m *gh4130ExecPersister) SetApprovalDecision(_ context.Context, _, _, _ str
 func (m *gh4130ExecPersister) RecordExecutionEvent(_ string, _ memory.Stage, _ string) error {
 	return nil
 }
+func (m *gh4130ExecPersister) HasExecutionEventStage(_ string, _ memory.Stage) (bool, error) {
+	return false, nil
+}
 func (m *gh4130ExecPersister) GetLatestExecutionByTaskID(taskID, _ string) (*memory.Execution, error) {
 	exec, ok := m.execByTask[taskID]
 	if !ok {

--- a/internal/autopilot/release_backfill.go
+++ b/internal/autopilot/release_backfill.go
@@ -1,0 +1,178 @@
+package autopilot
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// maxReleaseBackfillTags bounds how many of the most recent tags
+// earliestReleaseTagContaining inspects. GitHub's tags endpoint returns
+// newest-first and this reconciliation only ever targets recent release-train
+// residue (GH-4370), so 100 (GitHub's per-page max, and ListTags's only
+// supported page) comfortably covers the window without unbounded pagination.
+const maxReleaseBackfillTags = 100
+
+// reconcileReleaseBackfill is GH-4370's periodic release-ledger reconciliation.
+// A manual tag push (bypassing the automated release train entirely) leaves
+// every PR physically contained in that release wedged in autopilot_pr_state
+// at StageFailed or StageReleasing forever: RestoreState refuses to rehydrate
+// StageFailed rows ("shouldn't be active"), and a scope carrier whose
+// autopilot_scope_release row already resolved terminal is skipped too
+// (GH-4331) — both classes are permanently invisible to the normal poll loop
+// once orphaned. This sweep reads every persisted row directly from the state
+// store (not c.activePRs, which the orphans were never rehydrated into) and
+// heals any row whose PR did in fact merge and ship. Ground truth is git
+// ancestry: a PR is released iff its merge commit is an ancestor of an
+// existing release tag; the earliest such tag names the version.
+func (c *Controller) reconcileReleaseBackfill(ctx context.Context) {
+	if c.stateStore == nil || c.ghClient == nil {
+		return
+	}
+	states, err := c.stateStore.LoadAllPRStates(c.repoKey())
+	if err != nil {
+		c.log.Warn("reconcileReleaseBackfill: failed to load PR states", "error", err)
+		return
+	}
+	for _, prState := range states {
+		if prState.Stage != StageFailed && prState.Stage != StageReleasing {
+			continue
+		}
+		c.healReleaseBackfillRow(ctx, prState)
+	}
+}
+
+// healReleaseBackfillRow resolves prState's live merge status and tag
+// ancestry and, on a confirmed release match, backfills the execution ladder
+// and drains the residue row — mirroring exactly what a successful
+// handleReleasing does on the normal path, without re-running any of the
+// tag-creation logic (the tag already exists; this is bookkeeping, not a new
+// release).
+func (c *Controller) healReleaseBackfillRow(ctx context.Context, prState *PRState) {
+	owner, repo := prState.RepoOwnerAndName(c.owner, c.repo)
+
+	ghPR, err := c.ghClient.GetPullRequest(ctx, owner, repo, prState.PRNumber)
+	if err != nil {
+		c.log.Debug("reconcileReleaseBackfill: failed to fetch PR, skipping",
+			"pr", prState.PRNumber, "error", err)
+		return
+	}
+	if !ghPR.Merged || ghPR.MergeCommitSHA == "" {
+		// Genuinely unreleased (or never merged) — leave the row exactly as is.
+		return
+	}
+
+	tag, err := c.earliestReleaseTagContaining(ctx, owner, repo, ghPR.MergeCommitSHA)
+	if err != nil {
+		c.log.Warn("reconcileReleaseBackfill: tag ancestry lookup failed",
+			"pr", prState.PRNumber, "sha", ShortSHA(ghPR.MergeCommitSHA), "error", err)
+		return
+	}
+	if tag == "" {
+		// Merged, but not yet covered by any tag — genuinely unreleased.
+		return
+	}
+
+	previousStage := prState.Stage
+	c.recordReleaseBackfillEvent(prState, ghPR.MergeCommitSHA, tag)
+
+	prState.ReleaseVersion = tag
+	prState.HeadSHA = ghPR.MergeCommitSHA
+	if prState.ScopeKey != "" {
+		c.markScopeReleaseDone(prState, tag)
+	}
+	c.removePR(prState.PRNumber)
+
+	c.log.Info("reconcileReleaseBackfill: healed merged-but-unreleased residue row",
+		"pr", prState.PRNumber, "stage_was", previousStage, "version", tag,
+		"sha", ShortSHA(ghPR.MergeCommitSHA))
+}
+
+// recordReleaseBackfillEvent writes the released execution event for
+// prState, unless one is already recorded. Idempotent so a repeat sweep — or
+// a crash between this write and the row-drain in healReleaseBackfillRow —
+// never double-stamps the ladder (GH-4370, mirrors GH-4277's heal semantics:
+// this only appends the missing terminal event, it never re-stamps the
+// execution row's own timestamps to "now").
+func (c *Controller) recordReleaseBackfillEvent(prState *PRState, mergeSHA, tag string) {
+	if c.memoryStore == nil {
+		return
+	}
+	taskID := fmt.Sprintf("GH-%d", prState.IssueNumber)
+	if prState.IssueNumber == 0 {
+		taskID = fmt.Sprintf("PR-%d", prState.PRNumber)
+	}
+	exec, err := c.memoryStore.GetLatestExecutionByTaskID(taskID, c.projectPath)
+	if err != nil {
+		c.log.Warn("reconcileReleaseBackfill: no execution row for task, skipping event",
+			"pr", prState.PRNumber, "task_id", taskID, "error", err)
+		return
+	}
+	already, err := c.memoryStore.HasExecutionEventStage(exec.ID, memory.StageReleased)
+	if err != nil {
+		c.log.Warn("reconcileReleaseBackfill: failed to check existing released event",
+			"pr", prState.PRNumber, "execution_id", exec.ID, "error", err)
+		return
+	}
+	if already {
+		return
+	}
+	detail := fmt.Sprintf("release-backfill (GH-4370): pr #%d merge commit %s found in tag %s (manual tag push bypassed the release train)",
+		prState.PRNumber, ShortSHA(mergeSHA), tag)
+	if err := c.memoryStore.RecordExecutionEvent(exec.ID, memory.StageReleased, detail); err != nil {
+		c.log.Warn("reconcileReleaseBackfill: failed to record released event",
+			"pr", prState.PRNumber, "execution_id", exec.ID, "error", err)
+	}
+}
+
+// earliestReleaseTagContaining returns the earliest (lowest-semver) release
+// tag whose history contains sha, or "" if no tag among the most recent
+// maxReleaseBackfillTags contains it. The earliest tag is the one that
+// actually shipped the commit — a later tag also contains it by
+// transitivity, but naming that one would misreport when the work released.
+func (c *Controller) earliestReleaseTagContaining(ctx context.Context, owner, repo, sha string) (string, error) {
+	tags, err := c.ghClient.ListTags(ctx, owner, repo, maxReleaseBackfillTags)
+	if err != nil {
+		return "", err
+	}
+
+	type versionedTag struct {
+		name string
+		sha  string
+		ver  SemVer
+	}
+	versioned := make([]versionedTag, 0, len(tags))
+	for _, tag := range tags {
+		ver, err := ParseSemVer(tag.Name)
+		if err != nil {
+			continue // not a release tag — not a candidate
+		}
+		versioned = append(versioned, versionedTag{name: tag.Name, sha: tag.Commit.SHA, ver: ver})
+	}
+	sort.Slice(versioned, func(i, j int) bool {
+		a, b := versioned[i].ver, versioned[j].ver
+		if a.Major != b.Major {
+			return a.Major < b.Major
+		}
+		if a.Minor != b.Minor {
+			return a.Minor < b.Minor
+		}
+		return a.Patch < b.Patch
+	})
+
+	for _, t := range versioned {
+		if t.sha == sha {
+			return t.name, nil
+		}
+		status, err := c.ghClient.CompareStatus(ctx, owner, repo, sha, t.sha)
+		if err != nil {
+			return "", fmt.Errorf("compare %s against tag %s: %w", ShortSHA(sha), t.name, err)
+		}
+		if status == "ahead" || status == "identical" {
+			return t.name, nil
+		}
+	}
+	return "", nil
+}

--- a/internal/autopilot/release_backfill_test.go
+++ b/internal/autopilot/release_backfill_test.go
@@ -1,0 +1,249 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/memory"
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// releaseBackfillFakeTag is the minimal shape needed to serve GitHub's
+// /tags endpoint for earliestReleaseTagContaining.
+type releaseBackfillFakeTag struct {
+	name string
+	sha  string
+}
+
+// releaseBackfillServer serves the three endpoints GH-4370's reconciliation
+// needs: GetPullRequest (merge status + merge commit SHA), ListTags, and
+// CompareStatus (ancestry). compareStatus is keyed "base...head" exactly as
+// CompareStatus builds its request path.
+func releaseBackfillServer(t *testing.T, prs map[int]*github.PullRequest, tags []releaseBackfillFakeTag, compareStatus map[string]string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls/"):
+			var num int
+			if _, err := fmt.Sscanf(r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:], "%d", &num); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			pr, ok := prs[num]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(pr)
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
+			out := make([]*github.Tag, 0, len(tags))
+			for _, tag := range tags {
+				gt := &github.Tag{Name: tag.name}
+				gt.Commit.SHA = tag.sha
+				out = append(out, gt)
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(out)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/compare/"):
+			key := r.URL.Path[strings.LastIndex(r.URL.Path, "/compare/")+len("/compare/"):]
+			status, ok := compareStatus[key]
+			if !ok {
+				status = "diverged"
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": status})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// TestReconcileReleaseBackfill covers GH-4370's release-tag-ancestry
+// reconciliation: a manual tag push bypasses the release train entirely,
+// leaving autopilot_pr_state rows wedged at StageFailed/StageReleasing
+// forever even though the PR shipped. Ground truth is git ancestry.
+func TestReconcileReleaseBackfill(t *testing.T) {
+	tests := []struct {
+		name string
+		pr   *github.PullRequest
+		// stage is the pre-existing autopilot_pr_state row's stage — both
+		// StageFailed and StageReleasing residue are reconciliation candidates.
+		stage PRStage
+		tags  []releaseBackfillFakeTag
+		// compareStatus maps "<mergeSHA>...<tagSHA>" -> GitHub's compare status.
+		compareStatus map[string]string
+
+		// preExistingEvent seeds the mock execution ladder with a StageReleased
+		// event before the sweep runs, to test the already-released-row case.
+		preExistingEvent bool
+
+		wantDrained    bool
+		wantVersion    string
+		wantEventCount int
+	}{
+		{
+			name:  "manual-tag release (train never ran) backfilled with correct version",
+			pr:    &github.PullRequest{Number: 100, Merged: true, MergeCommitSHA: "sha100"},
+			stage: StageReleasing,
+			tags: []releaseBackfillFakeTag{
+				{name: "v2.240.0", sha: "tagsha240"},
+				{name: "v2.241.0", sha: "tagsha241"},
+			},
+			compareStatus: map[string]string{
+				"sha100...tagsha240": "ahead",
+				"sha100...tagsha241": "ahead",
+			},
+			wantDrained:    true,
+			wantVersion:    "v2.240.0", // earliest containing tag, not the newest
+			wantEventCount: 1,
+		},
+		{
+			name:  "merged PR not yet covered by any tag stays untouched",
+			pr:    &github.PullRequest{Number: 101, Merged: true, MergeCommitSHA: "sha101"},
+			stage: StageFailed,
+			tags: []releaseBackfillFakeTag{
+				{name: "v2.240.0", sha: "tagsha240"},
+			},
+			compareStatus: map[string]string{
+				"sha101...tagsha240": "diverged",
+			},
+			wantDrained:    false,
+			wantEventCount: 0,
+		},
+		{
+			name:           "never-merged failure stays untouched",
+			pr:             &github.PullRequest{Number: 102, Merged: false},
+			stage:          StageFailed,
+			wantDrained:    false,
+			wantEventCount: 0,
+		},
+		{
+			name:  "already-released row heals without a duplicate event",
+			pr:    &github.PullRequest{Number: 103, Merged: true, MergeCommitSHA: "sha103"},
+			stage: StageReleasing,
+			tags: []releaseBackfillFakeTag{
+				{name: "v2.239.0", sha: "tagsha239"},
+			},
+			compareStatus: map[string]string{
+				"sha103...tagsha239": "ahead",
+			},
+			preExistingEvent: true,
+			wantDrained:      true,
+			wantVersion:      "v2.239.0",
+			wantEventCount:   1, // still just the one pre-existing event, no duplicate
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prs := map[int]*github.PullRequest{tt.pr.Number: tt.pr}
+			server := releaseBackfillServer(t, prs, tt.tags, tt.compareStatus)
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+			store, err := NewStateStoreFromPath(":memory:")
+			if err != nil {
+				t.Fatalf("NewStateStoreFromPath: %v", err)
+			}
+			c.SetStateStore(store)
+
+			taskID := fmt.Sprintf("GH-%d", tt.pr.Number)
+			execID := fmt.Sprintf("exec-%d", tt.pr.Number)
+			mock := &mockApprovalPersister{
+				execByTask: map[string]string{taskID: execID},
+			}
+			if tt.preExistingEvent {
+				mock.executionEvents = append(mock.executionEvents, recordedExecutionEvent{
+					executionID: execID,
+					stage:       memory.StageReleased,
+					detail:      "released via the normal automated path",
+				})
+			}
+			c.memoryStore = mock
+
+			prURL := fmt.Sprintf("https://github.com/owner/repo/pull/%d", tt.pr.Number)
+			if err := store.SavePRState("owner/repo", &PRState{
+				PRNumber:    tt.pr.Number,
+				PRURL:       prURL,
+				IssueNumber: tt.pr.Number,
+				Stage:       tt.stage,
+			}); err != nil {
+				t.Fatalf("SavePRState: %v", err)
+			}
+
+			c.reconcileReleaseBackfill(context.Background())
+
+			row, err := store.GetPRState("owner/repo", tt.pr.Number)
+			if err != nil {
+				t.Fatalf("GetPRState: %v", err)
+			}
+			drained := row == nil
+			if drained != tt.wantDrained {
+				t.Errorf("drained = %v, want %v (row = %+v)", drained, tt.wantDrained, row)
+			}
+
+			var releasedEvents []recordedExecutionEvent
+			for _, ev := range mock.executionEvents {
+				if ev.executionID == execID && ev.stage == memory.StageReleased {
+					releasedEvents = append(releasedEvents, ev)
+				}
+			}
+			if len(releasedEvents) != tt.wantEventCount {
+				t.Errorf("released event count = %d, want %d (%+v)", len(releasedEvents), tt.wantEventCount, releasedEvents)
+			}
+			if tt.wantVersion != "" && len(releasedEvents) > 0 {
+				last := releasedEvents[len(releasedEvents)-1]
+				if !tt.preExistingEvent && !strings.Contains(last.detail, tt.wantVersion) {
+					t.Errorf("event detail = %q, want it to mention version %q", last.detail, tt.wantVersion)
+				}
+			}
+		})
+	}
+}
+
+// TestReconcileReleaseBackfill_SkipsNonCandidateStages verifies the sweep
+// never even fetches the PR for a row that isn't StageFailed/StageReleasing —
+// e.g. a genuinely in-flight PR mid-CI must never be perturbed by this heal.
+func TestReconcileReleaseBackfill_SkipsNonCandidateStages(t *testing.T) {
+	var pullFetches int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/pulls/") {
+			pullFetches++
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	store, err := NewStateStoreFromPath(":memory:")
+	if err != nil {
+		t.Fatalf("NewStateStoreFromPath: %v", err)
+	}
+	c.SetStateStore(store)
+
+	for i, stage := range []PRStage{StageWaitingCI, StageCIPassed, StageMerging, StageMerged, StagePostMergeCI, StageAwaitApproval} {
+		if err := store.SavePRState("owner/repo", &PRState{
+			PRNumber: 200 + i,
+			Stage:    stage,
+		}); err != nil {
+			t.Fatalf("SavePRState(%s): %v", stage, err)
+		}
+	}
+
+	c.reconcileReleaseBackfill(context.Background())
+
+	if pullFetches != 0 {
+		t.Errorf("pull fetches = %d, want 0 — non-candidate stages must never be touched", pullFetches)
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -877,6 +877,19 @@ func (s *Store) RecordExecutionEvent(executionID string, stage Stage, detail str
 	return recordExecutionEventOn(s.db, executionID, stage, detail)
 }
 
+// HasExecutionEventStage reports whether executionID's execution_events
+// ledger already carries an entry for stage. Used by heal/backfill passes
+// (e.g. GH-4370's release-tag-ancestry reconciliation) so a repeat sweep — or
+// a crash between writing the event and draining the row it healed — never
+// double-stamps the ladder.
+func (s *Store) HasExecutionEventStage(executionID string, stage Stage) (bool, error) {
+	var exists bool
+	err := s.db.QueryRow(`
+		SELECT EXISTS(SELECT 1 FROM execution_events WHERE execution_id = ? AND stage = ?)
+	`, executionID, string(stage)).Scan(&exists)
+	return exists, err
+}
+
 // dbExecer is satisfied by both *sql.DB and *sql.Tx. recordExecutionEventOn is
 // generalized over it so the GH-4292 heal paths can run the same validate-first
 // check and insert inside their own transaction, atomically with the status


### PR DESCRIPTION
## Summary
- Manual tag pushes bypass the release train entirely, leaving affected PRs wedged in `autopilot_pr_state` at `failed`/`releasing` forever — `RestoreState` skips `failed` rows and a scope carrier whose `scope_release` row already resolved terminal is skipped too, so both classes become permanently invisible to the normal poll loop.
- Adds a periodic reconciliation sweep (`reconcileReleaseBackfill`, wired into `Controller.Run`'s existing sweep block) that reads every persisted `autopilot_pr_state` row directly from the state store, resolves each residue row's live merge commit SHA via the GitHub API, checks ancestry against existing release tags (earliest containing tag by semver), and on a match backfills the `released` execution event idempotently and drains the row exactly as a normal successful release would.
- Rows genuinely unreleased (merge commit not yet in any tag) are left untouched.

## Test plan
- [x] `internal/autopilot/release_backfill_test.go`: table-driven — manual-tag release (train never ran) backfilled with correct (earliest) version; merged-but-not-yet-tagged PR stays untouched; never-merged failure stays untouched; already-released row heals without a duplicate event.
- [x] `TestReconcileReleaseBackfill_SkipsNonCandidateStages`: confirms non-`failed`/`releasing` rows are never even fetched.
- [x] `go build ./...`, `go vet ./internal/autopilot/... ./internal/memory/...`, `go test ./...` all green.
- [x] `golangci-lint run ./internal/autopilot/... ./internal/memory/...` clean (repo-wide `make lint` has one pre-existing unrelated failure in `internal/dashboard/grom_chrome.go`, untouched by this change).