### PR TITLE
fix(cli): pilot trace scoped by project like pilot logs (GH-4378)

### DIFF
--- a/cmd/pilot/trace.go
+++ b/cmd/pilot/trace.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -17,6 +19,8 @@ import (
 // for a task, so retries and stage-level durations are visible without
 // grepping raw logs.
 func newTraceCmd() *cobra.Command {
+	var projectFlag string
+
 	cmd := &cobra.Command{
 		Use:   "trace <task-id>",
 		Short: "Render the stage-transition timeline for a task's executions",
@@ -25,9 +29,17 @@ every execution of a task, newest execution first. Retries are rendered as
 separate blocks; each stage line shows a UTC timestamp and the duration since
 the previous stage.
 
+task_id is not unique across projects (every freshly onboarded repo starts
+issue numbering at #1), so the trace is scoped to a single project: --project
+if given, otherwise the current directory if it matches one of the task's
+projects, otherwise (when the task_id only ever ran in one project) that
+project. If the task_id collides across multiple projects and neither of
+those resolves it, the candidate projects are listed instead of merged.
+
 Examples:
-  pilot trace GH-42       # Show the stage timeline for task GH-42
-  pilot trace TASK-379    # Show the stage timeline for a Navigator task ID`,
+  pilot trace GH-42                         # Show the stage timeline for task GH-42
+  pilot trace TASK-379                      # Show the stage timeline for a Navigator task ID
+  pilot trace GH-1 --project /path/to/repo  # Scope to a specific project`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configPath := cfgFile
@@ -46,24 +58,41 @@ Examples:
 			}
 			defer func() { _ = store.Close() }()
 
-			return runTrace(cmd.OutOrStdout(), store, args[0])
+			return runTrace(cmd.OutOrStdout(), store, args[0], projectFlag)
 		},
 	}
+
+	cmd.Flags().StringVarP(&projectFlag, "project", "p", "", "Project path to scope the trace to (default: current directory, auto-resolved if unambiguous)")
 
 	return cmd
 }
 
