### PR TITLE
fix(executor): intent judge no longer cites its own truncation marker as missing implementation

### DIFF
--- a/.agent/sops/quality/llm-judge-truncation-markers.md
+++ b/.agent/sops/quality/llm-judge-truncation-markers.md
@@ -1,0 +1,63 @@
+# SOP: never let an LLM judge see its own truncation marker as evidence
+
+**Category:** Quality / LLM-as-judge prompt construction
+**Implemented:** 2026-07-17
+**Source incident:** GH-4407 (intent judge vetoed GH-15 and GH-12 at
+0.85-0.95 confidence, citing the `...[truncated]` marker *we* injected as
+proof the implementation was "incomplete" or "missing")
+
+## Problem
+
+`IntentJudge.Judge` (internal/executor/intent_judge.go) truncated large git
+diffs with a single global char cutoff (`diff[:maxChars] + "...[truncated]"`)
+before sending them to the Haiku judge model. For any diff over the cap
+(previously 8000 chars — roughly 150 changed lines), the cutoff usually fell
+mid-file, sometimes before any real content of files late in the diff order
+appeared at all.
+
+The judge model then read the literal string `[truncated]` in its own
+context and reasoned from it: "this content isn't shown, therefore it
+doesn't exist" — and issued a high-confidence FAIL, citing the marker
+itself as the reason. This scales inversely with task size: the bigger and
+more legitimate the PR, the more likely it hits the cap, the more likely it
+gets falsely vetoed.
+
+## Root cause
+
+Any prompt that (a) truncates input data and (b) asks an LLM to judge
+*completeness* of that data has this failure mode by construction — a
+truncation marker is indistinguishable from "absence of the thing" unless
+you tell the model otherwise, AND give it a way to independently confirm
+scope.
+
+## Fix pattern (applies to any LLM-judge prompt, not just this one)
+
+1. **Never drop a unit to zero visible content.** If you must truncate a
+   multi-file diff to a budget, split the budget per-file first
+   (`splitDiffByFile` + `buildJudgeDiffPayload` in intent_judge.go) so every
+   file keeps a floor of visible content (`minPerFileDiffChars`), instead of
+   letting the first file(s) in the diff exhaust the whole budget.
+2. **Ship an out-of-band manifest that is never truncated.** A short
+   "## Changed Files (N total)" list with every path + stat line costs
+   almost nothing and gives the judge a scope-of-record independent of the
+   (possibly abbreviated) diff body.
+3. **Say so in the system prompt, explicitly and by name.** Tell the judge
+   the exact marker string means "omitted for length," not "missing," and
+   forbid citing the marker itself as a FAIL reason. Models will use
+   whatever text is in front of them as evidence unless told not to.
+4. **Prefer raising the cap over aggressive truncation when cheap.** Haiku's
+   context window comfortably fits diffs an order of magnitude larger than
+   the old 8000-char cap; raise the default before reaching for cleverer
+   truncation. `IntentJudgeConfig.MaxDiffChars` (backend.go) is the operator
+   knob — default raised to 32000.
+
+## Prevention checklist for new LLM-judge prompts
+
+- [ ] Does truncation ever fully drop a unit (file, section, item) the judge
+      is asked to reason about? If yes, floor it instead.
+- [ ] Is there an always-complete manifest/summary the judge can fall back
+      on when body content is cut?
+- [ ] Does the system prompt explicitly state what the truncation marker
+      means and forbid citing it as evidence?
+- [ ] Is the cap itself justified by the model's actual context window, or
+      is it a stale/arbitrary number from an earlier, smaller model?

