### PR TITLE
fix(executor): reconcile plan-vs-existing on partial epic sub-issue recovery (GH-4406)

### DIFF
--- a/.agent/tasks/gh-4406.md
+++ b/.agent/tasks/gh-4406.md
@@ -1,0 +1,37 @@
+# GH-4406
+
+**Created:** 2026-07-17
+
+## Problem
+
+GitHub Issue GH-4406: fix(executor): epic sub-issue recovery livelock when partial children exist — refuses to create missing subs, declines, retries forever (pointer GH-8)
+
+## Symptom
+
+Pointer epic GH-8 ("TASK-03: MariaDB Adapter") is in a deterministic decline→retry livelock:
+
+```
+11:10:41 msg="Skipping sub-issue creation: open children already exist" parent_id=GH-8
+11:10:41 msg="Sub-issues already exist, attempting recovery" task_id=GH-8
+11:10:42 ERROR msg="sub-issue creation incomplete — refusing to finalize epic parent" planned=9 created=2 cause="open sub-issues already exist for this parent"
+11:10:42 msg="Task ended without success" task_id=GH-8 status=declined
+11:10:42 msg="Execution failed without PR, unmarking for retry" number=8
+```
+
+Planner wants 9 sub-issues; 2 open children exist (from a prior attempt); recovery refuses to create the missing 7 because "open sub-issues already exist"; the epic declines; the poller unmarks it for retry; next cycle repeats identically. Each cycle burns a full planning run (~45s + planning tokens).
+
+## Expected
+
+Recovery should reconcile plan-vs-existing: adopt matching open children, create only the missing sub-issues (dedup by title), then finalize. Refusing entirely is only right if the existing children conflict with the plan.
+
+## Consequence
+
+GH-8 can never proceed, and it serializes the pointer project queue (tasks log "queued behind GH-8"). This also blocks the #4388 verification gate (pointer epics GH-8/GH-10 completing without reconcileChildOutcome timeouts).
+
+## Refs
+
+- Related: prefixed-id `gh` CLI failures on the same path (filed separately) mean the coverage-gap comment/label that would have surfaced this never landed on the issue.
+- TASK-401 (single-child decomposition fixes) touched adjacent code.
+
+## Acceptance Criteria
+

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -1301,6 +1301,114 @@ func creatableSubtasks(subtasks []PlannedSubtask, parentID string, log *slog.Log
 	return foldVerifyOnlySubtasks(valid)
 }
 
