### PR TITLE
fix(autopilot,github): budget-aware GitHub client with poller reserve + staggered/conditional startup scans

### DIFF
--- a/.agent/tasks/gh-4391.md
+++ b/.agent/tasks/gh-4391.md
@@ -1,0 +1,41 @@
+# GH-4391
+
+**Created:** 2026-07-17
+
+## Problem
+
+GitHub Issue GH-4391: fix(autopilot,github): startup rescans burn the full GitHub rate budget and starve pollers — budget-aware client with poller reserve + cheap conditional scans
+
+## Context
+
+**Post-restart dispatch freeze: startup rescans burn the entire GitHub rate budget, starving the pollers.** Observed 2026-07-16 22:26Z–23:35Z on the founder box (first hour after the S6-lite cutover, daemon v2.241.1, 11 configured projects):
+
+- 22:26Z daemon start → autopilot startup scans: "scanning for recently merged Pilot PRs … window=720h0m0s" per repo (30-DAY window × 11 repos), orphan-PR sweeps, PR-state restore.
+- Within the hour: 44× "reconciler: GitHub rate limit hit, pausing orphan-PR sweep until cooldown elapses", 173× `API error (status 503)` (GitHub unicorn HTML — burst pressure), then pollers fail hard: `Failed to fetch issues … API error (status 403): "API rate limit exceeded for user ID 5360806"`.
+- Net effect: **zero dispatches for 67+ minutes** — 5 queued tasks frozen (GH-4383/4384/4387 + pointer #8/#10) while the daemon was healthy by every other measure.
+- Notable: `gh api rate_limit` on the box showed `5000/5000 remaining` at the same moment the daemon 403'd — the daemon burns the config-token's pool, not the gh-CLI token's; the two pools differ (OAuth-app vs PAT pooling). The daemon has no view of its own remaining budget and no reservation for its highest-value consumer (the issue pollers).
+
+Single concern, **do not decompose**. <!-- pilot:no-decompose -->
+
+## Approach
+
+1. **Budget-aware GitHub client**: track `X-RateLimit-Remaining`/`Reset` from every response on the shared client; when remaining falls below a floor (e.g. 15% of limit), suspend background consumers (merged-PR scans, orphan sweeps, reconciler evidence fetches) — **pollers and active-PR CI watches always get the reserve**. Priority classes, not a global pause.
+2. **Cheapen the startup rescan**: the 720h merged-PR scan window is the dominant cost at boot — make it configurable with a sane default (e.g. 72h), and/or use conditional requests (ETag / If-Modified-Since — 304s are FREE against the rate limit) for repeat scans; persist the last-scanned cursor per repo in the store so a restart resumes instead of re-reading 30 days × N repos.
+3. **Stagger per-repo scans** at boot (jittered, serialized) instead of bursting all 11 repos — also addresses the 173× 503s (secondary/abuse pressure).
+4. Metric + WARN when the budget floor engages, so a rate-starved daemon is visible on the dashboard instead of presenting as a mysteriously idle queue.
+
+## Acceptance
+
+- Fake GitHub client returning rate-limit headers: when remaining < floor, background scans pause but a poller fetch still executes; table-driven.
+- Startup with 10+ repos performs staggered scans; total startup API spend bounded and asserted (fake counts calls; must be an order of magnitude below the 5000 budget with default window).
+- Conditional-request path: second scan of an unchanged repo costs 304s only.
+- Budget-floor engagement increments a metric and logs one WARN (not per-call spam).
+- `make build/test/lint` green.
+
+## Refs
+
+- Evidence: founder-box daemon.log 2026-07-16 22:26–23:35Z (44 cooldown pauses, 173× 503, 403 user-pool exhaustion); executions ledger — no rows created 22:26→23:35 despite 5 queued.
+- Related: #4376 (repick backoff — poller-side discipline; this is the autopilot/scan-side counterpart), GH-4384 (CI watcher API split).
+
+## Acceptance Criteria
+

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -662,8 +662,12 @@ Examples:
 							// ghClient stays for the legacy poller/webhook until later phases.
 							apGHClient := githubSDK.NewClient(ghToken)
 
-							// GH-1870: Board sync option for gateway autopilot controller.
+							// GH-4391: budget-aware gate for background scans (merged-PR
+							// scans, orphan-PR sweeps) — pollers and active-PR CI watches
+							// are never gated by it.
 							var gwBoardOpts []autopilot.ControllerOption
+							gwBoardOpts = append(gwBoardOpts, autopilot.WithRateLimitBudget(autopilot.NewGitHubBudgetClient(ghToken)))
+							// GH-1870: Board sync option for gateway autopilot controller.
 							if cfg.Adapters.GitHub.ProjectBoard != nil && cfg.Adapters.GitHub.ProjectBoard.Enabled {
 								bs := githubSDK.NewProjectBoardSync(apGHClient, toSDKProjectBoardConfig(cfg.Adapters.GitHub.ProjectBoard), parts[0])
 								statuses := cfg.Adapters.GitHub.ProjectBoard.GetStatuses()
@@ -1584,8 +1588,15 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			// (graceful no-op) when ANTHROPIC_API_KEY is unset.
 			releaseSummaryGen := autopilot.NewReleaseSummaryGenerator(apGHClient, os.Getenv("ANTHROPIC_API_KEY"), logging.WithComponent("autopilot"))
 
-			// GH-1870: Build board sync option for autopilot controllers.
+			// GH-4391: one shared budget-aware gate for every controller
+			// constructed below (default + per-project) — background scans
+			// (merged-PR scans, orphan-PR sweeps) suspend when the token's
+			// GitHub primary-rate-limit budget falls below the configured
+			// floor; pollers and active-PR CI watches are never gated by it.
 			var autopilotBoardOpts []autopilot.ControllerOption
+			autopilotBoardOpts = append(autopilotBoardOpts, autopilot.WithRateLimitBudget(autopilot.NewGitHubBudgetClient(ghToken)))
+
+			// GH-1870: Build board sync option for autopilot controllers.
 			if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.ProjectBoard != nil && cfg.Adapters.GitHub.ProjectBoard.Enabled {
 				owner := ""
 				if parts := strings.SplitN(cfg.Adapters.GitHub.Repo, "/", 2); len(parts) == 2 {
@@ -2430,32 +2441,18 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 					fmt.Printf("   ◌ sequential mode · waiting for PR merge before next issue (timeout: %s)\n", prTimeout)
 				}
 
-				// Start autopilot processing loops for all controllers
+				// GH-4391: scans (ScanExistingPRs, ScanRecentlyMergedPRsWithWindow,
+				// Start's recovery sweep) run staggered, one repo at a time, instead
+				// of bursting all repos concurrently — bursting all 11 configured
+				// repos' 30-day merged-PR lookback at once burned the entire GitHub
+				// rate budget and produced 173x secondary-rate-limit 503s on the
+				// founder box (2026-07-16 22:26Z), starving the issue pollers for
+				// 67+ minutes. The scan window is now configurable (default 72h, not
+				// the historical 720h) via autopilot.startup_merged_pr_scan_window.
+				autopilot.RunStaggeredStartupScans(ctx, autopilotControllers, cfg.Orchestrator.Autopilot.StartupScanWindow(), time.Sleep)
+
+				// Start each controller's run loop.
 				for repoName, controller := range autopilotControllers {
-					// Scan for existing PRs
-					if err := controller.ScanExistingPRs(ctx); err != nil {
-						logging.WithComponent("autopilot").Warn("failed to scan existing PRs",
-							slog.String("repo", repoName),
-							slog.Any("error", err),
-						)
-					}
-
-					// Scan for recently merged PRs (GH-416). TASK-399/GH-4209: startup
-					// uses the wide-lookback catch-up sweep — not the periodic loop's
-					// 30-min scanWindow — so a merge that landed while the daemon was
-					// down still self-heals its execution row (and any orphaned
-					// 'running' rows resolve) instead of staying red in HISTORY forever.
-					if err := controller.ScanRecentlyMergedPRsWithWindow(ctx, autopilot.StartupMergedPRLookback); err != nil {
-						logging.WithComponent("autopilot").Warn("failed to scan merged PRs",
-							slog.String("repo", repoName),
-							slog.Any("error", err),
-						)
-					}
-
-					// GH-2970: startup recovery sweep for stale parent issues
-					controller.Start(ctx)
-
-					// Start controller run loop
 					go func(c *autopilot.Controller, repo string) {
 						if err := c.Run(ctx); err != nil && err != context.Canceled {
 							logging.WithComponent("autopilot").Error("autopilot controller stopped",

--- a/internal/autopilot/budget_client.go
+++ b/internal/autopilot/budget_client.go
@@ -1,0 +1,224 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// githubAPIURL is the production GitHub REST API base. Tests use
+// NewGitHubBudgetClientWithBaseURL against an httptest server instead.
+const githubAPIURL = "https://api.github.com"
+
+// budgetCacheTTL bounds how often GitHubBudgetClient re-fetches /rate_limit.
+// GET /rate_limit is documented as free against the primary rate limit, but
+// caching still avoids every concurrent background scan issuing its own
+// request on every tick.
+const budgetCacheTTL = 10 * time.Second
+
+// DefaultRateLimitFloorPercent is the fallback floor (as a percentage of the
+// token's total primary-rate-limit budget) below which background GitHub
+// consumers pause — see Config.RateLimitFloorPercent (GH-4391).
+const DefaultRateLimitFloorPercent = 15
+
+// RateLimitBudget is a point-in-time snapshot of the GitHub primary rate
+// limit for the token backing a GitHubBudgetClient.
+type RateLimitBudget struct {
+	Limit     int
+	Remaining int
+	Reset     time.Time
+}
+
+// PercentRemaining returns Remaining/Limit as a percentage (0-100). A Limit
+// of zero (budget never successfully fetched) is treated as 100% remaining
+// so callers fail open rather than wedging every background scan on a
+// transient /rate_limit error.
+func (b RateLimitBudget) PercentRemaining() float64 {
+	if b.Limit <= 0 {
+		return 100
+	}
+	return float64(b.Remaining) / float64(b.Limit) * 100
+}
+
+// GitHubBudgetClient tracks the shared GitHub primary-rate-limit budget for
+// the daemon's configured token, and provides a cheap "has anything changed"
+// probe for merged-PR rescans — both GH-4391.
+//
+// It is deliberately independent of the studio-sdk github.Client that
+// Controller uses for everything else: that SDK is an external, versioned
+// dependency (no vendor/replace directive in go.mod) with no exposed
+// rate-limit-header tracking or conditional-request support. Rather than
+// forking it, GitHubBudgetClient makes its own raw HTTP calls against two
+// endpoints GitHub documents as NOT counting against the primary rate limit:
+//
+//   - GET /rate_limit (always free) — backs BelowFloor.
+//   - A conditional GET with If-None-Match (a 304 response is free) against
+//     the closed-PR list — backs ProbeRepoChanged.
+type GitHubBudgetClient struct {
+	token      string
+	baseURL    string
+	httpClient *http.Client
+
+	mu           sync.Mutex
+	cached       RateLimitBudget
+	cachedAt     time.Time
+	floorEngaged bool
+	etags        map[string]string // "owner/repo" -> ETag from the last conditional probe
+}
+
+// NewGitHubBudgetClient creates a GitHubBudgetClient against the production
+// GitHub API.
+func NewGitHubBudgetClient(token string) *GitHubBudgetClient {
+	return NewGitHubBudgetClientWithBaseURL(token, githubAPIURL)
+}
+
+// NewGitHubBudgetClientWithBaseURL creates a GitHubBudgetClient against a
+// custom base URL (for testing).
+func NewGitHubBudgetClientWithBaseURL(token, baseURL string) *GitHubBudgetClient {
+	return &GitHubBudgetClient{
+		token:      token,
+		baseURL:    baseURL,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		etags:      make(map[string]string),
+	}
+}
+
+// Status returns the current rate-limit budget, using a cached value when
+// available (see budgetCacheTTL) rather than re-fetching /rate_limit on
+// every call.
+func (b *GitHubBudgetClient) Status(ctx context.Context) (RateLimitBudget, error) {
+	b.mu.Lock()
+	if time.Since(b.cachedAt) < budgetCacheTTL {
+		cached := b.cached
+		b.mu.Unlock()
+		return cached, nil
+	}
+	b.mu.Unlock()
+
+	budget, err := b.fetch(ctx)
+	if err != nil {
+		return RateLimitBudget{}, err
+	}
+
+	b.mu.Lock()
+	b.cached = budget
+	b.cachedAt = time.Now()
+	b.mu.Unlock()
+
+	return budget, nil
+}
+
+func (b *GitHubBudgetClient) fetch(ctx context.Context) (RateLimitBudget, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, b.baseURL+"/rate_limit", nil)
+	if err != nil {
+		return RateLimitBudget{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+b.token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := b.httpClient.Do(req)
+	if err != nil {
+		return RateLimitBudget{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return RateLimitBudget{}, fmt.Errorf("rate_limit check: unexpected status %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		Resources struct {
+			Core struct {
+				Limit     int   `json:"limit"`
+				Remaining int   `json:"remaining"`
+				Reset     int64 `json:"reset"`
+			} `json:"core"`
+		} `json:"resources"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return RateLimitBudget{}, fmt.Errorf("rate_limit check: decode response: %w", err)
+	}
+
+	return RateLimitBudget{
+		Limit:     payload.Resources.Core.Limit,
+		Remaining: payload.Resources.Core.Remaining,
+		Reset:     time.Unix(payload.Resources.Core.Reset, 0),
+	}, nil
+}
+
+// BelowFloor reports whether the current remaining budget is below
+// floorPercent (e.g. 15 for 15%). justCrossed is true only on the
+// below-floor edge (the previous call was above-floor or this is the first
+// call), so callers can log a single WARN per engagement instead of one per
+// call. A Status() fetch error fails open (below=false, justCrossed=false):
+// an unreachable /rate_limit endpoint must not itself starve background
+// scans.
+func (b *GitHubBudgetClient) BelowFloor(ctx context.Context, floorPercent int) (below, justCrossed bool) {
+	budget, err := b.Status(ctx)
+	if err != nil {
+		return false, false
+	}
+
+	below = budget.PercentRemaining() < float64(floorPercent)
+
+	b.mu.Lock()
+	was := b.floorEngaged
+	b.floorEngaged = below
+	b.mu.Unlock()
+
+	return below, below && !was
+}
+
+// ProbeRepoChanged performs a conditional GET against a repo's closed-PR
+// list (the cheapest page — per_page=1, sorted by most-recently-updated)
+// using the ETag from the previous probe for that repo, if any.
+//
+// It reports changed=true (and remembers the new ETag) on a 200 response —
+// either the first probe for this owner/repo, or genuine new activity — and
+// changed=false on 304 Not Modified, which GitHub does not count against the
+// primary rate limit (unlike the full paginated ListPullRequests call this
+// is meant to gate). A transport or unexpected-status error also reports
+// changed=true so callers fail open to the full scan rather than silently
+// going stale.
+func (b *GitHubBudgetClient) ProbeRepoChanged(ctx context.Context, owner, repo string) (changed bool, err error) {
+	key := owner + "/" + repo
+
+	b.mu.Lock()
+	etag := b.etags[key]
+	b.mu.Unlock()
+
+	url := fmt.Sprintf("%s/repos/%s/%s/pulls?state=closed&per_page=1&sort=updated&direction=desc", b.baseURL, owner, repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return true, err
+	}
+	req.Header.Set("Authorization", "Bearer "+b.token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if etag != "" {
+		req.Header.Set("If-None-Match", etag)
+	}
+
+	resp, err := b.httpClient.Do(req)
+	if err != nil {
+		return true, err
+	}
+	defer resp.Body.Close()
+
+	if newETag := resp.Header.Get("ETag"); newETag != "" {
+		b.mu.Lock()
+		b.etags[key] = newETag
+		b.mu.Unlock()
+	}
+
+	switch resp.StatusCode {
+	case http.StatusNotModified:
+		return false, nil
+	case http.StatusOK:
+		return true, nil
+	default:
+		return true, fmt.Errorf("repo activity probe: unexpected status %d", resp.StatusCode)
+	}
+}

--- a/internal/autopilot/budget_client_test.go
+++ b/internal/autopilot/budget_client_test.go
@@ -1,0 +1,172 @@
+package autopilot
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// TestGitHubBudgetClient_BelowFloor is table-driven over remaining/limit
+// combinations, verifying the floor comparison and the justCrossed edge
+// (GH-4391 acceptance: "when remaining < floor, background scans pause").
+func TestGitHubBudgetClient_BelowFloor(t *testing.T) {
+	tests := []struct {
+		name      string
+		remaining int
+		limit     int
+		floor     int
+		wantBelow bool
+	}{
+		{"plenty of budget", 4500, 5000, 15, false},
+		{"exactly at floor", 750, 5000, 15, false}, // 15.0% is not < 15
+		{"just below floor", 700, 5000, 15, true},  // 14% < 15%
+		{"budget exhausted", 0, 5000, 15, true},
+		{"custom lower floor", 400, 5000, 5, false}, // 8% not below a 5% floor
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/rate_limit" {
+					t.Errorf("unexpected path %s", r.URL.Path)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintf(w, `{"resources":{"core":{"limit":%d,"remaining":%d,"reset":0}}}`, tt.limit, tt.remaining)
+			}))
+			defer server.Close()
+
+			bc := NewGitHubBudgetClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			below, _ := bc.BelowFloor(context.Background(), tt.floor)
+			if below != tt.wantBelow {
+				t.Errorf("BelowFloor() = %v, want %v (remaining=%d limit=%d floor=%d)", below, tt.wantBelow, tt.remaining, tt.limit, tt.floor)
+			}
+		})
+	}
+}
+
+// TestGitHubBudgetClient_BelowFloor_JustCrossed verifies justCrossed only
+// fires on the below-floor transition, not on every call while still below —
+// this is what lets callers log a single WARN instead of per-call spam.
+func TestGitHubBudgetClient_BelowFloor_JustCrossed(t *testing.T) {
+	var remaining int32 = 4500 // 90% of 5000: above a 15% floor
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"resources":{"core":{"limit":5000,"remaining":%d,"reset":0}}}`, atomic.LoadInt32(&remaining))
+	}))
+	defer server.Close()
+
+	bc := NewGitHubBudgetClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	below, justCrossed := bc.BelowFloor(context.Background(), 15)
+	if below || justCrossed {
+		t.Fatalf("expected above-floor with no crossing on first call, got below=%v justCrossed=%v", below, justCrossed)
+	}
+
+	// Drop below the floor and force a fresh fetch by bypassing the cache:
+	// use a client with cachedAt zero-valued (fresh client) to simulate the
+	// next tick's re-fetch.
+	atomic.StoreInt32(&remaining, 100) // 2%: below a 15% floor
+	bc2 := NewGitHubBudgetClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	bc2.mu.Lock()
+	bc2.floorEngaged = false
+	bc2.mu.Unlock()
+
+	below, justCrossed = bc2.BelowFloor(context.Background(), 15)
+	if !below || !justCrossed {
+		t.Fatalf("expected below-floor with justCrossed=true on first below-floor call, got below=%v justCrossed=%v", below, justCrossed)
+	}
+
+	// A second below-floor call must not re-signal justCrossed.
+	below, justCrossed = bc2.BelowFloor(context.Background(), 15)
+	if !below || justCrossed {
+		t.Fatalf("expected below-floor with justCrossed=false on repeat call, got below=%v justCrossed=%v", below, justCrossed)
+	}
+}
+
+// TestGitHubBudgetClient_BelowFloor_FailsOpen verifies an unreachable
+// /rate_limit endpoint does not itself block background scans.
+func TestGitHubBudgetClient_BelowFloor_FailsOpen(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	bc := NewGitHubBudgetClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	below, justCrossed := bc.BelowFloor(context.Background(), 15)
+	if below || justCrossed {
+		t.Fatalf("expected fail-open (below=false, justCrossed=false) on fetch error, got below=%v justCrossed=%v", below, justCrossed)
+	}
+}
+
+// TestGitHubBudgetClient_ProbeRepoChanged verifies the conditional-request
+// path: the first probe for a repo costs a real 200, and a second probe of
+// an unchanged repo costs only a 304 (GH-4391 acceptance).
+func TestGitHubBudgetClient_ProbeRepoChanged(t *testing.T) {
+	var calls int32
+	const etag = `"deadbeef"`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		if r.URL.Path != "/repos/owner/repo/pulls" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		if r.Header.Get("If-None-Match") == etag {
+			w.Header().Set("ETag", etag)
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("ETag", etag)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `[]`)
+	}))
+	defer server.Close()
+
+	bc := NewGitHubBudgetClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	changed, err := bc.ProbeRepoChanged(context.Background(), "owner", "repo")
+	if err != nil {
+		t.Fatalf("first probe: unexpected error %v", err)
+	}
+	if !changed {
+		t.Fatal("first probe: expected changed=true (no prior ETag)")
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected 1 call after first probe, got %d", got)
+	}
+
+	changed, err = bc.ProbeRepoChanged(context.Background(), "owner", "repo")
+	if err != nil {
+		t.Fatalf("second probe: unexpected error %v", err)
+	}
+	if changed {
+		t.Fatal("second probe: expected changed=false (304, unchanged)")
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("expected 2 total calls after second probe, got %d", got)
+	}
+}
+
+// TestGitHubBudgetClient_ProbeRepoChanged_TransportErrorFailsOpen verifies a
+// probe request failure reports changed=true so callers fall back to the
+// full scan rather than silently skipping it.
+func TestGitHubBudgetClient_ProbeRepoChanged_TransportErrorFailsOpen(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	bc := NewGitHubBudgetClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	changed, err := bc.ProbeRepoChanged(context.Background(), "owner", "repo")
+	if err == nil {
+		t.Fatal("expected an error for unexpected status")
+	}
+	if !changed {
+		t.Fatal("expected changed=true (fail open) on probe error")
+	}
+}

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -245,6 +245,19 @@ func WithReleaseNotOptedIn() ControllerOption {
 	}
 }
 
+// WithRateLimitBudget wires a shared GitHubBudgetClient so background GitHub
+// consumers — merged-PR scans, orphan-PR sweeps — suspend when the daemon's
+// GitHub primary-rate-limit budget falls below config.RateLimitFloorPercent,
+// while pollers and active-PR CI watches (processAllPRs, ScanExistingPRs)
+// keep running regardless (GH-4391). Nil is a no-op: background scans
+// always run, matching pre-GH-4391 behavior for callers that don't
+// construct a budget client.
+func WithRateLimitBudget(bc *GitHubBudgetClient) ControllerOption {
+	return func(c *Controller) {
+		c.budgetClient = bc
+	}
+}
+
 // Controller orchestrates the autopilot loop for PR processing.
 // It manages the state machine: PR created → CI check → merge → post-merge CI → feedback loop.
 type Controller struct {
@@ -410,6 +423,13 @@ type Controller struct {
 	// window with no backoff left green, approved PRs unmerged for over an hour because
 	// every tick burned through the exhausted quota re-fetching every tracked PR.
 	rateLimitedUntil time.Time
+
+	// budgetClient tracks the shared GitHub primary-rate-limit budget across
+	// the daemon's background consumers (GH-4391). Nil (the zero value) is
+	// valid: backgroundScanAllowed treats "no budget client wired" as
+	// always-allowed, so this is purely additive for callers that don't opt
+	// in via WithRateLimitBudget.
+	budgetClient *GitHubBudgetClient
 }
 
 // NewController creates an autopilot controller with all required components.
@@ -4274,6 +4294,9 @@ func (c *Controller) reconcileOrphanPRs(ctx context.Context) {
 	if c.rateLimitCooldownActive() {
 		return
 	}
+	if !c.backgroundScanAllowed(ctx) {
+		return
+	}
 
 	prs, err := c.ghClient.ListPullRequests(ctx, c.owner, c.repo, "open")
 	if err != nil {
@@ -4388,6 +4411,29 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 // the last restart — still self-heals its execution row instead of leaving it
 // permanently red in HISTORY.
 func (c *Controller) ScanRecentlyMergedPRsWithWindow(ctx context.Context, scanWindow time.Duration) error {
+	// GH-4391: this scan is the dominant startup API cost (a full paginated
+	// closed-PR list, up to 5 000 PRs across pages) — skip it entirely when
+	// the shared rate-limit budget is below floor. Background scans yield to
+	// pollers/active-PR CI watches; a skipped tick self-heals on the next
+	// periodic call once the budget recovers.
+	if !c.backgroundScanAllowed(ctx) {
+		return nil
+	}
+
+	// GH-4391: before paying for the full paginated fetch, ask "has anything
+	// changed since the last scan of this repo" via a conditional GET — a
+	// 304 (unchanged) response is free against the primary rate limit. Only
+	// the full scan below costs real budget. A probe error falls through to
+	// the full scan (fail open) rather than silently skipping.
+	if c.budgetClient != nil {
+		changed, err := c.budgetClient.ProbeRepoChanged(ctx, c.owner, c.repo)
+		if err == nil && !changed {
+			c.log.Debug("skipping merged-PR scan: no repo activity since last scan (304)",
+				"owner", c.owner, "repo", c.repo)
+			return nil
+		}
+	}
+
 	// Run the scan unconditionally — it covers self-heal + merge metrics even when
 	// neither auto-release nor board sync is enabled (e.g. a plain GH-issue-source
 	// deployment). Internal gates below handle release-trigger and board-writeback
@@ -4824,6 +4870,39 @@ func (c *Controller) enterRateLimitCooldown(retryAfter time.Duration) time.Durat
 	c.rateLimitedUntil = time.Now().Add(retryAfter)
 	c.mu.Unlock()
 	return retryAfter
+}
+
+// backgroundScanAllowed reports whether a background GitHub consumer
+// (merged-PR scan, orphan-PR sweep) may proceed right now. It is the
+// proactive counterpart to rateLimitCooldownActive's reactive backoff:
+// rather than waiting for a 403 to already have happened, it checks GitHub's
+// free /rate_limit endpoint and pauses background work before the budget is
+// exhausted — while pollers and active-PR CI watches (processAllPRs,
+// ScanExistingPRs) never call this and always get the reserve (GH-4391).
+//
+// A nil budgetClient (not wired via WithRateLimitBudget) always allows,
+// keeping this additive rather than a behavior change for existing callers.
+func (c *Controller) backgroundScanAllowed(ctx context.Context) bool {
+	if c.budgetClient == nil {
+		return true
+	}
+
+	floor := c.config.RateLimitFloorPercent
+	if floor <= 0 {
+		floor = DefaultRateLimitFloorPercent
+	}
+
+	below, justCrossed := c.budgetClient.BelowFloor(ctx, floor)
+	if !below {
+		return true
+	}
+
+	c.metrics.RecordRateLimitFloorEngaged()
+	if justCrossed {
+		c.log.Warn("GitHub rate-limit budget below floor, pausing background scans (merged-PR scan, orphan-PR sweep) until it recovers",
+			"floor_percent", floor, "owner", c.owner, "repo", c.repo)
+	}
+	return false
 }
 
 // processAllPRs processes all active PRs in one iteration.

--- a/internal/autopilot/controller_budget_test.go
+++ b/internal/autopilot/controller_budget_test.go
@@ -1,0 +1,198 @@
+package autopilot
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestController_BackgroundScanAllowed_RateLimitFloor is table-driven over
+// the GitHub rate-limit budget (GH-4391 acceptance): a fake GitHub client
+// returning rate-limit headers must gate backgroundScanAllowed once
+// remaining budget drops below the configured floor.
+func TestController_BackgroundScanAllowed_RateLimitFloor(t *testing.T) {
+	tests := []struct {
+		name        string
+		remaining   int
+		limit       int
+		floorPct    int
+		wantAllowed bool
+	}{
+		{"plenty of budget, default floor", 4500, 5000, 0, true},
+		{"below default floor", 100, 5000, 0, false},
+		{"exactly at a custom floor", 500, 5000, 10, true}, // 10.0% not < 10%
+		{"below a custom floor", 400, 5000, 10, false},     // 8% < 10%
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			budgetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintf(w, `{"resources":{"core":{"limit":%d,"remaining":%d,"reset":0}}}`, tt.limit, tt.remaining)
+			}))
+			defer budgetServer.Close()
+
+			ghClient := github.NewClient(testutil.FakeGitHubToken) // never called by backgroundScanAllowed
+			cfg := DefaultConfig()
+			cfg.RateLimitFloorPercent = tt.floorPct
+			bc := NewGitHubBudgetClientWithBaseURL(testutil.FakeGitHubToken, budgetServer.URL)
+			c := NewController(cfg, ghClient, nil, "owner", "repo", WithRateLimitBudget(bc))
+
+			if got := c.backgroundScanAllowed(context.Background()); got != tt.wantAllowed {
+				t.Errorf("backgroundScanAllowed() = %v, want %v (remaining=%d limit=%d floor=%d)",
+					got, tt.wantAllowed, tt.remaining, tt.limit, tt.floorPct)
+			}
+		})
+	}
+}
+
+// TestController_NoBudgetClient_BackgroundScansAlwaysAllowed verifies
+// WithRateLimitBudget is opt-in: a controller with no budget client wired
+// behaves exactly as before GH-4391.
+func TestController_NoBudgetClient_BackgroundScansAlwaysAllowed(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+	if !c.backgroundScanAllowed(context.Background()) {
+		t.Fatal("expected backgroundScanAllowed=true when no budget client is wired")
+	}
+}
+
+// TestController_BudgetFloor_PausesBackgroundScans_PollerStillRuns is the
+// end-to-end acceptance case for GH-4391: when the shared rate-limit budget
+// is below floor, reconcileOrphanPRs and ScanRecentlyMergedPRsWithWindow
+// (background scans) make zero GitHub calls, while processAllPRs — standing
+// in for the poller/active-PR-CI-watch priority tier, which always gets the
+// reserve — still executes its GitHub call. A single WARN (not per-call
+// spam) is logged and the RateLimitFloorHits metric increments.
+func TestController_BudgetFloor_PausesBackgroundScans_PollerStillRuns(t *testing.T) {
+	var listCalls, pullCalls int32
+
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/pulls":
+			atomic.AddInt32(&listCalls, 1)
+		case "/repos/owner/repo/pulls/42":
+			atomic.AddInt32(&pullCalls, 1)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ghServer.Close()
+
+	budgetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// 2% remaining: below the default 15% floor.
+		fmt.Fprint(w, `{"resources":{"core":{"limit":5000,"remaining":100,"reset":0}}}`)
+	}))
+	defer budgetServer.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, ghServer.URL)
+	bc := NewGitHubBudgetClientWithBaseURL(testutil.FakeGitHubToken, budgetServer.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithRateLimitBudget(bc))
+
+	c.mu.Lock()
+	c.activePRs[42] = &PRState{
+		PRNumber:    42,
+		IssueNumber: 100,
+		BranchName:  "pilot/GH-100",
+		HeadSHA:     "abc1234",
+		Stage:       StageWaitingCI,
+	}
+	c.mu.Unlock()
+
+	c.reconcileOrphanPRs(context.Background())
+	if got := atomic.LoadInt32(&listCalls); got != 0 {
+		t.Fatalf("reconcileOrphanPRs: expected 0 GitHub calls under budget floor, got %d", got)
+	}
+
+	if err := c.ScanRecentlyMergedPRsWithWindow(context.Background(), time.Hour); err != nil {
+		t.Fatalf("ScanRecentlyMergedPRsWithWindow: unexpected error %v", err)
+	}
+	if got := atomic.LoadInt32(&listCalls); got != 0 {
+		t.Fatalf("ScanRecentlyMergedPRsWithWindow: expected 0 GitHub calls under budget floor, got %d", got)
+	}
+
+	c.processAllPRs(context.Background())
+	if got := atomic.LoadInt32(&pullCalls); got != 1 {
+		t.Fatalf("processAllPRs: expected 1 GitHub call even under budget floor, got %d", got)
+	}
+
+	if got := c.metrics.Snapshot().RateLimitFloorHits; got == 0 {
+		t.Fatal("expected RateLimitFloorHits metric to be incremented by the two skipped background scans")
+	}
+}
+
+// TestController_ScanRecentlyMergedPRsWithWindow_ConditionalProbeSkipsFullScan
+// verifies the 304 conditional-request path (GH-4391 acceptance): a second
+// scan of an unchanged repo costs only the cheap probe request, not the full
+// paginated closed-PR list.
+func TestController_ScanRecentlyMergedPRsWithWindow_ConditionalProbeSkipsFullScan(t *testing.T) {
+	var listCalls, probeCalls int32
+	const etag = `"deadbeef"`
+
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/pulls" {
+			atomic.AddInt32(&listCalls, 1)
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `[]`)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ghServer.Close()
+
+	// The conditional probe hits a separate server since GitHubBudgetClient
+	// makes its own raw HTTP calls (studio-sdk's Client has no ETag support
+	// to instrument) — a real deployment points both at api.github.com.
+	probeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rate_limit" {
+			// backgroundScanAllowed's floor check shares this server/baseURL;
+			// answer with plenty of budget so it never gates this test.
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"resources":{"core":{"limit":5000,"remaining":4500,"reset":0}}}`)
+			return
+		}
+		atomic.AddInt32(&probeCalls, 1)
+		if r.Header.Get("If-None-Match") == etag {
+			w.Header().Set("ETag", etag)
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("ETag", etag)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `[]`)
+	}))
+	defer probeServer.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, ghServer.URL)
+	bc := NewGitHubBudgetClientWithBaseURL(testutil.FakeGitHubToken, probeServer.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithRateLimitBudget(bc))
+
+	if err := c.ScanRecentlyMergedPRsWithWindow(context.Background(), time.Hour); err != nil {
+		t.Fatalf("first scan: unexpected error %v", err)
+	}
+	if got := atomic.LoadInt32(&probeCalls); got != 1 {
+		t.Fatalf("expected 1 probe call after first scan, got %d", got)
+	}
+	if got := atomic.LoadInt32(&listCalls); got != 1 {
+		t.Fatalf("expected 1 full-list call after first scan (no prior ETag), got %d", got)
+	}
+
+	if err := c.ScanRecentlyMergedPRsWithWindow(context.Background(), time.Hour); err != nil {
+		t.Fatalf("second scan: unexpected error %v", err)
+	}
+	if got := atomic.LoadInt32(&probeCalls); got != 2 {
+		t.Fatalf("expected 2 total probe calls after second scan, got %d", got)
+	}
+	if got := atomic.LoadInt32(&listCalls); got != 1 {
+		t.Fatalf("expected still only 1 full-list call after an unchanged (304) second scan, got %d", got)
+	}
+}

--- a/internal/autopilot/metrics.go
+++ b/internal/autopilot/metrics.go
@@ -81,6 +81,13 @@ type Metrics struct {
 	// is already handled safely (no-op, not a bug).
 	DuplicateRegistrationsSkipped int64
 
+	// RateLimitFloorHits counts every background-scan tick (merged-PR scan,
+	// orphan-PR sweep) skipped because the GitHub primary rate-limit budget
+	// was below the configured floor (GH-4391). A sustained non-zero rate
+	// means the daemon is rate-starved — see the paired WARN log, emitted
+	// once per below-floor engagement rather than per tick.
+	RateLimitFloorHits int64
+
 	// Gauges (point-in-time values)
 	ActivePRsByStage map[PRStage]int
 	QueueDepth       int // issues with `pilot` label, no `pilot-in-progress`
@@ -182,6 +189,16 @@ func (m *Metrics) RecordDuplicateRegistrationSkipped() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.DuplicateRegistrationsSkipped++
+}
+
+// RecordRateLimitFloorEngaged increments the counter for a background scan
+// skipped because the GitHub rate-limit budget was below the configured
+// floor (GH-4391). Called once per skipped tick — the caller is
+// responsible for only logging a WARN on the below-floor edge.
+func (m *Metrics) RecordRateLimitFloorEngaged() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.RateLimitFloorHits++
 }
 
 // RecordPRMerged increments the merged PR counter.
@@ -461,6 +478,7 @@ func (m *Metrics) Snapshot() MetricsSnapshot {
 		PollerDeferredScopeOverlap:    copyStringIntMap(m.PollerDeferredScopeOverlap),
 		OrphanPRsRegistered:           copyStringIntMap(m.OrphanPRsRegistered),
 		DuplicateRegistrationsSkipped: m.DuplicateRegistrationsSkipped,
+		RateLimitFloorHits:            m.RateLimitFloorHits,
 		ActivePRsByStage:              copyStageIntMap(m.ActivePRsByStage),
 		QueueDepth:                    m.QueueDepth,
 		FailedQueueDepth:              m.FailedQueueDepth,
@@ -543,6 +561,9 @@ type MetricsSnapshot struct {
 
 	// Duplicate registration skips (GH-3828)
 	DuplicateRegistrationsSkipped int64
+
+	// Background scans skipped for GitHub rate-limit budget floor (GH-4391)
+	RateLimitFloorHits int64
 
 	// Gauges
 	ActivePRsByStage map[PRStage]int

--- a/internal/autopilot/metrics_aggregate.go
+++ b/internal/autopilot/metrics_aggregate.go
@@ -109,6 +109,7 @@ func (a *AggregateMetrics) Snapshot() MetricsSnapshot {
 			agg.OrphanPRsRegistered[k] += v
 		}
 		agg.DuplicateRegistrationsSkipped += s.DuplicateRegistrationsSkipped
+		agg.RateLimitFloorHits += s.RateLimitFloorHits
 
 		for stage, count := range s.ActivePRsByStage {
 			agg.ActivePRsByStage[stage] += count

--- a/internal/autopilot/startup_scan.go
+++ b/internal/autopilot/startup_scan.go
@@ -1,0 +1,64 @@
+package autopilot
+
+import (
+	"context"
+	"math/rand"
+	"time"
+)
+
+// StartupScanStaggerBase and StartupScanStaggerJitter bound the delay
+// RunStaggeredStartupScans waits between each repo's startup-scan slot.
+// GH-4391: bursting every configured repo's startup rescan in the same
+// instant is what produced 173x secondary-rate-limit 503s on the founder
+// box (2026-07-16 22:26Z) — GitHub's abuse-detection layer penalizes
+// concurrent bursts independently of the primary rate limit, so serializing
+// with jitter addresses that even though the requests themselves are cheap.
+const (
+	StartupScanStaggerBase   = 2 * time.Second
+	StartupScanStaggerJitter = 2 * time.Second
+)
+
+// RunStaggeredStartupScans performs the two startup catch-up scans
+// (ScanExistingPRs, ScanRecentlyMergedPRsWithWindow) plus Start's recovery
+// sweeps, one repo at a time with a jittered delay between slots — instead
+// of bursting every controller's startup scan concurrently (GH-4391).
+//
+// ScanExistingPRs is never gated by the rate-limit budget floor: restoring
+// in-flight PR state on restart is the same priority tier as the pollers.
+// ScanRecentlyMergedPRsWithWindow honors backgroundScanAllowed and the
+// conditional-probe skip internally, so a rate-starved or quiet repo costs
+// little to nothing here.
+//
+// sleepFn is injected so tests can run this instantly (e.g. a no-op or a
+// call counter); production callers pass time.Sleep. A nil sleepFn defaults
+// to time.Sleep. Map iteration order (and therefore scan order) is
+// intentionally left up to Go's randomized map ordering — no repo is
+// special-cased.
+func RunStaggeredStartupScans(ctx context.Context, controllers map[string]*Controller, scanWindow time.Duration, sleepFn func(time.Duration)) {
+	if sleepFn == nil {
+		sleepFn = time.Sleep
+	}
+
+	first := true
+	for repoName, controller := range controllers {
+		if ctx.Err() != nil {
+			return
+		}
+		if !first {
+			delay := StartupScanStaggerBase
+			if StartupScanStaggerJitter > 0 {
+				delay += time.Duration(rand.Int63n(int64(StartupScanStaggerJitter)))
+			}
+			sleepFn(delay)
+		}
+		first = false
+
+		if err := controller.ScanExistingPRs(ctx); err != nil {
+			controller.log.Warn("startup: failed to scan existing PRs", "repo", repoName, "error", err)
+		}
+		if err := controller.ScanRecentlyMergedPRsWithWindow(ctx, scanWindow); err != nil {
+			controller.log.Warn("startup: failed to scan merged PRs", "repo", repoName, "error", err)
+		}
+		controller.Start(ctx)
+	}
+}

--- a/internal/autopilot/startup_scan_test.go
+++ b/internal/autopilot/startup_scan_test.go
@@ -1,0 +1,93 @@
+package autopilot
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestRunStaggeredStartupScans_StaggersAndBoundsAPISpend is the GH-4391
+// acceptance case: startup with 10+ repos performs staggered (not
+// concurrent-burst) scans, and total startup API spend stays an order of
+// magnitude below the 5000-request primary rate-limit budget — the
+// founder-box incident burned the entire budget bursting 11 repos' 30-day
+// merged-PR scans at once.
+func TestRunStaggeredStartupScans_StaggersAndBoundsAPISpend(t *testing.T) {
+	const numRepos = 12
+
+	var totalCalls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&totalCalls, 1)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `[]`)
+	}))
+	defer server.Close()
+
+	controllers := make(map[string]*Controller, numRepos)
+	for i := 0; i < numRepos; i++ {
+		repo := fmt.Sprintf("repo%d", i)
+		ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+		controllers[repo] = NewController(DefaultConfig(), ghClient, nil, "owner", repo)
+	}
+
+	var sleepCalls int32
+	var sleptDurations []time.Duration
+	fakeSleep := func(d time.Duration) {
+		atomic.AddInt32(&sleepCalls, 1)
+		sleptDurations = append(sleptDurations, d)
+	}
+
+	RunStaggeredStartupScans(context.Background(), controllers, DefaultStartupMergedPRScanWindow, fakeSleep)
+
+	// One stagger delay between each pair of consecutive repo slots — not a
+	// single burst with zero delays.
+	if got := atomic.LoadInt32(&sleepCalls); got != numRepos-1 {
+		t.Errorf("expected %d stagger sleeps for %d repos, got %d", numRepos-1, numRepos, got)
+	}
+	for _, d := range sleptDurations {
+		if d < StartupScanStaggerBase || d >= StartupScanStaggerBase+StartupScanStaggerJitter {
+			t.Errorf("stagger delay %v outside expected [%v, %v)", d, StartupScanStaggerBase, StartupScanStaggerBase+StartupScanStaggerJitter)
+		}
+	}
+
+	// Each repo's startup slot issues a handful of calls (ScanExistingPRs,
+	// ScanRecentlyMergedPRsWithWindow, Start's epic-parent recovery probes)
+	// — bounded per repo, not a 5 000-request burst across all repos.
+	got := atomic.LoadInt32(&totalCalls)
+	const wantMax = 10 * numRepos // generous per-repo upper bound
+	if got == 0 {
+		t.Fatal("expected at least some GitHub calls from the startup scans")
+	}
+	if got > wantMax {
+		t.Errorf("total startup API calls = %d, want <= %d (order of magnitude below the 5000 budget)", got, wantMax)
+	}
+	if got >= 500 {
+		t.Errorf("total startup API calls = %d must be an order of magnitude below the 5000 primary rate-limit budget", got)
+	}
+}
+
+// TestRunStaggeredStartupScans_RespectsContextCancellation verifies the
+// stagger loop stops issuing scans once the context is cancelled, instead of
+// draining every remaining repo.
+func TestRunStaggeredStartupScans_RespectsContextCancellation(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	controllers := map[string]*Controller{
+		"repo-a": NewController(DefaultConfig(), ghClient, nil, "owner", "repo-a"),
+		"repo-b": NewController(DefaultConfig(), ghClient, nil, "owner", "repo-b"),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Must return promptly without panicking or blocking on a cancelled ctx.
+	RunStaggeredStartupScans(ctx, controllers, DefaultStartupMergedPRScanWindow, func(time.Duration) {
+		t.Fatal("sleepFn should not be called once ctx is already cancelled")
+	})
+}

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -174,6 +174,25 @@ type Config struct {
 	// This catches PRs that were merged while Pilot was offline.
 	MergedPRScanWindow time.Duration `yaml:"merged_pr_scan_window"`
 
+	// StartupMergedPRScanWindow is how far back the one-time startup
+	// catch-up sweep (ScanRecentlyMergedPRsWithWindow, called once per
+	// controller before the Run loop starts) looks — distinct from the
+	// periodic loop's MergedPRScanWindow above. GH-4391: defaults to 72h via
+	// StartupScanWindow(), not the historical 30-day StartupMergedPRLookback
+	// — that 720h window was the dominant startup API cost that starved the
+	// GitHub issue pollers of rate-limit budget on 2026-07-16. Configurable
+	// for deployments whose merge cadence genuinely needs a longer catch-up.
+	StartupMergedPRScanWindow time.Duration `yaml:"startup_merged_pr_scan_window"`
+
+	// RateLimitFloorPercent is the GitHub primary-rate-limit floor (as a
+	// percentage of the token's total budget, e.g. 15 for 15%) below which
+	// background GitHub consumers — merged-PR scans, orphan-PR sweeps —
+	// pause until the budget recovers (GH-4391). Pollers and active-PR CI
+	// watches (processAllPRs, ScanExistingPRs) are never gated by this
+	// floor: they are the reserve it protects. Zero uses
+	// DefaultRateLimitFloorPercent.
+	RateLimitFloorPercent int `yaml:"rate_limit_floor_percent"`
+
 	// Name is a user-friendly label for this environment (e.g. "staging", "production").
 	// When empty, defaults to the Environment value.
 	Name string `yaml:"name"`
@@ -389,6 +408,20 @@ func DefaultConfig() *Config {
 		MergedPRScanWindow:   30 * time.Minute,
 		Environments:         defaultEnvironments(),
 	}
+}
+
+// DefaultStartupMergedPRScanWindow is the fallback for
+// Config.StartupMergedPRScanWindow (GH-4391).
+const DefaultStartupMergedPRScanWindow = 72 * time.Hour
+
+// StartupScanWindow returns the configured startup merged-PR catch-up
+// lookback, falling back to DefaultStartupMergedPRScanWindow when unset
+// (GH-4391).
+func (c *Config) StartupScanWindow() time.Duration {
+	if c.StartupMergedPRScanWindow > 0 {
+		return c.StartupMergedPRScanWindow
+	}
+	return DefaultStartupMergedPRScanWindow
 }
 
 // ReleaseConfig holds configuration for automatic release creation.


### PR DESCRIPTION
Fixes GH-4391.

## Summary

Startup autopilot rescans (a hardcoded 720h merged-PR lookback x N repos, bursted concurrently) burned the daemon's entire GitHub primary rate-limit budget on 2026-07-16 22:26Z-23:35Z, producing 44x rate-limit cooldown pauses, 173x secondary-rate-limit 503s, and then hard 403s on the issue pollers -- zero dispatches for 67+ minutes despite 5 queued tasks, even though the daemon was healthy by every other measure. The daemon had no visibility into its own remaining budget and no reservation for its highest-value consumer (the issue pollers).

- **`GitHubBudgetClient`** (`internal/autopilot/budget_client.go`) tracks the shared rate-limit budget via GitHub's free `GET /rate_limit` endpoint, independent of the external studio-sdk `github.Client` (no exposed header tracking / ETag support to instrument). It also exposes a conditional-GET probe (`ETag`/`If-None-Match` -- 304s are free) so a repeat scan of an unchanged repo skips the expensive paginated fetch entirely.
- **`Controller.backgroundScanAllowed`** gates the two background consumers -- `ScanRecentlyMergedPRsWithWindow` and `reconcileOrphanPRs` -- behind a configurable rate-limit floor (`config.RateLimitFloorPercent`, default 15%). Pollers and active-PR CI watches (`processAllPRs`, `ScanExistingPRs`) are never gated -- they get the reserve. `WithRateLimitBudget` wires this in as an opt-in `ControllerOption`.
- **`RunStaggeredStartupScans`** (`internal/autopilot/startup_scan.go`) runs each repo's startup scan slot serially with jitter instead of bursting every repo at once -- addresses the secondary-rate-limit 503s too.
- **`StartupMergedPRScanWindow`** defaults to 72h (via `Config.StartupScanWindow()`), replacing the historical 720h burst window as the startup default (the old `StartupMergedPRLookback` constant remains available for explicit opt-in / existing callers).
- **`RateLimitFloorHits`** metric + a single WARN per below-floor engagement (not per-call spam) make a rate-starved daemon visible on the dashboard instead of presenting as a mysteriously idle queue.

## Test plan

- [x] `internal/autopilot/budget_client_test.go` -- table-driven `BelowFloor` (plenty/exact/below/custom floor), justCrossed edge, fail-open on fetch error, conditional-probe 304 behavior, fail-open on probe error.
- [x] `internal/autopilot/controller_budget_test.go` -- table-driven `backgroundScanAllowed`, no-budget-client-wired always-allowed, end-to-end: background scans skipped under floor while `processAllPRs` still runs and `RateLimitFloorHits` increments, conditional-probe skips the full scan on an unchanged repo.
- [x] `internal/autopilot/startup_scan_test.go` -- 12 fake repos: staggered (not bursted) scans, total startup API spend bounded (order of magnitude below the 5000 budget), context-cancellation short-circuit.
- [x] `go build ./...`, `go test ./...` (full repo), `go vet ./...`, `gofmt -l` all clean. `golangci-lint` not installed in this sandbox; Makefile's own fallback ("skipping...") was exercised instead.