### PR TITLE
GH-4436: fix(autopilot): confirm restore-path bug in check-runs polling

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "updated": "2026-07-17T22:50:46+00:00",
+  "updated": "2026-07-17T23:47:35+00:00",
   "nodes": {
     "concepts": {
       "pilot-architecture": {
@@ -3058,6 +3058,20 @@
         ],
         "confidence": 0.9,
         "created": "2026-07-17"
+      },
+      "gh4436-restore-ci-poll-hypothesis-refuted": {
+        "type": "learning",
+        "summary": "GH-4415 hypothesis (RestoreState watchers only listen for new check-run events, skipping current-state poll) refuted: autopilot CI checking is 100% poll-based with no event/webhook watcher architecture at all, applied identically to restored and fresh PRs",
+        "file": ".agent/knowledge/memories/learnings/gh4436-restore-ci-poll-hypothesis-refuted.md",
+        "concepts": [
+          "autopilot",
+          "ci-monitor",
+          "restore-state",
+          "gh-4415",
+          "epic-decomposition"
+        ],
+        "confidence": 0.95,
+        "created": "2026-07-17"
       }
     }
   },
@@ -4191,6 +4205,11 @@
       "from": "rlimit-as-breaks-node-subprocesses",
       "to": "absolute-state-paths-bypass-cutover-shim",
       "type": "related"
+    },
+    {
+      "from": "gh4436-restore-ci-poll-hypothesis-refuted",
+      "to": "autopilot",
+      "type": "relates_to"
     }
   ],
   "concept_index": {
@@ -4744,10 +4763,10 @@
       "decomposer-narrative-bullets-as-subtask-boundaries"
     ]
   },
-  "last_updated": "2026-07-17T22:50:46+00:00",
+  "last_updated": "2026-07-17T23:47:35+00:00",
   "stats": {
-    "total_nodes": 262,
-    "total_edges": 226,
-    "memory_count": 166
+    "total_nodes": 265,
+    "total_edges": 227,
+    "memory_count": 169
   }
 }

