### PR TITLE
feat(executor): guard finalize path against deleting graph-indexed memory files (GH-4387)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-17 (v2.151.0)
+**Last Updated:** 2026-07-16 (v2.151.0)
 
 ## Legend
 
@@ -228,6 +228,7 @@
 | CI log pattern learning | ✅ | autopilot | - | - | Wire CI log learning into autopilot feedback loop (v2.50.0, PR #1977) |
 | Staticcheck S1011 fix | ✅ | memory | - | - | Replace loop with append for staticcheck compliance (v2.46.1, PR #1971) |
 | Execution stage ledger (data layer) | ✅ | memory | - | - | `execution_events` table + Stage enum, `InsertExecutionEvent`/`ListExecutionEvents`/`ListExecutionsForTask`; no consumers wired yet (TASK-379 C3, GH-3844, v2.208.0) |
+| Graph-indexed memory-file deletion guard | ✅ | executor | - | - | `GitOperations.RestoreDeletedIndexedMemoryDocs` runs in the finalize path (before push) on all three PR-creating paths (direct, epic, decomposed-parent): restores any `.agent/knowledge/memories/**` file the branch deleted despite a surviving node in `.agent/knowledge/graph.json` (handles both `file` and legacy `path` node keys, resolved as of the base branch so a since-deleted file can still be matched), commits the restoration, logs a WARN, and records `memory.StageMemoryGuardRestore`. No-ops when `graph.json` is absent. Converts the recurring "drift gate red, PR wedged in awaiting" failure class (PR #4385, #4375) into a self-healing no-op (GH-4387, v2.241.2+) |
 
 ## Dashboard
 

--- a/internal/executor/git.go
+++ b/internal/executor/git.go
@@ -307,6 +307,191 @@ func (g *GitOperations) StripUnindexedMemoryDocs(ctx context.Context, baseBranch
 	return unindexed, nil
 }
 
+// deletedMemoryDocs returns memory doc paths (relative to the repo root)
+// deleted between baseBranch and HEAD. Mirrors addedMemoryDocs but for
+// diff-filter=D (deletions) instead of =A (additions).
+func (g *GitOperations) deletedMemoryDocs(ctx context.Context, baseBranch string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "git", "diff", "--name-only", "--diff-filter=D",
+		baseBranch+"...HEAD", "--", memoryDocsRelDir)
+	cmd.Dir = g.projectPath
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to diff deleted memory docs: %w", err)
+	}
+
+	var docs []string
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if line == "" || !strings.HasSuffix(line, ".md") {
+			continue
+		}
+		docs = append(docs, line)
+	}
+	return docs, nil
+}
+
+// existsAtRef reports whether path resolves as of ref (e.g. "git cat-file -e
+// ref:path").
+func (g *GitOperations) existsAtRef(ctx context.Context, ref, path string) bool {
+	cmd := exec.CommandContext(ctx, "git", "cat-file", "-e", ref+":"+path)
+	cmd.Dir = g.projectPath
+	return cmd.Run() == nil
+}
+
+// readAtRef returns the contents of path as of ref (e.g. "git show
+// ref:path").
+func (g *GitOperations) readAtRef(ctx context.Context, ref, path string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", "show", ref+":"+path)
+	cmd.Dir = g.projectPath
+	return cmd.Output()
+}
+
+// indexedMemoryPathsAtRef is indexedMemoryPaths' resolution logic run
+// against a git ref (typically baseBranch) instead of the live worktree. It
+// exists because RestoreDeletedIndexedMemoryDocs must resolve which paths
+// graph.json indexed BEFORE a later commit deleted them: by the time that
+// deletion has happened, indexedMemoryPaths' os.Stat-based resolution can no
+// longer see the file on disk to confirm the candidate path. Reading through
+// `git show`/`git cat-file -e` against ref instead resolves against that
+// ref's tree, which still has both graph.json and the (not-yet-deleted)
+// memory file. Returns (nil, nil) when graph.json does not resolve at ref —
+// a project without the file has no drift gate to protect.
+func (g *GitOperations) indexedMemoryPathsAtRef(ctx context.Context, ref string) (map[string]string, error) {
+	if !g.existsAtRef(ctx, ref, graphJSONRelPath) {
+		return nil, nil
+	}
+	raw, err := g.readAtRef(ctx, ref, graphJSONRelPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read graph.json at %s: %w", ref, err)
+	}
+
+	var graph struct {
+		Nodes struct {
+			Memories map[string]map[string]any `json:"memories"`
+		} `json:"nodes"`
+	}
+	if err := json.Unmarshal(raw, &graph); err != nil {
+		return nil, fmt.Errorf("failed to parse graph.json at %s: %w", ref, err)
+	}
+
+	indexed := make(map[string]string)
+	for nodeID, node := range graph.Nodes.Memories {
+		for _, field := range graphJSONPathFields {
+			rawPath, ok := node[field].(string)
+			if !ok {
+				continue
+			}
+			for _, candidate := range []string{
+				rawPath,
+				filepath.ToSlash(filepath.Join(".agent", "knowledge", rawPath)),
+			} {
+				if g.existsAtRef(ctx, ref, candidate) {
+					indexed[candidate] = nodeID
+					break
+				}
+			}
+			break
+		}
+	}
+	return indexed, nil
+}
+
+// RestoredMemoryDoc pairs a restored memory-doc path with the graph node
+// that still references it (GH-4387).
+type RestoredMemoryDoc struct {
+	// Path is the repo-relative path of the restored file.
+	Path string
+	// NodeID is the .agent/knowledge/graph.json node id that references Path.
+	NodeID string
+}
+
+// RestoreDeletedIndexedMemoryDocs detects memory doc deletions (relative to
+// baseBranch) that removed a file still referenced by a node in
+// .agent/knowledge/graph.json as of baseBranch, restores each such file from
+// baseBranch, and commits the restoration. Returns the restored (path,
+// nodeID) pairs, or (nil, nil) if there was nothing to restore.
+//
+// GH-4387: executor sessions have repeatedly deleted indexed memory files
+// during end-of-run hygiene (commit messages like "chore(memory): strip
+// unindexed memory doc(s)"), judging them unindexed when a graph node in
+// fact still references them. The graph node then dangles — the Knowledge
+// Graph Drift Gate's "Broken file links" check (scripts/check-graph.py)
+// fails CI, autopilot approval never fires, and the PR wedges in
+// awaiting-approval (PR #4385, #4375). Restoring here (fail-safe, mirroring
+// StripUnindexedMemoryDocs' fail-safe-in-the-other-direction posture)
+// converts that failure class into a no-op instead of a stuck PR.
+func (g *GitOperations) RestoreDeletedIndexedMemoryDocs(ctx context.Context, baseBranch string) ([]RestoredMemoryDoc, error) {
+	deleted, err := g.deletedMemoryDocs(ctx, baseBranch)
+	if err != nil || len(deleted) == 0 {
+		return nil, err
+	}
+
+	indexed, err := g.indexedMemoryPathsAtRef(ctx, baseBranch)
+	if err != nil {
+		return nil, err
+	}
+	if indexed == nil {
+		// No graph.json at base - nothing to protect.
+		return nil, nil
+	}
+
+	var restored []RestoredMemoryDoc
+	var paths []string
+	for _, doc := range deleted {
+		if nodeID, ok := indexed[doc]; ok {
+			restored = append(restored, RestoredMemoryDoc{Path: doc, NodeID: nodeID})
+			paths = append(paths, doc)
+		}
+	}
+	if len(restored) == 0 {
+		return nil, nil
+	}
+
+	checkoutArgs := append([]string{"checkout", baseBranch, "--"}, paths...)
+	checkoutCmd := exec.CommandContext(ctx, "git", checkoutArgs...)
+	checkoutCmd.Dir = g.projectPath
+	if output, err := checkoutCmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("failed to restore deleted indexed memory doc(s): %w: %s", err, output)
+	}
+
+	var msg strings.Builder
+	msg.WriteString("chore(memory): restore graph-indexed memory doc(s) deleted during execution\n\n")
+	msg.WriteString("GH-4387: these file(s) were deleted from this branch but are still\n")
+	msg.WriteString("referenced by a node in .agent/knowledge/graph.json. Left deleted, the\n")
+	msg.WriteString("dangling node trips the Knowledge Graph Drift Gate. Restored:\n")
+	for _, rd := range restored {
+		fmt.Fprintf(&msg, "- %s (node %s)\n", rd.Path, rd.NodeID)
+	}
+
+	commitCmd := exec.CommandContext(ctx, "git", "commit", "-m", msg.String())
+	commitCmd.Dir = g.projectPath
+	if output, err := commitCmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("failed to commit restored memory doc(s): %w: %s", err, output)
+	}
+
+	return restored, nil
+}
+
+// restoredMemoryDocPaths extracts the Path field from a RestoredMemoryDoc
+// slice for compact logging (e.g. slog.Any("files", ...)).
+func restoredMemoryDocPaths(restored []RestoredMemoryDoc) []string {
+	paths := make([]string, len(restored))
+	for i, rd := range restored {
+		paths[i] = rd.Path
+	}
+	return paths
+}
+
+// formatRestoredMemoryDocs renders a RestoredMemoryDoc slice as the
+// execution-event Detail string for memory.StageMemoryGuardRestore:
+// "restored=<path> (node=<id>)" lines, one per file.
+func formatRestoredMemoryDocs(restored []RestoredMemoryDoc) string {
+	lines := make([]string, len(restored))
+	for i, rd := range restored {
+		lines[i] = fmt.Sprintf("restored=%s (node=%s)", rd.Path, rd.NodeID)
+	}
+	return strings.Join(lines, "\n")
+}
+
 // Push pushes the current branch to remote
 func (g *GitOperations) Push(ctx context.Context, branchName string) error {
 	cmd := exec.CommandContext(ctx, "git", "push", "-u", "origin", branchName)

--- a/internal/executor/git_test.go
+++ b/internal/executor/git_test.go
@@ -970,6 +970,190 @@ func TestStripUnindexedMemoryDocs(t *testing.T) {
 	})
 }
 
