### PR TITLE
fix(executor): anchor reconcileChildOutcome's 5m ceiling to child started_at, not queue-wait

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "updated": "2026-07-17T15:18:52+00:00",
+  "updated": "2026-07-17T19:10:00+00:00",
   "nodes": {
     "concepts": {
       "pilot-architecture": {
@@ -2990,6 +2990,17 @@
         ],
         "confidence": 0.9,
         "created": "2026-07-17"
+      },
+      "reconcile-timeout-counts-queue-wait": {
+        "type": "pitfall",
+        "summary": "reconcileChildOutcome's 5m ceiling was anchored to when the parent started polling, not to when the child actually started running — a child queued behind the busy single-lane ProjectWorker (TASK-393) burned the same budget meant for detecting a stuck execution, failing epics on busy projects structurally (GH-9/GH-26). Fixed by anchoring the deadline to the child's own started_at, applied only once the child is observed running.",
+        "file": ".agent/knowledge/memories/pitfalls/bug_reconcile_timeout_counts_queue_wait.md",
+        "concepts": [
+          "executor",
+          "dispatcher"
+        ],
+        "confidence": 0.95,
+        "created": "2026-07-17"
       }
     }
   },
@@ -4668,10 +4679,10 @@
       "mem-152"
     ]
   },
-  "last_updated": "2026-07-17T09:45:00+00:00",
+  "last_updated": "2026-07-17T19:10:00+00:00",
   "stats": {
-    "total_nodes": 257,
+    "total_nodes": 258,
     "total_edges": 226,
-    "memory_count": 161
+    "memory_count": 162
   }
 }