--- a/.agent/knowledge/memories/learnings/gh4436-restore-ci-poll-hypothesis-refuted.md
+++ b/.agent/knowledge/memories/learnings/gh4436-restore-ci-poll-hypothesis-refuted.md
@@ -1,0 +1,96 @@
+---
+name: gh4436-restore-ci-poll-hypothesis-refuted
+description: GH-4415's hypothesis ("watchers re-armed via RestoreState only listen for new check-run events, skipping the initial current-state poll") does not match the codebase — autopilot has no event/webhook-driven CI watcher at all; it is pure poll, applied identically to restored and fresh PRs
+type: learning
+---
+
+# GH-4436: restore-path CI-watcher hypothesis is refuted by the code
+
+**Task:** GH-4436 (child 1/7 of epic GH-4415), scoped to inspect
+`internal/autopilot/controller.go` `RestoreState()` and `ci_monitor.go` "arm"
+logic and confirm/refute the hypothesis before siblings #4437-#4442 implement
+a fix for it.
+
+## The hypothesis (from GH-4415)
+
+> The re-armed `waiting_ci` state (`RestoreState` after restart) may take a
+> different code path than fresh PR registration... if the watcher only
+> reacts to *new* check-run events rather than reading current state on arm,
+> an already-green PR never produces an event and dies at timeout.
+
+Evidence cited: canary-sandbox PRs 87/90/94/98 timed out at exactly ~30m
+after a 14:22Z restart despite `gh pr checks` showing green, while pointer
+PRs #29/#31 (registered fresh, no restart in their window) progressed fine
+under the same binary (v2.241.2).
+
+## Finding: the hypothesized mechanism does not exist
+
+1. **No check-run webhook handler exists anywhere in the repo.**
+   `internal/adapters/github/webhook.go`'s `Handle()` only switches on
+   `"issues"` and `"pull_request_review"` event types. There is no
+   `check_run`/`check_suite`/`workflow_run` case, no `OnCheckRun` callback, no
+   push-based CI listener of any kind (grep confirmed across
+   `internal/adapters`, `internal/gateway`, `internal/autopilot`).
+
+2. **CI status is 100% poll-based, uniformly, for every PR.**
+   `Controller.Run()` (controller.go:4702) runs a single ticker that calls
+   `processAllPRs` → `ProcessPR` → `handleWaitingCI` (controller.go:1438) →
+   `CIMonitor.CheckCI` (ci_monitor.go:480) → `checkStatus` (ci_monitor.go:160)
+   → `ghClient.ListCheckRuns` — a full "current state" GitHub API read — on
+   **every single tick, for every PR in `StageWaitingCI`**, with no
+   distinction based on how the PR entered `c.activePRs`.
+
+3. **`RestoreState()` (controller.go:1071) does nothing CI-related.** It only
+   copies `PRState`/`prFailureState` rows from SQLite into
+   `c.activePRs`/`c.prFailures`. It never touches `c.ciMonitor`, never sets a
+   flag consulted by `checkStatus`/`checkAutoDiscoveredRuns`, and does not
+   distinguish "restored" state from state built by `OnPRCreated`
+   (controller.go:1161) in any way visible to the CI-check path — both just
+   become entries in the same map, walked by the same loop.
+
+4. **`checkAutoDiscoveredRuns` (ci_monitor.go:279) always re-reads
+   `ListCheckRuns` results passed in from `checkStatus`, fresh, every call.**
+   There is no "listen for events, fall back to poll" branch — an
+   already-green check-run set is aggregated to `CISuccess` on the very first
+   post-restart tick, same as it would be for a freshly-registered PR.
+
+## Conclusion
+
+The specific mechanism GH-4415 hypothesizes (an event-driven watcher that
+only reacts to *new* check-run events post-restore, skipping a "current
+state" read) **cannot be the cause**, because that architecture does not
+exist in this codebase — everything is poll, always current-state, always
+uniform. Implementing #4437 ("extract shared current-state polling helper")
+and #4438 ("invoke it immediately on restore") against this premise would be
+inert: there is nothing to extract (checkStatus is already the single shared
+helper) and nothing to "invoke immediately" that isn't already invoked on
+the very next tick (≤30s later, per default `CIPollInterval`).
+
+## What's NOT resolved
+
+The canary incident itself (real, evidenced) is not explained by this
+investigation — something did cause PRs 87/90/94/98 to sit at `waiting_ci`
+for the full 30m post-restart despite green checks. Candidates not yet ruled
+out (out of this subtask's scope, flagged for whoever re-scopes the epic):
+per-PR circuit breaker state (`isPRCircuitOpen`, controller.go:3969)
+restored via `LoadAllPRFailures` blocking `ProcessPR` entirely — though the
+observed "CI timeout" log line proves `handleWaitingCI` *did* eventually run
+and evaluate the deadline, so a persistently-open circuit isn't a clean fit
+either; GitHub primary-rate-limit cooldown (`enterRateLimitCooldown`,
+controller.go:4814, up to 20m) suppressing `processAllPRs` entirely across
+several ticks; or a canary-specific `ci_checks.exclude`/check-name mismatch
+in `matchesExclude` (ci_monitor.go:411) filtering the real checks out of
+`filteredRuns`. Recommend re-diagnosing from daemon logs for the 14:22Z
+restart window before proceeding with #4437-#4442 as currently scoped.
+
+## How to apply
+
+- Before implementing a fix for a hypothesized bug in an epic's child issue,
+  verify the hypothesized *mechanism* actually exists in the code — an epic
+  decomposer can generate plausible-sounding hypotheses from symptom
+  correlation alone (restart timing + timeout duration) without having read
+  the implementation. GH-4415's hypothesis 2 is exactly this: plausible,
+  cited as "fits both facts," but wrong about the architecture.
+- Related: #4415 (parent epic), #4408/#4384 (prior, unrelated combined-status
+  fix this epic's evidence is comparing against), #4437-#4442 (sibling
+  subtasks whose premise this finding challenges).

--- a/.agent/tasks/gh-4436.md
+++ b/.agent/tasks/gh-4436.md
@@ -1,0 +1,80 @@
+# GH-4436
+
+**Created:** 2026-07-17
+
+## Problem
+
+Inspect internal/autopilot/controller.go RestoreState and ci_monitor.go arm logic to confirm hypothesis: watchers re-armed via RestoreState only listen for new check-run events and skip the initial current-state poll that fresh registrations perform (per the #4408 fix), causing already-completed check-runs to go undetected until the 30m timeout.
+
+## Investigation Result: hypothesis REFUTED
+
+The hypothesized mechanism does not exist in this codebase.
+
+- **No check-run webhook handler exists.** `internal/adapters/github/webhook.go`'s
+  `Handle()` only switches on `"issues"` and `"pull_request_review"` events —
+  there is no `check_run`/`check_suite`/`workflow_run` case anywhere in the
+  repo. There is no event-driven CI watcher to "re-arm."
+- **CI status is 100% poll-based, uniformly for every PR.** `Controller.Run()`
+  (controller.go:4702) drives a single ticker → `processAllPRs` → `ProcessPR`
+  → `handleWaitingCI` (controller.go:1438) → `CIMonitor.CheckCI`
+  (ci_monitor.go:480) → `checkStatus` (ci_monitor.go:160) →
+  `ghClient.ListCheckRuns` — a genuine current-state read — on **every tick,
+  for every PR in `StageWaitingCI`**, regardless of whether that PR entered
+  `c.activePRs` via `RestoreState()` (restart) or `OnPRCreated()` (fresh
+  registration). Both paths converge on the identical map and the identical
+  loop; there is no branch anywhere that treats them differently.
+- **`RestoreState()` (controller.go:1071) does nothing CI-related** — it only
+  copies `PRState`/`prFailureState` rows from SQLite into
+  `c.activePRs`/`c.prFailures`. It never touches `c.ciMonitor` and sets no
+  flag that `checkStatus`/`checkAutoDiscoveredRuns` consult.
+- **`checkAutoDiscoveredRuns` (ci_monitor.go:279)** aggregates whatever
+  `ListCheckRuns` returns on that call, fresh, every time — an already-green
+  check-run set resolves to `CISuccess` on the very first post-restart tick
+  (≤30s later by default `CIPollInterval`), same as for a fresh PR. There is
+  no "listen for new events only" code path to skip a poll from.
+
+Full write-up, evidence trail, and file:line citations:
+`.agent/knowledge/memories/learnings/gh4436-restore-ci-poll-hypothesis-refuted.md`
+(indexed in `.agent/knowledge/graph.json`).
+
+### Implication for sibling subtasks
+
+#4437 ("extract shared current-state polling helper") and #4438 ("invoke it
+immediately on restore") are built on this hypothesis. Since the
+already-shared `checkStatus` helper is already invoked on every tick for
+restored PRs, those two subtasks as scoped have no code to act on.
+
+### Unresolved
+
+The canary incident (PRs 87/90/94/98 timing out at exactly 30m post-restart
+despite green checks) is real per the cited logs, but this subtask's scope
+(RestoreState + ci_monitor arm logic) does not explain it — that mechanism
+isn't present to be buggy. Candidates flagged for re-diagnosis, not
+implemented here (out of scope fence): per-PR circuit breaker state restored
+via `LoadAllPRFailures`/`isPRCircuitOpen` (controller.go:3969); GitHub
+rate-limit cooldown (`enterRateLimitCooldown`, controller.go:4814, up to 20m)
+suppressing `processAllPRs` across ticks; or a canary-specific
+`ci_checks.exclude` pattern (`matchesExclude`, ci_monitor.go:411) filtering
+real checks out of `filteredRuns`. Recommend re-diagnosing from the actual
+14:22Z daemon log window before proceeding with #4439-#4442 as currently
+scoped.
+
+## Acceptance Criteria
+
+- [x] `RestoreState()` inspected line-by-line — confirmed CI-agnostic.
+- [x] `ci_monitor.go` "arm"/discovery logic inspected — confirmed there is no
+      event-only path distinct from current-state polling.
+- [x] Hypothesis confirmed or refuted with file:line evidence — **refuted**.
+- [x] Findings captured in Navigator memory for the epic and sibling subtasks.
+
+## NO-OP RATIONALE
+
+`internal/autopilot/controller.go` and `internal/autopilot/ci_monitor.go`:
+no source change made. This subtask's scope is investigation-only ("inspect
+... to confirm hypothesis"), and the investigation concluded the hypothesis
+is false — there is no event-driven watcher/arm mechanism in either file for
+a code fix to target. Modifying either file to "fix" a mechanism that
+doesn't exist would be either a no-op refactor or would risk masking the
+real (still-unidentified) root cause of the canary incident. See
+`.agent/knowledge/memories/learnings/gh4436-restore-ci-poll-hypothesis-refuted.md`
+for full evidence and recommended next steps.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4436.

Closes #4436

## Changes

Inspect internal/autopilot/controller.go RestoreState and ci_monitor.go arm logic to confirm hypothesis: watchers re-armed via RestoreState only listen for new check-run events and skip the initial current-state poll that fresh registrations perform (per the #4408 fix), causing already-completed check-runs to go undetected until the 30m timeout.