### PR TITLE
feat(executor): wire graph-indexed memory deletion guard into push/PR-create path (GH-4397)

### DIFF
--- a/.agent/tasks/gh-4397.md
+++ b/.agent/tasks/gh-4397.md
@@ -1,0 +1,25 @@
+# GH-4397
+
+**Created:** 2026-07-17
+
+## Problem
+
+GitHub Issue GH-4397: feat(executor): detect deletions of graph-indexed memory files before push/PR...
+
+<!--autopilot-meta
+parent: GH-4387
+inherited-spec: true
+-->
+
+Parent: GH-4387
+
+Add a deterministic in-tree guard (in git.go's push/PR-create path or the finalize step in runner.go, mirroring the pre-push merge check) that diffs the worktree's staged/committed changes against the branch base and detects any deletion under .agent/knowledge/memories/ whose path is in the protected set collected from graph.json.
+
+## Scope fence
+
+Implement ONLY the slice described above. The parent issue GH-4387 is decomposed
+into sibling sub-issues that cover the rest of its spec — consult the parent
+for context, but do NOT implement parts of it that fall outside this subtask.
+
+## Acceptance Criteria
+

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1613,6 +1613,20 @@ func (r *Runner) finalizeEpicBranchPR(ctx context.Context, task *Task, git *GitO
 		)
 	}
 
+	// GH-4397: restore any graph-indexed memory doc the epic session deleted —
+	// the file's graph.json node survives, so an unrestored deletion trips the
+	// Knowledge Graph Drift Gate the same way an unindexed addition does (see
+	// GH-4286 above). Runs after the strip guard and before push so the
+	// restoration commit rides the same branch this PR is built from.
+	if restored, restoreErr := git.RestoreDeletedIndexedMemoryDocs(ctx, baseBranch); restoreErr != nil {
+		r.log.Warn("Failed to restore deleted protected memory doc(s) on epic branch",
+			slog.String("task_id", task.ID),
+			slog.Any("error", restoreErr),
+		)
+	} else if len(restored) > 0 {
+		r.recordMemoryGuardRestoreEvents(task.LogExecutionID(), restored)
+	}
+
 	r.reportProgress(task.ID, "Creating PR", 96, "Pushing epic branch...")
 
 	// Push the parent branch. TASK-359: a real deliverable that fails to push is a
@@ -4104,6 +4118,21 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 					slog.String("task_id", task.ID),
 					slog.Any("files", stripped),
 				)
+			}
+
+			// GH-4397: restore any graph-indexed memory doc this session deleted
+			// — the file's graph.json node survives, so an unrestored deletion
+			// trips the Knowledge Graph Drift Gate the same way an unindexed
+			// addition does (see GH-4286 above). Runs after the strip guard and
+			// before push so the restoration commit rides the same branch this
+			// PR is built from.
+			if restored, restoreErr := git.RestoreDeletedIndexedMemoryDocs(ctx, baseBranch); restoreErr != nil {
+				log.Warn("Failed to restore deleted protected memory doc(s) from branch",
+					slog.String("task_id", task.ID),
+					slog.Any("error", restoreErr),
+				)
+			} else if len(restored) > 0 {
+				r.recordMemoryGuardRestoreEvents(task.LogExecutionID(), restored)
 			}
 
 			// Pre-push lint gate (GH-1376)

--- a/internal/executor/runner_decompose.go
+++ b/internal/executor/runner_decompose.go
@@ -422,6 +422,20 @@ func (r *Runner) finalizeDecomposedParentPR(ctx context.Context, task *Task, git
 		)
 	}
 
+	// GH-4397: restore any graph-indexed memory doc a subtask session deleted
+	// — the file's graph.json node survives, so an unrestored deletion trips
+	// the Knowledge Graph Drift Gate the same way an unindexed addition does
+	// (see GH-4286 above). Runs after the strip guard and before push so the
+	// restoration commit rides the same branch this PR is built from.
+	if restored, restoreErr := git.RestoreDeletedIndexedMemoryDocs(ctx, baseBranch); restoreErr != nil {
+		log.Warn("Failed to restore deleted protected memory doc(s) from decomposed-parent branch",
+			slog.String("task_id", task.ID),
+			slog.Any("error", restoreErr),
+		)
+	} else if len(restored) > 0 {
+		r.recordMemoryGuardRestoreEvents(task.LogExecutionID(), restored)
+	}
+
 	r.reportProgress(task.ID, "Creating PR", 96, "Pushing branch...")
 
 	var pushErr error