-// runTrace writes the stage timeline for every execution of taskID to w,
-// newest execution first (matching store.ListExecutionsForTask). Returns an
-// error naming taskID when no executions are recorded, so the CLI exits
-// non-zero with a clear message instead of printing an empty report.
-func runTrace(w io.Writer, store *memory.Store, taskID string) error {
-	executions, err := store.ListExecutionsForTask(taskID)
+// runTrace writes the stage timeline for every execution of taskID within a
+// single, resolved project to w, newest execution first. Returns an error
+// naming taskID when no executions are recorded at all, or listing candidate
+// projects when taskID collides across projects and cwd/--project can't
+// disambiguate (GH-4378) — either way, the CLI exits non-zero with no
+// partial output rather than silently merging unrelated repos.
+func runTrace(w io.Writer, store *memory.Store, taskID, projectFlag string) error {
+	projects, err := store.ListProjectsForTask(taskID)
+	if err != nil {
+		return fmt.Errorf("failed to look up task %s: %w", taskID, err)
+	}
+	if len(projects) == 0 {
+		return fmt.Errorf("no executions found for task %s", taskID)
+	}
+
+	project := resolveTraceProject(projectFlag, projects)
+	if project == "" {
+		return ambiguousTraceProjectError(taskID, projects)
+	}
+
+	executions, err := store.ListExecutionsForTask(taskID, project)
 	if err != nil {
 		return fmt.Errorf("failed to look up task %s: %w", taskID, err)
 	}
 	if len(executions) == 0 {
-		return fmt.Errorf("no executions found for task %s", taskID)
+		return fmt.Errorf("no executions found for task %s in project %s", taskID, project)
 	}
 
 	for i, exec := range executions {
@@ -111,4 +140,43 @@ func writeEventTimeline(w io.Writer, events []*memory.Event) {
 
 		prev = e.OccurredAt
 	}
+}
+
+// resolveTraceProject picks the single project a trace should be scoped to,
+// given an optional --project override and the distinct projects that have
+// recorded executions for the task (newest-first, from
+// store.ListProjectsForTask). Returns "" when the task_id collides across
+// multiple projects and neither the override nor the current directory
+// resolves it — the caller must treat that as ambiguous rather than merging.
+func resolveTraceProject(projectFlag string, projects []memory.TaskProjectSummary) string {
+	if projectFlag != "" {
+		return projectFlag
+	}
+	// A task_id that only ever ran in one project is unambiguous regardless
+	// of where `pilot trace` is invoked from.
+	if len(projects) == 1 {
+		return projects[0].ProjectPath
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	for _, p := range projects {
+		if p.ProjectPath == cwd {
+			return cwd
+		}
+	}
+	return ""
+}
+
+// ambiguousTraceProjectError lists the projects a colliding task_id ran in,
+// newest execution first, so the caller can pick one via --project instead
+// of trace silently merging unrelated repos' executions (GH-4378).
+func ambiguousTraceProjectError(taskID string, projects []memory.TaskProjectSummary) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "task %s has executions in %d projects — pass --project to disambiguate:\n", taskID, len(projects))
+	for _, p := range projects {
+		fmt.Fprintf(&b, "  %s\t(latest %s)\n", p.ProjectPath, p.LatestAt.UTC().Format("2006-01-02 15:04:05 UTC"))
+	}
+	return errors.New(strings.TrimRight(b.String(), "\n"))
 }

--- a/cmd/pilot/trace_test.go
+++ b/cmd/pilot/trace_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -56,7 +57,7 @@ func TestRunTrace_UnknownTaskID(t *testing.T) {
 	store, _ := newTraceTestStore(t)
 
 	var buf bytes.Buffer
-	err := runTrace(&buf, store, "GH-does-not-exist")
+	err := runTrace(&buf, store, "GH-does-not-exist", "")
 	if err == nil {
 		t.Fatal("expected error for unknown task id, got nil")
 	}
@@ -66,6 +67,49 @@ func TestRunTrace_UnknownTaskID(t *testing.T) {
 	}
 	if buf.Len() != 0 {
 		t.Errorf("expected no output on error, got %q", buf.String())
+	}
+}
+
+// TestRunTrace_ProjectCollision covers GH-4378: the same task_id ran in two
+// unrelated projects. Without --project and with a cwd that matches neither
+// project, trace must list both as candidates and exit non-zero instead of
+// interleaving their executions into one timeline.
+func TestRunTrace_ProjectCollision(t *testing.T) {
+	store, _ := newTraceTestStore(t)
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "exec-pointer", TaskID: "GH-1", ProjectPath: "/repos/pointer", Status: "completed",
+	}); err != nil {
+		t.Fatalf("SaveExecution(exec-pointer) failed: %v", err)
+	}
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "exec-navigator", TaskID: "GH-1", ProjectPath: "/repos/navigator", Status: "completed",
+	}); err != nil {
+		t.Fatalf("SaveExecution(exec-navigator) failed: %v", err)
+	}
+
+	var buf bytes.Buffer
+	err := runTrace(&buf, store, "GH-1", "")
+	if err == nil {
+		t.Fatal("expected ambiguous-project error, got nil")
+	}
+	if !strings.Contains(err.Error(), "/repos/pointer") || !strings.Contains(err.Error(), "/repos/navigator") {
+		t.Errorf("error = %q, want it to list both candidate projects", err.Error())
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no output on ambiguous error, got %q", buf.String())
+	}
+
+	// --project resolves the collision directly.
+	buf.Reset()
+	if err := runTrace(&buf, store, "GH-1", "/repos/pointer"); err != nil {
+		t.Fatalf("runTrace with --project failed: %v", err)
+	}
+	if !strings.Contains(buf.String(), "exec-pointer") {
+		t.Errorf("output = %q, want it to include exec-pointer", buf.String())
+	}
+	if strings.Contains(buf.String(), "exec-navigator") {
+		t.Errorf("output = %q, want it to exclude exec-navigator", buf.String())
 	}
 }
 