+// normalizeSubtaskTitleForMatch canonicalizes a subtask title for recovery
+// reconciliation (GH-4406): case-insensitive, whitespace-trimmed, and
+// truncated to the same 80-char limit createSubIssuesViaGitHub/
+// createSubIssuesViaAdapter enforce via truncateTitle. This mirrors the
+// deterministic part of those functions' title-resolution pipeline, so a
+// freshly planned subtask's raw title compares equal to an already-created
+// issue's title in the common case (a well-formed conventional-commit title
+// never hits the analysis-title fallback in validateSubtaskTitle).
+func normalizeSubtaskTitleForMatch(title string) string {
+	return strings.ToLower(strings.TrimSpace(truncateTitle(title, 80)))
+}
+
+// reconcileRecoveredSubIssues matches recovered (already-existing) sub-issues
+// against the current plan's subtasks by normalized title (GH-4406). Matched
+// recovered issues are "adopted" — kept with their real tracker state/number,
+// but re-attached to this run's PlannedSubtask so Order/DependsOn/
+// Description reflect the current plan rather than whatever the prior run's
+// issue body happened to contain. Planned subtasks with no matching
+// recovered issue are returned as `missing` for the caller to create.
+func reconcileRecoveredSubIssues(planned []PlannedSubtask, recovered []CreatedIssue) (adopted []CreatedIssue, missing []PlannedSubtask) {
+	byTitle := make(map[string]CreatedIssue, len(recovered))
+	for _, iss := range recovered {
+		byTitle[normalizeSubtaskTitleForMatch(iss.Subtask.Title)] = iss
+	}
+
+	claimed := make(map[string]bool, len(recovered))
+	for _, st := range planned {
+		key := normalizeSubtaskTitleForMatch(st.Title)
+		if iss, ok := byTitle[key]; ok && !claimed[key] {
+			iss.Subtask = st
+			adopted = append(adopted, iss)
+			claimed[key] = true
+			continue
+		}
+		missing = append(missing, st)
+	}
+	return adopted, missing
+}
+
+// reconcilePartialSubIssueRecovery is the GH-4406 fix for the epic recovery
+// livelock: when recoverExistingSubIssues finds fewer children than the
+// current plan calls for, the old behavior treated ANY shortfall as a hard
+// coverage gap and declined unconditionally — so a partially-decomposed
+// epic (e.g., 2 of 9 planned sub-issues created by a prior, interrupted run)
+// would replan the same subtasks, recover the same 2 pre-existing children,
+// and decline again on every retry cycle, forever.
+//
+// This adopts recovered issues that match a planned subtask by (normalized)
+// title, then creates issues ONLY for the planned subtasks that have no
+// match — it never re-creates a sub-issue that already exists. If none of
+// the recovered issues match any planned subtask, the existing children are
+// assumed to be stale/unrelated to this plan (a genuine conflict) and are
+// returned unchanged so the caller falls back to its existing
+// decline-and-flag path (handleSubIssueCoverageGap).
+func (r *Runner) reconcilePartialSubIssueRecovery(ctx context.Context, plan *EpicPlan, planned []PlannedSubtask, recovered []CreatedIssue, executionPath string) ([]CreatedIssue, error) {
+	adopted, missing := reconcileRecoveredSubIssues(planned, recovered)
+	if len(adopted) == 0 || len(missing) == 0 {
+		// Nothing recognizable to adopt (a genuine conflict — let the caller
+		// decline), or nothing missing (the recovered set already covers the
+		// plan by title despite a raw count mismatch, e.g. duplicate titles).
+		return recovered, nil
+	}
+
+	r.log.Info("Reconciling partial sub-issue recovery: adopting matched children, creating missing subtasks",
+		"parent_id", plan.ParentTask.ID,
+		"adopted", len(adopted),
+		"missing", len(missing),
+	)
+
+	missingPlan := &EpicPlan{
+		ParentTask:  plan.ParentTask,
+		Subtasks:    missing,
+		TotalEffort: plan.TotalEffort,
+		PlanOutput:  plan.PlanOutput,
+	}
+
+	// Mirrors the useAdapterCreator determination in CreateSubIssues so the
+	// missing subtasks are created through the same backend the initial
+	// (blocked) creation attempt would have used.
+	useAdapterCreator := r.subIssueCreator != nil &&
+		plan.ParentTask != nil &&
+		plan.ParentTask.SourceAdapter != "" &&
+		plan.ParentTask.SourceAdapter != "github"
+
+	var createdMissing []CreatedIssue
+	var err error
+	if useAdapterCreator {
+		createdMissing, err = r.createSubIssuesViaAdapter(ctx, missingPlan)
+	} else {
+		createdMissing, err = r.createSubIssuesViaGitHub(ctx, missingPlan, executionPath)
+	}
+
+	merged := make([]CreatedIssue, 0, len(adopted)+len(createdMissing))
+	merged = append(merged, adopted...)
+	for _, iss := range createdMissing {
+		// createSubIssuesViaGitHub/createSubIssuesViaAdapter never set State —
+		// it's only populated by recoverExistingSubIssues. A sub-issue that
+		// was just created is always open; without this, the caller's
+		// State=="open" filter (runner.go, after this reconciliation) would
+		// silently drop every freshly-created child from execution.
+		if iss.State == "" {
+			iss.State = "open"
+		}
+		merged = append(merged, iss)
+	}
+	return merged, err
+}
+
 // createSubIssuesViaAdapter creates sub-issues using the SubIssueCreator interface.
 // Used for non-GitHub adapters like Linear, Jira, GitLab, Azure DevOps.
 func (r *Runner) createSubIssuesViaAdapter(ctx context.Context, plan *EpicPlan) ([]CreatedIssue, error) {

--- a/internal/executor/gh4406_test.go
+++ b/internal/executor/gh4406_test.go
@@ -1,0 +1,251 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// gh4406ThreeSubtasks returns three subtasks across distinct directories
+// (so isSinglePackageScope doesn't consolidate them into a single task),
+// mirroring the pointer epic GH-8 shape from the bug report: a plan wants
+// N sub-issues, but only some of them survived a prior, interrupted run.
+func gh4406ThreeSubtasks() []PlannedSubtask {
+	return []PlannedSubtask{
+		{Order: 1, Title: "feat(gateway): add websocket handler", Description: "Implement upgrade handler in internal/gateway/server.go"},
+		{Order: 2, Title: "feat(adapters): add telegram bot", Description: "Wire bot client in internal/adapters/telegram/bot.go"},
+		{Order: 3, Title: "feat(vectors): add duckdb store", Description: "Add vector store in internal/knowledge/vectors/store.go"},
+	}
+}
+
+// TestReconcileRecoveredSubIssues_AdoptsMatchesAndReportsMissing is the core
+// GH-4406 unit test: given a plan of 3 subtasks and only 2 recovered issues
+// whose titles match subtasks 1 and 3, the reconciler must adopt those two
+// and report subtask 2 as the only one missing — not decline the whole
+// batch because the raw counts (2 recovered vs 3 planned) don't line up.
+func TestReconcileRecoveredSubIssues_AdoptsMatchesAndReportsMissing(t *testing.T) {
+	planned := gh4406ThreeSubtasks()
+	recovered := []CreatedIssue{
+		{Number: 301, State: "open", Subtask: PlannedSubtask{Title: "feat(gateway): add websocket handler"}},
+		{Number: 303, State: "open", Subtask: PlannedSubtask{Title: "feat(vectors): add duckdb store"}},
+	}
+
+	adopted, missing := reconcileRecoveredSubIssues(planned, recovered)
+
+	if len(adopted) != 2 {
+		t.Fatalf("adopted = %d, want 2", len(adopted))
+	}
+	if len(missing) != 1 {
+		t.Fatalf("missing = %d, want 1", len(missing))
+	}
+	if missing[0].Title != "feat(adapters): add telegram bot" {
+		t.Errorf("missing[0].Title = %q, want the un-recovered second subtask", missing[0].Title)
+	}
+
+	// Adopted issues must keep their real tracker identity...
+	gotNumbers := map[int]bool{}
+	for _, iss := range adopted {
+		gotNumbers[iss.Number] = true
+	}
+	if !gotNumbers[301] || !gotNumbers[303] {
+		t.Errorf("adopted issue numbers = %v, want 301 and 303 preserved", gotNumbers)
+	}
+	// ...but be re-attached to the current plan's PlannedSubtask (Order set).
+	for _, iss := range adopted {
+		if iss.Subtask.Order == 0 {
+			t.Errorf("adopted issue %d has zero Order — expected it re-attached to the current plan's subtask", iss.Number)
+		}
+	}
+}
+
+// TestReconcileRecoveredSubIssues_NoMatchIsConflict covers the "refusing
+// entirely is only right if the existing children conflict with the plan"
+// half of the GH-4406 spec: when none of the recovered issues' titles match
+// any planned subtask, nothing should be adopted — every planned subtask
+// comes back as missing, signaling the caller should not blindly create over
+// unrelated existing children.
+func TestReconcileRecoveredSubIssues_NoMatchIsConflict(t *testing.T) {
+	planned := gh4406ThreeSubtasks()
+	recovered := []CreatedIssue{
+		{Number: 501, State: "open", Subtask: PlannedSubtask{Title: "chore(unrelated): totally different work"}},
+	}
+
+	adopted, missing := reconcileRecoveredSubIssues(planned, recovered)
+
+	if len(adopted) != 0 {
+		t.Fatalf("adopted = %d, want 0 (no titles match — this is a conflict, not partial progress)", len(adopted))
+	}
+	if len(missing) != len(planned) {
+		t.Fatalf("missing = %d, want %d (every planned subtask, since nothing recovered matches)", len(missing), len(planned))
+	}
+}
+
+// TestReconcilePartialSubIssueRecovery_CreatesOnlyMissingSubtasks drives the
+// Runner method end-to-end against a faked `gh` CLI: 2 of 3 planned
+// subtasks already exist (recovered), 1 is missing. The reconciler must
+// create an issue for ONLY the missing subtask — never re-invoking `gh issue
+// create` for the two that already exist — and return all 3 as the merged
+// set.
+func TestReconcilePartialSubIssueRecovery_CreatesOnlyMissingSubtasks(t *testing.T) {
+	fakeBin := t.TempDir()
+	logFile := filepath.Join(t.TempDir(), "gh-calls.log")
+	script := filepath.Join(fakeBin, "gh")
+	content := "#!/bin/sh\n" +
+		`echo "$@" >> "` + logFile + `"
+if [ "$1" = "issue" ] && [ "$2" = "create" ]; then
+  echo "https://github.com/owner/repo/issues/999"
+fi
+`
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	origPATH := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+origPATH)
+
+	subtasks := gh4406ThreeSubtasks()
+	plan := &EpicPlan{
+		ParentTask: &Task{ID: "GH-4406P"},
+		Subtasks:   subtasks,
+	}
+	recovered := []CreatedIssue{
+		{Number: 301, State: "open", Subtask: subtasks[0]},
+		{Number: 303, State: "open", Subtask: subtasks[2]},
+	}
+
+	runner := NewRunner()
+
+	merged, err := runner.reconcilePartialSubIssueRecovery(context.Background(), plan, subtasks, recovered, t.TempDir())
+	if err != nil {
+		t.Fatalf("reconcilePartialSubIssueRecovery returned error: %v", err)
+	}
+	if len(merged) != 3 {
+		t.Fatalf("merged = %d, want 3 (2 adopted + 1 newly created)", len(merged))
+	}
+
+	logData, _ := os.ReadFile(logFile)
+	createCount := strings.Count(string(logData), "issue create")
+	if createCount != 1 {
+		t.Errorf("gh issue create invocation count = %d, want 1 (only the missing subtask), log:\n%s", createCount, logData)
+	}
+	if !strings.Contains(string(logData), "feat(adapters): add telegram bot") {
+		t.Errorf("expected the missing subtask's title in the gh issue create call, log:\n%s", logData)
+	}
+}
+
+// TestRunner_Execute_EpicReconcilesPartialRecoveryByCreatingMissingSubtasks
+// is the GH-4406 regression test for the reported livelock: pointer epic
+// GH-8 wanted N sub-issues, found fewer already-open children from a prior
+// attempt, and declined forever because recovery refused to create the
+// missing ones. This drives the real r.Execute entry point end-to-end with
+// a faked `gh` CLI and confirms the epic proceeds (adopts the 2 existing
+// children, creates the 1 missing one, executes all 3) instead of
+// declining.
+func TestRunner_Execute_EpicReconcilesPartialRecoveryByCreatingMissingSubtasks(t *testing.T) {
+	fakeBin := t.TempDir()
+	logFile := filepath.Join(t.TempDir(), "gh-calls.log")
+	script := filepath.Join(fakeBin, "gh")
+	content := "#!/bin/sh\n" +
+		`echo "$@" >> "` + logFile + `"
+if [ "$1" = "issue" ] && [ "$2" = "create" ]; then
+  echo "https://github.com/owner/repo/issues/999"
+fi
+`
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	origPATH := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+origPATH)
+
+	subtasks := gh4406ThreeSubtasks()
+
+	r := NewRunner()
+	r.skipPreflightChecks = true
+
+	r.openSubIssueCheck = func(_ context.Context, _, _ string) (bool, error) {
+		return true, nil // force ErrSubIssuesAlreadyExist -> recovery path
+	}
+	// Only subtasks 1 and 3 survived a prior partial run; subtask 2 was
+	// never created — the exact GH-4406 livelock shape (planner wants N,
+	// fewer than N children exist).
+	r.recoverSubIssuesFn = func(_ context.Context, _, _ string) ([]CreatedIssue, error) {
+		return []CreatedIssue{
+			{Number: 301, State: "open", Subtask: subtasks[0]},
+			{Number: 303, State: "open", Subtask: subtasks[2]},
+		}, nil
+	}
+	r.planEpicFn = func(_ context.Context, task *Task, _ string) (*EpicPlan, error) {
+		return &EpicPlan{ParentTask: task, Subtasks: subtasks}, nil
+	}
+
+	var executedIDs []string
+	r.executeFunc = func(_ context.Context, task *Task) (*ExecutionResult, error) {
+		executedIDs = append(executedIDs, task.ID)
+		// Non-zero tokens/files so the zero-delivery no_op guard
+		// (classifyZeroDeliveryEpicCompletion) doesn't reclassify this
+		// otherwise-successful epic — unrelated to the GH-4406 fix under test.
+		return &ExecutionResult{TaskID: task.ID, Success: true, TokensOutput: 100, FilesChanged: 1}, nil
+	}
+
+	task := &Task{ID: "GH-4406R", Title: "[epic] partial recovery reconciliation test"}
+
+	result, err := r.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute returned unexpected error: %v", err)
+	}
+	if result == nil || !result.Success {
+		t.Fatalf("expected successful epic result, got: %+v", result)
+	}
+	if result.Declined {
+		t.Error("expected Declined=false — the gap should have been reconciled instead of declined forever")
+	}
+	if len(executedIDs) != 3 {
+		t.Fatalf("expected 3 child executions (2 adopted + 1 newly created), got %d: %v", len(executedIDs), executedIDs)
+	}
+
+	logData, _ := os.ReadFile(logFile)
+	createCount := strings.Count(string(logData), "issue create")
+	if createCount != 1 {
+		t.Errorf("expected exactly 1 `gh issue create` call (only the missing subtask), got %d, log:\n%s", createCount, logData)
+	}
+}
+
+// TestRunner_Execute_EpicRecoveryConflictStillDeclines guards the other half
+// of the GH-4406 spec: when the recovered children's titles don't match the
+// current plan at all (a genuine conflict — e.g. stale children from an
+// unrelated prior decomposition), the epic must still decline rather than
+// blindly creating a full new batch on top of the unrelated existing
+// issues.
+func TestRunner_Execute_EpicRecoveryConflictStillDeclines(t *testing.T) {
+	subtasks := gh4406ThreeSubtasks()
+
+	r := NewRunner()
+	r.skipPreflightChecks = true
+	r.dryRun = true
+
+	r.openSubIssueCheck = func(_ context.Context, _, _ string) (bool, error) {
+		return true, nil
+	}
+	r.recoverSubIssuesFn = func(_ context.Context, _, _ string) ([]CreatedIssue, error) {
+		return []CreatedIssue{
+			{Number: 601, State: "open", Subtask: PlannedSubtask{Title: "chore(unrelated): totally different work"}},
+		}, nil
+	}
+	r.planEpicFn = func(_ context.Context, task *Task, _ string) (*EpicPlan, error) {
+		return &EpicPlan{ParentTask: task, Subtasks: subtasks}, nil
+	}
+
+	task := &Task{ID: "GH-4406C", Title: "[epic] recovery conflict test"}
+
+	result, err := r.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute returned unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if !result.Declined {
+		t.Error("expected Declined=true — unrelated existing children must not be treated as partial progress")
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2116,20 +2116,34 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 						// as if the plan were fully covered.
 						plannedNow := creatableSubtasks(plan.Subtasks, plan.ParentTask.ID, nil)
 						if len(recovered) < len(plannedNow) {
-							gapPlan := &EpicPlan{ParentTask: plan.ParentTask, Subtasks: plannedNow, TotalEffort: plan.TotalEffort, PlanOutput: plan.PlanOutput}
-							gapErr := r.handleSubIssueCoverageGap(ctx, gapPlan, recovered, executionPath, err)
-							r.reportProgress(task.ID, "Needs Clarification", 100, gapErr.Error())
-							return &ExecutionResult{
-								TaskID:         task.ID,
-								Success:        false,
-								Declined:       true,
-								DeclinedReason: gapErr.Error(),
-								Outcome:        "declined",
-								Error:          gapErr.Error(),
-								Duration:       time.Since(start),
-								IsEpic:         true,
-								EpicPlan:       plan,
-							}, nil
+							// GH-4406: a raw shortfall isn't necessarily a coverage gap —
+							// reconcile plan-vs-existing before declining. Adopts recovered
+							// children that match a planned subtask by title and creates
+							// issues only for the ones genuinely missing; only a real
+							// conflict (nothing recovered matches the plan) or a failed
+							// creation attempt falls through to the decline below.
+							reconciled, reconcileErr := r.reconcilePartialSubIssueRecovery(ctx, plan, plannedNow, recovered, executionPath)
+							cause := err
+							if reconcileErr != nil {
+								cause = reconcileErr
+							}
+							if len(reconciled) < len(plannedNow) {
+								gapPlan := &EpicPlan{ParentTask: plan.ParentTask, Subtasks: plannedNow, TotalEffort: plan.TotalEffort, PlanOutput: plan.PlanOutput}
+								gapErr := r.handleSubIssueCoverageGap(ctx, gapPlan, reconciled, executionPath, cause)
+								r.reportProgress(task.ID, "Needs Clarification", 100, gapErr.Error())
+								return &ExecutionResult{
+									TaskID:         task.ID,
+									Success:        false,
+									Declined:       true,
+									DeclinedReason: gapErr.Error(),
+									Outcome:        "declined",
+									Error:          gapErr.Error(),
+									Duration:       time.Since(start),
+									IsEpic:         true,
+									EpicPlan:       plan,
+								}, nil
+							}
+							recovered = reconciled
 						}
 
 						if allChildrenDone(recovered) {


### PR DESCRIPTION
## Summary

Fixes the epic sub-issue recovery livelock described in #4406: when the `ErrSubIssuesAlreadyExist` recovery pass found fewer children than the current plan required, the executor declined unconditionally — even when the existing children were a genuine subset of the plan. The poller then retries the same epic, replanning the same subtasks and hitting the identical shortfall on every cycle (pointer epic GH-8's decline→retry loop).

- Added `reconcileRecoveredSubIssues` (pure) which matches recovered issues against the current plan by normalized title, returning the adopted matches and the still-missing planned subtasks.
- Added `Runner.reconcilePartialSubIssueRecovery`, which adopts the matches and creates issues only for the subtasks that are genuinely missing (via the same GitHub/adapter backend `CreateSubIssues` would have used), instead of recreating everything or refusing outright.
- Wired this into the `ErrSubIssuesAlreadyExist` recovery path in `runner.go`: a shortfall now only falls through to the existing decline-and-flag path (`handleSubIssueCoverageGap`) when none of the recovered issues match the plan at all (a genuine conflict) or the missing-subtask creation itself fails.
- Freshly created sub-issues are marked `State: "open"` so they aren't silently dropped by the caller's open-children execution filter.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/executor/...` (full package, including new `gh4406_test.go`)
- [x] `go test ./...` (whole repo)
- [x] `go vet ./...`
- [x] New tests cover: title-matching adoption/missing split, conflict detection (no title matches → still declines), end-to-end `Runner.reconcilePartialSubIssueRecovery` creating only the missing subtask against a faked `gh` CLI, and a full `r.Execute` regression reproducing the GH-8 livelock shape (2 of 3 planned children recovered) now reconciling and executing instead of declining forever.