--- a/internal/executor/runner_gh4397_test.go
+++ b/internal/executor/runner_gh4397_test.go
@@ -1,0 +1,219 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// TestFinalizeDecomposedParentPR_RestoresDeletedIndexedMemoryDoc covers
+// GH-4397: the wiring leg of the GH-4387 protected-memory guard. Detection
+// and restore (GitOperations.RestoreDeletedIndexedMemoryDocs, GH-4398) and
+// event recording (Runner.recordMemoryGuardRestoreEvents) already existed,
+// but neither was ever called from a push/PR-create path — a subtask session
+// that deleted a graph-indexed memory doc during "cleanup" would still ship a
+// PR that trips the Knowledge Graph Drift Gate. This proves the wiring: a
+// deletion of a graph-indexed file is restored before push, the restored file
+// survives in the pushed branch's diff against base, and the intervention is
+// recorded as a StageMemoryGuardRestore execution event.
+func TestFinalizeDecomposedParentPR_RestoresDeletedIndexedMemoryDoc(t *testing.T) {
+	setUpFakeGhPATH(t, []byte(`[]`), []byte(`[]`)) // no pre-existing merged/open PR
+
+	repoDir, _ := setupFreshnessRepo(t)
+
+	// Seed graph.json + the indexed memory doc on main before branching.
+	docRel := ".agent/knowledge/memories/pitfalls/pitfall_gh4397_repro.md"
+	docPath := filepath.Join(repoDir, docRel)
+	if err := os.MkdirAll(filepath.Dir(docPath), 0755); err != nil {
+		t.Fatalf("mkdir memories dir: %v", err)
+	}
+	if err := os.WriteFile(docPath, []byte("# a pitfall the branch base already carries\n"), 0644); err != nil {
+		t.Fatalf("write memory doc: %v", err)
+	}
+	graph := `{"nodes":{"memories":{"mem-gh4397":{"file":"` + docRel + `"}}}}`
+	graphPath := filepath.Join(repoDir, ".agent", "knowledge", "graph.json")
+	if err := os.WriteFile(graphPath, []byte(graph), 0644); err != nil {
+		t.Fatalf("write graph.json: %v", err)
+	}
+	runGit(t, repoDir, "add", docRel, ".agent/knowledge/graph.json")
+	runGit(t, repoDir, "commit", "-m", "chore: seed indexed memory doc + graph.json")
+	runGit(t, repoDir, "push", "origin", "main")
+
+	runGit(t, repoDir, "checkout", "-b", "pilot/GH-9397")
+
+	// Real subtask work.
+	if err := os.WriteFile(filepath.Join(repoDir, "f.txt"), []byte("subtask work\n"), 0644); err != nil {
+		t.Fatalf("write f.txt: %v", err)
+	}
+	runGit(t, repoDir, "add", "f.txt")
+	runGit(t, repoDir, "commit", "-m", "subtask work")
+
+	// The session "cleans up" what it judges an unused doc — but it's still
+	// graph-indexed, the exact shape that produced the drift-gate-red PR #4385.
+	runGit(t, repoDir, "rm", docRel)
+	runGit(t, repoDir, "commit", "-m", "chore(memory): strip unindexed memory doc(s) added during execution")
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	r := newSilentRunnerTask359()
+	r.SetLogStore(store)
+	creator := &fakePRCreatorGH4031{url: "https://gitlab.example.com/o/r/-/merge_requests/12"}
+	r.prCreator = creator
+	task := &Task{
+		ID:            "GH-9397",
+		Title:         "fix something",
+		Description:   "d",
+		Branch:        "pilot/GH-9397",
+		BaseBranch:    "main",
+		CreatePR:      true,
+		SourceAdapter: "gitlab", // non-github so the registry PRCreator branch is used
+	}
+	if err := store.SaveExecution(&memory.Execution{ID: task.LogExecutionID(), TaskID: task.ID, Status: "running"}); err != nil {
+		t.Fatalf("SaveExecution failed: %v", err)
+	}
+	result := &ExecutionResult{TaskID: task.ID, Success: true, CommitSHA: "placeholder"}
+
+	r.finalizeDecomposedParentPR(context.Background(), task, NewGitOperations(repoDir), result)
+
+	if !result.Success {
+		t.Fatalf("expected Success=true (guard must restore, not block), got false (error=%q)", result.Error)
+	}
+	if result.PRUrl == "" {
+		t.Error("expected a PR URL")
+	}
+
+	// The pushed branch must no longer show the indexed doc as deleted
+	// relative to base — the guard restored it via a follow-up commit.
+	diffCmd := exec.Command("git", "diff", "--name-only", "--diff-filter=D", "origin/main...pilot/GH-9397")
+	diffCmd.Dir = repoDir
+	out, err := diffCmd.Output()
+	if err != nil {
+		t.Fatalf("git diff failed: %v", err)
+	}
+	if strings.Contains(string(out), docRel) {
+		t.Errorf("expected %s restored (not deleted) in pushed branch diff, got deletions: %s", docRel, out)
+	}
+	if _, statErr := os.Stat(docPath); statErr != nil {
+		t.Errorf("expected %s restored on disk, stat err = %v", docRel, statErr)
+	}
+
+	// The intervention must be visible in the execution_events ledger.
+	events, err := store.ListExecutionEvents(task.LogExecutionID())
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+	var found bool
+	for _, e := range events {
+		if e.Stage != memory.StageMemoryGuardRestore {
+			continue
+		}
+		var detail struct {
+			Path   string `json:"path"`
+			NodeID string `json:"node_id"`
+		}
+		if err := json.Unmarshal([]byte(e.Detail), &detail); err != nil {
+			t.Fatalf("failed to unmarshal event detail: %v", err)
+		}
+		if detail.Path == docRel && detail.NodeID == "mem-gh4397" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a StageMemoryGuardRestore event for %s (node mem-gh4397), got events: %+v", docRel, events)
+	}
+}
+
+// TestFinalizeDecomposedParentPR_AllowsDeletingUnindexedMemoryDoc covers the
+// inverse of GH-4397's guard: deleting a genuinely unindexed memory doc (no
+// surviving graph.json node) must remain allowed — the guard must not
+// resurrect files nobody references.
+func TestFinalizeDecomposedParentPR_AllowsDeletingUnindexedMemoryDoc(t *testing.T) {
+	setUpFakeGhPATH(t, []byte(`[]`), []byte(`[]`))
+
+	repoDir, _ := setupFreshnessRepo(t)
+
+	docRel := ".agent/knowledge/memories/pitfalls/pitfall_gh4397_unindexed.md"
+	docPath := filepath.Join(repoDir, docRel)
+	if err := os.MkdirAll(filepath.Dir(docPath), 0755); err != nil {
+		t.Fatalf("mkdir memories dir: %v", err)
+	}
+	if err := os.WriteFile(docPath, []byte("# never indexed\n"), 0644); err != nil {
+		t.Fatalf("write memory doc: %v", err)
+	}
+	graphPath := filepath.Join(repoDir, ".agent", "knowledge", "graph.json")
+	if err := os.MkdirAll(filepath.Dir(graphPath), 0755); err != nil {
+		t.Fatalf("mkdir graph dir: %v", err)
+	}
+	if err := os.WriteFile(graphPath, []byte(`{"nodes":{"memories":{}}}`), 0644); err != nil {
+		t.Fatalf("write graph.json: %v", err)
+	}
+	runGit(t, repoDir, "add", docRel, ".agent/knowledge/graph.json")
+	runGit(t, repoDir, "commit", "-m", "chore: seed unindexed memory doc + graph.json")
+	runGit(t, repoDir, "push", "origin", "main")
+
+	runGit(t, repoDir, "checkout", "-b", "pilot/GH-9398")
+	if err := os.WriteFile(filepath.Join(repoDir, "f.txt"), []byte("subtask work\n"), 0644); err != nil {
+		t.Fatalf("write f.txt: %v", err)
+	}
+	runGit(t, repoDir, "add", "f.txt")
+	runGit(t, repoDir, "commit", "-m", "subtask work")
+	runGit(t, repoDir, "rm", docRel)
+	runGit(t, repoDir, "commit", "-m", "chore(memory): remove genuinely unused doc")
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	r := newSilentRunnerTask359()
+	r.SetLogStore(store)
+	creator := &fakePRCreatorGH4031{url: "https://gitlab.example.com/o/r/-/merge_requests/13"}
+	r.prCreator = creator
+	task := &Task{
+		ID:            "GH-9398",
+		Title:         "fix something",
+		Description:   "d",
+		Branch:        "pilot/GH-9398",
+		BaseBranch:    "main",
+		CreatePR:      true,
+		SourceAdapter: "gitlab",
+	}
+	if err := store.SaveExecution(&memory.Execution{ID: task.LogExecutionID(), TaskID: task.ID, Status: "running"}); err != nil {
+		t.Fatalf("SaveExecution failed: %v", err)
+	}
+	result := &ExecutionResult{TaskID: task.ID, Success: true, CommitSHA: "placeholder"}
+
+	r.finalizeDecomposedParentPR(context.Background(), task, NewGitOperations(repoDir), result)
+
+	if !result.Success {
+		t.Fatalf("expected Success=true, got false (error=%q)", result.Error)
+	}
+
+	diffCmd := exec.Command("git", "diff", "--name-only", "--diff-filter=D", "origin/main...pilot/GH-9398")
+	diffCmd.Dir = repoDir
+	out, err := diffCmd.Output()
+	if err != nil {
+		t.Fatalf("git diff failed: %v", err)
+	}
+	if !strings.Contains(string(out), docRel) {
+		t.Errorf("expected %s to remain deleted (genuinely unindexed) in pushed branch diff, got: %s", docRel, out)
+	}
+	if _, statErr := os.Stat(docPath); !os.IsNotExist(statErr) {
+		t.Errorf("expected %s to remain absent on disk, stat err = %v", docRel, statErr)
+	}
+
+	events, err := store.ListExecutionEvents(task.LogExecutionID())
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+	for _, e := range events {
+		if e.Stage == memory.StageMemoryGuardRestore {
+			t.Errorf("expected no StageMemoryGuardRestore event for a genuinely unindexed doc, got: %+v", e)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes GH-4397 (sub-issue of GH-4387).

`GitOperations.RestoreDeletedIndexedMemoryDocs` (GH-4398) and
`Runner.recordMemoryGuardRestoreEvents` already detected/restored deletions
of `.agent/knowledge/memories/**` files still referenced by
`.agent/knowledge/graph.json`, and recorded the intervention as an
execution event — but neither was ever called from a finalize path. A
session that deleted a still-indexed memory doc during "cleanup" still
shipped a PR that trips the Knowledge Graph Drift Gate (the exact
recurring failure class GH-4387 documents, e.g. PR #4385).

- Call `RestoreDeletedIndexedMemoryDocs` right after the existing
  `StripUnindexedMemoryDocs` guard and before push, in all three
  finalize paths: the direct path (`executeWithOptions`),
  `finalizeEpicBranchPR`, and `finalizeDecomposedParentPR`.
- Record a `StageMemoryGuardRestore` execution event per restored file via
  the existing `recordMemoryGuardRestoreEvents`.

## Scope

Per the sub-issue's scope fence, this implements only the wiring/detection
leg. Collecting protected paths from `graph.json` (GH-4396) and the
restore + event-recording logic (GH-4398/GH-4399) already existed in
`git.go`/`runner.go` — this PR is what actually invokes them before
push/PR-create.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] `go test ./internal/executor/...` — full package green
- [x] New tests added in `internal/executor/runner_gh4397_test.go`:
  - `TestFinalizeDecomposedParentPR_RestoresDeletedIndexedMemoryDoc`: a
    graph-indexed memory doc deleted by a subtask session is restored
    before push, survives in the pushed branch's diff vs base, and is
    recorded as a `StageMemoryGuardRestore` execution event.
  - `TestFinalizeDecomposedParentPR_AllowsDeletingUnindexedMemoryDoc`:
    deleting a genuinely unindexed doc remains allowed, no event recorded.