+// TestRestoreDeletedIndexedMemoryDocs covers GH-4387: an executor session
+// that deletes a memory doc still referenced by a node in
+// .agent/knowledge/graph.json must have that deletion reverted before push,
+// so the PR never dangles the graph node and trips the Knowledge Graph
+// Drift Gate's "Broken file links" check (scripts/check-graph.py).
+func TestRestoreDeletedIndexedMemoryDocs(t *testing.T) {
+	dir, _ := initTestRepo(t)
+	ctx := context.Background()
+	git := NewGitOperations(dir)
+
+	base, err := git.GetCurrentBranch(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentBranch failed: %v", err)
+	}
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	write := func(rel, content string) {
+		t.Helper()
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatalf("mkdir for %s: %v", rel, err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	t.Run("restores an indexed memory doc deleted via the 'file' key", func(t *testing.T) {
+		docRel := ".agent/knowledge/memories/pitfalls/mem_indexed.md"
+		write(docRel, "# an indexed pitfall")
+		graph := fmt.Sprintf(`{"nodes":{"memories":{"mem-158":{"file":%q}}}}`, docRel)
+		write(".agent/knowledge/graph.json", graph)
+		run("add", docRel, ".agent/knowledge/graph.json")
+		run("commit", "-m", "docs: capture and index pitfall")
+
+		baseHere, err := git.GetCurrentBranch(ctx)
+		if err != nil {
+			t.Fatalf("GetCurrentBranch failed: %v", err)
+		}
+		run("checkout", "-b", "pilot/GH-delete-indexed")
+
+		run("rm", docRel)
+		run("commit", "-m", "chore(memory): strip unindexed memory doc(s) added during execution")
+
+		restored, err := git.RestoreDeletedIndexedMemoryDocs(ctx, baseHere)
+		if err != nil {
+			t.Fatalf("RestoreDeletedIndexedMemoryDocs failed: %v", err)
+		}
+		if len(restored) != 1 || restored[0].Path != docRel || restored[0].NodeID != "mem-158" {
+			t.Fatalf("restored = %+v, want [{%s mem-158}]", restored, docRel)
+		}
+
+		if _, statErr := os.Stat(filepath.Join(dir, docRel)); statErr != nil {
+			t.Errorf("expected %s restored to working tree, stat err = %v", docRel, statErr)
+		}
+
+		diffCmd := exec.Command("git", "diff", "--name-only", baseHere+"...HEAD")
+		diffCmd.Dir = dir
+		out, err := diffCmd.Output()
+		if err != nil {
+			t.Fatalf("git diff failed: %v", err)
+		}
+		if strings.Contains(string(out), docRel) {
+			t.Errorf("expected %s to have no net diff vs base after restore, got: %s", docRel, out)
+		}
+	})
+
+	t.Run("leaves a genuinely unindexed memory doc deletion alone", func(t *testing.T) {
+		run("checkout", base)
+		run("checkout", "-b", "pilot/GH-delete-unindexed")
+
+		docRel := ".agent/knowledge/memories/learnings/mem_unindexed.md"
+		write(docRel, "# a learning nobody indexed")
+		write(".agent/knowledge/graph.json", `{"nodes":{"memories":{}}}`)
+		run("add", docRel, ".agent/knowledge/graph.json")
+		run("commit", "-m", "docs: capture unindexed learning")
+
+		commitBeforeDelete, err := git.GetCurrentCommitSHA(ctx)
+		if err != nil {
+			t.Fatalf("GetCurrentCommitSHA failed: %v", err)
+		}
+
+		run("rm", docRel)
+		run("commit", "-m", "chore(memory): strip unindexed memory doc(s) added during execution")
+
+		restored, err := git.RestoreDeletedIndexedMemoryDocs(ctx, commitBeforeDelete)
+		if err != nil {
+			t.Fatalf("RestoreDeletedIndexedMemoryDocs failed: %v", err)
+		}
+		if len(restored) != 0 {
+			t.Fatalf("restored = %v, want none (doc was never indexed)", restored)
+		}
+		if _, statErr := os.Stat(filepath.Join(dir, docRel)); !os.IsNotExist(statErr) {
+			t.Errorf("expected %s to remain deleted, stat err = %v", docRel, statErr)
+		}
+	})
+
+	t.Run("protects nodes using the legacy 'path' key", func(t *testing.T) {
+		run("checkout", base)
+		run("checkout", "-b", "pilot/GH-delete-legacy-path")
+
+		docRel := ".agent/knowledge/memories/pitfalls/mem_legacy.md"
+		write(docRel, "# a pitfall indexed with the legacy path key")
+		// Legacy nodes reference the file relative to .agent/knowledge/, not
+		// the repo root (see indexedMemoryPathsAtRef / check-graph.py resolve_path).
+		graph := `{"nodes":{"memories":{"mem-153":{"path":"memories/pitfalls/mem_legacy.md"}}}}`
+		write(".agent/knowledge/graph.json", graph)
+		run("add", docRel, ".agent/knowledge/graph.json")
+		run("commit", "-m", "docs: capture and index pitfall (legacy path key)")
+
+		commitBeforeDelete, err := git.GetCurrentCommitSHA(ctx)
+		if err != nil {
+			t.Fatalf("GetCurrentCommitSHA failed: %v", err)
+		}
+
+		run("rm", docRel)
+		run("commit", "-m", "chore(memory): strip unindexed memory doc(s) added during execution")
+
+		restored, err := git.RestoreDeletedIndexedMemoryDocs(ctx, commitBeforeDelete)
+		if err != nil {
+			t.Fatalf("RestoreDeletedIndexedMemoryDocs failed: %v", err)
+		}
+		if len(restored) != 1 || restored[0].Path != docRel || restored[0].NodeID != "mem-153" {
+			t.Fatalf("restored = %+v, want [{%s mem-153}]", restored, docRel)
+		}
+		if _, statErr := os.Stat(filepath.Join(dir, docRel)); statErr != nil {
+			t.Errorf("expected %s restored to working tree, stat err = %v", docRel, statErr)
+		}
+	})
+
+	t.Run("no-op when graph.json is absent at base", func(t *testing.T) {
+		run("checkout", base)
+		run("checkout", "-b", "pilot/GH-no-graph")
+
+		docRel := ".agent/knowledge/memories/learnings/mem_no_graph.md"
+		write(docRel, "# a memory doc with no graph.json in play")
+		run("add", docRel)
+		run("commit", "-m", "docs: capture learning without a graph.json")
+
+		commitBeforeDelete, err := git.GetCurrentCommitSHA(ctx)
+		if err != nil {
+			t.Fatalf("GetCurrentCommitSHA failed: %v", err)
+		}
+
+		run("rm", docRel)
+		run("commit", "-m", "chore(memory): strip unindexed memory doc(s) added during execution")
+
+		restored, err := git.RestoreDeletedIndexedMemoryDocs(ctx, commitBeforeDelete)
+		if err != nil {
+			t.Fatalf("RestoreDeletedIndexedMemoryDocs failed: %v", err)
+		}
+		if len(restored) != 0 {
+			t.Fatalf("restored = %v, want none (no graph.json)", restored)
+		}
+		if _, statErr := os.Stat(filepath.Join(dir, docRel)); !os.IsNotExist(statErr) {
+			t.Errorf("expected %s to remain deleted, stat err = %v", docRel, statErr)
+		}
+	})
+
+	t.Run("no-op when nothing under memories/ was deleted", func(t *testing.T) {
+		run("checkout", base)
+		run("checkout", "-b", "pilot/GH-no-deletion")
+
+		write("internal/baz.go", "package baz")
+		run("add", "internal/baz.go")
+		run("commit", "-m", "feat: add baz")
+
+		restored, err := git.RestoreDeletedIndexedMemoryDocs(ctx, base)
+		if err != nil {
+			t.Fatalf("RestoreDeletedIndexedMemoryDocs failed: %v", err)
+		}
+		if len(restored) != 0 {
+			t.Fatalf("restored = %v, want none", restored)
+		}
+	})
+}
+
 // TestCreateRecoveryRef verifies GH-3785's recovery-ref mechanism: a commit
 // pinned under refs/pilot-recovery/<taskID> resolves to the expected sha,
 // survives being looked up independent of any branch, and sanitizes the

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1579,6 +1579,22 @@ func (r *Runner) finalizeEpicBranchPR(ctx context.Context, task *Task, git *GitO
 		)
 	}
 
+	// GH-4387: restore any indexed memory doc this epic session deleted —
+	// left deleted, the surviving graph.json node dangles and fails the
+	// Knowledge Graph Drift Gate's "Broken file links" check (PR #4385, #4375).
+	if restored, restoreErr := git.RestoreDeletedIndexedMemoryDocs(ctx, baseBranch); restoreErr != nil {
+		r.log.Warn("Failed to restore deleted indexed memory doc(s) on epic branch",
+			slog.String("task_id", task.ID),
+			slog.Any("error", restoreErr),
+		)
+	} else if len(restored) > 0 {
+		r.log.Warn("Restored deleted indexed memory doc(s) on epic branch to avoid drift-gate failure",
+			slog.String("task_id", task.ID),
+			slog.Any("files", restoredMemoryDocPaths(restored)),
+		)
+		r.recordExecutionEvent(task.LogExecutionID(), memory.StageMemoryGuardRestore, formatRestoredMemoryDocs(restored))
+	}
+
 	r.reportProgress(task.ID, "Creating PR", 96, "Pushing epic branch...")
 
 	// Push the parent branch. TASK-359: a real deliverable that fails to push is a
@@ -4056,6 +4072,23 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 					slog.String("task_id", task.ID),
 					slog.Any("files", stripped),
 				)
