### PR TITLE
GH-4399: test(executor): add unit tests for the guard logic

### DIFF
--- a/.agent/tasks/gh-4399.md
+++ b/.agent/tasks/gh-4399.md
@@ -26,48 +26,65 @@ for context, but do NOT implement parts of it that fall outside this subtask.
 
 ## Acceptance Criteria
 
-## NO-OP RATIONALE (2026-07-17)
+## NO-OP RATIONALE (2026-07-17, revised after intent-judge retry)
 
-**No code change made in this branch.** Investigated before writing anything
-(per the evidence-backed-changes rule) and found the requested tests already
-exist, verbatim, upstream of this branch's dependency:
+**Correction to the original NO-OP note (superseded below, was wrong):** it
+assumed PR #4419 would land and this task could simply be re-run afterward.
+Re-checked on this retry: **PR #4419 is `CLOSED` with `mergedAt: null`** —
+closed by the CI production-diff size guard ("243 production additions, over
+limit 200 ... likely cascade contamination — escalate to human"), not
+merged. There is nothing to defer to.
 
-- `internal/executor/git.go` on `main` @ `2478a1f4` (this branch's base) has
-  **no** `RestoreDeletedIndexedMemoryDocs` / guard logic at all — confirmed
-  via `grep -n "RestoreDeletedIndexedMemoryDocs\|indexedMemoryPathsAtRef\|StageMemoryGuardRestore"
-  internal/executor/git.go internal/memory/store.go internal/executor/runner.go
-  internal/executor/runner_decompose.go` → zero matches. The guard this task
-  is meant to test does not exist on `main`.
-- The guard (parent GH-4387) lives on open, unmerged **PR #4419**
-  (`origin/pilot/GH-4387`, commit `0fc4fd6e`), which adds
-  `internal/executor/git.go` (+185 lines: `RestoreDeletedIndexedMemoryDocs`,
-  `indexedMemoryPathsAtRef`, `existsAtRef`, `readAtRef`, `RestoredMemoryDoc`),
-  the `memory.StageMemoryGuardRestore` execution-event stage
-  (`internal/memory/store.go`), and the three call sites in `runner.go` /
-  `runner_decompose.go`.
-- **The same commit already contains the exact test coverage this task
-  asks for**: `internal/executor/git_test.go:978`
-  (`git show origin/pilot/GH-4387:internal/executor/git_test.go`), function
-  `TestRestoreDeletedIndexedMemoryDocs`, with subtests covering:
-  (a) an indexed doc deleted via the `file` key is restored (asserts
-  restored path/node ID, file back on disk, zero net diff vs base) —
-  matches acceptance criterion (a), including the WARN+execution-event
-  wiring exercised at the call sites;
-  (b) a genuinely unindexed doc deletion is left alone — matches (b);
-  (c) a legacy `path`-key node is also protected — matches (c);
-  (d) no-op when `graph.json` is absent at base — matches (d);
-  plus a bonus no-op case (nothing under `memories/` deleted).
+**Confirmed state of `main` (this branch's base, `2478a1f4`) as of this
+retry:**
+```
+grep -rn "RestoreDeletedIndexedMemoryDocs\|indexedMemoryPathsAtRef\|StageMemoryGuardRestore" internal/
+# zero matches — the guard logic this task is meant to test does not exist
+# anywhere reachable from main.
+```
+`internal/executor/git.go` only has `StripUnindexedMemoryDocs` (guards
+*additions* of unindexed docs) — not the deletion-restore guard GH-4399's
+acceptance criteria (a)-(d) describe. `internal/executor/git_test.go` has no
+`TestRestoreDeletedIndexedMemoryDocs`.
 
-**Why no change here**: writing a second copy of these tests in this branch
-would require first importing PR #4419's unmerged guard implementation,
-which is explicitly out of scope per this task's Scope Fence ("do NOT
-implement parts of [GH-4387] that fall outside this subtask"). Doing so
-would also produce code that duplicates and will merge-conflict with #4419
-once it lands. `go test ./...` on this branch (without the guard) trivially
-passes but does not exercise anything new, so it would not be evidence the
-acceptance criteria are met.
+**Why this task cannot be completed as scoped:** parent GH-4387 was
+decomposed into four sibling sub-issues, each a slice small enough to avoid
+the diff-size guard that killed #4419:
+- #4396 — parse `graph.json` into a protected-path set (handles `file` +
+  legacy `path` keys)
+- #4397 — detect deletions of protected paths in the branch-vs-base diff
+- #4398 — restore deleted protected files + WARN + execution event
+- #4399 (this task) — unit tests for the assembled behavior
 
-**Recommendation**: close GH-4399 as satisfied-by-#4419 once that PR merges
-(or re-run this subtask after the merge to confirm no further gap exists).
-Left a comment on the GH-4399 issue with this finding for a human/Navigator
-to action.
+**All three of #4396/#4397/#4398 are still `OPEN`, unclaimed (no branch, no
+PR, no assignee) as of this retry.** GH-4399 depends on their code existing
+to have anything to test. Writing the tests here would require first writing
+the guard implementation myself, which is explicitly forbidden by this
+issue's own Scope Fence ("do NOT implement parts of [GH-4387] that fall
+outside this subtask") — and doing so would recreate the exact ~243-line
+production diff that got #4419 closed by the size guard in the first place,
+defeating the point of the decomposition.
+
+`go test ./...` on this branch passes trivially (no new code, nothing to
+break) but is not evidence the acceptance criteria are met, since there is no
+guard logic to exercise.
+
+**Recommendation (sequencing gap in the decomposition):** the four sub-issues
+have an implicit dependency chain (#4396 → #4397 → #4398 → #4399) but no
+explicit `depends-on` edge, so nothing prevents the dispatcher from picking
+#4399 before its prerequisites land — which is what happened here. Dispatch
+and merge #4396, then #4397, then #4398 first; re-run #4399 once
+`RestoreDeletedIndexedMemoryDocs` (or equivalent) exists on `main` to add
+real coverage for cases (a)-(d). Flagging back to parent GH-4387 /
+Navigator for re-sequencing.
+
+<details>
+<summary>Original (stale) NO-OP note, 2026-07-17 first pass</summary>
+
+No code change made in this branch. Investigated before writing anything and
+found (incorrectly, as it turned out) that the requested tests already
+existed on unmerged PR #4419 and recommended closing GH-4399 once #4419
+merged. That premise was wrong — #4419 was closed, not merged, by the CI
+size guard. See the corrected rationale above.
+
+</details>

--- a/.agent/tasks/gh-4399.md
+++ b/.agent/tasks/gh-4399.md
@@ -1,0 +1,73 @@
+# GH-4399
+
+**Created:** 2026-07-17
+
+## Problem
+
+GitHub Issue GH-4399: test(executor): add unit tests for the guard logic
+
+<!--autopilot-meta
+parent: GH-4387
+inherited-spec: true
+-->
+
+Parent: GH-4387
+
+In the same package, add unit tests covering: (a) deletion of an indexed memory file is restored with WARN logged and execution event recorded; (b) deletion of a genuinely unindexed memory file is still allowed; (c) a graph node using the legacy `path` key is also protected; (d) missing graph.json results in no behavior change.
+
+## Acceptance Criteria (folded)
+- [ ] Run `go test ./...` to confirm it passes, and verify the drift-gate self-check is unaffected by the new guard logic.
+
+## Scope fence
+
+Implement ONLY the slice described above. The parent issue GH-4387 is decomposed
+into sibling sub-issues that cover the rest of its spec — consult the parent
+for context, but do NOT implement parts of it that fall outside this subtask.
+
+## Acceptance Criteria
+
+## NO-OP RATIONALE (2026-07-17)
+
+**No code change made in this branch.** Investigated before writing anything
+(per the evidence-backed-changes rule) and found the requested tests already
+exist, verbatim, upstream of this branch's dependency:
+
+- `internal/executor/git.go` on `main` @ `2478a1f4` (this branch's base) has
+  **no** `RestoreDeletedIndexedMemoryDocs` / guard logic at all — confirmed
+  via `grep -n "RestoreDeletedIndexedMemoryDocs\|indexedMemoryPathsAtRef\|StageMemoryGuardRestore"
+  internal/executor/git.go internal/memory/store.go internal/executor/runner.go
+  internal/executor/runner_decompose.go` → zero matches. The guard this task
+  is meant to test does not exist on `main`.
+- The guard (parent GH-4387) lives on open, unmerged **PR #4419**
+  (`origin/pilot/GH-4387`, commit `0fc4fd6e`), which adds
+  `internal/executor/git.go` (+185 lines: `RestoreDeletedIndexedMemoryDocs`,
+  `indexedMemoryPathsAtRef`, `existsAtRef`, `readAtRef`, `RestoredMemoryDoc`),
+  the `memory.StageMemoryGuardRestore` execution-event stage
+  (`internal/memory/store.go`), and the three call sites in `runner.go` /
+  `runner_decompose.go`.
+- **The same commit already contains the exact test coverage this task
+  asks for**: `internal/executor/git_test.go:978`
+  (`git show origin/pilot/GH-4387:internal/executor/git_test.go`), function
+  `TestRestoreDeletedIndexedMemoryDocs`, with subtests covering:
+  (a) an indexed doc deleted via the `file` key is restored (asserts
+  restored path/node ID, file back on disk, zero net diff vs base) —
+  matches acceptance criterion (a), including the WARN+execution-event
+  wiring exercised at the call sites;
+  (b) a genuinely unindexed doc deletion is left alone — matches (b);
+  (c) a legacy `path`-key node is also protected — matches (c);
+  (d) no-op when `graph.json` is absent at base — matches (d);
+  plus a bonus no-op case (nothing under `memories/` deleted).
+
+**Why no change here**: writing a second copy of these tests in this branch
+would require first importing PR #4419's unmerged guard implementation,
+which is explicitly out of scope per this task's Scope Fence ("do NOT
+implement parts of [GH-4387] that fall outside this subtask"). Doing so
+would also produce code that duplicates and will merge-conflict with #4419
+once it lands. `go test ./...` on this branch (without the guard) trivially
+passes but does not exercise anything new, so it would not be evidence the
+acceptance criteria are met.
+
+**Recommendation**: close GH-4399 as satisfied-by-#4419 once that PR merges
+(or re-run this subtask after the merge to confirm no further gap exists).
+Left a comment on the GH-4399 issue with this finding for a human/Navigator
+to action.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4399.

Closes #4399

## Changes

GitHub Issue GH-4399: test(executor): add unit tests for the guard logic

<!--autopilot-meta
parent: GH-4387
inherited-spec: true
-->

Parent: GH-4387

In the same package, add unit tests covering: (a) deletion of an indexed memory file is restored with WARN logged and execution event recorded; (b) deletion of a genuinely unindexed memory file is still allowed; (c) a graph node using the legacy `path` key is also protected; (d) missing graph.json results in no behavior change.

## Acceptance Criteria (folded)
- [ ] Run `go test ./...` to confirm it passes, and verify the drift-gate self-check is unaffected by the new guard logic.

## Scope fence

Implement ONLY the slice described above. The parent issue GH-4387 is decomposed
into sibling sub-issues that cover the rest of its spec — consult the parent
for context, but do NOT implement parts of it that fall outside this subtask.