### PR TITLE
fix(agent): restore mem-153/154 pitfall files missing from disk — unblock drift gate

### DIFF
--- a/.agent/knowledge/memories/pitfalls/pitfall_noop_terminal_state_invisible_to_dispatch_guards.md
+++ b/.agent/knowledge/memories/pitfalls/pitfall_noop_terminal_state_invisible_to_dispatch_guards.md
@@ -1,0 +1,26 @@
+# Pitfall: no_op is terminal but invisible to "is this task done" dispatch guards
+
+## Summary
+`no_op` is a legitimate terminal outcome (common for epic sub-issues) but was invisible to every "is this task done" dispatch guard — `Store.HasCompletedExecution` requires `status='completed'` plus a deliverable, so the SDK poller's `ExecutionChecker` and dispatcher.go's `hasTerminalSuccessLedger` both re-treated no_op'd issues as fresh candidates forever (GH-4347: GH-82 dispatched 6x in one cycle).
+
+## Context
+RCA of GH-4347 duplicate-dispatch storm on the canary sandbox, 2026-07-15.
+
+## Details
+The completion predicate encoded one narrow definition of "done": completed + PR/commit deliverable. Epic sub-issues that resolve to no_op (work already done by a sibling, nothing to change) terminate legitimately without a deliverable — every admission gate using the narrow predicate saw them as never-run and re-admitted them each poll cycle. Fix: `Store.HasTerminalCompletion` — ANY-row check ORing deliverable-completion with no_op-with-no-error.
+
+## Recommended Approach
+New admission gates must use `executor.HasTerminalCompletion`, not `HasCompletedExecution` directly. When adding a terminal status to the execution vocabulary, sweep every dispatch/admission guard for completion predicates that don't know about it — a terminal state only one guard can see is a duplicate-dispatch bug waiting to fire.
+
+## Related
+- `internal/memory/store.go`
+- `internal/executor/dispatcher.go`
+- GH-4347
+
+---
+**Captured**: 2026-07-15
+**Confidence**: 90%
+**Concepts**: dispatcher, sdk-poller, ledger, canary
+
+> Note: file reconstructed 2026-07-16 from its graph.json entry — the original
+> was indexed but never committed (drift-gate FAIL on main); summary preserved verbatim.

--- a/.agent/knowledge/memories/pitfalls/pitfall_sqlite_time_bind_default_format.md
+++ b/.agent/knowledge/memories/pitfalls/pitfall_sqlite_time_bind_default_format.md
@@ -1,0 +1,25 @@
+# Pitfall: modernc.org/sqlite binds time.Time as Go String() format — date() returns NULL, ordering breaks
+
+## Summary
+modernc.org/sqlite writes bound `time.Time` params using Go's `time.Time.String()` format by default, which SQLite's `date()`/`datetime()` can't parse (returns NULL) and sorts inconsistently against `DEFAULT CURRENT_TIMESTAMP` columns. Fix: open the DB with `?_time_format=sqlite`.
+
+## Context
+Root-causing internal/briefs's flaky `TestGeneratorGenerate`, 2026-07-15.
+
+## Details
+Two compounding issues: (1) the driver's default time binding produces `2026-07-15 10:00:00.123456789 +0200 CEST m=+0.001` style strings — SQLite date functions return NULL on them, and lexicographic ordering against `CURRENT_TIMESTAMP`-defaulted columns (format `2026-07-15 08:00:00`) is inconsistent, so time-window queries silently drop rows. (2) `SaveExecution`'s INSERT omitted `created_at`, letting the DB default silently override caller-supplied timestamps — tests that constructed executions with explicit timestamps got CURRENT_TIMESTAMP instead, making the assertion window flaky.
+
+## Recommended Approach
+Open modernc.org/sqlite DBs with `?_time_format=sqlite` in the DSN. When an INSERT is meant to honor caller-supplied timestamps, bind the column explicitly — never rely on a DB default to "usually match". For flaky time-window tests, check binding format vs column default format first.
+
+## Related
+- `internal/memory/store.go`
+- `internal/briefs`
+
+---
+**Captured**: 2026-07-15
+**Confidence**: 90%
+**Concepts**: sqlite, database, testing, flaky-test
+
+> Note: file reconstructed 2026-07-16 from its graph.json entry — the original
+> was indexed but never committed (drift-gate FAIL on main); summary preserved verbatim.


### PR DESCRIPTION
The Knowledge Graph Drift Gate fails on every `main` push and every PR since 2026-07-15: `graph.json` indexes mem-153 and mem-154 but their pitfall files were never committed (authored in a worktree that didn't land them).

- Reconstructed both files from their graph entries (summaries verbatim, reconstruction noted in-file).
- `scripts/check-graph.py` green in this branch (concept WARNs only, non-fatal).

This is the sole red check on **#4373** (the GH-4372 claim-retry fix) — merging this + re-running #4373's CI unblocks the autopilot merge chain and ends the current poller retry storm.