@@ -106,7 +150,7 @@ func TestRunTrace_Golden(t *testing.T) {
 	seedEventAt(t, dbPath, "exec-2", memory.StageMerged, "", retryBase.Add(5*time.Minute))
 
 	var buf bytes.Buffer
-	if err := runTrace(&buf, store, "GH-42"); err != nil {
+	if err := runTrace(&buf, store, "GH-42", ""); err != nil {
 		t.Fatalf("runTrace failed: %v", err)
 	}
 
@@ -118,5 +162,37 @@ func TestRunTrace_Golden(t *testing.T) {
 
 	if buf.String() != string(want) {
 		t.Errorf("output mismatch\n--- got ---\n%s\n--- want ---\n%s", buf.String(), string(want))
+	}
+}
+
+func TestResolveTraceProject(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd failed: %v", err)
+	}
+
+	single := []memory.TaskProjectSummary{{ProjectPath: "/repos/only"}}
+	collision := []memory.TaskProjectSummary{{ProjectPath: "/repos/newer"}, {ProjectPath: "/repos/older"}}
+	collisionWithCwd := []memory.TaskProjectSummary{{ProjectPath: cwd}, {ProjectPath: "/repos/other"}}
+
+	tests := []struct {
+		name        string
+		projectFlag string
+		projects    []memory.TaskProjectSummary
+		want        string
+	}{
+		{"explicit --project always wins", "/repos/explicit", collision, "/repos/explicit"},
+		{"single project auto-resolves regardless of cwd", "", single, "/repos/only"},
+		{"collision resolved by cwd match", "", collisionWithCwd, cwd},
+		{"collision with no cwd match is ambiguous", "", collision, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveTraceProject(tt.projectFlag, tt.projects)
+			if got != tt.want {
+				t.Errorf("resolveTraceProject(%q, %v) = %q, want %q", tt.projectFlag, tt.projects, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/memory/execution_events_test.go
+++ b/internal/memory/execution_events_test.go
@@ -205,12 +205,14 @@ func TestRecordExecutionEvent_ValidatesFirst(t *testing.T) {
 	})
 }
 
-// TestListExecutionsForTask covers newest-first ordering and an unknown task id.
+// TestListExecutionsForTask covers newest-first ordering, an unknown task id,
+// and project_path scoping (GH-4378: task_id collides across projects).
 func TestListExecutionsForTask(t *testing.T) {
 	tests := []struct {
 		name      string
 		seedIDs   []string // in insertion order
 		queryTask string
+		queryProj string
 		wantIDs   []string // expected order returned
 	}{
 		{
@@ -221,6 +223,13 @@ func TestListExecutionsForTask(t *testing.T) {
 			name:      "multiple executions returned newest first",
 			seedIDs:   []string{"exec-1", "exec-2", "exec-3"},
 			queryTask: "GH-1",
+			wantIDs:   []string{"exec-3", "exec-2", "exec-1"},
+		},
+		{
+			name:      "empty projectPath does not filter",
+			seedIDs:   []string{"exec-1", "exec-2", "exec-3"},
+			queryTask: "GH-1",
+			queryProj: "",
 			wantIDs:   []string{"exec-3", "exec-2", "exec-1"},
 		},
 	}
@@ -243,7 +252,7 @@ func TestListExecutionsForTask(t *testing.T) {
 				time.Sleep(time.Millisecond)
 			}
 
-			got, err := store.ListExecutionsForTask(tt.queryTask)
+			got, err := store.ListExecutionsForTask(tt.queryTask, tt.queryProj)
 			if err != nil {
 				t.Fatalf("ListExecutionsForTask failed: %v", err)
 			}
@@ -257,4 +266,27 @@ func TestListExecutionsForTask(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("scoped to project_path excludes other projects' executions", func(t *testing.T) {
+		store := newExecutionEventsTestStore(t)
+
+		if err := store.SaveExecution(&Execution{
+			ID: "exec-pointer", TaskID: "GH-1", ProjectPath: "/repos/pointer", Status: "completed",
+		}); err != nil {
+			t.Fatalf("SaveExecution(exec-pointer) failed: %v", err)
+		}
+		if err := store.SaveExecution(&Execution{
+			ID: "exec-navigator", TaskID: "GH-1", ProjectPath: "/repos/navigator", Status: "completed",
+		}); err != nil {
+			t.Fatalf("SaveExecution(exec-navigator) failed: %v", err)
+		}
+
+		got, err := store.ListExecutionsForTask("GH-1", "/repos/pointer")
+		if err != nil {
+			t.Fatalf("ListExecutionsForTask failed: %v", err)
+		}
+		if len(got) != 1 || got[0].ID != "exec-pointer" {
+			t.Fatalf("ListExecutionsForTask(GH-1, /repos/pointer) = %v, want only exec-pointer", got)
+		}
+	})
 }

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -751,13 +751,20 @@ func (s *Store) GetLatestExecutionByTaskIDExcluding(taskID, projectPath, exclude
 // newest first. Unlike GetLatestExecutionByTaskID (single row, exact-or-substring
 // match), this returns the full history so the CLI can render a per-execution
 // stage timeline across retries (TASK-379 C4).
-func (s *Store) ListExecutionsForTask(taskID string) ([]*Execution, error) {
+//
+// GH-4378: task_id is not unique across projects (every freshly onboarded
+// repo starts issue numbering at #1 — same collision class as GH-4276), so
+// an unscoped lookup interleaves unrelated repos' executions into one
+// timeline. projectPath scopes the same way GetLatestExecutionByTaskID does:
+// empty projectPath skips the filter (cross-project, for callers that have
+// already resolved ambiguity another way, e.g. via ListProjectsForTask).
+func (s *Store) ListExecutionsForTask(taskID, projectPath string) ([]*Execution, error) {
 	rows, err := s.db.Query(`
 		SELECT `+executionDetailColumns+`
 		FROM executions
-		WHERE task_id = ?
+		WHERE task_id = ? AND (? = '' OR project_path = ?)
 		ORDER BY created_at DESC, rowid DESC
-	`, taskID)
+	`, taskID, projectPath, projectPath)
 	if err != nil {
 		return nil, err
 	}
@@ -772,6 +779,51 @@ func (s *Store) ListExecutionsForTask(taskID string) ([]*Execution, error) {
 		executions = append(executions, exec)
 	}
 	return executions, rows.Err()
+}
+
+// TaskProjectSummary identifies one project's most recent execution for a
+// given task_id. Used by `pilot trace` to detect when a task_id collides
+// across multiple projects (GH-4378) so it can list candidates instead of
+// silently merging their executions into one timeline.
+type TaskProjectSummary struct {
+	ProjectPath string
+	LatestAt    time.Time
+}
+
+// ListProjectsForTask returns, for every distinct project_path with a
+// recorded execution for taskID, that project's most recent execution
+// timestamp — newest first. Scans every row rather than GROUP BY
+// MAX(created_at) because the sqlite driver can't map an aggregate
+// expression back to time.Time (only declared-typed columns get that
+// treatment) — reading created_at directly newest-first and keeping the
+// first occurrence per project_path sidesteps that.
+func (s *Store) ListProjectsForTask(taskID string) ([]TaskProjectSummary, error) {
+	rows, err := s.db.Query(`
+		SELECT project_path, created_at
+		FROM executions
+		WHERE task_id = ?
+		ORDER BY created_at DESC, rowid DESC
+	`, taskID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	seen := make(map[string]bool)
+	var summaries []TaskProjectSummary
+	for rows.Next() {
+		var projectPath string
+		var createdAt time.Time
+		if err := rows.Scan(&projectPath, &createdAt); err != nil {
+			return nil, err
+		}
+		if seen[projectPath] {
+			continue
+		}
+		seen[projectPath] = true
+		summaries = append(summaries, TaskProjectSummary{ProjectPath: projectPath, LatestAt: createdAt})
+	}
+	return summaries, rows.Err()
 }
 
 // Stage identifies a discrete milestone in an execution's lifecycle. Stage events

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -3837,6 +3837,59 @@ func TestGetRecentExecutions_ProjectFilter(t *testing.T) {
 	}
 }
 
+// TestListProjectsForTask covers GH-4378: task_id is not unique across
+// projects, so `pilot trace` needs to know which distinct projects recorded
+// executions for a given task_id (and each project's most recent execution)
+// in order to disambiguate instead of merging.
+func TestListProjectsForTask(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	t.Run("unknown task id returns empty result", func(t *testing.T) {
+		got, err := store.ListProjectsForTask("GH-does-not-exist")
+		if err != nil {
+			t.Fatalf("ListProjectsForTask: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("got %d projects, want 0", len(got))
+		}
+	})
+
+	t.Run("collision across projects returns each distinct project, newest first", func(t *testing.T) {
+		older := time.Now().Add(-time.Hour)
+		newer := time.Now()
+
+		if err := store.SaveExecution(&Execution{
+			ID: "exec-navigator", TaskID: "GH-1", ProjectPath: "/repos/navigator", Status: "completed", CreatedAt: older,
+		}); err != nil {
+			t.Fatalf("SaveExecution(exec-navigator): %v", err)
+		}
+		if err := store.SaveExecution(&Execution{
+			ID: "exec-pointer", TaskID: "GH-1", ProjectPath: "/repos/pointer", Status: "completed", CreatedAt: newer,
+		}); err != nil {
+			t.Fatalf("SaveExecution(exec-pointer): %v", err)
+		}
+
+		got, err := store.ListProjectsForTask("GH-1")
+		if err != nil {
+			t.Fatalf("ListProjectsForTask: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("got %d projects, want 2: %+v", len(got), got)
+		}
+		if got[0].ProjectPath != "/repos/pointer" {
+			t.Errorf("got[0].ProjectPath = %q, want /repos/pointer (most recent)", got[0].ProjectPath)
+		}
+		if got[1].ProjectPath != "/repos/navigator" {
+			t.Errorf("got[1].ProjectPath = %q, want /repos/navigator", got[1].ProjectPath)
+		}
+	})
+}
+
 func TestGetLifetimeTokens_ProjectFilter(t *testing.T) {
 	tmpDir := t.TempDir()
 	store, err := NewStore(tmpDir)


### PR DESCRIPTION
## Summary
- `task_id` is not repo-scoped: `SELECT ... WHERE task_id='GH-1'` matches rows across every project that has ever numbered an issue #1, so `pilot trace GH-N` interleaved unrelated repos' executions into one stage timeline.
- `pilot trace` now resolves a single project to scope to: `--project` override, else the current directory if it matches one of the task's recorded projects, else the task's single project if it only ever ran in one.
- When the task_id collides across multiple projects and neither of those resolves it, `pilot trace` lists the candidate projects (path + latest execution timestamp) and exits non-zero instead of merging them.
- Added `internal/memory.Store.ListProjectsForTask` (distinct project_path + latest execution per project) and scoped `ListExecutionsForTask` by project_path (mirrors the existing `GetLatestExecutionByTaskID` pattern).

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/memory/... ./cmd/pilot/...`
- [x] `go test ./...` (full suite)
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] New tests: `TestListProjectsForTask`, project-scoping case in `TestListExecutionsForTask`, `TestRunTrace_ProjectCollision`, `TestResolveTraceProject`