### PR TITLE
fix(autopilot): orphan-running sweep kills live executions, SIGKILL mislabeled as OOM (GH-4412)

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "updated": "2026-07-17T11:05:00+00:00",
+  "updated": "2026-07-17T15:18:52+00:00",
   "nodes": {
     "concepts": {
       "pilot-architecture": {
@@ -2973,6 +2973,23 @@
         ],
         "confidence": 0.95,
         "created": "2026-07-17"
+      },
+      "bare-exit-137-mislabeled-oom": {
+        "type": "pitfall",
+        "summary": "classifyClaudeCodeError labeled every unexplained exit 137/139 \"oom_killed\" with zero kernel evidence — heartbeat/watchdog self-kills and external SIGKILLs (e.g. the orphan-running sweep) got the same label as a real kernel OOM",
+        "file": ".agent/knowledge/memories/pitfalls/bare-exit-137-mislabeled-oom.md",
+        "concepts": [
+          "executor",
+          "error-classification",
+          "oom",
+          "sigkill",
+          "heartbeat",
+          "watchdog",
+          "dmesg",
+          "retry"
+        ],
+        "confidence": 0.9,
+        "created": "2026-07-17"
       }
     }
   },
@@ -4653,8 +4670,8 @@
   },
   "last_updated": "2026-07-17T09:45:00+00:00",
   "stats": {
-    "total_nodes": 256,
+    "total_nodes": 257,
     "total_edges": 226,
-    "memory_count": 160
+    "memory_count": 161
   }
 }

--- a/.agent/knowledge/memories/pitfalls/bare-exit-137-mislabeled-oom.md
+++ b/.agent/knowledge/memories/pitfalls/bare-exit-137-mislabeled-oom.md
@@ -1,0 +1,64 @@
+---
+name: bare-exit-137-mislabeled-oom
+description: classifyClaudeCodeError labeled every unexplained exit 137/139 "oom_killed" with zero kernel evidence — heartbeat/watchdog self-kills and external SIGKILLs (e.g. the orphan-running sweep) got the same label as a real kernel OOM
+type: pitfall
+---
+
+# Bare exit 137/139 is not proof of OOM — classifier needs kernel evidence
+
+**What happened (GH-4412, 2026-07-17):** `classifyClaudeCodeError` in
+`internal/executor/backend_claudecode.go` treated exit code 137 (SIGKILL) or
+139 (SIGSEGV) as `oom_killed` any time the run's `ctx.Err()` was nil — no
+dmesg/cgroup check, no other corroborating signal. Two independent kill paths
+route around that guard entirely:
+
+1. **Heartbeat-timeout kill** and **watchdog-timeout kill** (both in the same
+   file) call `cmd.Process.Kill()` directly rather than cancelling `ctx`, so
+   `ctx.Err() != nil` stays false for them. A hung-process kill from Pilot's
+   own heartbeat watchdog was mislabeled `oom_killed` even though Pilot
+   killed it on purpose.
+2. **Any external SIGKILL** — a `kill -9`, a buggy sweep (the parent GH-4412
+   story: the orphan-running sweep killing live executions), a genuine
+   kernel OOM — all produce the identical exit code 137. Without checking
+   dmesg, the classifier can't tell these apart, yet it always answered "OOM".
+
+## Fix
+- Track heartbeat/watchdog self-kills with an `atomic.Bool` set at the same
+  place `cmd.Process.Kill()` succeeds; feed that into classification as
+  `selfKillReason` so it's tagged `shutdown_terminated` (not OOM) same as the
+  GH-4105 context-cancellation case.
+- For the remaining unexplained-kill case, added `hasKernelOOMEvidence(pid,
+  since)` — best-effort `dmesg -T` scan for a `Killed process <pid>` line
+  timestamped after the subprocess's start time. Only when that returns true
+  does the classifier emit `oom_killed`; otherwise it emits `timeout`
+  ("no kernel OOM evidence found") — the same bucket already used for
+  stderr-detected signal kills.
+- dmesg is frequently inaccessible in production (`kernel.dmesg_restrict=1`
+  on hardened hosts) — absence of evidence must never be treated as evidence
+  of OOM, so failure/permission-denied/no-match all fold to "unconfirmed",
+  never silently default back to OOM.
+
+## Recommended Approach
+When a subprocess-killing code path exists outside of `ctx` cancellation
+(heartbeat, watchdog, or any future direct `Process.Kill()` call), it must
+set an explicit self-kill flag threaded into error classification — don't
+rely on `ctx.Err()` alone as the "did we do this on purpose" signal. When
+classifying an ambiguous kill signal (SIGKILL/SIGSEGV) as a specific root
+cause (OOM, in this case), require positive evidence (dmesg / cgroup
+`memory.events` once #4401's per-subprocess cgroup delegation lands) rather
+than inferring cause from exit code alone.
+
+## Related
+- GH-4412 (this fix) / GH-4412-1, GH-4412-2 (sibling subtasks: orphan-running
+  sweep threshold + live-worker check)
+- GH-4105 (prior partial fix: ctx-cancellation-aware shutdown_terminated)
+- GH-2112 (original OOM-via-exit-code detection)
+- `internal/executor/backend_claudecode.go` (`classifyClaudeCodeError`,
+  `hasKernelOOMEvidence`, `dmesgHasRecentOOMKill`)
+- #4401 (cgroup work — natural home for a `memory.events` oom_kill check
+  once subprocesses run inside a delegated cgroup)
+
+---
+**Captured**: 2026-07-17
+**Confidence**: 0.9
+**Concepts**: executor, error-classification, oom, sigkill, heartbeat, watchdog, dmesg, retry

--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-17 (v2.151.0)
+**Last Updated:** 2026-07-16 (v2.151.0)
 
 ## Legend
 
@@ -68,6 +68,7 @@
 | Branch switch hard fail | ✅ | executor | - | - | Abort execution on git checkout failure (v0.34.0) |
 | Sub-issue PR callback | ✅ | executor | - | - | Wire sub-issue PRs back to autopilot controller chain (v0.23.1, GH-588) |
 | Error classification engine | ✅ | executor | - | - | parseClaudeCodeError() routes rate_limit/api_error/timeout for retry (v0.48.0, GH-917) |
+| Kernel-evidence-gated OOM classification | ✅ | executor | - | - | Exit 137/139 requires dmesg OOM-killer evidence (or a heartbeat/watchdog self-kill flag) before labeling oom_killed; bare exit code alone now classifies as unconfirmed "timeout" (v2.241.2, GH-4412) |
 | Retry on label removal | ✅ | executor | - | - | Allow retry when pilot-failed label is manually removed (v0.33.2) |
 | Code simplification pipeline | ✅ | executor | - | - | simplify.go integrated into execution pipeline for code quality (v0.61.0, GH-995) |
 | Context markers | ✅ | executor | - | - | markers.go for context save points before risky operations (v0.61.0) |

--- a/.agent/tasks/gh-4412-1.md
+++ b/.agent/tasks/gh-4412-1.md
@@ -1,0 +1,23 @@
+# GH-4412-1
+
+**Created:** 2026-07-17
+
+## Problem
+
+## Subtask 1 of 3
+
+**Parent Task:** GH-4412 - fix(autopilot): orphan-running sweep kills live 14-min-old executions ('no merge evidence') — SIGKILL mislabeled as OOM, work lost and re-run (GH-24)
+
+## Objective
+
+Same class as today's dispatcher-side races (#4404 family): a sweep taking ownership of an execution a live worker still owns. This variant **kills real work** mid-flight and pollutes metrics with fake OOM/infra outcomes.
+
+## Context
+
+This is part of a larger task that has been decomposed for better execution.
+Focus on this specific objective. Other subtasks will handle the remaining work.
+
+
+
+## Acceptance Criteria
+