--- a/.agent/tasks/gh-4407.md
+++ b/.agent/tasks/gh-4407.md
@@ -1,0 +1,29 @@
+# GH-4407
+
+**Created:** 2026-07-17
+
+## Problem
+
+GitHub Issue GH-4407: fix(executor): intent judge vetoes large diffs because judge input is truncated — cites '[truncated]' content as missing implementation (GH-15/GH-12 false vetoes)
+
+## Symptom
+
+The intent judge receives a **truncated** diff for large changes, then vetoes at high confidence citing exactly the truncated content as "missing". Two occurrences on 2026-07-17 (AWS daemon, v2.241.1-3-g70b28845):
+
+- GH-15 (diff_len=23923): veto reason: "The diff is incomplete/truncated … indicated by the \"...[truncated]\" marker … component definitions themselves are not visible." confidence=0.95
+- GH-12 (diff_len=54240): veto reason: "The diff shows only go.mod and go.sum dependency changes—no implementation files … are present." confidence=0.95 — the implementation files existed; PR #20 contains them (21 files written).
+
+## Consequence
+
+Every large-diff task gets vetoed regardless of actual quality — false-negative class. Work is complete and the PR exists, but the execution records the veto, poisoning outcome metrics and any veto-gated downstream behavior. Scales inversely with task size: the biggest tasks are judged the worst.
+
+## Fix sketch
+
+Either (a) raise/remove the diff truncation cap for the judge and rely on the judge model's context window, (b) truncate per-file with a manifest (file list + stats always intact) so the judge sees full scope, or (c) instruct the judge that `[truncated]` means "not shown", never "not implemented", and pass the full changed-file list alongside. (b)+(c) combined is likely the cheap durable fix.
+
+## Refs
+
+- Log evidence: "Intent judge vetoed diff" entries at 10:22:39Z (GH-15) and 10:58:45Z (GH-12).
+
+## Acceptance Criteria
+

