### PR TITLE
fix(executor): fall through dangling claims to done-check; heal epic children on recorded branch (GH-4409)

### DIFF
--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -271,7 +271,7 @@ func (d *Dispatcher) reconcileOrphanedExecutions() int {
 		}
 
 		if exec.Status == string(ExecStatusRunning) {
-			branch := fmt.Sprintf("pilot/%s", exec.TaskID)
+			branch := mergedPRCheckBranch(exec)
 			if mergedURL, mergedErr := staleRunningMergedPRCheck(d.ctx, exec.ProjectPath, branch); mergedErr == nil && mergedURL != "" {
 				durationMs := time.Since(exec.CreatedAt).Milliseconds()
 				if err := d.store.MarkExecutionCompleted(exec.ID, mergedURL, "", durationMs); err != nil {
@@ -473,8 +473,11 @@ func (d *Dispatcher) recoverStaleRunningTasks() int {
 		// own status update raced the reap. HasCompletedExecution above only
 		// catches a *separate* completed row for the same task; this row IS the
 		// one being reaped, so it never satisfies that check. Consult the task
-		// branch's PR state directly before failing it.
-		branch := fmt.Sprintf("pilot/%s", exec.TaskID)
+		// branch's PR state directly before failing it. GH-4409: prefer the
+		// branch actually recorded on the row (mergedPRCheckBranch) over
+		// reconstructing "pilot/{TaskID}" — a decomposed subtask's work lands
+		// on its parent's branch, not a branch named after the subtask.
+		branch := mergedPRCheckBranch(exec)
 		if mergedURL, mergedErr := staleRunningMergedPRCheck(d.ctx, exec.ProjectPath, branch); mergedErr == nil && mergedURL != "" {
 			d.log.Info("Stale running task's branch already merged; healing to completed instead of failed",
 				slog.String("execution_id", exec.ID),
@@ -527,6 +530,25 @@ func (d *Dispatcher) deleteOrphanRunningRow(exec *memory.Execution) {
 	} else if pruned > 0 {
 		d.log.Info("Pruned orphaned task worktree", slog.String("task_id", exec.TaskID), slog.Int("count", pruned))
 	}
+}
+
+// mergedPRCheckBranch reports the branch staleRunningMergedPRCheck should
+// probe for exec: exec.TaskBranch when the row recorded one, falling back to
+// reconstructing "pilot/{TaskID}" only for legacy rows saved before
+// TaskBranch was persisted (or a row where it was never set).
+//
+// GH-4409: reconstructing "pilot/{TaskID}" unconditionally was wrong for a
+// decomposed subtask — decompose.go stamps subtask.Branch = parent.Branch,
+// so a child's real work lands on its PARENT's branch (e.g. GH-4393-5 ships
+// on pilot/GH-4393, not pilot/GH-4393-5). Probing the reconstructed
+// child-only branch found nothing to merge, so a claimed running child whose
+// work already shipped via the parent missed this heal and was re-run at
+// stalled->generation+1.
+func mergedPRCheckBranch(exec *memory.Execution) string {
+	if exec.TaskBranch != "" {
+		return exec.TaskBranch
+	}
+	return fmt.Sprintf("pilot/%s", exec.TaskID)
 }
 
 // staleRunningMergedPRCheck reports the URL of a merged PR for branch in
@@ -856,16 +878,22 @@ func (d *Dispatcher) nextRetryGeneration(taskID, projectPath string) (generation
 	}
 
 	claimedExec, err := d.store.GetExecution(execID)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			// Claim row landed but its executions row never did (Begin's
-			// save-failure case) — treat conservatively as still owned
-			// rather than guessing a retry is safe.
-			return 0, false, nil
-		}
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return 0, false, err
 	}
-	if !isTerminalExecutionStatus(claimedExec.Status) {
+	// GH-4409: sql.ErrNoRows means the claim row survives but the executions
+	// row it names does not — either Begin's save-failure case (claim landed,
+	// the executions INSERT never did) or a dangling claim left behind by
+	// deleteOrphanRunningRow / boot reconciliation deleting an execution row
+	// without pruning its claims (both current call sites only delete rows
+	// they've already confirmed are done, but a future caller deleting a
+	// claimed row for a NOT-done task must not wedge that task forever).
+	// Neither case is a live owner, so fall through to the done-check below
+	// instead of the old conservative "treat as still owned" — that
+	// short-circuited before HasTerminalCompletion could ever run, so a
+	// not-done task behind a dangling claim retried nothing, silently,
+	// forever.
+	if err == nil && !isTerminalExecutionStatus(claimedExec.Status) {
 		return 0, false, nil // live owner — today's ErrClaimLost drop path
 	}
 

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -871,6 +871,60 @@ func TestRecoverStaleRunningTasks_HealsToCompletedWhenBranchMerged(t *testing.T)
 	}
 }
 
+// TestRecoverStaleRunningTasks_HealsUsingRecordedBranchNotTaskID is the
+// GH-4409 regression guard for finding #2 in the #4403 review: a decomposed
+// subtask's real work lands on its PARENT's branch (decompose.go stamps
+// subtask.Branch = parent.Branch before the subtask ever runs), not a branch
+// reconstructed from the subtask's own task ID. A stale "running" row for a
+// subtask (e.g. GH-4393-5) whose recorded TaskBranch is the parent's branch
+// (pilot/GH-4393) must probe THAT branch for a merged PR — probing the
+// reconstructed "pilot/GH-4393-5" finds nothing, since nothing ever pushes
+// there, so the heal is missed and the child re-runs already-shipped work.
+func TestRecoverStaleRunningTasks_HealsUsingRecordedBranchNotTaskID(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	exec := &memory.Execution{
+		ID: "exec-subtask-run", TaskID: "GH-4393-5", ProjectPath: "/project-epic",
+		Status: "running", TaskBranch: "pilot/GH-4393",
+	}
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("failed to save execution: %v", err)
+	}
+
+	const mergedPRURL = "https://github.com/qf-studio/pilot/pull/4393"
+	origCheck := staleRunningMergedPRCheck
+	staleRunningMergedPRCheck = func(_ context.Context, projectPath, branch string) (string, error) {
+		if branch == "pilot/GH-4393-5" {
+			t.Errorf("staleRunningMergedPRCheck probed the reconstructed subtask branch %q instead of the recorded parent branch", branch)
+		}
+		if projectPath == "/project-epic" && branch == "pilot/GH-4393" {
+			return mergedPRURL, nil
+		}
+		return "", nil
+	}
+	defer func() { staleRunningMergedPRCheck = origCheck }()
+
+	config := &DispatcherConfig{
+		StaleRunningThreshold: 0,
+		StaleQueuedThreshold:  0,
+		StaleRecoveryInterval: time.Hour,
+	}
+	dispatcher := NewDispatcher(store, NewRunner(), config)
+	dispatcher.recoverStaleRunningTasks()
+
+	got, err := store.GetExecution("exec-subtask-run")
+	if err != nil {
+		t.Fatalf("failed to get execution: %v", err)
+	}
+	if got.Status != "completed" {
+		t.Errorf("expected subtask row with merged parent branch to heal to 'completed', got %q (error=%q)", got.Status, got.Error)
+	}
+	if got.PRUrl != mergedPRURL {
+		t.Errorf("expected pr_url = %q, got %q", mergedPRURL, got.PRUrl)
+	}
+}
+
 // TestRecoverStaleRunningTasks_MarksFailedWhenNoMergedPR guards the negative
 // case: a genuinely orphaned running row (no live worker, no merged PR on its
 // branch) must still be marked "failed" — the GH-4092 healing path must not
@@ -2635,6 +2689,48 @@ func TestDispatcher_ReconcileOrphanedExecutions(t *testing.T) {
 		}
 	})
 
