### PR TITLE
fix(approval): approval requests undeliverable — routing, destination validation, wedge alerting (GH-4380)

### DIFF
--- a/.agent/sops/autopilot/approval-channel-routing.md
+++ b/.agent/sops/autopilot/approval-channel-routing.md
@@ -1,0 +1,66 @@
+# SOP: Approval channel routing (GH-4380)
+
+## Problem
+
+`environments.<env>.approval_source: slack` (or any non-default channel)
+had zero effect. Every async approval request silently fell through to
+whichever handler won Go map iteration order, and — if that happened to
+be Telegram — could dial an `Approvers[0]` value meant for a different
+channel, producing a per-tick `chat not found` 400 with no alert, no
+comment, no metric. PRs sat in `awaiting_approval` for hours
+(#4373/#4374, v2.241.0 regression).
+
+## Root cause
+
+Three independent gaps stacked:
+
+1. **Config field never read.** `EnvironmentConfig.ApprovalSource` existed
+   in the config struct and YAML schema, but nothing in
+   `internal/autopilot/controller.go`'s `submitAsyncApprovalRequest` ever
+   read it — `approval.Request.PreferredChannel` was never set. The
+   wiring (`req.PreferredChannel = string(cfg.ApprovalSource)`) lived in
+   `auto_merger.go:requestApproval` per TASK-26, but that function was
+   deleted when TASK-36 migrated approval submission off the legacy
+   blocking path into `controller.go` — and the PreferredChannel
+   assignment was never carried over to the new call site.
+2. **Silent nondeterministic fallback.** `Manager.SubmitApprovalRequest`
+   treated "PreferredChannel set but not registered" the same as
+   "PreferredChannel unset": WARN + pick any registered handler via map
+   iteration. A `PreferredChannel` that's always non-empty (which it now
+   is, since the controller always resolves *some* approval source) makes
+   this branch always active whenever the intended channel isn't wired
+   up — never a hard failure.
+3. **No destination validation.** `TelegramHandler` used
+   `req.Approvers[0]` verbatim as the Telegram chat id when present,
+   without checking it looked like a Telegram destination at all. Since
+   `Approvers` is a config-level, channel-agnostic list, a value meant for
+   a different channel landing here (via gap #2) produced a live 400 on
+   every retry instead of one diagnosable warning.
+
+## Fix
+
+- `autopilot.Config.EffectiveApprovalSource()` resolves per-env override →
+  top-level default, and `submitAsyncApprovalRequest` sets
+  `req.PreferredChannel` from it on every request.
+- `Manager.SubmitApprovalRequest`: an explicit, unregistered
+  `PreferredChannel` now returns a named error — no fallback. Fallback is
+  preserved only when `PreferredChannel` is genuinely unset.
+- `TelegramHandler.resolveDestChatID` validates `Approvers[0]` looks like
+  a Telegram destination (`isValidTelegramChatID`) before using it;
+  otherwise falls back to the configured `chat_id` and logs once (deduped
+  per bad value).
+- `Controller.alertApprovalSubmitFailureOnce`: on submit failure, increments
+  `ApprovalSubmitFailures` (exposed as `pilot_approval_submit_failures_total`),
+  fires an `alerts.EventTypeTaskFailed` event, and posts a PR comment
+  mentioning the repo owner — all deduped per PR so a retried tick doesn't
+  spam either.
+
+## Prevention
+
+When adding a new per-environment config knob that's supposed to override
+routing/behavior (anything under `EnvironmentConfig`), grep for every call
+site that constructs the object it's meant to influence
+(`approval.Request{...}`, etc.) and confirm the field is actually read —
+struct field + YAML tag existing is not proof of wiring. This class of bug
+(field defined, never consumed) is easy to reintroduce during a refactor
+that moves the one call site that used to read it (as TASK-36 did here).

--- a/internal/approval/manager.go
+++ b/internal/approval/manager.go
@@ -246,16 +246,12 @@ func (m *Manager) SubmitApprovalRequest(ctx context.Context, req *Request) (stri
 
 	m.mu.RLock()
 	var handler Handler
+	preferredMissing := false
 	if req.PreferredChannel != "" {
 		if h, ok := m.handlers[req.PreferredChannel]; ok {
 			handler = h
 		} else {
-			m.log.Warn("preferred approval channel not registered, falling back",
-				slog.String("preferred_channel", req.PreferredChannel))
-			for _, h := range m.handlers {
-				handler = h
-				break
-			}
+			preferredMissing = true
 		}
 	} else {
 		for _, h := range m.handlers {
@@ -264,6 +260,18 @@ func (m *Manager) SubmitApprovalRequest(ctx context.Context, req *Request) (stri
 		}
 	}
 	m.mu.RUnlock()
+
+	// GH-4380: a request with an explicit PreferredChannel must go through
+	// that channel or fail loudly — never a silent, nondeterministic fallback
+	// to whatever handler wins Go's map iteration order. The old "WARN + pick
+	// any registered handler" behavior is how a request configured for Slack
+	// (approval_source: slack) silently landed on Telegram with a Slack-shaped
+	// destination in req.Approvers, producing a per-tick "chat not found" 400
+	// instead of a single actionable error.
+	if preferredMissing {
+		return "", fmt.Errorf("approval channel %q is not registered (check adapters.%s.enabled + credentials, and adapters.%s.approval.enabled)",
+			req.PreferredChannel, req.PreferredChannel, req.PreferredChannel)
+	}
 
 	if handler == nil {
 		m.log.Warn("no approval handlers registered for async dispatch",

--- a/internal/approval/manager_test.go
+++ b/internal/approval/manager_test.go
@@ -3,6 +3,7 @@ package approval
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -292,6 +293,113 @@ func TestManager_SubmitApprovalRequest_NonBlocking(t *testing.T) {
 	}
 	if elapsed > 500*time.Millisecond {
 		t.Errorf("SubmitApprovalRequest should return immediately, took %v", elapsed)
+	}
+	if len(handler.sentReqs) != 1 {
+		t.Errorf("expected 1 request sent to handler, got %d", len(handler.sentReqs))
+	}
+}
+
+// TestManager_SubmitApprovalRequest_PreferredChannelRouting verifies that a
+// request with PreferredChannel set is routed to that handler even when
+// multiple handlers are registered — never to whichever handler happens to
+// win map iteration order (GH-4380).
+func TestManager_SubmitApprovalRequest_PreferredChannelRouting(t *testing.T) {
+	config := DefaultConfig()
+	config.Enabled = true
+	config.PreExecution.Enabled = true
+	config.PreExecution.Timeout = 5 * time.Second
+
+	m := NewManager(config)
+
+	telegram := &mockHandler{name: "telegram"}
+	slack := &mockHandler{name: "slack"}
+	m.RegisterHandler(telegram)
+	m.RegisterHandler(slack)
+
+	req := &Request{
+		ID:               "async-preferred-1",
+		TaskID:           "TASK-01",
+		Stage:            StagePreExecution,
+		Title:            "Test task",
+		CreatedAt:        time.Now(),
+		PreferredChannel: "slack",
+	}
+
+	if _, err := m.SubmitApprovalRequest(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(slack.sentReqs) != 1 {
+		t.Errorf("expected 1 request sent to slack handler, got %d", len(slack.sentReqs))
+	}
+	if len(telegram.sentReqs) != 0 {
+		t.Errorf("expected 0 requests sent to telegram handler, got %d", len(telegram.sentReqs))
+	}
+}
+
+// TestManager_SubmitApprovalRequest_PreferredChannelMissing_FailsExplicitly
+// verifies that when PreferredChannel names a handler that isn't registered,
+// SubmitApprovalRequest returns a named error instead of silently falling
+// back to an arbitrary registered handler. Before GH-4380, this fell through
+// to whichever handler won Go's map iteration order — the root cause of an
+// approval_source: slack request silently landing on Telegram with a
+// Slack-shaped Approvers[0] as the chat destination.
+func TestManager_SubmitApprovalRequest_PreferredChannelMissing_FailsExplicitly(t *testing.T) {
+	config := DefaultConfig()
+	config.Enabled = true
+	config.PreExecution.Enabled = true
+	config.PreExecution.Timeout = 5 * time.Second
+
+	m := NewManager(config)
+
+	telegram := &mockHandler{name: "telegram"}
+	m.RegisterHandler(telegram)
+
+	req := &Request{
+		ID:               "async-preferred-missing-1",
+		TaskID:           "TASK-01",
+		Stage:            StagePreExecution,
+		Title:            "Test task",
+		CreatedAt:        time.Now(),
+		PreferredChannel: "slack",
+	}
+
+	_, err := m.SubmitApprovalRequest(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected an error when the preferred channel is not registered, got nil")
+	}
+	if !strings.Contains(err.Error(), "slack") {
+		t.Errorf("expected error to name the missing channel %q, got: %v", "slack", err)
+	}
+	if len(telegram.sentReqs) != 0 {
+		t.Errorf("expected no silent fallback to telegram handler, got %d requests", len(telegram.sentReqs))
+	}
+}
+
+// TestManager_SubmitApprovalRequest_NoPreferredChannel_FallsBackToFirstAvailable
+// preserves the pre-existing behavior for requests that don't specify a
+// PreferredChannel at all (e.g. legacy callers) — the fail-fast behavior only
+// applies when PreferredChannel is explicitly set but unregistered.
+func TestManager_SubmitApprovalRequest_NoPreferredChannel_FallsBackToFirstAvailable(t *testing.T) {
+	config := DefaultConfig()
+	config.Enabled = true
+	config.PreExecution.Enabled = true
+	config.PreExecution.Timeout = 5 * time.Second
+
+	m := NewManager(config)
+	handler := &mockHandler{name: "test"}
+	m.RegisterHandler(handler)
+
+	req := &Request{
+		ID:        "async-no-preferred-1",
+		TaskID:    "TASK-01",
+		Stage:     StagePreExecution,
+		Title:     "Test task",
+		CreatedAt: time.Now(),
+	}
+
+	if _, err := m.SubmitApprovalRequest(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(handler.sentReqs) != 1 {
 		t.Errorf("expected 1 request sent to handler, got %d", len(handler.sentReqs))

--- a/internal/approval/telegram.go
+++ b/internal/approval/telegram.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -55,6 +56,11 @@ type TelegramHandler struct {
 	log      *slog.Logger
 	store    PendingApprovalStore // optional; enables restart persistence
 	recorder DecisionRecorder     // optional; persists decisions directly (restart-safe)
+
+	// warnedInvalidDest dedupes the "Approvers[0] is not a valid Telegram
+	// destination" warning per bad value (GH-4380), so a persistently
+	// misconfigured Approvers entry logs once instead of once per tick.
+	warnedInvalidDest map[string]bool
 }
 
 // telegramPending tracks a pending Telegram approval request
@@ -86,12 +92,66 @@ const resolvedRetention = 24 * time.Hour
 // NewTelegramHandler creates a new Telegram approval handler
 func NewTelegramHandler(client TelegramClient, chatID string) *TelegramHandler {
 	return &TelegramHandler{
-		client:   client,
-		chatID:   chatID,
-		pending:  make(map[string]*telegramPending),
-		resolved: make(map[string]*telegramResolved),
-		log:      logging.WithComponent("approval.telegram"),
+		client:            client,
+		chatID:            chatID,
+		pending:           make(map[string]*telegramPending),
+		resolved:          make(map[string]*telegramResolved),
+		log:               logging.WithComponent("approval.telegram"),
+		warnedInvalidDest: make(map[string]bool),
 	}
+}
+
+// isValidTelegramChatID reports whether s looks like a destination the
+// Telegram Bot API will accept: a numeric chat id (negative for groups/
+// channels) or an "@username" public channel/group handle. Approvers is a
+// channel-agnostic config list ("user IDs/handles who can approve") shared
+// across whichever handler ends up serving a request — when the operator
+// intends a different channel's approver identity (e.g. a Slack channel name)
+// and it lands here anyway (see resolveDestChatID), sending to it verbatim
+// produces a Telegram "chat not found" 400 on every retry instead of a single
+// diagnosable warning (GH-4380).
+func isValidTelegramChatID(s string) bool {
+	if s == "" {
+		return false
+	}
+	if strings.HasPrefix(s, "@") {
+		return len(s) > 1
+	}
+	_, err := strconv.ParseInt(s, 10, 64)
+	return err == nil
+}
+
+// resolveDestChatID picks the Telegram destination for req: the first
+// approver when it's a plausible Telegram chat id, otherwise the handler's
+// own configured chatID. An invalid override is logged once (deduped by
+// value) rather than retried against the Telegram API every tick (GH-4380).
+func (h *TelegramHandler) resolveDestChatID(req *Request) string {
+	if len(req.Approvers) == 0 {
+		return h.chatID
+	}
+	if isValidTelegramChatID(req.Approvers[0]) {
+		return req.Approvers[0]
+	}
+	h.warnInvalidDestOnce(req.ID, req.Approvers[0])
+	return h.chatID
+}
+
+// warnInvalidDestOnce logs the first time a given invalid Approvers[0] value
+// is seen, then suppresses repeats of the same value (GH-4380).
+func (h *TelegramHandler) warnInvalidDestOnce(requestID, badDest string) {
+	h.mu.Lock()
+	if h.warnedInvalidDest == nil {
+		h.warnedInvalidDest = make(map[string]bool)
+	}
+	if h.warnedInvalidDest[badDest] {
+		h.mu.Unlock()
+		return
+	}
+	h.warnedInvalidDest[badDest] = true
+	h.mu.Unlock()
+
+	h.log.Warn("approval request Approvers[0] is not a valid Telegram destination, falling back to configured chat_id",
+		slog.String("request_id", requestID), slog.String("invalid_approver", badDest))
 }
 
 // Name returns the handler name
@@ -154,10 +214,7 @@ func (h *TelegramHandler) Rehydrate(ctx context.Context) error {
 			CreatedAt:        row.CreatedAt,
 			ExpiresAt:        row.ExpiresAt,
 		}
-		destChatID := h.chatID
-		if len(req.Approvers) > 0 {
-			destChatID = req.Approvers[0]
-		}
+		destChatID := h.resolveDestChatID(req)
 		responseCh := make(chan *Response, 1)
 		h.mu.Lock()
 		if _, exists := h.pending[req.ID]; !exists {
@@ -283,11 +340,10 @@ func (h *TelegramHandler) SendApprovalRequest(ctx context.Context, req *Request)
 	// Create inline keyboard with approve/reject buttons
 	keyboard := h.createApprovalKeyboard(req)
 
-	// Resolve destination: use first approver's chat_id when available
-	destChatID := h.chatID
-	if len(req.Approvers) > 0 {
-		destChatID = req.Approvers[0]
-	}
+	// Resolve destination: use first approver's chat_id when it's a valid
+	// Telegram destination, otherwise fall back to the configured chat_id
+	// (GH-4380).
+	destChatID := h.resolveDestChatID(req)
 
 	// Send message
 	resp, err := h.client.SendMessageWithKeyboard(ctx, destChatID, text, "", keyboard)

--- a/internal/approval/telegram_test.go
+++ b/internal/approval/telegram_test.go
@@ -1033,6 +1033,66 @@ func TestTelegramHandler_ApproverRouting(t *testing.T) {
 		}
 	})
 
+	t.Run("uses @channel approver as-is", func(t *testing.T) {
+		client := &mockTelegramClient{}
+		handler := NewTelegramHandler(client, "constructor-chat")
+
+		req := &Request{
+			ID:        "req-approver-channel",
+			TaskID:    "TASK-01",
+			Stage:     StagePreMerge,
+			Title:     "Test",
+			Approvers: []string{"@mychannel"},
+			ExpiresAt: time.Now().Add(1 * time.Hour),
+		}
+
+		_, err := handler.SendApprovalRequest(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		msgs := client.getSentMessages()
+		if len(msgs) != 1 {
+			t.Fatalf("expected 1 message sent, got %d", len(msgs))
+		}
+		if msgs[0].ChatID != "@mychannel" {
+			t.Errorf("expected chat_id '@mychannel', got '%s'", msgs[0].ChatID)
+		}
+	})
+
+	// GH-4380: a request routed here (e.g. by the manager's PreferredChannel
+	// fallback, or a config where Approvers was populated with an identity
+	// meant for a different channel) must not blindly dial an
+	// Approvers[0] that isn't a plausible Telegram destination — that
+	// produced a "chat not found" 400 on every retry against the live
+	// incident's PRs #4373/#4374.
+	t.Run("falls back to constructor chat_id when approver is not a valid telegram destination", func(t *testing.T) {
+		client := &mockTelegramClient{}
+		handler := NewTelegramHandler(client, "constructor-chat")
+
+		req := &Request{
+			ID:        "req-invalid-approver",
+			TaskID:    "TASK-01",
+			Stage:     StagePreMerge,
+			Title:     "Test",
+			Approvers: []string{"#pointer"}, // Slack channel name, not a Telegram chat id
+			ExpiresAt: time.Now().Add(1 * time.Hour),
+		}
+
+		_, err := handler.SendApprovalRequest(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		msgs := client.getSentMessages()
+		if len(msgs) != 1 {
+			t.Fatalf("expected 1 message sent, got %d", len(msgs))
+		}
+		if msgs[0].ChatID != "constructor-chat" {
+			t.Errorf("expected fallback to constructor chat_id 'constructor-chat', got '%s'", msgs[0].ChatID)
+		}
+	})
+
 	t.Run("edit after callback uses same chat_id as original send", func(t *testing.T) {
 		client := &mockTelegramClient{}
 		handler := NewTelegramHandler(client, "constructor-chat")
@@ -1061,6 +1121,60 @@ func TestTelegramHandler_ApproverRouting(t *testing.T) {
 			t.Errorf("expected edit chat_id '99999', got '%s'", edited[0].ChatID)
 		}
 	})
+}
+
+func TestIsValidTelegramChatID(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"empty string", "", false},
+		{"positive numeric chat id", "283716179", true},
+		{"negative numeric group chat id", "-1001234567890", true},
+		{"public channel handle", "@mychannel", true},
+		{"bare @", "@", false},
+		{"slack channel name", "#pointer", false},
+		{"slack user id", "U012ABCDEF", false},
+		{"non-numeric garbage", "not-a-chat-id", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidTelegramChatID(tt.in); got != tt.want {
+				t.Errorf("isValidTelegramChatID(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTelegramHandler_InvalidApprover_WarnsOnce verifies that a persistently
+// invalid Approvers[0] value logs a warning only once (deduped by value)
+// rather than once per SendApprovalRequest call, so a misconfigured
+// approvers list doesn't spam the log every controller tick (GH-4380).
+func TestTelegramHandler_InvalidApprover_WarnsOnce(t *testing.T) {
+	client := &mockTelegramClient{}
+	handler := NewTelegramHandler(client, "constructor-chat")
+	logger, buf := newCapturingLogger()
+	handler.log = logger
+
+	for i := 0; i < 3; i++ {
+		req := &Request{
+			ID:        "req-warn-once",
+			TaskID:    "TASK-01",
+			Stage:     StagePreMerge,
+			Title:     "Test",
+			Approvers: []string{"#pointer"},
+			ExpiresAt: time.Now().Add(1 * time.Hour),
+		}
+		if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	warnCount := strings.Count(buf.String(), "not a valid Telegram destination")
+	if warnCount != 1 {
+		t.Errorf("expected exactly 1 warning log for the repeated invalid approver, got %d\nlog:\n%s", warnCount, buf.String())
+	}
 }
 
 // --- store tests ---

--- a/internal/approval/types.go
+++ b/internal/approval/types.go
@@ -40,7 +40,7 @@ type Request struct {
 	CreatedAt        time.Time              // When request was created
 	ExpiresAt        time.Time              // When request expires (timeout)
 	Approvers        []string               // Required approvers (user IDs, handles)
-	PreferredChannel string                 `json:",omitempty"` // Preferred approval channel (e.g., "telegram", "slack"); falls back to first-available when unset or unregistered
+	PreferredChannel string                 `json:",omitempty"` // Preferred approval channel (e.g., "telegram", "slack"); falls back to first-available only when unset. When set but not registered, SubmitApprovalRequest fails with a named error instead of silently picking another handler (GH-4380).
 
 	// ReleasePlan is a human-readable, pre-rendered description of what happens
 	// after this request is approved (e.g. "Will release immediately after

--- a/internal/autopilot/approval_submit_failure_test.go
+++ b/internal/autopilot/approval_submit_failure_test.go
@@ -1,0 +1,145 @@
+package autopilot
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/alerts"
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestSubmitAsyncApprovalRequest_PreferredChannelRoutesToConfiguredEnvSource
+// is the GH-4380 regression test: a per-env approval_source (e.g.
+// environments.stage.approval_source: slack) must actually determine which
+// handler receives the request. Before the fix, submitAsyncApprovalRequest
+// never set PreferredChannel at all, so the request always fell through to
+// Manager's arbitrary-handler fallback regardless of this config.
+func TestSubmitAsyncApprovalRequest_PreferredChannelRoutesToConfiguredEnvSource(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+	cfg.Environments["stage"] = &EnvironmentConfig{
+		Branch:          "main",
+		RequireApproval: true,
+		ApprovalSource:  ApprovalSourceSlack,
+	}
+	if err := cfg.SetActiveEnvironment("stage"); err != nil {
+		t.Fatalf("SetActiveEnvironment: %v", err)
+	}
+
+	mgr := asyncApprovalManager()
+	telegram := &mockCapturingApprovalHandler{}
+	slack := &mockCapturingApprovalHandler{}
+	// Distinguish the two handlers by name so Manager can route deterministically.
+	mgr.RegisterHandler(&namedApprovalHandler{mockCapturingApprovalHandler: telegram, name: "telegram"})
+	mgr.RegisterHandler(&namedApprovalHandler{mockCapturingApprovalHandler: slack, name: "slack"})
+
+	c := NewController(cfg, ghClient, mgr, "owner", "repo")
+	prState := &PRState{PRNumber: 42, PRURL: "https://github.com/owner/repo/pull/42", Stage: StageAwaitApproval}
+
+	if err := c.submitAsyncApprovalRequest(context.Background(), prState); err != nil {
+		t.Fatalf("submitAsyncApprovalRequest returned error: %v", err)
+	}
+
+	if len(slack.sent) != 1 {
+		t.Errorf("expected 1 request routed to the slack handler (per environments.stage.approval_source), got %d", len(slack.sent))
+	}
+	if len(telegram.sent) != 0 {
+		t.Errorf("expected 0 requests routed to telegram, got %d", len(telegram.sent))
+	}
+	if got := slack.sent[0].PreferredChannel; got != "slack" {
+		t.Errorf("PreferredChannel = %q, want %q", got, "slack")
+	}
+}
+
+// namedApprovalHandler wraps mockCapturingApprovalHandler with a configurable
+// Name() so two instances can be registered under distinct channel keys.
+type namedApprovalHandler struct {
+	*mockCapturingApprovalHandler
+	name string
+}
+
+func (n *namedApprovalHandler) Name() string { return n.name }
+
+// TestSubmitAsyncApprovalRequest_SubmitFailure_AlertsCommentsAndCountsOnce is
+// the GH-4380 regression test for defect 3 (the wedge is invisible): when
+// SubmitApprovalRequest fails (e.g. approval_source names an unregistered
+// handler), the controller must increment the ApprovalSubmitFailures metric,
+// fire an alerts.Event, and post a PR comment — exactly once, even across
+// repeated ticks (handleAwaitApproval calls this on every tick a PR sits in
+// StageAwaitApproval, so without dedup the PR would either spam an alert
+// every tick, or — once the circuit breaker opens and ProcessPR stops
+// reaching this code at all — never alert again).
+func TestSubmitAsyncApprovalRequest_SubmitFailure_AlertsCommentsAndCountsOnce(t *testing.T) {
+	var postCount int
+	var postedBodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/comments") {
+			postCount++
+			buf := make([]byte, r.ContentLength)
+			_, _ = r.Body.Read(buf)
+			postedBodies = append(postedBodies, string(buf))
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":1,"body":"posted"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig() // ApprovalSource defaults to telegram; no handler registered below.
+
+	mgr := asyncApprovalManager() // PreMerge stage enabled, zero handlers registered.
+	c := NewController(cfg, ghClient, mgr, "owner", "repo")
+
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	prState := &PRState{PRNumber: 42, PRURL: "https://github.com/owner/repo/pull/42", Stage: StageAwaitApproval}
+
+	// Tick 1: submit fails (no "telegram" handler registered).
+	err := c.submitAsyncApprovalRequest(context.Background(), prState)
+	if err == nil {
+		t.Fatal("expected submitAsyncApprovalRequest to return an error")
+	}
+
+	if got := c.metrics.Snapshot().ApprovalSubmitFailures; got != 1 {
+		t.Errorf("ApprovalSubmitFailures = %d, want 1", got)
+	}
+	if len(sink.events) != 1 {
+		t.Fatalf("expected 1 alert event, got %d", len(sink.events))
+	}
+	if sink.events[0].Type != alerts.EventTypeTaskFailed {
+		t.Errorf("alert Type = %q, want %q", sink.events[0].Type, alerts.EventTypeTaskFailed)
+	}
+	if !strings.Contains(sink.events[0].Error, "42") {
+		t.Errorf("alert Error %q should mention the PR number", sink.events[0].Error)
+	}
+	if postCount != 1 {
+		t.Fatalf("postCount after tick 1 = %d, want 1", postCount)
+	}
+	if !strings.Contains(postedBodies[0], "@owner") {
+		t.Errorf("PR comment %q should @mention the repo owner", postedBodies[0])
+	}
+
+	// Tick 2 (e.g. a retried controller loop before the circuit breaker
+	// opens): must NOT alert or comment again.
+	err = c.submitAsyncApprovalRequest(context.Background(), prState)
+	if err == nil {
+		t.Fatal("expected submitAsyncApprovalRequest to return an error on tick 2 too")
+	}
+	if got := c.metrics.Snapshot().ApprovalSubmitFailures; got != 2 {
+		t.Errorf("ApprovalSubmitFailures after tick 2 = %d, want 2 (metric increments every failure)", got)
+	}
+	if len(sink.events) != 1 {
+		t.Errorf("expected alert to fire exactly once across 2 ticks, got %d events", len(sink.events))
+	}
+	if postCount != 1 {
+		t.Errorf("expected PR comment to post exactly once across 2 ticks, got %d", postCount)
+	}
+}

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -355,6 +355,14 @@ type Controller struct {
 	// adopt-fail-evict cycle forever (GH-4053).
 	persistFailedPRs map[int]time.Time
 
+	// alertedApprovalFailures deduplicates approval-submit-failure alerts and
+	// PR-comment fallbacks per PR number, guarded by mu — same rationale as
+	// alertedPersistFailures: handleAwaitApproval retries submitAsyncApprovalRequest
+	// every tick while a PR sits in StageAwaitApproval, and without this map a
+	// misrouted/unreachable approval channel would either alert every tick or,
+	// once the per-PR circuit breaker opens, never alert at all (GH-4380).
+	alertedApprovalFailures map[int]bool
+
 	// epicVeto tracks, per epic parent issue number, how many consecutive
 	// reconcile passes have failed the SAME close-veto (same blocking child +
 	// same reason), guarded by mu. Lets reconcileEpicParent tell "still
@@ -391,23 +399,24 @@ type Controller struct {
 // NewController creates an autopilot controller with all required components.
 func NewController(cfg *Config, ghClient *github.Client, approvalMgr *approval.Manager, owner, repo string, opts ...ControllerOption) *Controller {
 	c := &Controller{
-		config:                 cfg,
-		ghClient:               ghClient,
-		approvalMgr:            approvalMgr,
-		owner:                  owner,
-		repo:                   repo,
-		activePRs:              make(map[int]*PRState),
-		recordedMerges:         make(map[int]bool),
-		prFailures:             make(map[int]*prFailureState),
-		lastProgressAt:         time.Now(), // Initialize to now to avoid false alarm on startup
-		metrics:                NewMetrics(),
-		log:                    slog.Default().With("component", "autopilot"),
-		alertedMissingReleases: make(map[string]bool),
-		alertedStaleScopes:     make(map[string]bool),
-		alertedPersistFailures: make(map[int]bool),
-		persistFailedPRs:       make(map[int]time.Time),
-		epicVeto:               make(map[int]*epicCloseVetoTracking),
-		epicResolvedParents:    make(map[int]bool),
+		config:                  cfg,
+		ghClient:                ghClient,
+		approvalMgr:             approvalMgr,
+		owner:                   owner,
+		repo:                    repo,
+		activePRs:               make(map[int]*PRState),
+		recordedMerges:          make(map[int]bool),
+		prFailures:              make(map[int]*prFailureState),
+		lastProgressAt:          time.Now(), // Initialize to now to avoid false alarm on startup
+		metrics:                 NewMetrics(),
+		log:                     slog.Default().With("component", "autopilot"),
+		alertedMissingReleases:  make(map[string]bool),
+		alertedStaleScopes:      make(map[string]bool),
+		alertedPersistFailures:  make(map[int]bool),
+		persistFailedPRs:        make(map[int]time.Time),
+		alertedApprovalFailures: make(map[int]bool),
+		epicVeto:                make(map[int]*epicCloseVetoTracking),
+		epicResolvedParents:     make(map[int]bool),
 	}
 
 	// Options must apply before the releaser is constructed below: the
@@ -790,6 +799,71 @@ func (c *Controller) alertPersistFailureOnce(prNumber int, persistErr error) {
 			"pr":   strconv.Itoa(prNumber),
 		},
 	})
+}
+
+// approvalFailedCommentMarker is embedded in the PR comment so
+// alertApprovalSubmitFailureOnce's fallback comment is only ever posted once
+// per PR, mirroring misconfigCommentMarker's idempotency check.
+const approvalFailedCommentMarker = "<!-- pilot-approval-submit-failed -->"
+
+// alertApprovalSubmitFailureOnce fires the first time submitAsyncApprovalRequest
+// fails for a PR, deduplicated per PR number via alertedApprovalFailures — the
+// controller retries the submit every tick while StageAwaitApproval holds, and
+// once enough consecutive failures trip the per-PR circuit breaker (isPRCircuitOpen)
+// ProcessPR stops calling this handler at all, so without a one-time alert here the
+// PR goes fully silent: no more log lines, no notification, parked until a human
+// happens to notice (GH-4380 — PRs #4373/#4374 sat undeliverable for hours behind
+// nothing but a repeating WARN in daemon.log).
+//
+// Does three things, all best-effort: increments the ApprovalSubmitFailures
+// counter, routes the failure through the same alerts.EventTypeTaskFailed
+// dispatch used for execution failures (so configured Slack/Telegram/PagerDuty
+// channels still receive it even though the approval channel itself is the
+// thing that's broken), and posts a PR comment mentioning the repo owner as a
+// last-resort channel that doesn't depend on any approval adapter at all.
+func (c *Controller) alertApprovalSubmitFailureOnce(ctx context.Context, prState *PRState, submitErr error) {
+	c.metrics.RecordApprovalSubmitFailure()
+
+	c.mu.Lock()
+	if c.alertedApprovalFailures == nil {
+		c.alertedApprovalFailures = make(map[int]bool)
+	}
+	if c.alertedApprovalFailures[prState.PRNumber] {
+		c.mu.Unlock()
+		return
+	}
+	c.alertedApprovalFailures[prState.PRNumber] = true
+	c.mu.Unlock()
+
+	msg := fmt.Sprintf(
+		"PR #%d (%s) approval request could not be delivered via the configured channel (%s): %s — it will not merge until a human intervenes",
+		prState.PRNumber, c.repoKey(), c.config.EffectiveApprovalSource(), submitErr,
+	)
+	c.log.Error("approval submit failed", "pr", prState.PRNumber, "error", submitErr)
+
+	if c.alertsEngine == nil {
+		c.log.Error("approval_submit_failed alert not delivered: SetAlertsEngine was never called", "pr", prState.PRNumber, "error", submitErr)
+	} else {
+		c.alertsEngine.ProcessEvent(alerts.Event{
+			Type:      alerts.EventTypeTaskFailed,
+			TaskID:    fmt.Sprintf("pr-%d-approval", prState.PRNumber),
+			TaskTitle: fmt.Sprintf("Approval request undeliverable for PR #%d", prState.PRNumber),
+			Project:   c.repoKey(),
+			Error:     msg,
+			Timestamp: time.Now(),
+			Metadata: map[string]string{
+				"repo":            c.repoKey(),
+				"pr":              strconv.Itoa(prState.PRNumber),
+				"approval_source": string(c.config.EffectiveApprovalSource()),
+			},
+		})
+	}
+
+	comment := fmt.Sprintf("%s\n🚨 **Approval request undeliverable**\n\n@%s %s\n\nCheck the approval channel config (`approval_source: %s`) — the adapter/handler for it may not be registered or reachable. This PR is stuck in `awaiting_approval` until it's fixed.",
+		approvalFailedCommentMarker, c.owner, msg, c.config.EffectiveApprovalSource())
+	if _, cerr := c.ghClient.AddPRComment(ctx, c.owner, c.repo, prState.PRNumber, comment); cerr != nil {
+		c.log.Warn("failed to post approval-submit-failed PR comment", "pr", prState.PRNumber, "error", cerr)
+	}
 }
 
 // evictPersistFailedPR drops a PR that has failed to persist
@@ -1943,10 +2017,16 @@ func (c *Controller) submitAsyncApprovalRequest(ctx context.Context, prState *PR
 			"pr_title":  prState.PRTitle,
 			"pr_number": prState.PRNumber,
 		},
+		// GH-4380: route to the channel the operator actually configured.
+		// Before this, PreferredChannel was never set on this path, so
+		// Manager.SubmitApprovalRequest always fell through to whichever
+		// handler happened to win Go's map iteration order.
+		PreferredChannel: string(c.config.EffectiveApprovalSource()),
 	}
 
 	requestID, err := c.approvalMgr.SubmitApprovalRequest(ctx, req)
 	if err != nil {
+		c.alertApprovalSubmitFailureOnce(ctx, prState, err)
 		return fmt.Errorf("submit approval request for PR %d: %w", prState.PRNumber, err)
 	}
 

--- a/internal/autopilot/controller_duplicate_registration_test.go
+++ b/internal/autopilot/controller_duplicate_registration_test.go
@@ -195,6 +195,11 @@ func TestController_OnPRCreated_DuplicateDoesNotDuplicateApprovalRequest(t *test
 			Enabled: true,
 		},
 	})
+	// GH-4380: the controller always sets PreferredChannel from the resolved
+	// approval source (telegram by default), so a handler named "telegram"
+	// must be registered or SubmitApprovalRequest fails fast instead of the
+	// old silent no-handler no-op.
+	mgr.RegisterHandler(&mockCapturingApprovalHandler{})
 
 	c := NewController(cfg, ghClient, mgr, "owner", "repo")
 	c.OnPRCreated(3820, "https://github.com/owner/repo/pull/3820", 200, "sha", "pilot/GH-200", "")

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -4908,10 +4908,10 @@ type mockEvalStore struct {
 
 	// TASK-399/GH-4209: orphan-running sweep + pr_url fallback test hooks.
 	prURLHealed        []string                   // SelfHealExecutionByPRURL calls
-	orphanedRunning    []*memory.Execution         // FindOrphanedRunningExecutions candidate pool
-	lastExcludeTaskIDs []string                    // last exclude set FindOrphanedRunningExecutions was called with
-	resolvedOrphans    []resolveOrphanCall         // ResolveOrphanedRunningExecution calls
-	executionEvents    map[string][]*memory.Event  // ListExecutionEvents responses keyed by execution ID
+	orphanedRunning    []*memory.Execution        // FindOrphanedRunningExecutions candidate pool
+	lastExcludeTaskIDs []string                   // last exclude set FindOrphanedRunningExecutions was called with
+	resolvedOrphans    []resolveOrphanCall        // ResolveOrphanedRunningExecution calls
+	executionEvents    map[string][]*memory.Event // ListExecutionEvents responses keyed by execution ID
 }
 
 // resolveOrphanCall records one ResolveOrphanedRunningExecution invocation. TASK-399/GH-4209.
@@ -7653,6 +7653,11 @@ func TestController_AwaitApproval_StaysInStageUntilDecision(t *testing.T) {
 	cfg.Environment = EnvProd
 
 	mgr := asyncApprovalManager()
+	// GH-4380: the controller always sets PreferredChannel from the resolved
+	// approval source (telegram by default), so a handler named "telegram"
+	// must be registered or SubmitApprovalRequest fails fast instead of the
+	// old silent no-handler no-op.
+	mgr.RegisterHandler(&mockCapturingApprovalHandler{})
 	c := NewController(cfg, ghClient, mgr, "owner", "repo")
 
 	// Plant a PR directly in StageAwaitApproval.

--- a/internal/autopilot/metrics.go
+++ b/internal/autopilot/metrics.go
@@ -49,6 +49,10 @@ type Metrics struct {
 	// poller's pre-flight gate previously failed open on every judge crash
 	// with no visible signal that the judge was effectively dead.
 	IntentJudgeFailures map[string]int64
+	// ApprovalSubmitFailures counts Manager.SubmitApprovalRequest errors — an
+	// unregistered/misrouted approval channel, distinct from a normal timeout
+	// or rejection decision (GH-4380).
+	ApprovalSubmitFailures int64
 	// TokensConsumed, ExecutionCostUSD, and ExecutionsByResult are persisted per
 	// snapshot to SQLite (GH-2856) so historical data survives across runs.
 	// However, on daemon restart the in-memory counters reset to zero and
@@ -263,6 +267,14 @@ func (m *Metrics) RecordIntentJudgeFailure(cause string) {
 	m.IntentJudgeFailures[cause]++
 }
 
+// RecordApprovalSubmitFailure increments the counter for SubmitApprovalRequest
+// errors (GH-4380).
+func (m *Metrics) RecordApprovalSubmitFailure() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ApprovalSubmitFailures++
+}
+
 // RecordTokens adds n tokens to the {model, direction} bucket.
 func (m *Metrics) RecordTokens(model, direction string, n int64) {
 	m.mu.Lock()
@@ -440,6 +452,7 @@ func (m *Metrics) Snapshot() MetricsSnapshot {
 		LabelCleanups:                 copyStringIntMap(m.LabelCleanups),
 		ApprovalPersistMisses:         copyStringIntMap(m.ApprovalPersistMisses),
 		IntentJudgeFailures:           copyStringIntMap(m.IntentJudgeFailures),
+		ApprovalSubmitFailures:        m.ApprovalSubmitFailures,
 		TokensConsumed:                copyTokenKeyMap(m.TokensConsumed),
 		ExecutionCostUSD:              copyStringFloatMap(m.ExecutionCostUSD),
 		ExecutionsByResult:            copyExecKeyMap(m.ExecutionsByResult),
@@ -505,19 +518,20 @@ func (m *Metrics) apiErrorRate() float64 {
 // MetricsSnapshot is a read-only copy of metrics at a point in time.
 type MetricsSnapshot struct {
 	// Counters
-	IssuesProcessed       map[string]int64
-	PRsMerged             int64
-	PRsFailed             int64
-	PRsConflicting        int64
-	CIRuns                map[string]int64 // GH-4134: result → count (pass, fail)
-	CircuitBreakerTrips   int64
-	APIErrors             map[string]int64
-	LabelCleanups         map[string]int64
-	ApprovalPersistMisses map[string]int64
-	IntentJudgeFailures   map[string]int64 // GH-4377: cause → count
-	TokensConsumed        map[tokenKey]int64
-	ExecutionCostUSD      map[string]float64
-	ExecutionsByResult    map[execKey]int64
+	IssuesProcessed        map[string]int64
+	PRsMerged              int64
+	PRsFailed              int64
+	PRsConflicting         int64
+	CIRuns                 map[string]int64 // GH-4134: result → count (pass, fail)
+	CircuitBreakerTrips    int64
+	APIErrors              map[string]int64
+	LabelCleanups          map[string]int64
+	ApprovalPersistMisses  map[string]int64
+	ApprovalSubmitFailures int64
+	IntentJudgeFailures    map[string]int64 // GH-4377: cause → count
+	TokensConsumed         map[tokenKey]int64
+	ExecutionCostUSD       map[string]float64
+	ExecutionsByResult     map[execKey]int64
 
 	// Poller dispatch/skip counters (TASK-293)
 	PollerSkipped              map[pollerSkipKey]int64

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -292,6 +292,19 @@ func (c *Config) ResolvedEnv() *EnvironmentConfig {
 	return defaults["stage"]
 }
 
+// EffectiveApprovalSource returns the approval channel that actually governs
+// requests submitted under the active environment: the active environment's
+// ApprovalSource when set, otherwise the top-level Config.ApprovalSource
+// (GH-4380). Before this existed, nothing read EnvironmentConfig.ApprovalSource
+// at all — a per-env `approval_source: slack` override in the environments
+// map silently had zero effect on which handler a request was routed to.
+func (c *Config) EffectiveApprovalSource() ApprovalSource {
+	if env := c.ResolvedEnv(); env != nil && env.ApprovalSource != "" {
+		return env.ApprovalSource
+	}
+	return c.ApprovalSource
+}
+
 // EnvironmentName returns the human-readable active environment name.
 // Checks Name field first (user-friendly label), then activeEnvName,
 // then falls back to the Environment enum value.

--- a/internal/autopilot/types_test.go
+++ b/internal/autopilot/types_test.go
@@ -351,6 +351,48 @@ func TestResolvedEnv_NewOverridesLegacy(t *testing.T) {
 	}
 }
 
+// TestEffectiveApprovalSource_EnvOverridesTopLevel verifies that a per-env
+// approval_source (e.g. environments.stage.approval_source: slack) actually
+// takes effect. Before GH-4380, nothing ever read this field — a config with
+// approval_source: slack at the environment level silently had zero routing
+// effect, and every request fell through to Manager's arbitrary-handler
+// fallback regardless of what the operator configured.
+func TestEffectiveApprovalSource_EnvOverridesTopLevel(t *testing.T) {
+	cfg := &Config{
+		ApprovalSource: ApprovalSourceTelegram,
+		Environments: map[string]*EnvironmentConfig{
+			"stage": {ApprovalSource: ApprovalSourceSlack},
+		},
+	}
+	if err := cfg.SetActiveEnvironment("stage"); err != nil {
+		t.Fatalf("SetActiveEnvironment: %v", err)
+	}
+
+	if got := cfg.EffectiveApprovalSource(); got != ApprovalSourceSlack {
+		t.Errorf("EffectiveApprovalSource() = %q, want %q", got, ApprovalSourceSlack)
+	}
+}
+
+// TestEffectiveApprovalSource_FallsBackToTopLevel verifies that when the
+// active environment does not set its own ApprovalSource, the top-level
+// Config.ApprovalSource is used instead — the pre-existing behavior for
+// configs without a per-env override must be preserved.
+func TestEffectiveApprovalSource_FallsBackToTopLevel(t *testing.T) {
+	cfg := &Config{
+		ApprovalSource: ApprovalSourceGitHubReview,
+		Environments: map[string]*EnvironmentConfig{
+			"stage": {}, // no ApprovalSource set
+		},
+	}
+	if err := cfg.SetActiveEnvironment("stage"); err != nil {
+		t.Fatalf("SetActiveEnvironment: %v", err)
+	}
+
+	if got := cfg.EffectiveApprovalSource(); got != ApprovalSourceGitHubReview {
+		t.Errorf("EffectiveApprovalSource() = %q, want %q", got, ApprovalSourceGitHubReview)
+	}
+}
+
 func TestPRState_RepoOwnerAndName(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/gateway/prometheus.go
+++ b/internal/gateway/prometheus.go
@@ -165,6 +165,11 @@ func (e *PrometheusExporter) WritePrometheus(w io.Writer) error {
 		}
 	}
 
+	// pilot_approval_submit_failures_total (GH-4380)
+	writeHelp(w, "pilot_approval_submit_failures_total", "Total SubmitApprovalRequest errors (unregistered/misrouted approval channel)")
+	writeType(w, "pilot_approval_submit_failures_total", "counter")
+	writeCounter(w, "pilot_approval_submit_failures_total", snap.ApprovalSubmitFailures)
+
 	// pilot_tokens_consumed_total
 	writeHelp(w, "pilot_tokens_consumed_total", "Total tokens consumed by model and direction")
 	writeType(w, "pilot_tokens_consumed_total", "counter")


### PR DESCRIPTION
## Summary
- Wires `EnvironmentConfig.ApprovalSource` (e.g. `environments.stage.approval_source: slack`) into `approval.Request.PreferredChannel` via a new `Config.EffectiveApprovalSource()` — this was silently dropped when TASK-36 migrated approval submission off the legacy blocking path, so per-env approval routing has had zero effect since.
- `Manager.SubmitApprovalRequest` now fails with a named error when `PreferredChannel` names an unregistered handler, instead of silently falling back to an arbitrary registered handler via Go map iteration.
- `TelegramHandler` validates that `Approvers[0]` looks like a real Telegram destination (numeric chat id or `@channel`) before dialing it; an invalid override now falls back to the configured `chat_id` with a deduped warning instead of a per-tick "chat not found" 400.
- Added `Controller.alertApprovalSubmitFailureOnce`: on a submit failure, fires an `alerts.EventTypeTaskFailed` event, posts a PR comment (`@owner` mention), and increments a new `ApprovalSubmitFailures` counter (`pilot_approval_submit_failures_total`) — all deduped per PR so a PR can no longer sit in `awaiting_approval` with an open circuit breaker and zero operator-visible signal.

Fixes GH-4380 (regression in v2.241.0; PRs #4373/#4374 stuck for hours with only a repeating WARN log).

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/approval/... ./internal/autopilot/... ./internal/gateway/...`
- [x] `go test ./...` (full repo, no regressions)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] New regression tests: preferred-channel routing/fail-fast (manager_test.go), Telegram destination validation + dedup warning (telegram_test.go), per-env `approval_source` wiring (types_test.go), controller-level alert/comment/metric dedup (approval_submit_failure_test.go)