--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -584,7 +584,7 @@ func DefaultEffortClassifierConfig() *EffortClassifierConfig {
 //	  intent_judge:
 //	    enabled: true
 //	    model: "claude-haiku-4-5-20251001"
-//	    max_diff_chars: 8000
+//	    max_diff_chars: 32000
 type IntentJudgeConfig struct {
 	// Enabled controls whether the intent judge runs after execution.
 	// Default: true (when config block is present).
@@ -593,8 +593,9 @@ type IntentJudgeConfig struct {
 	// Model is the model to use for intent evaluation. Default: "claude-haiku-4-5-20251001"
 	Model string `yaml:"model,omitempty"`
 
-	// MaxDiffChars is the maximum diff size in characters before truncation.
-	// Default: 8000.
+	// MaxDiffChars is the maximum diff size in characters before truncation
+	// falls back to per-file truncation with a full file manifest (GH-4407).
+	// Default: 32000.
 	MaxDiffChars int `yaml:"max_diff_chars,omitempty"`
 }
 
@@ -604,7 +605,7 @@ func DefaultIntentJudgeConfig() *IntentJudgeConfig {
 	return &IntentJudgeConfig{
 		Enabled:      &enabled,
 		Model:        "claude-haiku-4-5-20251001",
-		MaxDiffChars: 8000,
+		MaxDiffChars: 32000,
 	}
 }
 

--- a/internal/executor/intent_judge.go
+++ b/internal/executor/intent_judge.go
@@ -33,8 +33,12 @@ type IntentJudge struct {
 	model            string
 	judgeTimeout     time.Duration
 	preflightTimeout time.Duration
-	log              *slog.Logger
-	cmdRunner        func(ctx context.Context, args ...string) ([]byte, error)
+	// maxDiffChars caps the diff payload sent to the judge. GH-4407: kept
+	// per-instance (not just a package constant) so it can be overridden
+	// from IntentJudgeConfig.MaxDiffChars.
+	maxDiffChars int
+	log          *slog.Logger
+	cmdRunner    func(ctx context.Context, args ...string) ([]byte, error)
 }
 
 // NewIntentJudge creates a new IntentJudge that calls Claude Code subprocess.
@@ -48,6 +52,7 @@ func NewIntentJudge(claudeCmd string) *IntentJudge {
 		model:            "claude-haiku-4-5-20251001",
 		judgeTimeout:     30 * time.Second,
 		preflightTimeout: 20 * time.Second,
+		maxDiffChars:     maxDiffCharsDefault,
 		log:              slog.Default(),
 	}
 	j.cmdRunner = j.defaultCmdRunner
@@ -184,10 +189,28 @@ func (v *PreFlightVerdict) IsRejection() bool {
 }
 
 var (
-	verdictPassRegex    = regexp.MustCompile(`VERDICT:\s*PASS`)
-	verdictFailRegex    = regexp.MustCompile(`VERDICT:\s*FAIL`)
-	confidenceRegex     = regexp.MustCompile(`CONFIDENCE:\s*([0-9]*\.?[0-9]+)`)
-	maxDiffCharsDefault = 8000
+	verdictPassRegex = regexp.MustCompile(`VERDICT:\s*PASS`)
+	verdictFailRegex = regexp.MustCompile(`VERDICT:\s*FAIL`)
+	confidenceRegex  = regexp.MustCompile(`CONFIDENCE:\s*([0-9]*\.?[0-9]+)`)
+
+	// maxDiffCharsDefault caps the total diff payload sent to the judge model.
+	// GH-4407: raised from 8000 — that cap sliced mid-file on any diff over
+	// ~150 changed lines (e.g. GH-15 at 23923 chars, GH-12 at 54240 chars),
+	// and the judge then cited its own injected "...[truncated]" marker as
+	// proof the implementation was missing, vetoing legitimate large PRs at
+	// 0.85-0.95 confidence. Diffs still over this larger cap fall back to
+	// per-file truncation (buildJudgeDiffPayload) instead of a raw cutoff.
+	maxDiffCharsDefault = 32000
+
+	// minPerFileDiffChars is the floor every file gets when a diff must be
+	// truncated to fit maxDiffCharsDefault, so per-file truncation never
+	// drops a file's visible content to (near) zero — which is exactly what
+	// the judge misread as "this file was not touched" in GH-12.
+	minPerFileDiffChars = 500
+
+	// diffGitHeaderRegex matches the "diff --git a/X b/Y" line that begins
+	// each file's section in a unified git diff.
+	diffGitHeaderRegex = regexp.MustCompile(`^diff --git a/(?:.+) b/(.+)$`)
 
 	preflightDecisionRegex   = regexp.MustCompile(`DECISION:\s*(\S+)`)
 	preflightReasonRegex     = regexp.MustCompile(`REASON:\s*(.+)`)
@@ -218,6 +241,8 @@ Check for:
 3) Unrelated changes (refactoring or cleanup not mentioned in issue)
 4) Incomplete multi-file changes (if the issue implies changes to multiple backends, adapters, or sibling files, verify ALL were updated — not just one)
 
+IMPORTANT — truncation handling: Large diffs are prefixed with a "## Changed Files" manifest listing every file the diff touches, with add/remove line counts. That manifest is always complete and NEVER truncated, even when the diff body below it is shortened for length. A "...[truncated: N more bytes ... omitted]" marker inside a file's diff body means ONLY that content was cut to fit — it is NOT evidence that the file, a function, or a feature is missing or unimplemented. Judge scope and completeness using the Changed Files manifest, not the presence of a truncation marker. Never cite a truncation marker itself as a reason for VERDICT:FAIL.
+
 Output exactly one of: VERDICT:PASS or VERDICT:FAIL followed by a brief reason on the next line.
 Then output CONFIDENCE:X.X (0.0-1.0).`
 
@@ -227,11 +252,13 @@ func (j *IntentJudge) Judge(ctx context.Context, issueTitle, issueBody, diff str
 		return nil, fmt.Errorf("empty diff")
 	}
 
-	// Truncate diff to prevent token overflow
-	maxChars := maxDiffCharsDefault
-	if len(diff) > maxChars {
-		diff = diff[:maxChars] + "\n...[truncated]"
+	// Truncate diff to prevent token overflow, distributing the cut across
+	// files (with a full file manifest) rather than a single blind cutoff.
+	maxChars := j.maxDiffChars
+	if maxChars <= 0 {
+		maxChars = maxDiffCharsDefault
 	}
+	diff = buildJudgeDiffPayload(diff, maxChars)
 
 	prompt := fmt.Sprintf("%s\n\n## Issue Title\n%s\n\n## Issue Description\n%s\n\n## Git Diff\n```diff\n%s\n```",
 		intentJudgeSystemPrompt, issueTitle, issueBody, diff)
@@ -245,6 +272,106 @@ func (j *IntentJudge) Judge(ctx context.Context, issueTitle, issueBody, diff str
 	}
 
 	return parseJudgeResponse(string(output))
+}
+
+// diffFileSection is one file's slice of a unified diff, delimited by
+// "diff --git a/X b/Y" header lines.
+type diffFileSection struct {
+	path    string
+	body    string
+	added   int
+	removed int
+}
+
+// splitDiffByFile breaks a unified diff into per-file sections so truncation
+// can be distributed fairly across files instead of a single char cutoff
+// that can consume the whole budget on the first file(s) and leave later
+// files with zero visible content. GH-4407.
+func splitDiffByFile(diff string) []diffFileSection {
+	lines := strings.Split(diff, "\n")
+	var sections []diffFileSection
+	var cur *diffFileSection
+
+	flush := func() {
+		if cur != nil {
+			cur.body = strings.TrimSuffix(cur.body, "\n")
+			sections = append(sections, *cur)
+		}
+	}
+
+	for _, line := range lines {
+		if m := diffGitHeaderRegex.FindStringSubmatch(line); m != nil {
+			flush()
+			cur = &diffFileSection{path: m[1]}
+		} else if cur == nil {
+			// Content before any "diff --git" header (malformed/partial
+			// diff) - don't drop it, buffer under a synthetic path.
+			cur = &diffFileSection{path: "(diff)"}
+		}
+		cur.body += line + "\n"
+		switch {
+		case strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---"):
+			// File marker lines, not content changes.
+		case strings.HasPrefix(line, "+"):
+			cur.added++
+		case strings.HasPrefix(line, "-"):
+			cur.removed++
+		}
+	}
+	flush()
+	return sections
+}
+
+// buildJudgeDiffPayload prepares the diff text sent to the judge model.
+// Diffs within maxChars are returned unmodified. Diffs over the cap are
+// truncated per-file — never dropping a whole file's content to zero — and
+// prefixed with a complete file manifest, so the judge always has full
+// visibility into diff *scope* even when it can't see every changed line.
+//
+// GH-4407: the previous global char-cutoff sliced mid-file on large diffs,
+// and the judge then cited its own injected "...[truncated]" marker as
+// proof the implementation was missing.
+func buildJudgeDiffPayload(diff string, maxChars int) string {
+	if len(diff) <= maxChars {
+		return diff
+	}
+
+	sections := splitDiffByFile(diff)
+	if len(sections) <= 1 {
+		// No parseable per-file boundaries (single-file or malformed diff) -
+		// fall back to a plain tail cutoff.
+		return diff[:maxChars] + "\n...[truncated]"
+	}
+
+	var manifest strings.Builder
+	manifest.WriteString(fmt.Sprintf("## Changed Files (%d total, full list — not truncated)\n", len(sections)))
+	for _, s := range sections {
+		manifest.WriteString(fmt.Sprintf("- %s (+%d/-%d)\n", s.path, s.added, s.removed))
+	}
+	manifest.WriteString("\n## Diff Content (per-file, may be truncated for length — see manifest above for the full file list)\n")
+
+	budget := maxChars - manifest.Len()
+	if budget < 0 {
+		budget = 0
+	}
+	perFile := budget / len(sections)
+	if perFile < minPerFileDiffChars {
+		perFile = minPerFileDiffChars
+	}
+
+	var body strings.Builder
+	for _, s := range sections {
+		if len(s.body) <= perFile {
+			body.WriteString(s.body)
+			body.WriteString("\n")
+			continue
+		}
+		omitted := len(s.body) - perFile
+		body.WriteString(s.body[:perFile])
+		body.WriteString(fmt.Sprintf("\n...[truncated: %d more bytes of %s omitted for length, see manifest above for full file list]\n", omitted, s.path))
+	}
+
+	return manifest.String() + body.String()
 }
 
 // JudgeIssue evaluates whether a GitHub issue is actionable before dispatching to a worker.

--- a/internal/executor/intent_judge_test.go
+++ b/internal/executor/intent_judge_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
@@ -100,8 +101,9 @@ func TestIntentJudge_DiffTruncation(t *testing.T) {
 		return []byte("VERDICT: PASS\nLooks good.\nCONFIDENCE: 0.9"), nil
 	}
 
-	// Create a diff larger than maxDiffCharsDefault (8000)
-	largeDiff := strings.Repeat("x", 10000)
+	// Create a diff larger than maxDiffCharsDefault (32000), with no
+	// "diff --git" boundaries - exercises the plain-cutoff fallback path.
+	largeDiff := strings.Repeat("x", 40000)
 
 	judge := newIntentJudgeWithRunner(runner)
 	verdict, err := judge.Judge(context.Background(), "title", "body", largeDiff)
@@ -113,6 +115,93 @@ func TestIntentJudge_DiffTruncation(t *testing.T) {
 	}
 	if !strings.Contains(receivedPrompt, "...[truncated]") {
 		t.Error("expected diff to be truncated in prompt")
+	}
+}
+
+// TestIntentJudge_UnderCapNotTruncated verifies diffs within the (raised)
+// cap are sent through unmodified - GH-15 (23923 chars) previously exceeded
+// the old 8000-char cap and got a mid-file cutoff; it must now fit whole.
+func TestIntentJudge_UnderCapNotTruncated(t *testing.T) {
+	var receivedPrompt string
+	runner := func(ctx context.Context, args ...string) ([]byte, error) {
+		for i, arg := range args {
+			if arg == "-p" && i+1 < len(args) {
+				receivedPrompt = args[i+1]
+				break
+			}
+		}
+		return []byte("VERDICT: PASS\nLooks good.\nCONFIDENCE: 0.9"), nil
+	}
+
+	diff := "diff --git a/foo.go b/foo.go\n" + strings.Repeat("+line of code\n", 1000) // ~24923 chars incl header, mirrors GH-15's 23923
+
+	judge := newIntentJudgeWithRunner(runner)
+	verdict, err := judge.Judge(context.Background(), "title", "body", diff)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !verdict.Passed {
+		t.Error("expected PASS verdict")
+	}
+	if strings.Contains(receivedPrompt, "...[truncated]") {
+		t.Error("diff under maxDiffCharsDefault must not be truncated")
+	}
+	if !strings.Contains(receivedPrompt, diff) {
+		t.Error("expected full, unmodified diff to be present in prompt")
+	}
+}
+
+// TestIntentJudge_PerFileTruncationPreservesManifest is the direct
+// regression test for GH-4407: a diff that spans many files and exceeds the
+// cap must (1) list every touched file in a never-truncated manifest and
+// (2) never zero out any single file's visible content, so the judge can't
+// mistake a truncation marker for "this file wasn't touched".
+func TestIntentJudge_PerFileTruncationPreservesManifest(t *testing.T) {
+	var receivedPrompt string
+	runner := func(ctx context.Context, args ...string) ([]byte, error) {
+		for i, arg := range args {
+			if arg == "-p" && i+1 < len(args) {
+				receivedPrompt = args[i+1]
+				break
+			}
+		}
+		return []byte("VERDICT: PASS\nLooks good.\nCONFIDENCE: 0.9"), nil
+	}
+
+	// Simulate GH-12: many files, total diff far over the cap.
+	var sb strings.Builder
+	var paths []string
+	for i := 0; i < 25; i++ {
+		path := fmt.Sprintf("internal/pkg/file%d.go", i)
+		paths = append(paths, path)
+		sb.WriteString(fmt.Sprintf("diff --git a/%s b/%s\n", path, path))
+		sb.WriteString("--- a/" + path + "\n+++ b/" + path + "\n")
+		sb.WriteString(strings.Repeat(fmt.Sprintf("+func Impl%d() {}\n", i), 200))
+	}
+	diff := sb.String()
+	if len(diff) <= maxDiffCharsDefault {
+		t.Fatalf("test fixture diff (%d chars) must exceed maxDiffCharsDefault (%d) to exercise truncation", len(diff), maxDiffCharsDefault)
+	}
+
+	judge := newIntentJudgeWithRunner(runner)
+	verdict, err := judge.Judge(context.Background(), "title", "body", diff)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !verdict.Passed {
+		t.Error("expected PASS verdict")
+	}
+
+	if !strings.Contains(receivedPrompt, "## Changed Files (25 total") {
+		t.Error("expected a complete Changed Files manifest header")
+	}
+	for _, path := range paths {
+		if !strings.Contains(receivedPrompt, path) {
+			t.Errorf("expected manifest to list every file, missing %q", path)
+		}
+	}
+	if !strings.Contains(receivedPrompt, "...[truncated:") {
+		t.Error("expected per-file truncation markers for a diff this large")
 	}
 }
 

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -864,7 +864,13 @@ func NewRunnerWithConfig(config *BackendConfig) (*Runner, error) {
 			if config.IntentJudge.Model != "" {
 				runner.intentJudge.model = config.IntentJudge.Model
 			}
-			runner.log.Info("Intent judge initialized", slog.String("model", runner.intentJudge.model))
+			if config.IntentJudge.MaxDiffChars > 0 {
+				runner.intentJudge.maxDiffChars = config.IntentJudge.MaxDiffChars
+			}
+			runner.log.Info("Intent judge initialized",
+				slog.String("model", runner.intentJudge.model),
+				slog.Int("max_diff_chars", runner.intentJudge.maxDiffChars),
+			)
 		}
 	} else if config != nil && config.IntentJudge == nil {
 		runner.log.Debug("Intent judge disabled: no config")

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -2247,6 +2247,59 @@ func TestNewRunnerWithConfig_SkipSelfReview(t *testing.T) {
 	}
 }
 
+// Test that IntentJudgeConfig.MaxDiffChars flows into the wired IntentJudge (GH-4407).
+func TestNewRunnerWithConfig_IntentJudgeMaxDiffChars(t *testing.T) {
+	enabled := true
+	config := &BackendConfig{
+		Type: "claude-code",
+		ClaudeCode: &ClaudeCodeConfig{
+			Command: "sh", // guaranteed present on PATH so exec.LookPath succeeds
+		},
+		IntentJudge: &IntentJudgeConfig{
+			Enabled:      &enabled,
+			MaxDiffChars: 64000,
+		},
+	}
+
+	runner, err := NewRunnerWithConfig(config)
+	if err != nil {
+		t.Fatalf("NewRunnerWithConfig failed: %v", err)
+	}
+	if runner.intentJudge == nil {
+		t.Fatal("expected intent judge to be wired")
+	}
+	if runner.intentJudge.maxDiffChars != 64000 {
+		t.Errorf("maxDiffChars = %d, want 64000", runner.intentJudge.maxDiffChars)
+	}
+}
+
+// Test that an unset MaxDiffChars falls back to the package default rather
+// than zero (which would defeat truncation entirely). GH-4407.
+func TestNewRunnerWithConfig_IntentJudgeDefaultMaxDiffChars(t *testing.T) {
+	enabled := true
+	config := &BackendConfig{
+		Type: "claude-code",
+		ClaudeCode: &ClaudeCodeConfig{
+			Command: "sh",
+		},
+		IntentJudge: &IntentJudgeConfig{
+			Enabled: &enabled,
+			// MaxDiffChars left zero - NewIntentJudge should apply the default.
+		},
+	}
+
+	runner, err := NewRunnerWithConfig(config)
+	if err != nil {
+		t.Fatalf("NewRunnerWithConfig failed: %v", err)
+	}
+	if runner.intentJudge == nil {
+		t.Fatal("expected intent judge to be wired")
+	}
+	if runner.intentJudge.maxDiffChars != maxDiffCharsDefault {
+		t.Errorf("maxDiffChars = %d, want default %d", runner.intentJudge.maxDiffChars, maxDiffCharsDefault)
+	}
+}
+
 // Test ExtractRepoName function (GH-386)
 func TestExtractRepoName(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

Fixes GH-4407: the intent judge falsely vetoed large-diff PRs at 0.85-0.95 confidence, citing the `...[truncated]` marker it injected as evidence that files/features were missing.

- GH-15 (diff_len=23923): veto cited `"...[truncated]" marker` as proof "component definitions themselves are not visible"
- GH-12 (diff_len=54240): veto claimed "no implementation files ... are present" — the 21 implementation files existed in PR #20, but the naive 8000-char cutoff consumed the whole budget before reaching them

## Changes

- Raise the default diff truncation cap from 8000 to 32000 chars (`maxDiffCharsDefault` in `internal/executor/intent_judge.go`), and wire the previously dead `IntentJudgeConfig.MaxDiffChars` config field through to the judge so it's operator-configurable.
- When a diff still exceeds the cap, fall back to per-file truncation (`splitDiffByFile` / `buildJudgeDiffPayload`) instead of a single blind cutoff: every file gets a truncation floor (never zeroed out), and a "Changed Files" manifest listing every touched file + stats is always sent in full, never truncated.
- Update the judge's system prompt to explicitly state that a truncation marker means content was omitted for length, not that it's missing, and to judge scope from the manifest rather than the abbreviated diff body.
- Add `.agent/sops/quality/llm-judge-truncation-markers.md` documenting the general failure pattern (LLM judges over truncated inputs) for future prompt work.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/executor/...` (full package, including new tests)
- [x] `go test ./internal/wiring/...`
- [x] New regression test `TestIntentJudge_PerFileTruncationPreservesManifest` reproduces the GH-12 shape (25 files, diff over cap) and asserts the manifest lists every file and no file's content is dropped to zero
- [x] New test `TestIntentJudge_UnderCapNotTruncated` reproduces the GH-15 shape (~24k chars) and asserts it now passes through untouched
- [x] New wiring tests confirm `IntentJudgeConfig.MaxDiffChars` flows into the constructed judge, with a sane default when unset