### PR TITLE
fix(executor): reconcileChildOutcome blind to no_op terminal state (GH-4381)

### DIFF
--- a/.agent/knowledge/memories/pitfalls/pitfall_noop_terminal_state_invisible_to_dispatch_guards.md
+++ b/.agent/knowledge/memories/pitfalls/pitfall_noop_terminal_state_invisible_to_dispatch_guards.md
@@ -12,15 +12,52 @@ The completion predicate encoded one narrow definition of "done": completed + PR
 ## Recommended Approach
 New admission gates must use `executor.HasTerminalCompletion`, not `HasCompletedExecution` directly. When adding a terminal status to the execution vocabulary, sweep every dispatch/admission guard for completion predicates that don't know about it — a terminal state only one guard can see is a duplicate-dispatch bug waiting to fire.
 
+## Third instance (GH-4381, 2026-07-16)
+
+Same class, a different call site: `Runner.reconcileChildOutcome`'s
+"externally-owned child" wait (`internal/executor/epic.go`) — the poll loop
+introduced for TASK-407/GH-4349 claim routing (#4363) — grew its own third
+copy of the terminal-status classification (`childExecutionNonTerminalStatuses`,
+a `queued`/`pending`/`running` set) instead of consulting dispatcher.go's
+`terminalExecutionStatuses`/`isTerminalExecutionStatus` (the single definition
+#4373 had just introduced specifically so `WaitForExecution` and the GH-4372
+retry decider couldn't drift apart — this wait was the drift).
+
+Worse, it also hit the ordering trap `Store.HasTerminalCompletion` was built
+to avoid: it read only the *latest* row (`GetExecutionStatusByTaskIDExcluding`,
+`ORDER BY created_at DESC LIMIT 1`). A child whose real execution had already
+reached the terminal `no_op` outcome, but which then had a fresh "queued"
+duplicate row appear alongside it (a re-pick from another dispatch channel),
+had that duplicate sort as "latest" and hide the terminal `no_op` — the wait
+timed out with `reconcileChildOutcome: timed out waiting for externally-owned
+child execution to reach a terminal state`, failing the parent epic even
+though the child was legitimately done. Observed live on pilot-canary-sandbox
+GH-91 (parent) / GH-92 (child), 2026-07-16 18:46–18:53Z.
+
+Fix: replaced the status-string lookup with `Store.ListExecutionsByTaskIDExcluding`
+(scans every row, not just latest) + `isTerminalExecutionStatus` to find the
+most recent *terminal* row, whatever its position in created_at order. Added
+`TestTerminalStatusInventory_NoStrayStatusSets` (AST-scans
+`internal/executor/*.go` for map literals keyed on 2+ execution-status
+strings outside `dispatcher.go`) so a 4th copy fails CI instead of a sandbox.
+
+**Updated rule**: a "sub-issue" or "is task X done" wait must (1) consult
+`isTerminalExecutionStatus`/`HasTerminalCompletion`, never a locally-defined
+status set, and (2) scan every row for the task, never just the row a plain
+`ORDER BY created_at DESC LIMIT 1` returns — a fresh duplicate row can always
+sort ahead of an older terminal one.
+
 ## Related
 - `internal/memory/store.go`
 - `internal/executor/dispatcher.go`
-- GH-4347
+- `internal/executor/epic.go` (`reconcileChildOutcome`, `findTerminalChildExecution`)
+- `internal/executor/terminal_status_inventory_test.go`
+- GH-4347, GH-4381
 
 ---
-**Captured**: 2026-07-15
+**Captured**: 2026-07-15 (updated 2026-07-16 with 3rd instance, GH-4381)
 **Confidence**: 90%
-**Concepts**: dispatcher, sdk-poller, ledger, canary
+**Concepts**: dispatcher, sdk-poller, ledger, canary, epic-reconcile
 
 > Note: file reconstructed 2026-07-16 from its graph.json entry — the original
 > was indexed but never committed (drift-gate FAIL on main); summary preserved verbatim.

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -1910,14 +1910,6 @@ const (
 	defaultChildOutcomeReconcileTimeout      = 5 * time.Minute
 )
 
-// childExecutionNonTerminalStatuses are executions.status values that mean a
-// child's own tracked run has not finished yet.
-var childExecutionNonTerminalStatuses = map[string]bool{
-	"queued":  true,
-	"pending": true,
-	"running": true,
-}
-
 // reconcileChildOutcome re-checks a sub-issue's own execution row before
 // letting a synchronous exec signal (err or result.Success=false) fail the
 // epic. GH-3786 (TASK-382 D3): GH-3760 failed on "sub-issue 3769 failed:
@@ -1945,15 +1937,15 @@ var childExecutionNonTerminalStatuses = map[string]bool{
 //
 // When no failure signal is present and the child is not externally owned,
 // or no log store is wired to check against, the original (result, err) pass
-// through unchanged. Otherwise this polls GetExecutionStatusByTaskIDExcluding
-// for taskID (scoped to projectPath) until it reports a terminal status, the
-// context is cancelled, or childOutcomeReconcileTimeout elapses — whichever
-// comes first, so this can never block the epic indefinitely. On terminal
-// success ("completed" / "no_op") it synthesizes a passing ExecutionResult
-// from the tracked row so the caller's normal success/no-op handling
-// applies; on terminal failure it enriches the returned error with the
-// tracked row's real error message instead of the uninformative "unknown:
-// exit status 1" backend classification.
+// through unchanged. Otherwise this polls findTerminalChildExecution for
+// taskID (scoped to projectPath) until it finds a terminal row, the context
+// is cancelled, or childOutcomeReconcileTimeout elapses — whichever comes
+// first, so this can never block the epic indefinitely. On terminal success
+// ("completed" / "no_op") it synthesizes a passing ExecutionResult from the
+// tracked row so the caller's normal success/no-op handling applies; on
+// terminal failure it enriches the returned error with the tracked row's
+// real error message instead of the uninformative "unknown: exit status 1"
+// backend classification.
 func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath, selfExecID string, result *ExecutionResult, execErr error, externallyOwned bool) (*ExecutionResult, error) {
 	hasFailureSignal := execErr != nil || (result != nil && !result.Success)
 	if !hasFailureSignal && !externallyOwned {
@@ -1977,7 +1969,7 @@ func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath,
 		// means "not visible yet," not "no one owns this" — always enter the
 		// bounded poll loop below instead, which already tolerates ErrNoRows
 		// on every tick.
-		status, err := r.logStore.GetExecutionStatusByTaskIDExcluding(taskID, projectPath, selfExecID)
+		row, err := r.findTerminalChildExecution(taskID, projectPath, selfExecID)
 		if err != nil {
 			if !errors.Is(err, sql.ErrNoRows) {
 				r.log.Warn("reconcileChildOutcome: execution status lookup failed",
@@ -1985,8 +1977,8 @@ func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath,
 			}
 			return result, execErr
 		}
-		if !childExecutionNonTerminalStatuses[status] {
-			return r.resolveChildTerminalOutcome(taskID, projectPath, selfExecID, status, result, execErr)
+		if row != nil {
+			return r.resolveChildTerminalOutcome(row, result, execErr)
 		}
 	}
 
@@ -2017,9 +2009,9 @@ func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath,
 		case <-ticker.C:
 		}
 
-		status, err := r.logStore.GetExecutionStatusByTaskIDExcluding(taskID, projectPath, selfExecID)
-		if err == nil && !childExecutionNonTerminalStatuses[status] {
-			return r.resolveChildTerminalOutcome(taskID, projectPath, selfExecID, status, result, execErr)
+		row, err := r.findTerminalChildExecution(taskID, projectPath, selfExecID)
+		if err == nil && row != nil {
+			return r.resolveChildTerminalOutcome(row, result, execErr)
 		}
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			r.log.Warn("reconcileChildOutcome: execution status lookup failed",
@@ -2036,8 +2028,43 @@ func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath,
 	}
 }
 
-// resolveChildTerminalOutcome turns a terminal execution-row status for
-// taskID into the (result, error) pair reconcileChildOutcome should return.
+// findTerminalChildExecution scans every execution row tracked for taskID
+// (scoped to projectPath), excluding selfExecID, and returns the most recent
+// one whose status is terminal per isTerminalExecutionStatus — the same
+// definition dispatcher.go's WaitForExecution and GH-4372 retry decider
+// consult, so this wait can't grow a third, driftable copy of "what counts
+// as done" (mem-154 pitfall class; prior instances: #4350, #4373).
+//
+// This is deliberately NOT "the latest row's status": GH-4381 observed a
+// child whose real, older row had already reached the terminal "no_op"
+// outcome while a newer "queued" duplicate row existed alongside it — a
+// latest-row-only lookup (ORDER BY created_at DESC LIMIT 1) returns the
+// duplicate's non-terminal status and hides the terminal one forever,
+// timing out the parent epic. Scanning every row for a terminal one avoids
+// that ordering trap the same way Store.HasTerminalCompletion does for
+// admission gates (GH-4347).
+//
+// Returns (nil, nil) when rows exist for the task but none is terminal yet
+// (still worth polling), and (nil, sql.ErrNoRows) when no other row exists
+// at all (nothing to wait for).
+func (r *Runner) findTerminalChildExecution(taskID, projectPath, selfExecID string) (*memory.Execution, error) {
+	rows, err := r.logStore.ListExecutionsByTaskIDExcluding(taskID, projectPath, selfExecID)
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, sql.ErrNoRows
+	}
+	for _, row := range rows {
+		if isTerminalExecutionStatus(row.Status) {
+			return row, nil
+		}
+	}
+	return nil, nil
+}
+
+// resolveChildTerminalOutcome turns a terminal execution row into the
+// (result, error) pair reconcileChildOutcome should return.
 // "completed" / "no_op" become a synthetic success/no-op ExecutionResult so
 // the normal caller-side handling (PR registration, merge wait, no-op
 // continue) applies unchanged; any other terminal status is a genuine
@@ -2055,19 +2082,13 @@ func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath,
 // entry itself or the card is stuck showing "● running 100%" forever even
 // though the child is done. Mirrors handler_common.go's branch: nil error →
 // Complete, non-nil error → Fail.
-func (r *Runner) resolveChildTerminalOutcome(taskID, projectPath, selfExecID, status string, result *ExecutionResult, execErr error) (*ExecutionResult, error) {
-	row, rowErr := r.logStore.GetLatestExecutionByTaskIDExcluding(taskID, projectPath, selfExecID)
-	if rowErr != nil {
-		row = nil
-	}
+func (r *Runner) resolveChildTerminalOutcome(row *memory.Execution, result *ExecutionResult, execErr error) (*ExecutionResult, error) {
+	taskID := row.TaskID
+	status := row.Status
 
 	switch status {
 	case "completed":
-		synth := &ExecutionResult{TaskID: taskID, Success: true}
-		if row != nil {
-			synth.PRUrl = row.PRUrl
-			synth.CommitSHA = row.CommitSHA
-		}
+		synth := &ExecutionResult{TaskID: taskID, Success: true, PRUrl: row.PRUrl, CommitSHA: row.CommitSHA}
 		r.log.Info("reconcileChildOutcome: child execution row reached terminal success after a synchronous failure signal; treating as succeeded",
 			"task_id", taskID, "status", status)
 		if r.monitor != nil {
@@ -2076,7 +2097,7 @@ func (r *Runner) resolveChildTerminalOutcome(taskID, projectPath, selfExecID, st
 		return synth, nil
 	case "no_op":
 		synth := &ExecutionResult{TaskID: taskID, Success: false, Outcome: "no_op"}
-		if row != nil && row.Error != "" {
+		if row.Error != "" {
 			synth.Error = row.Error
 		}
 		r.log.Info("reconcileChildOutcome: child execution row reached terminal no_op after a synchronous failure signal; treating as no-op",
@@ -2087,7 +2108,7 @@ func (r *Runner) resolveChildTerminalOutcome(taskID, projectPath, selfExecID, st
 		return synth, nil
 	default:
 		msg := ""
-		if row != nil && strings.TrimSpace(row.Error) != "" {
+		if strings.TrimSpace(row.Error) != "" {
 			msg = row.Error
 		} else if execErr != nil {
 			msg = execErr.Error()

--- a/internal/executor/epic_child_reconcile_test.go
+++ b/internal/executor/epic_child_reconcile_test.go
@@ -290,6 +290,156 @@ func TestExecuteSubIssues_ClaimLost_PollsExternallyOwnedChildToSuccess(t *testin
 	}
 }
 
+// TestExecuteSubIssues_ClaimLost_NoOpChildIsTerminalNotTimeout is the
+// GH-4381 regression: an externally-owned child whose real execution ends
+// "no_op" (a legitimate terminal outcome — GH-92's "no new commit produced,
+// worktree HEAD matches base branch parent") must be reconciled as terminal
+// immediately once observed, not treated as still in flight until
+// childOutcomeReconcileTimeout fires "reconcileChildOutcome: timed out
+// waiting for externally-owned child execution to reach a terminal state"
+// and fails the parent epic (mem-154 pitfall class, 3rd instance; prior:
+// #4350's HasTerminalCompletion, #4373's terminalExecutionStatuses).
+func TestExecuteSubIssues_ClaimLost_NoOpChildIsTerminalNotTimeout(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const taskID = "GH-92"
+	const projectPath = ""
+
+	claimed, err := store.ClaimExecution(taskID, projectPath, 0, "exec-owner")
+	if err != nil {
+		t.Fatalf("ClaimExecution: %v", err)
+	}
+	if !claimed {
+		t.Fatal("test setup: expected the seeded claim to win")
+	}
+
+	issues := makeSubIssues(1, 92)
+	parent := &Task{ID: "GH-91", Title: "[epic] no-op child"}
+
+	execCalled := false
+	execFn := func(ctx context.Context, task *Task) (*ExecutionResult, error) {
+		execCalled = true
+		return &ExecutionResult{TaskID: task.ID, Success: true}, nil
+	}
+
+	runner := newTestRunnerWithExecFunc(execFn)
+	runner.logStore = store
+	runner.childOutcomeReconcilePollInterval = 20 * time.Millisecond
+	runner.childOutcomeReconcileTimeout = 2 * time.Second
+
+	// The claim-winning channel's own execution appears and resolves to a
+	// legitimate no-op — "no new commit produced" — shortly after.
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		if saveErr := store.SaveExecution(&memory.Execution{
+			ID:          "exec-owner",
+			TaskID:      taskID,
+			ProjectPath: projectPath,
+			Status:      "running",
+		}); saveErr != nil {
+			t.Errorf("SaveExecution: %v", saveErr)
+		}
+		time.Sleep(30 * time.Millisecond)
+		if uErr := store.UpdateExecutionStatus("exec-owner", "no_op"); uErr != nil {
+			t.Errorf("UpdateExecutionStatus: %v", uErr)
+		}
+	}()
+
+	start := time.Now()
+	err = runner.ExecuteSubIssues(context.Background(), parent, issues, parent.ProjectPath, "")
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("ExecuteSubIssues returned error, want nil (no_op is a legitimate terminal outcome): %v", err)
+	}
+	if execCalled {
+		t.Error("expected the backend NOT to be invoked when the execution claim was already lost")
+	}
+	if elapsed >= runner.childOutcomeReconcileTimeout {
+		t.Errorf("ExecuteSubIssues took %s (>= the %s reconcile timeout) — no_op child was not recognized as terminal", elapsed, runner.childOutcomeReconcileTimeout)
+	}
+}
+
+// TestExecuteSubIssues_ClaimLost_NoOpBehindFreshQueuedDuplicateIsTerminal is
+// the GH-4381 regression for the "mixed row" trap the pitfall calls out: a
+// terminal no_op row plus a newer "queued" duplicate row (e.g. a re-pick by
+// another dispatch channel) must still resolve as terminal — a check that
+// only inspects the latest row by created_at would see the fresh queued row
+// and conclude the child is still running, hiding the older no_op verdict
+// forever.
+func TestExecuteSubIssues_ClaimLost_NoOpBehindFreshQueuedDuplicateIsTerminal(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const taskID = "GH-92"
+	const projectPath = ""
+
+	claimed, err := store.ClaimExecution(taskID, projectPath, 0, "exec-owner")
+	if err != nil {
+		t.Fatalf("ClaimExecution: %v", err)
+	}
+	if !claimed {
+		t.Fatal("test setup: expected the seeded claim to win")
+	}
+
+	// The child's real execution already reached a terminal no_op outcome...
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-owner",
+		TaskID:      taskID,
+		ProjectPath: projectPath,
+		Status:      "no_op",
+	}); err != nil {
+		t.Fatalf("SaveExecution (terminal no_op row): %v", err)
+	}
+
+	// ...but a fresh duplicate "queued" row was written afterward (e.g. a
+	// re-pick from another channel), which would sort as "latest" by
+	// created_at ahead of the terminal row above.
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-duplicate",
+		TaskID:      taskID,
+		ProjectPath: projectPath,
+		Status:      "queued",
+	}); err != nil {
+		t.Fatalf("SaveExecution (fresh queued duplicate): %v", err)
+	}
+
+	issues := makeSubIssues(1, 92)
+	parent := &Task{ID: "GH-91", Title: "[epic] no-op behind queued duplicate"}
+
+	execCalled := false
+	execFn := func(ctx context.Context, task *Task) (*ExecutionResult, error) {
+		execCalled = true
+		return &ExecutionResult{TaskID: task.ID, Success: true}, nil
+	}
+
+	runner := newTestRunnerWithExecFunc(execFn)
+	runner.logStore = store
+	runner.childOutcomeReconcilePollInterval = 20 * time.Millisecond
+	runner.childOutcomeReconcileTimeout = 2 * time.Second
+
+	start := time.Now()
+	err = runner.ExecuteSubIssues(context.Background(), parent, issues, parent.ProjectPath, "")
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("ExecuteSubIssues returned error, want nil (older no_op row is terminal despite the newer queued duplicate): %v", err)
+	}
+	if execCalled {
+		t.Error("expected the backend NOT to be invoked when the execution claim was already lost")
+	}
+	if elapsed >= runner.childOutcomeReconcileTimeout {
+		t.Errorf("ExecuteSubIssues took %s (>= the %s reconcile timeout) — the terminal no_op row was hidden by the fresh queued duplicate", elapsed, runner.childOutcomeReconcileTimeout)
+	}
+}
+
 // TestExecuteSubIssues_NoLogStoreFailsImmediately verifies that without a
 // log store wired, a synchronous child failure fails the epic immediately
 // (unchanged pre-GH-3786 behavior) rather than blocking on a poll it has no

--- a/internal/executor/terminal_status_inventory_test.go
+++ b/internal/executor/terminal_status_inventory_test.go
@@ -1,0 +1,110 @@
+package executor
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// executionStatusVocabulary is every executions.status value the codebase
+// writes or reads (dispatcher.go's terminalExecutionStatuses plus the
+// non-terminal values a hand-rolled "is it still running" set would use).
+var executionStatusVocabulary = map[string]bool{
+	"queued": true, "pending": true, "running": true,
+	"completed": true, "failed": true, "cancelled": true, "declined": true,
+	"no_op": true, "rate_limited": true, "skipped": true, "stalled": true, "infra": true,
+}
+
+// terminalStatusInventoryAllowFiles lists the source files permitted to
+// define a map/set literal keyed on execution-status strings — i.e. the
+// single owner of "what counts as terminal," dispatcher.go's
+// terminalExecutionStatuses.
+var terminalStatusInventoryAllowFiles = map[string]bool{
+	"dispatcher.go": true,
+}
+
+// TestTerminalStatusInventory_NoStrayStatusSets is the GH-4381 guard for the
+// mem-154 pitfall class ("no_op invisible to a dispatch guard's terminal
+// check") recurring a 4th time. Prior instances each grew their own
+// hand-rolled map of execution-status strings instead of consulting
+// dispatcher.go's terminalExecutionStatuses/isTerminalExecutionStatus — most
+// recently epic.go's now-removed childExecutionNonTerminalStatuses, which
+// didn't know how a fresh "queued" duplicate row could hide an older
+// terminal "no_op" row (GH-4381) and silently drifted from the shared
+// definition.
+//
+// This walks every non-test .go file in this package looking for composite
+// map literals whose keys are execution-status string constants — if two or
+// more distinct status values keys show up in the same literal outside
+// dispatcher.go, that's a second (or third, or fourth) copy of the terminal
+// classification being grown, and this test fails naming the file:line so
+// CI catches it instead of a sandbox canary.
+func TestTerminalStatusInventory_NoStrayStatusSets(t *testing.T) {
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		if terminalStatusInventoryAllowFiles[name] {
+			continue
+		}
+
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatalf("ParseFile(%s): %v", name, err)
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, ok := n.(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			if _, isMap := lit.Type.(*ast.MapType); !isMap {
+				return true
+			}
+
+			seen := map[string]bool{}
+			for _, elt := range lit.Elts {
+				kv, ok := elt.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				keyLit, ok := kv.Key.(*ast.BasicLit)
+				if !ok || keyLit.Kind != token.STRING {
+					continue
+				}
+				key, err := strconv.Unquote(keyLit.Value)
+				if err != nil {
+					continue
+				}
+				if executionStatusVocabulary[key] {
+					seen[key] = true
+				}
+			}
+
+			if len(seen) >= 2 {
+				keys := make([]string, 0, len(seen))
+				for k := range seen {
+					keys = append(keys, k)
+				}
+				pos := fset.Position(lit.Pos())
+				t.Errorf(
+					"%s:%d: map literal keys %v look like a second execution-status terminal/non-terminal classification outside dispatcher.go's terminalExecutionStatuses — consult isTerminalExecutionStatus instead of growing a new copy (mem-154 pitfall class)",
+					filepath.Base(pos.Filename), pos.Line, keys,
+				)
+			}
+			return true
+		})
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -747,6 +747,40 @@ func (s *Store) GetLatestExecutionByTaskIDExcluding(taskID, projectPath, exclude
 	return scanExecutionDetail(row)
 }
 
+// ListExecutionsByTaskIDExcluding returns every execution row for taskID
+// (exact match, scoped to projectPath), excluding excludeID, newest first —
+// the full history, unlike GetLatestExecutionByTaskIDExcluding's single
+// "latest by created_at" row.
+//
+// GH-4381: a caller reconciling a child's outcome must scan every row for a
+// terminal one, not just the most recent — a fresh "queued" duplicate row
+// can be written after an older terminal "no_op" row and would sort first,
+// hiding it from any check that only looks at the latest row (the same
+// latest-row-ordering trap HasTerminalCompletion was built to avoid for
+// admission gates, GH-4347).
+func (s *Store) ListExecutionsByTaskIDExcluding(taskID, projectPath, excludeID string) ([]*Execution, error) {
+	rows, err := s.db.Query(`
+		SELECT `+executionDetailColumns+`
+		FROM executions
+		WHERE task_id = ? AND (? = '' OR project_path = ?) AND id != ?
+		ORDER BY created_at DESC, rowid DESC
+	`, taskID, projectPath, projectPath, excludeID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var executions []*Execution
+	for rows.Next() {
+		exec, err := scanExecutionDetail(rows)
+		if err != nil {
+			return nil, err
+		}
+		executions = append(executions, exec)
+	}
+	return executions, rows.Err()
+}
+
 // ListExecutionsForTask returns every execution recorded for taskID (exact match),
 // newest first. Unlike GetLatestExecutionByTaskID (single row, exact-or-substring
 // match), this returns the full history so the CLI can render a per-execution


### PR DESCRIPTION
## Summary

Third instance of the mem-154 "no_op invisible to a dispatch guard's terminal check" pitfall class (prior: #4350, #4373).

- `reconcileChildOutcome`'s externally-owned-child wait (`internal/executor/epic.go`) defined its own `childExecutionNonTerminalStatuses` (queued/pending/running) instead of consulting `dispatcher.go`'s shared `terminalExecutionStatuses`/`isTerminalExecutionStatus` — the single definition #4373 introduced specifically so waits couldn't drift apart.
- It also only inspected the *latest* execution row (`GetExecutionStatusByTaskIDExcluding`, `ORDER BY created_at DESC LIMIT 1`). A child whose real execution had already reached terminal `no_op` could have a fresh "queued" duplicate row appear afterward (e.g. a re-pick from another dispatch channel) that sorts as "latest" and hides the terminal outcome — the wait then timed out with `reconcileChildOutcome: timed out waiting for externally-owned child execution to reach a terminal state`, failing the parent epic even though the child was legitimately done.
- Reproduced live on `pilot-canary-sandbox` GH-91 (parent) / GH-92 (child), 2026-07-16 18:46–18:53Z.

## Changes

- `internal/memory/store.go`: added `Store.ListExecutionsByTaskIDExcluding`, returning every execution row for a task (not just the latest), so a caller can scan for a terminal one regardless of row ordering.
- `internal/executor/epic.go`: replaced the status-string lookup + local `childExecutionNonTerminalStatuses` map with `findTerminalChildExecution`, which scans all rows and consults `isTerminalExecutionStatus`. `resolveChildTerminalOutcome` now takes the resolved row directly instead of re-querying "latest" (which had the same ordering trap).
- `internal/executor/terminal_status_inventory_test.go`: new AST-based guard test — scans every non-test `.go` file in `internal/executor` for map literals keyed on 2+ execution-status strings outside `dispatcher.go`, so a 4th copy of this classification fails CI instead of a sandbox canary. Verified it fails against the pre-fix `childExecutionNonTerminalStatuses`.
- `internal/executor/epic_child_reconcile_test.go`: two new regression tests — a plain no_op externally-owned child, and the mixed "terminal no_op row + newer queued duplicate" case (verified this one fails against the pre-fix code with the exact reported error string).
- Updated the mem-154 pitfall doc with this third instance.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/executor/... ./internal/memory/...` (all green)
- [x] `make test` (full suite green)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` (0 issues)
- [x] New regression tests verified to fail against pre-fix code, pass against the fix
- [x] Inventory test verified to fail against the removed `childExecutionNonTerminalStatuses`, pass after removal