+			}
+
+			// GH-4387: restore any indexed memory doc this session deleted —
+			// left deleted, the surviving graph.json node dangles and fails
+			// the Knowledge Graph Drift Gate's "Broken file links" check
+			// (PR #4385, #4375).
+			if restored, restoreErr := git.RestoreDeletedIndexedMemoryDocs(ctx, baseBranch); restoreErr != nil {
+				log.Warn("Failed to restore deleted indexed memory doc(s) on branch",
+					slog.String("task_id", task.ID),
+					slog.Any("error", restoreErr),
+				)
+			} else if len(restored) > 0 {
+				log.Warn("Restored deleted indexed memory doc(s) on branch to avoid drift-gate failure",
+					slog.String("task_id", task.ID),
+					slog.Any("files", restoredMemoryDocPaths(restored)),
+				)
+				r.recordExecutionEvent(task.LogExecutionID(), memory.StageMemoryGuardRestore, formatRestoredMemoryDocs(restored))
 			}
 
 			// Pre-push lint gate (GH-1376)

--- a/internal/executor/runner_decompose.go
+++ b/internal/executor/runner_decompose.go
@@ -422,6 +422,22 @@ func (r *Runner) finalizeDecomposedParentPR(ctx context.Context, task *Task, git
 		)
 	}
 