+	t.Run("claimed running row heals using recorded branch, not reconstructed task-id branch", func(t *testing.T) {
+		// GH-4409: boot reconciliation's own merged-PR heal check must use the
+		// same branch-derivation fix as recoverStaleRunningTasks — a claimed
+		// decomposed-subtask row found at boot recorded its PARENT's branch,
+		// not one reconstructed from its own task ID.
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+
+		subtask := &Task{ID: "GH-4409-5", ProjectPath: "/project-epic-boot", Branch: "pilot/GH-4409"}
+		execID, err := NewExecutionLifecycle(store).Begin(subtask, ExecStatusRunning)
+		if err != nil {
+			t.Fatalf("setup Begin: %v", err)
+		}
+
+		const mergedPRURL = "https://github.com/qf-studio/pilot/pull/9202"
+		origCheck := staleRunningMergedPRCheck
+		staleRunningMergedPRCheck = func(_ context.Context, projectPath, branch string) (string, error) {
+			if branch == "pilot/GH-4409-5" {
+				t.Errorf("staleRunningMergedPRCheck probed the reconstructed subtask branch %q instead of the recorded parent branch", branch)
+			}
+			if projectPath == "/project-epic-boot" && branch == "pilot/GH-4409" {
+				return mergedPRURL, nil
+			}
+			return "", nil
+		}
+		defer func() { staleRunningMergedPRCheck = origCheck }()
+
+		dispatcher := NewDispatcher(store, NewRunner(), nil)
+		dispatcher.reconcileOrphanedExecutions()
+
+		exec, err := store.GetExecution(execID)
+		if err != nil {
+			t.Fatalf("GetExecution: %v", err)
+		}
+		if exec.Status != "completed" {
+			t.Errorf("expected status 'completed', got %q", exec.Status)
+		}
+		if exec.PRUrl != mergedPRURL {
+			t.Errorf("expected pr_url %q, got %q", mergedPRURL, exec.PRUrl)
+		}
+	})
+
 	t.Run("unclaimed queued row (bare SaveExecution) is left untouched", func(t *testing.T) {
 		store, cleanup := setupTestStore(t)
 		defer cleanup()
@@ -3172,6 +3268,82 @@ func TestDispatcher_ExecutionGeneration(t *testing.T) {
 	} else if gen != 1 {
 		t.Errorf("expected generation 1 after a re-pick claimed it, got %d", gen)
 	}
+}
+
+// TestNextRetryGeneration_DanglingClaimFallsThroughToDoneCheck is the GH-4409
+// regression guard for finding #1 in the #4403 review: nextRetryGeneration's
+// GetExecution(execID) call can return sql.ErrNoRows for a claim row whose
+// executions row was deleted out from under it (Begin's own save-failure
+// case, or a future path that deletes a claimed row — mirroring
+// deleteOrphanRunningRow — without pruning execution_claims). The old code
+// treated ErrNoRows as "still owned" unconditionally, short-circuiting
+// before HasTerminalCompletion ever ran — a not-done task behind such a
+// dangling claim could never retry, silently, forever. The fix falls
+// through to the done-check instead: retry only when the task genuinely
+// isn't done yet, preserving GH-4350's "never re-arm a done task" invariant
+// for the case where it IS done.
+func TestNextRetryGeneration_DanglingClaimFallsThroughToDoneCheck(t *testing.T) {
+	t.Run("not done: dangling claim yields a generation+1 retry instead of wedging", func(t *testing.T) {
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+
+		task := &Task{ID: "GH-4409-DANGLE-1", ProjectPath: "/project-dangle-1"}
+		execID, err := NewExecutionLifecycle(store).Begin(task, ExecStatusRunning)
+		if err != nil {
+			t.Fatalf("setup Begin: %v", err)
+		}
+		// Simulate a future row-delete path (mirroring deleteOrphanRunningRow)
+		// deleting the execution row without pruning its execution_claims
+		// entry, for a task that is NOT actually done — unlike today's real
+		// call sites, which only ever delete after confirming completion.
+		if err := store.DeleteExecution(execID); err != nil {
+			t.Fatalf("DeleteExecution: %v", err)
+		}
+
+		dispatcher := NewDispatcher(store, NewRunner(), nil)
+		gen, retry, err := dispatcher.nextRetryGeneration(task.ID, task.ProjectPath)
+		if err != nil {
+			t.Fatalf("nextRetryGeneration: %v", err)
+		}
+		if !retry {
+			t.Fatalf("expected retry=true for a dangling claim on a not-done task, got retry=false (task permanently wedged)")
+		}
+		if gen != 1 {
+			t.Errorf("expected generation 1, got %d", gen)
+		}
+	})
+
+	t.Run("done: dangling claim must not re-arm an already-completed task", func(t *testing.T) {
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+
+		task := &Task{ID: "GH-4409-DANGLE-2", ProjectPath: "/project-dangle-2"}
+		execID, err := NewExecutionLifecycle(store).Begin(task, ExecStatusRunning)
+		if err != nil {
+			t.Fatalf("setup Begin: %v", err)
+		}
+		// A separate execution row proves the task's real deliverable already
+		// shipped (HasCompletedExecution's own-task-id definition of "done")
+		// before the claimed row is deleted out from under it.
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-done-elsewhere", TaskID: task.ID, ProjectPath: task.ProjectPath,
+			Status: "completed", PRUrl: "https://github.com/qf-studio/pilot/pull/1",
+		}); err != nil {
+			t.Fatalf("SaveExecution(done): %v", err)
+		}
+		if err := store.DeleteExecution(execID); err != nil {
+			t.Fatalf("DeleteExecution: %v", err)
+		}
+
+		dispatcher := NewDispatcher(store, NewRunner(), nil)
+		_, retry, err := dispatcher.nextRetryGeneration(task.ID, task.ProjectPath)
+		if err != nil {
+			t.Fatalf("nextRetryGeneration: %v", err)
+		}
+		if retry {
+			t.Fatalf("expected retry=false — GH-4350's no_op/done invariant must not be reopened by a dangling claim, got retry=true")
+		}
+	})
 }
 
 // TestStore_GetQueuedProjectPaths verifies the distinct-project query backing

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -2323,7 +2323,7 @@ func (s *Store) UpdateExecutionTitle(executionID, title string) error {
 // (bypassing UpdateExecutionStatus, e.g. in tests).
 func (s *Store) GetStaleRunningExecutions(staleDuration time.Duration) ([]*Execution, error) {
 	rows, err := s.db.Query(`
-		SELECT id, task_id, project_path, status, output, error, duration_ms, pr_url, commit_sha, created_at, started_at, completed_at
+		SELECT id, task_id, project_path, status, output, error, duration_ms, pr_url, commit_sha, created_at, started_at, completed_at, COALESCE(task_branch, '')
 		FROM executions
 		WHERE status = 'running'
 	`)
@@ -2337,7 +2337,7 @@ func (s *Store) GetStaleRunningExecutions(staleDuration time.Duration) ([]*Execu
 		var exec Execution
 		var startedAt sql.NullTime
 		var completedAt sql.NullTime
-		if err := rows.Scan(&exec.ID, &exec.TaskID, &exec.ProjectPath, &exec.Status, &exec.Output, &exec.Error, &exec.DurationMs, &exec.PRUrl, &exec.CommitSHA, &exec.CreatedAt, &startedAt, &completedAt); err != nil {
+		if err := rows.Scan(&exec.ID, &exec.TaskID, &exec.ProjectPath, &exec.Status, &exec.Output, &exec.Error, &exec.DurationMs, &exec.PRUrl, &exec.CommitSHA, &exec.CreatedAt, &startedAt, &completedAt, &exec.TaskBranch); err != nil {
 			return nil, err
 		}
 		if startedAt.Valid {
@@ -2451,7 +2451,7 @@ func filterAndSortStale(execs []*Execution, staleDuration time.Duration) []*Exec
 // restart adoption still owns getting it a worker, unchanged by this fix.
 func (s *Store) GetClaimedNonTerminalExecutions() ([]*Execution, error) {
 	rows, err := s.db.Query(`
-		SELECT DISTINCT e.id, e.task_id, e.project_path, e.status, e.output, e.error, e.duration_ms, e.pr_url, e.commit_sha, e.created_at, e.started_at, e.completed_at
+		SELECT DISTINCT e.id, e.task_id, e.project_path, e.status, e.output, e.error, e.duration_ms, e.pr_url, e.commit_sha, e.created_at, e.started_at, e.completed_at, COALESCE(e.task_branch, '')
 		FROM executions e
 		JOIN execution_claims c ON c.execution_id = e.id
 		WHERE e.status IN ('queued', 'running')
@@ -2466,7 +2466,7 @@ func (s *Store) GetClaimedNonTerminalExecutions() ([]*Execution, error) {
 		var exec Execution
 		var startedAt sql.NullTime
 		var completedAt sql.NullTime
-		if err := rows.Scan(&exec.ID, &exec.TaskID, &exec.ProjectPath, &exec.Status, &exec.Output, &exec.Error, &exec.DurationMs, &exec.PRUrl, &exec.CommitSHA, &exec.CreatedAt, &startedAt, &completedAt); err != nil {
+		if err := rows.Scan(&exec.ID, &exec.TaskID, &exec.ProjectPath, &exec.Status, &exec.Output, &exec.Error, &exec.DurationMs, &exec.PRUrl, &exec.CommitSHA, &exec.CreatedAt, &startedAt, &completedAt, &exec.TaskBranch); err != nil {
 			return nil, err
 		}
 		if startedAt.Valid {


### PR DESCRIPTION
## Summary

Follow-up to the #4403 review (two non-blocking findings):

1. **Dangling `execution_claims` read as "live owner" forever.** `nextRetryGeneration` treated `sql.ErrNoRows` from `GetExecution` as "still owned" unconditionally, short-circuiting before `HasTerminalCompletion` ever ran. A claim row surviving after its executions row was deleted (e.g. by `deleteOrphanRunningRow`) without pruning the claim would wedge a not-done task's retries forever, silently — the GH-4392 symptom class. Now falls through to the done-check instead.

2. **Merged-PR heal probed the wrong branch for epic children.** `staleRunningMergedPRCheck` reconstructed `pilot/{TaskID}` for every claimed row, but a decomposed subtask's real work lands on its *parent's* branch (`decompose.go` stamps `subtask.Branch = parent.Branch`) — e.g. GH-4393-5 ships on `pilot/GH-4393`, not `pilot/GH-4393-5`. A claimed running child whose work merged via the parent missed the heal and was re-run at stalled→generation+1. Both merged-PR heal call sites now prefer the branch actually recorded on the execution row (`mergedPRCheckBranch`), falling back to reconstruction only for legacy rows that never recorded one.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/executor/...` — includes new `TestNextRetryGeneration_DanglingClaimFallsThroughToDoneCheck` and `TestRecoverStaleRunningTasks_HealsUsingRecordedBranchNotTaskID`
- [x] `go test ./internal/memory/...`

Refs: PR #4403 review thread, #4392 (parent fix), #4404 (re-pick class)