--- a/.agent/knowledge/memories/pitfalls/bug_reconcile_timeout_counts_queue_wait.md
+++ b/.agent/knowledge/memories/pitfalls/bug_reconcile_timeout_counts_queue_wait.md
@@ -1,0 +1,24 @@
+# Pitfall: reconcileChildOutcome's 5m ceiling counted child queue-wait, not just execution time
+
+## Summary
+`Runner.reconcileChildOutcome` (`internal/executor/epic.go`) polls a child sub-issue's execution row until it reaches a terminal status, bounded by `childOutcomeReconcileTimeout` (default 5m). The deadline was anchored to when the *parent* started polling, not to when the *child* actually started executing. Pilot dispatches one task per project at a time (ProjectWorker, TASK-393 single-lane serialization) — a child epic sub-issue landing behind other queued work on a busy project can legitimately sit `queued` for well over 5 minutes before a worker ever picks it up. That queue-wait ate the same budget meant to detect a genuinely stalled/silent execution, so any epic whose child landed behind other work on a busy project failed structurally regardless of whether the child itself was healthy.
+
+## Context
+GH-4413, 2026-07-17. Pointer epic GH-9 (TASK-04) failed at 12:58:36Z: `reconcileChildOutcome: gave up waiting for terminal child execution state` for child GH-26, which was queued behind the busy pointer project worker — not stuck. GH-26 completed fine standalone moments later. 5 timeout instances logged in one day (00:13, 00:59, 01:18, 09:47, 12:58), the last two on binaries that already carried #4388 (the sibling no_op-blindness fix, mem-154 class). This was the residual failure mode behind the #4388 verification gate.
+
+## Details
+The old code computed `deadline := time.Now().Add(timeout)` once, before entering the poll loop, and fired that same deadline regardless of whether the child's own execution row was still `queued` (nobody executing it yet) or `running` (actively executing, possibly stuck). Fix: track the deadline lazily, only once the child's execution row is observed `running` — anchored to that row's `started_at` column (GH-4033's "worker actually began running" stamp, set by `UpdateExecutionStatus`'s transition to `running`) rather than to when this call started polling. While `queued`, there is no ceiling at all; a queued row behind a live project worker is legitimately waiting its turn (same reasoning as `recoverStaleQueuedTasks`'s `StaleQueuedThreshold` guard, GH-2331 — that sweep only reaps queued rows with a *dead* claim, never a live one), and a queued row with a dead claim gets reaped to a terminal status by that same sweep, which the reconcile poll picks up on its next terminal-row check. `ctx` cancellation remains the only bound while queued.
+
+Implementation: `findChildExecutionState` (epic.go) is `findTerminalChildExecution`'s sibling — same terminal-row scan, plus reports whether the newest non-terminal row is `running` and its `started_at`. Note `SaveExecution` does NOT persist `started_at` (only `UpdateExecutionStatus`'s transition to `"running"` does, via `CURRENT_TIMESTAMP`), so a row written directly with `Status: "running"` (e.g. the epic loop's own inline sub-issue rows, GH-4141) has a nil `started_at` — callers fall back to treating "now" (first observation) as the effective start in that case.
+
+## Recommended Approach
+Any future timeout/deadline guarding a *dispatched* child (something that goes through admission/queueing before it executes) must distinguish "hasn't started" from "is stuck" — anchor the ceiling to the child's own execution-start signal, not to when the watcher began watching. Don't reuse a single wall-clock deadline across a wait that spans both queue-admission and execution phases; they have structurally different failure modes (queue-wait is bounded by sibling task count and worker throughput, execution-hang is bounded by the work itself).
+
+Test note: SQLite's `CURRENT_TIMESTAMP` has whole-second resolution, so tests asserting on a `started_at`-anchored deadline need enough margin (~1.5-2s minimum) over that rounding error to stay deterministic — see `TestExecuteSubIssues_ClaimLost_QueuedBeyondTimeoutStillSucceeds` / `TestExecuteSubIssues_ClaimLost_RunningSilentlyTimesOutFromStartedAt` in `internal/executor/epic_child_reconcile_test.go`.
+
+## Related
+- #4388 (fixed the no_op-blindness flavor of this same gate; this was the queue-wait flavor)
+- TASK-393 (ProjectWorker single-lane decision — this timeout interacts directly with lane concurrency)
+- GH-2331 (`recoverStaleQueuedTasks` / `StaleQueuedThreshold` — established that a queued row behind a live worker must not be treated as stuck)
+- GH-4033 (`started_at` stamp on the `running` transition)
+- `internal/executor/epic.go` (`reconcileChildOutcome`, `findChildExecutionState`)

--- a/.agent/tasks/gh-4413.md
+++ b/.agent/tasks/gh-4413.md
@@ -1,0 +1,43 @@
+# GH-4413
+
+**Created:** 2026-07-17
+
+## Problem
+
+GitHub Issue GH-4413: fix(executor): reconcileChildOutcome 5m wait counts child queue-wait — epics on busy projects fail structurally (GH-9/GH-26, residual #4388 gate blocker)
+
+## Symptom
+
+Pointer epic GH-9 (TASK-04) failed at 12:58:36Z:
+
+```
+WARN msg="reconcileChildOutcome: gave up waiting for terminal child execution state" task_id=GH-26 project_path=.../pointer timeout=5m0s
+WARN msg="Task ended without success" task_id=GH-9 status=failed error="sub-issue execution failed: sub-issue 26 failed: reconcileChildOutcome: time..."
+```
+
+Child GH-26 wasn't failing — it was **queued behind the busy pointer project worker** (single-lane serialization). The parent's 5-minute wait for a terminal child state counts queue-wait time, so any epic whose child lands behind other work loses the race structurally. GH-26 later ran fine as a standalone task.
+
+## Expected
+
+The 5m ceiling should only clock while the child is actually executing (or: wait indefinitely while the child is `queued` with a live claim, timing out only on a running-but-silent child). Distinguish "child hasn't started" from "child is stuck".
+
+## Impact
+
+This is the residual failure mode behind the #4388 verification gate: epics on busy projects fail nondeterministically depending on queue depth. Today's evidence: 5 timeout instances in the log (00:13, 00:59, 01:18, 09:47, 12:58) — the last two on binaries that already carry #4388.
+
+## Refs
+
+- #4388 (fixed the no_op-blindness flavor; this is the queue-wait flavor), TASK-393 (ProjectWorker single-lane decision — this timeout interacts with lane concurrency).
+
+## Acceptance Criteria
+
+- [x] `reconcileChildOutcome`'s timeout no longer fires while the child's execution row is `queued` (no ceiling applies until the row is observed `running`).
+- [x] The ceiling, once applied, is anchored to the child's own `started_at` (GH-4033 stamp on the `running` transition), not to when the parent started polling — a long queue-wait no longer erodes the running budget.
+- [x] A child stuck silently `running` past the timeout still times out (ceiling not removed, only narrowed to when it's actually earned).
+- [x] Regression tests: `TestExecuteSubIssues_ClaimLost_QueuedBeyondTimeoutStillSucceeds`, `TestExecuteSubIssues_ClaimLost_RunningSilentlyTimesOutFromStartedAt` (`internal/executor/epic_child_reconcile_test.go`).
+- [x] Full `internal/executor` suite green; no change to existing terminal-status / no_op reconciliation behavior (mem-154 class untouched).
+
+## Resolution
+
+Fixed in `internal/executor/epic.go`: `reconcileChildOutcome`'s poll loop now tracks a lazily-set `runningDeadline`, only starting the clock once the child's execution row is observed `running` (via new sibling helper `findChildExecutionState`), anchored to that row's `started_at` when available. See pitfall writeup: `.agent/knowledge/memories/pitfalls/bug_reconcile_timeout_counts_queue_wait.md`.
+

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -2045,15 +2045,35 @@ const (
 //
 // When no failure signal is present and the child is not externally owned,
 // or no log store is wired to check against, the original (result, err) pass
-// through unchanged. Otherwise this polls findTerminalChildExecution for
-// taskID (scoped to projectPath) until it finds a terminal row, the context
-// is cancelled, or childOutcomeReconcileTimeout elapses — whichever comes
-// first, so this can never block the epic indefinitely. On terminal success
-// ("completed" / "no_op") it synthesizes a passing ExecutionResult from the
-// tracked row so the caller's normal success/no-op handling applies; on
-// terminal failure it enriches the returned error with the tracked row's
-// real error message instead of the uninformative "unknown: exit status 1"
-// backend classification.
+// through unchanged. Otherwise this polls findChildExecutionState for taskID
+// (scoped to projectPath) until it finds a terminal row or the context is
+// cancelled. On terminal success ("completed" / "no_op") it synthesizes a
+// passing ExecutionResult from the tracked row so the caller's normal
+// success/no-op handling applies; on terminal failure it enriches the
+// returned error with the tracked row's real error message instead of the
+// uninformative "unknown: exit status 1" backend classification.
+//
+// GH-4413: childOutcomeReconcileTimeout only bounds time spent with the
+// child actually RUNNING, not time spent QUEUED behind a busy project
+// worker. Pilot dispatches one task per project at a time (ProjectWorker,
+// TASK-393) — a child epic sub-issue landing behind other queued work on a
+// busy project can legitimately wait well past 5 minutes before a worker
+// ever picks it up, and that queue-wait was previously charged against the
+// same 5m ceiling used for detecting a genuinely stuck/silent execution.
+// GH-9 (TASK-04) failed exactly this way: child GH-26 was still "queued"
+// when the 5m deadline fired, then went on to complete fine standalone
+// moments later. The ceiling below is now anchored to the child's own
+// started_at (GH-4033's "worker actually began running" stamp, set by
+// UpdateExecutionStatus's transition to "running") rather than to when this
+// call started polling, so a long queue-wait no longer erodes the budget the
+// child gets once it actually starts executing. While the child is still
+// "queued" (or no row is visible yet), this keeps polling with no ceiling at
+// all — the dispatcher's own recoverStaleQueuedTasks sweep (GH-2331,
+// StaleQueuedThreshold) already reaps a queued row whose owning project has
+// no live worker (a dead claim) to a terminal status, which surfaces here on
+// the next tick via the terminal-row check; a queued row with a live worker
+// is, by that same GH-2331 reasoning, just waiting its turn and must not be
+// timed out. ctx cancellation remains the only bound while queued.
 func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath, selfExecID string, result *ExecutionResult, execErr error, externallyOwned bool) (*ExecutionResult, error) {
 	hasFailureSignal := execErr != nil || (result != nil && !result.Success)
 	if !hasFailureSignal && !externallyOwned {
@@ -2099,9 +2119,17 @@ func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath,
 		timeout = defaultChildOutcomeReconcileTimeout
 	}
 
-	deadline := time.Now().Add(timeout)
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
+
+	// runningDeadline is set lazily, only once the child is actually
+	// observed "running" — until then it stays zero and no timeout applies
+	// (GH-4413: queue-wait must not erode the running budget). It anchors to
+	// the row's own started_at when available so a slow first poll after the
+	// child started doesn't donate free extra time, and falls back to "now"
+	// for rows written directly as "running" with no started_at stamp (e.g.
+	// the epic loop's own inline sub-issue rows, GH-4141).
+	var runningDeadline time.Time
 
 	for {
 		select {
@@ -2117,15 +2145,34 @@ func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath,
 		case <-ticker.C:
 		}
 
-		row, err := r.findTerminalChildExecution(taskID, projectPath, selfExecID)
-		if err == nil && row != nil {
-			return r.resolveChildTerminalOutcome(row, result, execErr)
+		terminal, running, startedAt, err := r.findChildExecutionState(taskID, projectPath, selfExecID)
+		if err == nil && terminal != nil {
+			return r.resolveChildTerminalOutcome(terminal, result, execErr)
 		}
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			r.log.Warn("reconcileChildOutcome: execution status lookup failed",
 				"task_id", taskID, "project_path", projectPath, "error", err)
 		}
-		if time.Now().After(deadline) {
+
+		if !running {
+			// Still queued (or no row visible yet): no ceiling applies. A
+			// queued row behind a live worker is legitimately waiting its
+			// turn (GH-2331); a queued row with a dead claim gets reaped to
+			// a terminal status by recoverStaleQueuedTasks and will be
+			// caught by the terminal check above on a later tick. Reset any
+			// previously-observed running deadline in case the child
+			// regressed to queued (a fresh re-pick row sorting first).
+			runningDeadline = time.Time{}
+			continue
+		}
+		if runningDeadline.IsZero() {
+			if startedAt != nil {
+				runningDeadline = startedAt.Add(timeout)
+			} else {
+				runningDeadline = time.Now().Add(timeout)
+			}
+		}
+		if time.Now().After(runningDeadline) {
 			r.log.Warn("reconcileChildOutcome: gave up waiting for terminal child execution state",
 				"task_id", taskID, "project_path", projectPath, "timeout", timeout)
 			if externallyOwned {
@@ -2169,6 +2216,47 @@ func (r *Runner) findTerminalChildExecution(taskID, projectPath, selfExecID stri
 		}
 	}
 	return nil, nil
+}
+
+// findChildExecutionState is findTerminalChildExecution's sibling for the
+// reconcileChildOutcome poll loop (GH-4413): alongside the terminal-row scan
+// it also reports whether the child is actually executing, so the loop can
+// tell "hasn't started" (queued behind a busy ProjectWorker, TASK-393) apart
+// from "stuck" (running but silent past the timeout) instead of charging
+// queue-wait against the same ceiling meant for a stalled execution.
+//
+// running is derived from the newest non-terminal row (rows are ordered
+// created_at DESC by ListExecutionsByTaskIDExcluding) rather than any
+// non-terminal row, mirroring GH-4381's ordering trap avoidance for the
+// terminal case: a fresh re-pick can leave an older "running" row behind a
+// newer "queued" duplicate, and the newest row is the one actually governing
+// the child's current state. startedAt is that row's started_at column
+// (GH-4033: stamped by UpdateExecutionStatus's transition to "running"),
+// nil when unset — callers fall back to treating "now" as the observed
+// start in that case.
+//
+// Return shape mirrors findTerminalChildExecution: (nil, false, nil,
+// sql.ErrNoRows) when no other row exists at all (nothing to wait for);
+// (nil, false, nil, nil) when rows exist but the newest is still "queued";
+// (nil, true, startedAt, nil) when the newest is "running".
+func (r *Runner) findChildExecutionState(taskID, projectPath, selfExecID string) (terminal *memory.Execution, running bool, startedAt *time.Time, err error) {
+	rows, err := r.logStore.ListExecutionsByTaskIDExcluding(taskID, projectPath, selfExecID)
+	if err != nil {
+		return nil, false, nil, err
+	}
+	if len(rows) == 0 {
+		return nil, false, nil, sql.ErrNoRows
+	}
+	for _, row := range rows {
+		if isTerminalExecutionStatus(row.Status) {
+			return row, false, nil, nil
+		}
+	}
+	newest := rows[0]
+	if newest.Status == string(ExecStatusRunning) {
+		return nil, true, newest.StartedAt, nil
+	}
+	return nil, false, nil, nil
 }
 
 // resolveChildTerminalOutcome turns a terminal execution row into the

--- a/internal/executor/epic_child_reconcile_test.go
+++ b/internal/executor/epic_child_reconcile_test.go
@@ -473,3 +473,177 @@ func TestExecuteSubIssues_NoLogStoreFailsImmediately(t *testing.T) {
 		t.Errorf("ExecuteSubIssues took %s, want near-immediate failure with no log store wired", elapsed)
 	}
 }
+
+// TestExecuteSubIssues_ClaimLost_QueuedBeyondTimeoutStillSucceeds is the
+// GH-4413 regression: pointer epic GH-9 (TASK-04) failed because child GH-26
+// was queued behind the busy pointer project's single-lane worker
+// (ProjectWorker, TASK-393) — not stuck or silent, just waiting its turn —
+// and childOutcomeReconcileTimeout's 5m ceiling counted that queue-wait
+// against the same budget meant for detecting a genuinely stalled
+// execution. GH-26 went on to complete fine once it was actually picked up.
+// The child here stays "queued" (no started_at) for longer than
+// childOutcomeReconcileTimeout before finally transitioning to "running"
+// and completing quickly — this must succeed, not time out, because the
+// ceiling only applies once the child is actually executing.
+func TestExecuteSubIssues_ClaimLost_QueuedBeyondTimeoutStillSucceeds(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const taskID = "GH-301"
+	const projectPath = ""
+
+	claimed, err := store.ClaimExecution(taskID, projectPath, 0, "exec-owner")
+	if err != nil {
+		t.Fatalf("ClaimExecution: %v", err)
+	}
+	if !claimed {
+		t.Fatal("test setup: expected the seeded claim to win")
+	}
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-owner",
+		TaskID:      taskID,
+		ProjectPath: projectPath,
+		Status:      "queued",
+	}); err != nil {
+		t.Fatalf("SaveExecution (queued row): %v", err)
+	}
+
+	issues := makeSubIssues(1, 301)
+	parent := &Task{ID: "GH-93", Title: "[epic] queued behind busy project worker"}
+
+	execCalled := false
+	execFn := func(ctx context.Context, task *Task) (*ExecutionResult, error) {
+		execCalled = true
+		return &ExecutionResult{TaskID: task.ID, Success: true}, nil
+	}
+
+	runner := newTestRunnerWithExecFunc(execFn)
+	runner.logStore = store
+	runner.childOutcomeReconcilePollInterval = 20 * time.Millisecond
+	// SQLite's CURRENT_TIMESTAMP (what UpdateExecutionStatus stamps started_at
+	// with) has only whole-second resolution, so a startedAt-anchored deadline
+	// can read up to ~1s earlier than the real transition moment. timeout and
+	// queuedPhase below are sized with enough margin over that 1s ceiling that
+	// the assertions are deterministic rather than flaky.
+	const timeout = 1500 * time.Millisecond
+	const queuedPhase = 2000 * time.Millisecond // > timeout: proves queue-wait isn't charged against it
+	runner.childOutcomeReconcileTimeout = timeout
+
+	// Simulate the child sitting queued behind other work on a busy project
+	// for longer than childOutcomeReconcileTimeout, then finally being
+	// picked up (started_at stamped by the "running" transition, GH-4033)
+	// and completing quickly once it actually starts.
+	go func() {
+		time.Sleep(queuedPhase)
+		if uErr := store.UpdateExecutionStatus("exec-owner", "running"); uErr != nil {
+			t.Errorf("UpdateExecutionStatus(running): %v", uErr)
+		}
+		time.Sleep(100 * time.Millisecond) // well under timeout, running phase
+		if mcErr := store.MarkExecutionCompleted("exec-owner", "https://github.com/owner/repo/pull/9301", "sha-301", 500); mcErr != nil {
+			t.Errorf("MarkExecutionCompleted: %v", mcErr)
+		}
+	}()
+
+	start := time.Now()
+	err = runner.ExecuteSubIssues(context.Background(), parent, issues, parent.ProjectPath, "")
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("ExecuteSubIssues returned error, want nil (queue-wait must not count against the running timeout): %v", err)
+	}
+	if execCalled {
+		t.Error("expected the backend NOT to be invoked when the execution claim was already lost")
+	}
+	if elapsed < queuedPhase {
+		t.Errorf("elapsed = %s, want >= %s (test setup kept the child queued past the timeout before it started running)", elapsed, queuedPhase)
+	}
+}
+
+// TestExecuteSubIssues_ClaimLost_RunningSilentlyTimesOutFromStartedAt is the
+// GH-4413 counterpart to the queued case above: once the child is actually
+// "running" (started_at stamped) and then goes silent past
+// childOutcomeReconcileTimeout without reaching a terminal state, the epic
+// must still time out — the fix narrows what counts against the ceiling, it
+// does not remove the ceiling for a genuinely stuck execution. The queued
+// phase before the child starts running is deliberately longer than the
+// timeout itself, so a passing run also proves the deadline is anchored to
+// started_at (when the child began running) rather than to when this call
+// started polling.
+func TestExecuteSubIssues_ClaimLost_RunningSilentlyTimesOutFromStartedAt(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const taskID = "GH-302"
+	const projectPath = ""
+
+	claimed, err := store.ClaimExecution(taskID, projectPath, 0, "exec-owner")
+	if err != nil {
+		t.Fatalf("ClaimExecution: %v", err)
+	}
+	if !claimed {
+		t.Fatal("test setup: expected the seeded claim to win")
+	}
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-owner",
+		TaskID:      taskID,
+		ProjectPath: projectPath,
+		Status:      "queued",
+	}); err != nil {
+		t.Fatalf("SaveExecution (queued row): %v", err)
+	}
+
+	issues := makeSubIssues(1, 302)
+	parent := &Task{ID: "GH-94", Title: "[epic] running child goes silent"}
+
+	execCalled := false
+	execFn := func(ctx context.Context, task *Task) (*ExecutionResult, error) {
+		execCalled = true
+		return &ExecutionResult{TaskID: task.ID, Success: true}, nil
+	}
+
+	runner := newTestRunnerWithExecFunc(execFn)
+	runner.logStore = store
+	runner.childOutcomeReconcilePollInterval = 20 * time.Millisecond
+	// See the queued-success test above for why timeout/queuedPhase are sized
+	// against SQLite's whole-second CURRENT_TIMESTAMP resolution.
+	const timeout = 1500 * time.Millisecond
+	const queuedPhase = 2000 * time.Millisecond // > timeout: a call-start-anchored deadline would fire before this elapses
+	runner.childOutcomeReconcileTimeout = timeout
+
+	// Queued longer than the timeout (must not count against it), then
+	// starts running and never reaches a terminal state.
+	go func() {
+		time.Sleep(queuedPhase)
+		if uErr := store.UpdateExecutionStatus("exec-owner", "running"); uErr != nil {
+			t.Errorf("UpdateExecutionStatus(running): %v", uErr)
+		}
+	}()
+
+	start := time.Now()
+	err = runner.ExecuteSubIssues(context.Background(), parent, issues, parent.ProjectPath, "")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected a timeout error for a child stuck silently running, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out waiting for externally-owned child execution") {
+		t.Errorf("error = %q, want it to contain the reconcile timeout message", err.Error())
+	}
+	if execCalled {
+		t.Error("expected the backend NOT to be invoked when the execution claim was already lost")
+	}
+	// The deadline must anchor to started_at (~queuedPhase in), not to when
+	// this call began polling — a call-start-anchored deadline would have
+	// fired at ~timeout, well before the child ever started running.
+	if elapsed < queuedPhase {
+		t.Errorf("elapsed = %s, want >= %s (timed out before the child even started running — deadline not anchored to started_at)", elapsed, queuedPhase)
+	}
+}