+	// GH-4387: restore any indexed memory doc a subtask session deleted —
+	// left deleted, the surviving graph.json node dangles and fails the
+	// Knowledge Graph Drift Gate's "Broken file links" check (PR #4385, #4375).
+	if restored, restoreErr := git.RestoreDeletedIndexedMemoryDocs(ctx, baseBranch); restoreErr != nil {
+		log.Warn("Failed to restore deleted indexed memory doc(s) on decomposed-parent branch",
+			slog.String("task_id", task.ID),
+			slog.Any("error", restoreErr),
+		)
+	} else if len(restored) > 0 {
+		log.Warn("Restored deleted indexed memory doc(s) on decomposed-parent branch to avoid drift-gate failure",
+			slog.String("task_id", task.ID),
+			slog.Any("files", restoredMemoryDocPaths(restored)),
+		)
+		r.recordExecutionEvent(task.LogExecutionID(), memory.StageMemoryGuardRestore, formatRestoredMemoryDocs(restored))
+	}
+
 	r.reportProgress(task.ID, "Creating PR", 96, "Pushing branch...")
 
 	var pushErr error

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -935,6 +935,15 @@ const (
 	// of a second execution starting silently. Detail carries a short
 	// human-readable note naming which sub-issue/task lost the claim.
 	StageDispatchClaimLost Stage = "dispatch_claim_lost"
+	// StageMemoryGuardRestore records that the finalize-path guard
+	// (GitOperations.RestoreDeletedIndexedMemoryDocs) restored one or more
+	// .agent/knowledge/memories/** files that this execution's branch had
+	// deleted despite a surviving node in .agent/knowledge/graph.json (GH-4387).
+	// Left deleted, the dangling node fails the Knowledge Graph Drift Gate and
+	// wedges the PR in awaiting-approval (PR #4385, #4375) — this stage makes
+	// the automatic recovery visible in `pilot trace` / the ledger. Detail
+	// carries "restored=<path> (node=<id>)" lines, one per file.
+	StageMemoryGuardRestore Stage = "memory_guard_restore"
 )
 
 // Event represents a single stage-transition record for an execution.