--- a/.agent/tasks/gh-4412-2.md
+++ b/.agent/tasks/gh-4412-2.md
@@ -1,0 +1,23 @@
+# GH-4412-2
+
+**Created:** 2026-07-17
+
+## Problem
+
+## Subtask 2 of 3
+
+**Parent Task:** GH-4412 - fix(autopilot): orphan-running sweep kills live 14-min-old executions ('no merge evidence') — SIGKILL mislabeled as OOM, work lost and re-run (GH-24)
+
+## Objective
+
+14 minutes is far below every legitimate ceiling (30–60m task timeouts, 120m watchdog). Whatever threshold this sweep uses, it must (a) floor at the runner's own timeout ceiling like GH-4092 did for alert eviction, and (b) check for a live worker/process before declaring orphanhood.
+
+## Context
+
+This is part of a larger task that has been decomposed for better execution.
+Focus on this specific objective. Other subtasks will handle the remaining work.
+
+
+
+## Acceptance Criteria
+

--- a/.agent/tasks/gh-4412-3.md
+++ b/.agent/tasks/gh-4412-3.md
@@ -1,0 +1,24 @@
+# GH-4412-3
+
+**Created:** 2026-07-17
+
+## Problem
+
+## Subtask 3 of 3
+
+**Parent Task:** GH-4412 - fix(autopilot): orphan-running sweep kills live 14-min-old executions ('no merge evidence') — SIGKILL mislabeled as OOM, work lost and re-run (GH-24)
+
+## Objective
+
+"Backend OOM-killed" on exit 137 without kernel evidence is a misdiagnosis — classifier should require dmesg/cgroup evidence before labeling OOM (relevant to #4401 cgroup work).
+
+## Context
+
+This is part of a larger task that has been decomposed for better execution.
+Focus on this specific objective. Other subtasks will handle the remaining work.
+
+**Note:** This is the final subtask. Ensure all previous subtasks are complete before finishing.
+
+
+## Acceptance Criteria
+

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -677,6 +677,13 @@ Examples:
 							gwAutopilotController.SetReleaseSummaryGenerator(
 								autopilot.NewReleaseSummaryGenerator(apGHClient, os.Getenv("ANTHROPIC_API_KEY"), logging.WithComponent("autopilot")),
 							)
+							// GH-4412: wire the always-on Dispatcher liveness signal so the
+							// orphan-running sweep's live-worker exclusion set isn't silently
+							// empty outside --dashboard mode (see SetMonitor's dashboard-only
+							// wiring further down).
+							if gwDispatcher != nil {
+								gwAutopilotController.SetDispatcherLiveness(gwDispatcher)
+							}
 						}
 					}
 				}