### PR DESCRIPTION
## Summary

- `reconcileChildOutcome`'s poll loop previously computed its 5m deadline once, before entering the loop — so time a child spent `queued` behind the busy single-lane `ProjectWorker` (TASK-393) counted against the same budget meant to detect a stuck/silent execution.
- Pointer epic GH-9 (TASK-04) failed exactly this way: child GH-26 was still `queued` when the deadline fired, then completed fine standalone moments later. This was the residual failure mode behind the #4388 verification gate (5 timeout instances logged in one day, the last two on binaries already carrying #4388).
- The ceiling now applies only once the child's execution row is observed `running` (new `findChildExecutionState` helper), anchored to that row's `started_at` (GH-4033's stamp on the `running` transition) rather than to when the call started polling. While `queued`, there is no ceiling — mirrors `recoverStaleQueuedTasks`'s GH-2331 reasoning that a queued row behind a live worker is legitimately waiting its turn; a queued row with a dead claim gets reaped to terminal by that same sweep and is caught on the next terminal-row check.
- A child that starts running and then genuinely goes silent past the timeout still times out — the fix narrows what counts against the ceiling, it doesn't remove the ceiling.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/executor/...` (full suite, incl. all existing `reconcileChildOutcome`/no_op/claim-lost regression tests)
- [x] New regression tests added in `internal/executor/epic_child_reconcile_test.go`:
  - `TestExecuteSubIssues_ClaimLost_QueuedBeyondTimeoutStillSucceeds` — child queued past the timeout, then runs and completes quickly; must succeed.
  - `TestExecuteSubIssues_ClaimLost_RunningSilentlyTimesOutFromStartedAt` — child queued past the timeout, then runs and goes silent; must still time out, anchored to `started_at` not call-start.

Refs: #4388, TASK-393