### PR DESCRIPTION
## Summary

Executor sessions have repeatedly deleted `.agent/knowledge/memories/**` files that are still indexed in `.agent/knowledge/graph.json` during end-of-run hygiene (commit messages like `chore(memory): strip unindexed memory doc(s) added during execution`), leaving a dangling graph node that fails the Knowledge Graph Drift Gate's "Broken file links" check and wedges the PR in awaiting-approval (PR #4385, #4375).

- Adds `GitOperations.RestoreDeletedIndexedMemoryDocs` (`internal/executor/git.go`): diffs the branch against base for deletions under `.agent/knowledge/memories/`, resolves the indexed set from `graph.json` **as of base** (handling both the current `file` key and the legacy `path` key), restores any deleted-but-indexed file via `git checkout <base> -- <path>`, and commits the restoration.
- Wired into all three finalize/push paths — direct (`runner.go`), epic (`runner.go`), and decomposed-parent (`runner_decompose.go`) — logging a WARN naming the restored file(s)/node id(s) and recording a new `memory.StageMemoryGuardRestore` execution event so the intervention is visible in `pilot trace`/the ledger.
- No-ops when `graph.json` is absent at base, or when nothing indexed was deleted.

## Test plan

- [x] Unit test: indexed memory doc deleted (`file` key) → restored, no net diff vs base
- [x] Unit test: genuinely unindexed memory doc deletion is left alone
- [x] Unit test: legacy `path`-key nodes are also protected
- [x] Unit test: no-op when `graph.json` is absent at base
- [x] Unit test: no-op when nothing under `memories/` was deleted
- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./...` green

## Note for reviewer

`scripts/check-graph.py` (the CI drift gate) is currently failing on `main` (`origin/main` @ `2478a1f4`) independent of this PR — 3 memory docs were stripped by an unrelated commit (`6ca5c9c4`, PR #4410) without removing their `graph.json` nodes, and 2 edges use a legacy `source`/`target`/`relation` schema the checker doesn't recognize as `from`/`to`/`type`. Both pre-date this branch and are out of scope here (the guard added in this PR prevents *future* occurrences of the first class, but doesn't retroactively repair already-merged drift or the unrelated edge-schema issue) — flagging for a separate follow-up.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>