@@ -2206,6 +2213,17 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			dispatcher = nil
 		} else {
 			logging.WithComponent("start").Info("Task dispatcher started")
+		}
+	}
+
+	// GH-4412: wire the always-on Dispatcher liveness signal into every
+	// autopilot controller, unconditionally (unlike SetMonitor above, which
+	// only runs in --dashboard mode). Without this, the orphan-running sweep's
+	// live-worker exclusion set is silently empty in the common headless
+	// (--telegram/--github, no --dashboard) deployment.
+	if dispatcher != nil {
+		for _, ctrl := range autopilotControllers {
+			ctrl.SetDispatcherLiveness(dispatcher)
 		}
 	}
 

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -583,13 +583,39 @@ func (c *Controller) selfHealTask(taskID, prURL string) {
 // even though the execution itself is still progressing. This is the hard
 // regression gate for a genuinely running task (the GH-4206 case) — it must
 // never be flipped mid-execution. TASK-399/GH-4209.
+//
+// GH-4412: 10 minutes sits far below every legitimate runner ceiling (30-60m
+// per-complexity task timeouts, doubled to a 120m watchdog kill floor —
+// runner.go watchdogTimeout = 2 * timeout). A live execution mid-way through
+// one long tool call/build with no other heartbeat easily exceeds 10 minutes
+// while its worker is still legitimately running. minOrphanRunningThreshold
+// floors this window at that 120m runner ceiling, mirroring GH-4092's
+// minOrphanEvictionThreshold fix for the alert engine's stuck-task eviction.
 const orphanRunningHeartbeatWindow = 10 * time.Minute
+
+// minOrphanRunningThreshold floors orphanRunningHeartbeatWindow at the
+// runner's own worst-case single-attempt budget: a Complex task's 60m default
+// timeout doubled by the runner's watchdog (runner.go watchdogTimeout = 2 *
+// timeout) = 120m. GH-4412: mirrors GH-4092 (internal/alerts/engine.go's
+// minOrphanEvictionThreshold) — no heartbeat-based orphan window should ever
+// be shorter than the time the runner itself is willing to let a task run
+// before giving up on it.
+const minOrphanRunningThreshold = 120 * time.Minute
+
+// effectiveOrphanRunningWindow returns orphanRunningHeartbeatWindow floored at
+// minOrphanRunningThreshold (GH-4412).
+func effectiveOrphanRunningWindow() time.Duration {
+	if orphanRunningHeartbeatWindow < minOrphanRunningThreshold {
+		return minOrphanRunningThreshold
+	}
+	return orphanRunningHeartbeatWindow
+}
 
 // sweepOrphanedRunningExecutions resolves status='running' execution rows
 // that are not actually in flight: absent from both the live Monitor's
 // running/queued set (dashboard mode only) and the Dispatcher's live-worker
 // set (GH-4412, always available), and with no execution_events heartbeat
-// inside orphanRunningHeartbeatWindow. Each surviving candidate resolves to
+// inside effectiveOrphanRunningWindow(). Each surviving candidate resolves to
 // 'completed' when its pr_url or branch matches a PR in mergedPRs, else
 // 'failed'. mergedPRs is the same already-fetched PR list
 // ScanRecentlyMergedPRsWithWindow built for this tick — this sweep makes no
@@ -603,9 +629,9 @@ func (c *Controller) sweepOrphanedRunningExecutions(mergedPRs []*github.PullRequ
 	// Dispatcher liveness signal. Relying on c.monitor alone left this
 	// exclusion set silently empty in headless (--dashboard not passed)
 	// deployments, so a live 14+ minute execution with no execution_events
-	// heartbeat in the last orphanRunningHeartbeatWindow (e.g. one long tool
-	// call/build) had no other guard against being swept out from under its
-	// still-running worker.
+	// heartbeat in the last window (formerly a fixed 10 minutes, now floored
+	// at minOrphanRunningThreshold — see effectiveOrphanRunningWindow) had no
+	// other guard against being swept out from under its still-running worker.
 	var liveTaskIDs []string
 	if c.monitor != nil {
 		liveTaskIDs = append(liveTaskIDs, c.monitor.GetRunningTaskIDs()...)
@@ -620,6 +646,7 @@ func (c *Controller) sweepOrphanedRunningExecutions(mergedPRs []*github.PullRequ
 		return
 	}
 
+	heartbeatWindow := effectiveOrphanRunningWindow()
 	for _, exec := range orphans {
 		events, evErr := c.evalStore.ListExecutionEvents(exec.ID)
 		if evErr != nil {
@@ -629,7 +656,7 @@ func (c *Controller) sweepOrphanedRunningExecutions(mergedPRs []*github.PullRequ
 		}
 		if len(events) > 0 {
 			last := events[len(events)-1].OccurredAt
-			if time.Since(last) < orphanRunningHeartbeatWindow {
+			if time.Since(last) < heartbeatWindow {
 				c.log.Debug("orphan-running sweep: recent heartbeat, treating as in-flight",
 					"execution_id", exec.ID, "task_id", exec.TaskID, "last_event", last)
 				continue

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -123,6 +123,21 @@ type TaskMonitor interface {
 	GetRunningTaskIDs() []string
 }
 
+// DispatcherLiveness reports which task IDs a live executor.Dispatcher's
+// project workers are currently processing. GH-4412: TaskMonitor above is
+// only wired when the daemon runs with --dashboard (see cmd/pilot/main.go's
+// SetMonitor call sites), so in the common headless deployment
+// (`pilot start --telegram --github`) the orphan-running sweep's monitor-based
+// exclusion set was silently empty, leaving only the 10-minute
+// execution_events heartbeat window to protect a genuinely running task — not
+// reliably enough for a single long-running tool call/build. The Dispatcher
+// (and its workers) is always constructed regardless of dashboard mode, so
+// this interface gives the sweep an always-available "is a worker actually
+// holding this task right now" signal to union with the monitor's set.
+type DispatcherLiveness interface {
+	GetRunningTaskIDs() []string
+}
+
 // EvalStore persists eval tasks extracted from merged PRs.
 type EvalStore interface {
 	SaveEvalTask(task *memory.EvalTask) error
@@ -242,7 +257,8 @@ type Controller struct {
 	releaser         *Releaser
 	deployer         *Deployer
 	notifier         Notifier
-	monitor          TaskMonitor // GH-1336: sync dashboard state on merge
+	monitor          TaskMonitor        // GH-1336: sync dashboard state on merge
+	dispatcherLive   DispatcherLiveness // GH-4412: always-on live-worker signal (unlike monitor, dashboard-only)
 	boardSync        projectBoardSyncer
 	doneStatus       string
 	failStatus       string
@@ -570,9 +586,10 @@ func (c *Controller) selfHealTask(taskID, prURL string) {
 const orphanRunningHeartbeatWindow = 10 * time.Minute
 
 // sweepOrphanedRunningExecutions resolves status='running' execution rows
-// that are not actually in flight: absent from the live Monitor's
-// running/queued set, and with no execution_events heartbeat inside
-// orphanRunningHeartbeatWindow. Each surviving candidate resolves to
+// that are not actually in flight: absent from both the live Monitor's
+// running/queued set (dashboard mode only) and the Dispatcher's live-worker
+// set (GH-4412, always available), and with no execution_events heartbeat
+// inside orphanRunningHeartbeatWindow. Each surviving candidate resolves to
 // 'completed' when its pr_url or branch matches a PR in mergedPRs, else
 // 'failed'. mergedPRs is the same already-fetched PR list
 // ScanRecentlyMergedPRsWithWindow built for this tick — this sweep makes no
@@ -582,9 +599,19 @@ func (c *Controller) sweepOrphanedRunningExecutions(mergedPRs []*github.PullRequ
 		return
 	}
 
+	// GH-4412: union the optional dashboard Monitor's set with the always-on
+	// Dispatcher liveness signal. Relying on c.monitor alone left this
+	// exclusion set silently empty in headless (--dashboard not passed)
+	// deployments, so a live 14+ minute execution with no execution_events
+	// heartbeat in the last orphanRunningHeartbeatWindow (e.g. one long tool
+	// call/build) had no other guard against being swept out from under its
+	// still-running worker.
 	var liveTaskIDs []string
 	if c.monitor != nil {
-		liveTaskIDs = c.monitor.GetRunningTaskIDs()
+		liveTaskIDs = append(liveTaskIDs, c.monitor.GetRunningTaskIDs()...)
+	}
+	if c.dispatcherLive != nil {
+		liveTaskIDs = append(liveTaskIDs, c.dispatcherLive.GetRunningTaskIDs()...)
 	}
 
 	orphans, err := c.evalStore.FindOrphanedRunningExecutions(liveTaskIDs)
@@ -669,6 +696,14 @@ func (c *Controller) SetNotifier(n Notifier) {
 // shows correct "done" status instead of stale "failed" from earlier execution attempts.
 func (c *Controller) SetMonitor(m TaskMonitor) {
 	c.monitor = m
+}
+
+// SetDispatcherLiveness wires the always-on live-worker signal the
+// orphan-running sweep needs regardless of --dashboard mode. GH-4412: unlike
+// SetMonitor (dashboard-only), callers should wire this unconditionally
+// whenever an executor.Dispatcher exists.
+func (c *Controller) SetDispatcherLiveness(d DispatcherLiveness) {
+	c.dispatcherLive = d
 }
 
 // SetStateStore sets the persistent state store for crash recovery.

--- a/internal/autopilot/orphan_sweep_test.go
+++ b/internal/autopilot/orphan_sweep_test.go
@@ -14,6 +14,54 @@ import (
 	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 )
 
+// mockDispatcherLiveness implements DispatcherLiveness for testing the
+// GH-4412 always-on live-worker signal (independent of the dashboard-only
+// TaskMonitor).
+type mockDispatcherLiveness struct {
+	runningTaskIDs []string
+}
+
+func (m *mockDispatcherLiveness) GetRunningTaskIDs() []string {
+	return m.runningTaskIDs
+}
+
+// TestSweepOrphanedRunningExecutions_LiveDispatcherEntryNotFlipped is the
+// GH-4412 regression gate: a status='running' row whose task_id is in the
+// Dispatcher's live-worker set must never be resolved by the orphan sweep,
+// even with NO Monitor wired at all (the common headless --telegram/--github
+// deployment, where TaskMonitor is only set up in --dashboard mode). Before
+// this fix, an unwired c.monitor meant the sweep's exclusion set was silently
+// empty, so a genuinely running task with no execution_events heartbeat in
+// the last orphanRunningHeartbeatWindow (e.g. one long tool call) would be
+// wrongly marked failed out from under its still-running worker.
+func TestSweepOrphanedRunningExecutions_LiveDispatcherEntryNotFlipped(t *testing.T) {
+	cfg := DefaultConfig()
+	c := NewController(cfg, nil, nil, "owner", "repo")
+
+	evalMock := &mockEvalStore{
+		orphanedRunning: []*memory.Execution{
+			{ID: "exec-live", TaskID: "GH-4412", ProjectPath: "/proj"},
+		},
+		executionEvents: map[string][]*memory.Event{
+			"exec-live": {
+				{ExecutionID: "exec-live", Stage: memory.StageRunning, OccurredAt: time.Now().Add(-14 * time.Minute)},
+			},
+		},
+	}
+	c.SetEvalStore(evalMock)
+	// No monitor wired (headless mode) — only the Dispatcher liveness signal.
+	c.SetDispatcherLiveness(&mockDispatcherLiveness{runningTaskIDs: []string{"GH-4412"}})
+
+	c.sweepOrphanedRunningExecutions(nil)
+
+	if len(evalMock.resolvedOrphans) != 0 {
+		t.Fatalf("expected GH-4412 (live per Dispatcher, no Monitor wired) to never be resolved, got %d resolve calls: %+v", len(evalMock.resolvedOrphans), evalMock.resolvedOrphans)
+	}
+	if len(evalMock.lastExcludeTaskIDs) != 1 || evalMock.lastExcludeTaskIDs[0] != "GH-4412" {
+		t.Errorf("expected FindOrphanedRunningExecutions to be called with the Dispatcher's live set, got %v", evalMock.lastExcludeTaskIDs)
+	}
+}
+
 // TestSweepOrphanedRunningExecutions_LiveMonitorEntryNotFlipped is the GH-4206
 // regression gate: a status='running' row whose task_id is in the live
 // Monitor's running/queued set must never be resolved by the orphan sweep,

--- a/internal/autopilot/orphan_sweep_test.go
+++ b/internal/autopilot/orphan_sweep_test.go
@@ -118,6 +118,40 @@ func TestSweepOrphanedRunningExecutions_FreshHeartbeatNotFlipped(t *testing.T) {
 	}
 }
 
+// TestSweepOrphanedRunningExecutions_StaleHeartbeatWithinRunnerCeilingNotFlipped
+// is the GH-4412 regression gate for the heartbeat-window floor: a row whose
+// last heartbeat is old enough to have tripped the pre-fix fixed 10-minute
+// orphanRunningHeartbeatWindow (here, 20 minutes — comfortably past 10, but
+// still far inside the runner's own 30-60m task timeouts and 120m watchdog
+// kill ceiling) must survive the sweep even with no live Monitor/Dispatcher
+// entry at all. Only a genuinely runner-ceiling-exceeding silence (see
+// TestSweepOrphanedRunningExecutions_StaleNoEvidenceMarkedFailed's 2-hour gap)
+// may resolve the row.
+func TestSweepOrphanedRunningExecutions_StaleHeartbeatWithinRunnerCeilingNotFlipped(t *testing.T) {
+	cfg := DefaultConfig()
+	c := NewController(cfg, nil, nil, "owner", "repo")
+
+	evalMock := &mockEvalStore{
+		orphanedRunning: []*memory.Execution{
+			{ID: "exec-still-running", TaskID: "GH-4412", ProjectPath: "/proj"},
+		},
+		executionEvents: map[string][]*memory.Event{
+			"exec-still-running": {
+				{ExecutionID: "exec-still-running", Stage: memory.StageRunning, OccurredAt: time.Now().Add(-20 * time.Minute)},
+			},
+		},
+	}
+	c.SetEvalStore(evalMock)
+	// No monitor, no Dispatcher liveness wired — the heartbeat-window floor
+	// alone must be what protects this row.
+
+	c.sweepOrphanedRunningExecutions(nil)
+
+	if len(evalMock.resolvedOrphans) != 0 {
+		t.Fatalf("expected 20-minute-stale row to survive the sweep (within the runner's 120m ceiling), got resolve calls: %+v", evalMock.resolvedOrphans)
+	}
+}
+
 // TestSweepOrphanedRunningExecutions_StaleNoEvidenceMarkedFailed verifies that
 // a row with no live Monitor entry, no recent heartbeat, and no matching
 // merged PR resolves to 'failed' (empty prURL). TASK-399/GH-4209.

--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -106,7 +107,18 @@ func (e *ClaudeCodeError) ErrorStderr() string { return e.Stderr }
 // classifyClaudeCodeError examines stderr output and exit code to classify the error.
 // ctxCancelled indicates whether the run's context was already cancelled (by our
 // own shutdown or timeout path) at the time the process exited — GH-4105.
-func classifyClaudeCodeError(stderr string, originalErr error, ctxCancelled bool) *ClaudeCodeError {
+// selfKillReason, when non-empty, names the Pilot-internal watchdog that issued
+// the kill directly via cmd.Process.Kill() (e.g. "heartbeat timeout", "watchdog
+// timeout") — these kills happen outside the context-cancellation path, so
+// ctxCancelled alone doesn't catch them. GH-4412.
+// kernelOOMConfirmed indicates the caller already checked dmesg (or, in future,
+// a cgroup memory.events oom_kill counter) for a kernel OOM-killer entry naming
+// the subprocess PID. A bare 137/139 exit is NOT sufficient evidence of OOM on
+// its own — GH-4412: the orphan-running sweep and other SIGKILL sources produce
+// the identical exit code, and labeling every one of them "oom_killed" without
+// kernel evidence is a misdiagnosis that pollutes metrics and mis-routes retry
+// strategy.
+func classifyClaudeCodeError(stderr string, originalErr error, ctxCancelled bool, selfKillReason string, kernelOOMConfirmed bool) *ClaudeCodeError {
 	// GH-2112: Check exit code first — OOM kills (137=SIGKILL, 139=SIGSEGV) often
 	// produce no stderr, so exit code is the only reliable signal.
 	if exitCode := extractExitCode(originalErr); exitCode == 137 || exitCode == 139 {
@@ -114,9 +126,10 @@ func classifyClaudeCodeError(stderr string, originalErr error, ctxCancelled bool
 		if exitCode == 139 {
 			sigName = "SIGSEGV"
 		}
-		// GH-4105: if we ourselves cancelled the context (shutdown/timeout),
-		// the resulting SIGKILL/SIGSEGV-shaped exit is expected process
-		// teardown, not a genuine out-of-memory kill.
+		// GH-4105/GH-4412: if we ourselves cancelled the context (shutdown/
+		// timeout) OR killed the process directly via a heartbeat/watchdog
+		// timeout, the resulting SIGKILL/SIGSEGV-shaped exit is expected
+		// process teardown, not a genuine out-of-memory kill.
 		if ctxCancelled {
 			return &ClaudeCodeError{
 				Type:    ErrorTypeShutdownTerminated,
@@ -124,9 +137,30 @@ func classifyClaudeCodeError(stderr string, originalErr error, ctxCancelled bool
 				Stderr:  strings.TrimSpace(stderr),
 			}
 		}
+		if selfKillReason != "" {
+			return &ClaudeCodeError{
+				Type:    ErrorTypeShutdownTerminated,
+				Message: fmt.Sprintf("Process terminated by %s after Pilot %s (exit code %d)", sigName, selfKillReason, exitCode),
+				Stderr:  strings.TrimSpace(stderr),
+			}
+		}
+		// GH-4412: an unexplained 137/139 is NOT automatically OOM. Only
+		// label it oom_killed when the caller confirmed a kernel OOM-killer
+		// entry for this PID. Otherwise this is an external kill of unknown
+		// origin (another process's `kill -9`, a sweep/reaper bug, etc.) —
+		// classify it in the same "killed, cause unconfirmed" bucket as the
+		// stderr-detected signal-kill case below so it still gets a sane
+		// (non-OOM) retry strategy instead of silently defaulting to OOM.
+		if kernelOOMConfirmed {
+			return &ClaudeCodeError{
+				Type:    ErrorTypeOOM,
+				Message: fmt.Sprintf("Process killed by %s (exit code %d, confirmed via kernel OOM-killer log)", sigName, exitCode),
+				Stderr:  strings.TrimSpace(stderr),
+			}
+		}
 		return &ClaudeCodeError{
-			Type:    ErrorTypeOOM,
-			Message: fmt.Sprintf("Process killed by %s (exit code %d)", sigName, exitCode),
+			Type:    ErrorTypeTimeout,
+			Message: fmt.Sprintf("Process killed by %s (exit code %d, no kernel OOM evidence found)", sigName, exitCode),
 			Stderr:  strings.TrimSpace(stderr),
 		}
 	}
@@ -225,8 +259,64 @@ func extractExitCode(err error) int {
 
 // parseClaudeCodeError examines stderr output and exit code to classify the error.
 // This function matches the specification in GH-917 and returns error interface.
-func parseClaudeCodeError(stderr string, originalErr error, ctxCancelled bool) error {
-	return classifyClaudeCodeError(stderr, originalErr, ctxCancelled)
+func parseClaudeCodeError(stderr string, originalErr error, ctxCancelled bool, selfKillReason string, kernelOOMConfirmed bool) error {
+	return classifyClaudeCodeError(stderr, originalErr, ctxCancelled, selfKillReason, kernelOOMConfirmed)
+}
+
+// kernelOOMEvidenceTimeout bounds how long the dmesg subprocess may run before
+// classification gives up and treats the kill as unconfirmed — dmesg must
+// never block classification of an already-failed execution. GH-4412.
+const kernelOOMEvidenceTimeout = 2 * time.Second
+
+// dmesgTimestampRe matches the `[Mon Jan  2 15:04:05 2006]` prefix `dmesg -T`
+// emits on each ring-buffer line.
+var dmesgTimestampRe = regexp.MustCompile(`^\[([A-Za-z]{3} [A-Za-z]{3}\s+\d{1,2} \d{2}:\d{2}:\d{2} \d{4})\]`)
+
+// hasKernelOOMEvidence best-effort checks dmesg for a kernel OOM-killer log
+// line naming pid, logged at or after since. It returns false — "no evidence"
+// — on any failure: dmesg missing, permission denied (kernel.dmesg_restrict,
+// common on hardened hosts), or no matching entry. Absence of evidence must
+// never be treated as evidence of OOM; the caller falls back to a
+// cause-unconfirmed classification instead. GH-4412 (relevant to the #4401
+// cgroup work: once subprocesses run inside a delegated cgroup, a
+// memory.events oom_kill counter check can be added here alongside dmesg).
+func hasKernelOOMEvidence(pid int, since time.Time) bool {
+	if pid <= 0 {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), kernelOOMEvidenceTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "dmesg", "-T").Output()
+	if err != nil {
+		return false
+	}
+	return dmesgHasRecentOOMKill(string(out), pid, since)
+}
+
+// dmesgHasRecentOOMKill scans dmesg -T output for a "Killed process <pid>"
+// line (the kernel OOM-killer's signature message) timestamped at or after
+// since. Lines whose timestamp can't be parsed are skipped rather than
+// counted as evidence — a false negative here is far safer than a false
+// positive that mislabels an unrelated, recycled-PID kill as OOM.
+func dmesgHasRecentOOMKill(dmesgOutput string, pid int, since time.Time) bool {
+	needle := fmt.Sprintf("Killed process %d", pid)
+	for _, line := range strings.Split(dmesgOutput, "\n") {
+		if !strings.Contains(line, needle) {
+			continue
+		}
+		m := dmesgTimestampRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		ts, err := time.ParseInLocation("Mon Jan _2 15:04:05 2006", m[1], time.Local)
+		if err != nil {
+			continue
+		}
+		if !ts.Before(since) {
+			return true
+		}
+	}
+	return false
 }
 
 // ClaudeCodeBackend implements Backend for Claude Code CLI.
@@ -453,6 +543,10 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 	}
 
 	// Start the command
+	// GH-4412: recorded so an unexplained 137/139 exit's dmesg evidence check
+	// only considers OOM-killer log lines from this run, not a stale entry
+	// left over from an earlier process that reused the same PID.
+	startTime := time.Now()
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("failed to start Claude Code: %w", err)
 	}
@@ -477,6 +571,13 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 
 	// Channel to signal command completion
 	cmdDone := make(chan struct{})
+
+	// GH-4412: track whether Pilot itself killed the process directly via
+	// cmd.Process.Kill() (heartbeat/watchdog timeout) rather than through
+	// context cancellation. These kills produce the identical 137/139 exit
+	// code as a genuine kernel OOM kill but ctx.Err() stays nil for them, so
+	// without this flag they were silently mislabeled oom_killed.
+	var heartbeatKilled, watchdogKilled atomic.Bool
 
 	// Heartbeat tracking: store last event time as Unix nano (atomic int64)
 	var lastEventAt atomic.Int64
@@ -518,6 +619,9 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 								slog.Any("error", err),
 							)
 						} else {
+							// GH-4412: mark self-inflicted so classification
+							// doesn't mislabel the resulting 137 as OOM.
+							heartbeatKilled.Store(true)
 							b.log.Info("Hung process killed successfully",
 								slog.Int("pid", cmd.Process.Pid),
 							)
@@ -560,6 +664,9 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 						slog.Any("error", err),
 					)
 				} else {
+					// GH-4412: mark self-inflicted so classification doesn't
+					// mislabel the resulting 137 as OOM.
+					watchdogKilled.Store(true)
 					b.log.Info("Watchdog killed process successfully",
 						slog.Int("pid", cmd.Process.Pid),
 					)
@@ -733,7 +840,32 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 		// shutdown/timeout path) so 137/139 exits during teardown aren't
 		// misclassified as OOM kills.
 		stderr := stderrOutput.String()
-		ccErr := parseClaudeCodeError(stderr, err, ctx.Err() != nil).(*ClaudeCodeError)
+		ctxCancelled := ctx.Err() != nil
+
+		// GH-4412: heartbeat/watchdog kills call cmd.Process.Kill() directly
+		// (not through context cancellation), so ctxCancelled alone misses
+		// them — without this they were mislabeled oom_killed too.
+		selfKillReason := ""
+		switch {
+		case heartbeatKilled.Load():
+			selfKillReason = "heartbeat timeout"
+		case watchdogKilled.Load():
+			selfKillReason = "watchdog timeout"
+		}
+
+		// GH-4412: an unexplained 137/139 (not our own shutdown/heartbeat/
+		// watchdog kill) requires kernel dmesg evidence before it's labeled
+		// OOM — the exit code alone is also produced by external SIGKILL
+		// sources (e.g. the orphan-running sweep's prior kill-and-mislabel
+		// bug this task is part of).
+		kernelOOMConfirmed := false
+		if !ctxCancelled && selfKillReason == "" {
+			if exitCode := extractExitCode(err); exitCode == 137 || exitCode == 139 {
+				kernelOOMConfirmed = hasKernelOOMEvidence(cmd.Process.Pid, startTime)
+			}
+		}
+
+		ccErr := parseClaudeCodeError(stderr, err, ctxCancelled, selfKillReason, kernelOOMConfirmed).(*ClaudeCodeError)
 
 		// GH-2328: surface the raw stderr + classification so the runner can
 		// write them to execution_logs. Without this, "unknown: exit status 1"

--- a/internal/executor/backend_claudecode_test.go
+++ b/internal/executor/backend_claudecode_test.go
@@ -549,7 +549,7 @@ func TestClassifyClaudeCodeError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := classifyClaudeCodeError(tt.stderr, nil, false)
+			err := classifyClaudeCodeError(tt.stderr, nil, false, "", false)
 			if err.Type != tt.expectType {
 				t.Errorf("classifyClaudeCodeError() type = %q, want %q", err.Type, tt.expectType)
 			}
@@ -596,7 +596,7 @@ func TestParseClaudeCodeError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := parseClaudeCodeError(tt.stderr, nil, false)
+			err := parseClaudeCodeError(tt.stderr, nil, false, "", false)
 			ccErr, ok := err.(*ClaudeCodeError)
 			if !ok {
 				t.Errorf("parseClaudeCodeError() did not return *ClaudeCodeError, got %T", err)
@@ -685,34 +685,41 @@ func TestTruncate(t *testing.T) {
 }
 
 func TestClassifyClaudeCodeError_OOM(t *testing.T) {
-	// GH-2112: OOM/SIGKILL detection via exit code
+	// GH-2112/GH-4412: OOM/SIGKILL detection via exit code, gated on kernel
+	// OOM evidence — a bare 137/139 with no confirming dmesg entry must NOT
+	// be labeled oom_killed (see TestClassifyClaudeCodeError_ShutdownVsOOM
+	// for the unconfirmed-kill case).
 	tests := []struct {
-		name       string
-		exitCode   int
-		stderr     string
-		expectType ClaudeCodeErrorType
-		expectMsg  string
+		name               string
+		exitCode           int
+		stderr             string
+		kernelOOMConfirmed bool
+		expectType         ClaudeCodeErrorType
+		expectMsg          string
 	}{
 		{
-			name:       "exit 137 (SIGKILL) classified as OOM",
-			exitCode:   137,
-			stderr:     "",
-			expectType: ErrorTypeOOM,
-			expectMsg:  "Process killed by SIGKILL (exit code 137)",
+			name:               "exit 137 (SIGKILL) with kernel evidence classified as OOM",
+			exitCode:           137,
+			stderr:             "",
+			kernelOOMConfirmed: true,
+			expectType:         ErrorTypeOOM,
+			expectMsg:          "Process killed by SIGKILL (exit code 137, confirmed via kernel OOM-killer log)",
 		},
 		{
-			name:       "exit 139 (SIGSEGV) classified as OOM",
-			exitCode:   139,
-			stderr:     "",
-			expectType: ErrorTypeOOM,
-			expectMsg:  "Process killed by SIGSEGV (exit code 139)",
+			name:               "exit 139 (SIGSEGV) with kernel evidence classified as OOM",
+			exitCode:           139,
+			stderr:             "",
+			kernelOOMConfirmed: true,
+			expectType:         ErrorTypeOOM,
+			expectMsg:          "Process killed by SIGSEGV (exit code 139, confirmed via kernel OOM-killer log)",
 		},
 		{
-			name:       "exit 137 with stderr still classified as OOM",
-			exitCode:   137,
-			stderr:     "some output before death",
-			expectType: ErrorTypeOOM,
-			expectMsg:  "Process killed by SIGKILL (exit code 137)",
+			name:               "exit 137 with stderr and kernel evidence still classified as OOM",
+			exitCode:           137,
+			stderr:             "some output before death",
+			kernelOOMConfirmed: true,
+			expectType:         ErrorTypeOOM,
+			expectMsg:          "Process killed by SIGKILL (exit code 137, confirmed via kernel OOM-killer log)",
 		},
 		{
 			name:       "exit 1 with empty stderr is not OOM",
@@ -736,7 +743,7 @@ func TestClassifyClaudeCodeError_OOM(t *testing.T) {
 				cmd := exec.Command("sh", "-c", fmt.Sprintf("exit %d", tt.exitCode))
 				exitErr = cmd.Run()
 			}
-			err := classifyClaudeCodeError(tt.stderr, exitErr, false)
+			err := classifyClaudeCodeError(tt.stderr, exitErr, false, "", tt.kernelOOMConfirmed)
 			if err.Type != tt.expectType {
 				t.Errorf("type = %q, want %q", err.Type, tt.expectType)
 			}
@@ -747,48 +754,170 @@ func TestClassifyClaudeCodeError_OOM(t *testing.T) {
 	}
 }
 
-func TestClassifyClaudeCodeError_ShutdownVsOOM(t *testing.T) {
-	// GH-4105: exit 137/139 must be classified as oom_killed only when the run
-	// context was NOT already cancelled by our own shutdown/timeout path.
-	// When the context was cancelled, the same exit codes are expected
-	// teardown noise and must be tagged shutdown_terminated instead.
+// TestClassifyClaudeCodeError_UnconfirmedKillNotOOM covers the core GH-4412
+// fix: an exit 137/139 that is neither our own context-cancellation teardown
+// nor a Pilot-initiated heartbeat/watchdog kill nor backed by a dmesg
+// OOM-killer entry must NOT be labeled oom_killed. Bare exit code is not
+// evidence — plenty of external SIGKILL sources (the orphan-running sweep
+// bug this task is part of, a manual `kill -9`, cgroup OOM without dmesg
+// access) produce the identical exit code.
+func TestClassifyClaudeCodeError_UnconfirmedKillNotOOM(t *testing.T) {
 	tests := []struct {
-		name         string
-		exitCode     int
-		ctxCancelled bool
-		expectType   ClaudeCodeErrorType
-		expectMsg    string
+		name       string
+		exitCode   int
+		expectType ClaudeCodeErrorType
+		expectMsg  string
 	}{
 		{
-			// (a) exit 137, context not cancelled -> oom_killed
-			name:         "exit 137, context not cancelled -> oom_killed",
+			name:       "exit 137, no kernel evidence -> not OOM",
+			exitCode:   137,
+			expectType: ErrorTypeTimeout,
+			expectMsg:  "Process killed by SIGKILL (exit code 137, no kernel OOM evidence found)",
+		},
+		{
+			name:       "exit 139, no kernel evidence -> not OOM",
+			exitCode:   139,
+			expectType: ErrorTypeTimeout,
+			expectMsg:  "Process killed by SIGSEGV (exit code 139, no kernel OOM evidence found)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := exec.Command("sh", "-c", fmt.Sprintf("exit %d", tt.exitCode))
+			exitErr := cmd.Run()
+			err := classifyClaudeCodeError("", exitErr, false, "", false)
+			if err.Type != tt.expectType {
+				t.Errorf("type = %q, want %q (must not be oom_killed without kernel evidence)", err.Type, tt.expectType)
+			}
+			if err.Type == ErrorTypeOOM {
+				t.Errorf("unconfirmed kill must never classify as oom_killed")
+			}
+			if tt.expectMsg != "" && err.Message != tt.expectMsg {
+				t.Errorf("message = %q, want %q", err.Message, tt.expectMsg)
+			}
+		})
+	}
+}
+
+// TestClassifyClaudeCodeError_SelfKillNotOOM covers the second half of the
+// GH-4412 fix: heartbeat-timeout and watchdog-timeout kills call
+// cmd.Process.Kill() directly rather than going through context
+// cancellation, so ctx.Err() stays nil for them. Before this fix they fell
+// straight into the ctxCancelled==false branch and were mislabeled
+// oom_killed even though Pilot itself killed the process on purpose.
+func TestClassifyClaudeCodeError_SelfKillNotOOM(t *testing.T) {
+	tests := []struct {
+		name           string
+		exitCode       int
+		selfKillReason string
+		expectType     ClaudeCodeErrorType
+		expectMsg      string
+	}{
+		{
+			name:           "heartbeat timeout kill -> shutdown_terminated, not OOM",
+			exitCode:       137,
+			selfKillReason: "heartbeat timeout",
+			expectType:     ErrorTypeShutdownTerminated,
+			expectMsg:      "Process terminated by SIGKILL after Pilot heartbeat timeout (exit code 137)",
+		},
+		{
+			name:           "watchdog timeout kill -> shutdown_terminated, not OOM",
+			exitCode:       137,
+			selfKillReason: "watchdog timeout",
+			expectType:     ErrorTypeShutdownTerminated,
+			expectMsg:      "Process terminated by SIGKILL after Pilot watchdog timeout (exit code 137)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := exec.Command("sh", "-c", fmt.Sprintf("exit %d", tt.exitCode))
+			exitErr := cmd.Run()
+			// kernelOOMConfirmed=true is passed to prove selfKillReason takes
+			// precedence over evidence — Pilot's own kill is never OOM
+			// regardless of what dmesg says (e.g. host memory pressure that
+			// didn't actually kill this process).
+			err := classifyClaudeCodeError("", exitErr, false, tt.selfKillReason, true)
+			if err.Type != tt.expectType {
+				t.Errorf("type = %q, want %q", err.Type, tt.expectType)
+			}
+			if err.Type == ErrorTypeOOM {
+				t.Errorf("self-inflicted kill must never classify as oom_killed")
+			}
+			if tt.expectMsg != "" && err.Message != tt.expectMsg {
+				t.Errorf("message = %q, want %q", err.Message, tt.expectMsg)
+			}
+		})
+	}
+}
+
+func TestClassifyClaudeCodeError_ShutdownVsOOM(t *testing.T) {
+	// GH-4105/GH-4412: exit 137/139 must be classified as oom_killed only
+	// when the run context was NOT already cancelled by our own
+	// shutdown/timeout path AND kernel dmesg evidence confirms an actual
+	// OOM-killer event. When the context was cancelled, the same exit codes
+	// are expected teardown noise and must be tagged shutdown_terminated
+	// instead. Without kernel evidence, an unexplained kill is tagged
+	// "timeout" (cause unconfirmed), never oom_killed.
+	tests := []struct {
+		name               string
+		exitCode           int
+		ctxCancelled       bool
+		kernelOOMConfirmed bool
+		expectType         ClaudeCodeErrorType
+		expectMsg          string
+	}{
+		{
+			// (a) exit 137, context not cancelled, kernel evidence -> oom_killed
+			name:               "exit 137, context not cancelled, kernel evidence -> oom_killed",
+			exitCode:           137,
+			ctxCancelled:       false,
+			kernelOOMConfirmed: true,
+			expectType:         ErrorTypeOOM,
+			expectMsg:          "Process killed by SIGKILL (exit code 137, confirmed via kernel OOM-killer log)",
+		},
+		{
+			// (a2) exit 137, context not cancelled, NO kernel evidence -> not oom_killed
+			name:         "exit 137, context not cancelled, no kernel evidence -> not oom_killed",
 			exitCode:     137,
 			ctxCancelled: false,
-			expectType:   ErrorTypeOOM,
-			expectMsg:    "Process killed by SIGKILL (exit code 137)",
+			expectType:   ErrorTypeTimeout,
+			expectMsg:    "Process killed by SIGKILL (exit code 137, no kernel OOM evidence found)",
 		},
 		{
 			// (b) exit 137, context cancelled -> shutdown classification
-			name:         "exit 137, context cancelled -> shutdown_terminated",
-			exitCode:     137,
-			ctxCancelled: true,
-			expectType:   ErrorTypeShutdownTerminated,
-			expectMsg:    "Process terminated by SIGKILL after context cancellation (exit code 137)",
+			// (kernel evidence irrelevant — our own teardown wins)
+			name:               "exit 137, context cancelled -> shutdown_terminated",
+			exitCode:           137,
+			ctxCancelled:       true,
+			kernelOOMConfirmed: true,
+			expectType:         ErrorTypeShutdownTerminated,
+			expectMsg:          "Process terminated by SIGKILL after context cancellation (exit code 137)",
 		},
 		{
 			// (c) exit 139 mirror
-			name:         "exit 139, context not cancelled -> oom_killed",
-			exitCode:     139,
-			ctxCancelled: false,
-			expectType:   ErrorTypeOOM,
-			expectMsg:    "Process killed by SIGSEGV (exit code 139)",
+			name:               "exit 139, context not cancelled, kernel evidence -> oom_killed",
+			exitCode:           139,
+			ctxCancelled:       false,
+			kernelOOMConfirmed: true,
+			expectType:         ErrorTypeOOM,
+			expectMsg:          "Process killed by SIGSEGV (exit code 139, confirmed via kernel OOM-killer log)",
 		},
 		{
-			name:         "exit 139, context cancelled -> shutdown_terminated",
+			name:         "exit 139, context not cancelled, no kernel evidence -> not oom_killed",
 			exitCode:     139,
-			ctxCancelled: true,
-			expectType:   ErrorTypeShutdownTerminated,
-			expectMsg:    "Process terminated by SIGSEGV after context cancellation (exit code 139)",
+			ctxCancelled: false,
+			expectType:   ErrorTypeTimeout,
+			expectMsg:    "Process killed by SIGSEGV (exit code 139, no kernel OOM evidence found)",
+		},
+		{
+			name:               "exit 139, context cancelled -> shutdown_terminated",
+			exitCode:           139,
+			ctxCancelled:       true,
+			kernelOOMConfirmed: true,
+			expectType:         ErrorTypeShutdownTerminated,
+			expectMsg:          "Process terminated by SIGSEGV after context cancellation (exit code 139)",
 		},
 		{
 			// (d) clean exit unaffected — no exit error at all, ctxCancelled must not
@@ -807,7 +936,7 @@ func TestClassifyClaudeCodeError_ShutdownVsOOM(t *testing.T) {
 				cmd := exec.Command("sh", "-c", fmt.Sprintf("exit %d", tt.exitCode))
 				exitErr = cmd.Run()
 			}
-			err := classifyClaudeCodeError("", exitErr, tt.ctxCancelled)
+			err := classifyClaudeCodeError("", exitErr, tt.ctxCancelled, "", tt.kernelOOMConfirmed)
 			if err.Type != tt.expectType {
 				t.Errorf("type = %q, want %q", err.Type, tt.expectType)
 			}
@@ -815,6 +944,83 @@ func TestClassifyClaudeCodeError_ShutdownVsOOM(t *testing.T) {
 				t.Errorf("message = %q, want %q", err.Message, tt.expectMsg)
 			}
 		})
+	}
+}
+
+// TestDmesgHasRecentOOMKill covers the dmesg-parsing evidence check added by
+// GH-4412. It must (a) match the kernel's "Killed process <pid>" signature
+// line, (b) require the line be at-or-after the `since` cutoff so a
+// recycled-PID entry from an unrelated, older process doesn't produce a
+// false positive, and (c) fail closed (no evidence) on any parse ambiguity.
+func TestDmesgHasRecentOOMKill(t *testing.T) {
+	// Fixed reference instant so timestamp math is deterministic regardless
+	// of when the test runs.
+	base := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.Local)
+
+	tests := []struct {
+		name   string
+		output string
+		pid    int
+		since  time.Time
+		want   bool
+	}{
+		{
+			name: "recent OOM kill for pid matches",
+			output: "[Fri Jul 17 11:59:00 2026] some unrelated line\n" +
+				"[Fri Jul 17 12:00:30 2026] Out of memory: Killed process 4242 (claude) total-vm:..., anon-rss:...",
+			pid:   4242,
+			since: base,
+			want:  true,
+		},
+		{
+			name:   "OOM kill for a different pid does not match",
+			output: "[Fri Jul 17 12:00:30 2026] Out of memory: Killed process 9999 (claude) total-vm:...",
+			pid:    4242,
+			since:  base,
+			want:   false,
+		},
+		{
+			name:   "stale entry before since cutoff does not match (recycled PID guard)",
+			output: "[Fri Jul 17 08:00:00 2026] Out of memory: Killed process 4242 (some-other-process) total-vm:...",
+			pid:    4242,
+			since:  base,
+			want:   false,
+		},
+		{
+			name:   "no dmesg output at all",
+			output: "",
+			pid:    4242,
+			since:  base,
+			want:   false,
+		},
+		{
+			name:   "matching text but unparseable timestamp is not evidence",
+			output: "[not-a-timestamp] Killed process 4242 (claude)",
+			pid:    4242,
+			since:  base,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dmesgHasRecentOOMKill(tt.output, tt.pid, tt.since)
+			if got != tt.want {
+				t.Errorf("dmesgHasRecentOOMKill() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHasKernelOOMEvidence_InvalidPID verifies the pid<=0 guard short-circuits
+// without spawning dmesg at all — defensive against callers that pass an
+// unset/negative pid (e.g. cmd.Process nil-checked incorrectly upstream).
+func TestHasKernelOOMEvidence_InvalidPID(t *testing.T) {
+	if hasKernelOOMEvidence(0, time.Now()) {
+		t.Error("hasKernelOOMEvidence(0, ...) should return false")
+	}
+	if hasKernelOOMEvidence(-1, time.Now()) {
+		t.Error("hasKernelOOMEvidence(-1, ...) should return false")
 	}
 }
 

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -1041,6 +1041,38 @@ func (d *Dispatcher) GetWorkerStatus() map[string]WorkerStatus {
 	return status
 }
 
+// GetRunningTaskIDs returns the task IDs every ProjectWorker is currently
+// processing. Unlike executor.Monitor.GetRunningTaskIDs (only populated in
+// --dashboard mode, see cmd/pilot/main.go's SetMonitor wiring), the
+// Dispatcher and its workers are always constructed, so this is the
+// authoritative "is a live worker actually holding this task right now"
+// signal regardless of dashboard/headless mode. GH-4412: the autopilot
+// orphan-running sweep previously relied solely on the optional Monitor for
+// this exclusion set, which is empty in headless (--telegram/--github only)
+// deployments — silently disabling the "live worker" guard and leaving only
+// the 10-minute execution_events heartbeat window to protect a genuinely
+// running task, which a single long-running tool call can easily exceed.
+func (d *Dispatcher) GetRunningTaskIDs() []string {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	var ids []string
+	for _, worker := range d.workers {
+		// Read currentTaskID/processing directly instead of worker.Status(),
+		// which also queries the store for QueuedCount — unneeded here and
+		// this can be called on every sweep tick.
+		if !worker.processing.Load() {
+			continue
+		}
+		if v := worker.currentTaskID.Load(); v != nil {
+			if taskID, ok := v.(string); ok && taskID != "" {
+				ids = append(ids, taskID)
+			}
+		}
+	}
+	return ids
+}
+
 // GetExecutionStatus returns the current status of an execution.
 func (d *Dispatcher) GetExecutionStatus(execID string) (*memory.Execution, error) {
 	return d.store.GetExecution(execID)

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -271,6 +271,59 @@ func TestDispatcher_GetWorkerStatus(t *testing.T) {
 	}
 }
 
+// TestDispatcher_GetRunningTaskIDs verifies the GH-4412 always-on liveness
+// signal: it must report exactly the task IDs of workers currently marked
+// processing, and must not report idle workers or workers with no current
+// task. This is what the autopilot orphan-running sweep unions with the
+// (dashboard-only) Monitor's set so a live worker is never mistaken for an
+// orphan when the daemon runs headless (no --dashboard, no Monitor wired).
+func TestDispatcher_GetRunningTaskIDs(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runner := NewRunner()
+	dispatcher := NewDispatcher(store, runner, nil)
+
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	// No workers yet.
+	if ids := dispatcher.GetRunningTaskIDs(); len(ids) != 0 {
+		t.Errorf("expected 0 running task IDs with no workers, got %v", ids)
+	}
+
+	log := slog.Default()
+	idleWorker := NewProjectWorker("/proj-idle", store, runner, log)
+	dispatcher.mu.Lock()
+	dispatcher.workers["/proj-idle"] = idleWorker
+	dispatcher.mu.Unlock()
+
+	// Idle worker (processing=false) must not be reported live.
+	if ids := dispatcher.GetRunningTaskIDs(); len(ids) != 0 {
+		t.Errorf("expected 0 running task IDs with only an idle worker, got %v", ids)
+	}
+
+	liveWorker := NewProjectWorker("/proj-live", store, runner, log)
+	liveWorker.processing.Store(true)
+	liveWorker.currentTaskID.Store("GH-4412")
+	dispatcher.mu.Lock()
+	dispatcher.workers["/proj-live"] = liveWorker
+	dispatcher.mu.Unlock()
+
+	ids := dispatcher.GetRunningTaskIDs()
+	if len(ids) != 1 || ids[0] != "GH-4412" {
+		t.Errorf("expected [GH-4412], got %v", ids)
+	}
+
+	// Once the worker goes idle again, it must drop out of the live set.
+	liveWorker.processing.Store(false)
+	if ids := dispatcher.GetRunningTaskIDs(); len(ids) != 0 {
+		t.Errorf("expected 0 running task IDs after worker goes idle, got %v", ids)
+	}
+}
+
 func TestDispatcher_MultipleProjects(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

Fixes #4412 — a live 14-minute-old execution was declared orphaned by the
autopilot orphan-running sweep, killed, and the resulting SIGKILL was then
misdiagnosed by the executor's error classifier as an OOM kill (no kernel
evidence), causing the task to silently re-queue and re-run from scratch.

Three fixes, one per root cause identified in the issue:

- **Live-worker check** (3be7c5a7): `sweepOrphanedRunningExecutions` only
  excluded live tasks via the dashboard-only in-process `Monitor`, so in
  headless mode (`pilot start --telegram --github`, no `--dashboard`) the
  exclusion set was always empty. Added `Dispatcher.GetRunningTaskIDs()`,
  an always-on liveness signal wired unconditionally in both gateway and
  polling-mode startup paths.
- **Heartbeat window floor** (4a1c3b68): the sweep's 10-minute heartbeat
  window was far below every legitimate runner ceiling (30-60m task
  timeouts, 120m watchdog kill floor). Added `minOrphanRunningThreshold`
  (120m) mirroring GH-4092's eviction-floor fix, via
  `effectiveOrphanRunningWindow()`.
- **Kernel-evidence-gated OOM classification** (this commit): exit
  137/139 was labeled `oom_killed` any time `ctx.Err()` was nil, with no
  corroborating evidence. Heartbeat/watchdog self-kills (which use
  `cmd.Process.Kill()` directly, bypassing the ctx-cancellation guard) and
  any other unexplained SIGKILL both got mislabeled OOM. Now:
  self-kills are tracked via `atomic.Bool` flags and classified as the
  same terminated-on-purpose type already used for ctx cancellation;
  remaining ambiguous kills require a `dmesg -T` "Killed process \<pid\>"
  hit timestamped after the subprocess started, else they fall back to
  the existing `timeout` bucket rather than defaulting to OOM.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/executor/...`
- [x] `go test ./internal/executor/...` (full suite, incl. new
      `TestClassifyClaudeCodeError_UnconfirmedKillNotOOM`,
      `TestClassifyClaudeCodeError_SelfKillNotOOM`, `TestDmesgHasRecentOOMKill`)
- [x] `go test ./internal/autopilot/... ./internal/alerts/... ./internal/memory/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/executor/...` — 0 issues
- [x] `gofmt -l` clean on all changed files