### PR TITLE
test(autopilot): GH-4441 — re-run gh4384_ci_watcher_test.go, no regression

### DIFF
--- a/.agent/tasks/gh-4441.md
+++ b/.agent/tasks/gh-4441.md
@@ -1,0 +1,96 @@
+# GH-4441
+
+**Created:** 2026-07-18
+**Status:** Verified — no regression, no source change required (NO-OP with evidence)
+
+## Problem
+
+GitHub Issue GH-4441: test(autopilot): verify no regression in fresh pointer-PR event stream behavior
+
+<!--autopilot-meta
+parent: GH-4415
+inherited-spec: true
+-->
+
+Parent: GH-4415
+
+Re-run existing internal/autopilot/gh4384_ci_watcher_test.go to confirm pointer PRs (e.g. #29/#31) relying on fresh event streams still behave correctly after the refactor.
+
+## Scope fence
+
+Implement ONLY the slice described above. The parent issue GH-4415 is decomposed
+into sibling sub-issues that cover the rest of its spec — consult the parent
+for context, but do NOT implement parts of it that fall outside this subtask.
+
+## Acceptance Criteria
+
+- `internal/autopilot/gh4384_ci_watcher_test.go` re-run and passing after the
+  GH-4415 investigation wave (GH-4436/#4443, GH-4438, GH-4439, GH-4440).
+
+## Investigation
+
+GH-4415's sibling subtasks (GH-4436, GH-4439) already established that
+`RestoreState` never diverges from the fresh-registration path: it only
+copies persisted `*PRState` into `c.activePRs`, and the same
+`processAllPRs`/`ProcessPR` poll loop drives both restored and freshly
+registered PRs through `handleWaitingCI`/`handlePostMergeCI`
+(`controller.go:1438`, `2755`), which always do a full current-state
+check-runs read (per the GH-4384/#4408 fix), never an event diff. GH-4438
+(the proposed "invoke current-state poll immediately on restore" fix) was
+left `pilot-needs-clarification` and never merged, because there is no
+divergent restore-time code path to patch — confirmed again by grep: no
+`CheckRunEvent`/`check_run` webhook handler exists anywhere in
+`internal/autopilot`; all CI resolution is poll-based via `CIMonitor.CheckCI`.
+
+In short: **no production code under `internal/autopilot` changed** as part
+of the GH-4415 investigation wave (GH-4436, GH-4439, GH-4440, GH-4442 all
+landed as docs/tests/changelog-only commits — `git log --stat` for each
+confirms zero `.go` non-test diffs). `gh4384_ci_watcher_test.go` exercises
+exactly the fresh-registration path that pointer PRs #29/#31 took (a
+`*PRState` seeded once via `OnPRCreated`-equivalent setup, then driven purely
+by `ProcessPR` poll ticks against a stub GitHub server) — the same path the
+parent issue confirmed already worked correctly. Since nothing in that path
+was touched, no regression is possible by construction, but this subtask
+re-ran the suite directly rather than relying on that inference alone.
+
+### Re-run results
+
+```
+go test ./internal/autopilot/... -run TestCIMonitor_AutoDiscoveryCompletion_GH4384 -v
+--- PASS: TestCIMonitor_AutoDiscoveryCompletion_GH4384 (0.04s)
+    --- PASS: .../discovered_check-runs_green_+_combined-status_pending/total=0_->_success (0.00s)
+    --- PASS: .../previously_discovered_checks_+_later_transient_empty_check-runs_response_stays_pending (0.00s)
+    --- PASS: .../inverse:_repo_with_no_check-runs_ever,_legacy_statuses_only,_still_resolves_via_combined-status (0.03s)
+
+go test ./internal/autopilot/... -run TestController_ActionsOnlyRepo_AdvancesWaitingCIToCIPassed_GH4384 -v
+--- PASS: TestController_ActionsOnlyRepo_AdvancesWaitingCIToCIPassed_GH4384 (0.00s)
+
+go test ./internal/autopilot/...
+ok  	github.com/qf-studio/pilot/internal/autopilot	4.133s
+
+go build ./...
+(clean)
+```
+
+All three GH-4384 table cases and the controller-level acceptance test pass
+unchanged. The full `internal/autopilot` package suite (including the new
+GH-4440 restore-path regression tests in `gh4415_restore_ci_poll_test.go`)
+also passes, confirming the restore-path verification work added alongside
+GH-4415 did not regress the fresh-event-stream path that pointer PRs
+#29/#31 rely on.
+
+## NO-OP RATIONALE
+
+`internal/autopilot/gh4384_ci_watcher_test.go` (all cases): no source or
+test change required. The GH-4415 investigation wave made no production
+code changes to the fresh-PR poll path (`ProcessPR`/`handleWaitingCI`) —
+every sibling subtask that touched it (GH-4436, GH-4439) concluded the
+restore path already shares that exact code, and the one subtask proposing
+an actual patch (GH-4438) was never implemented (`pilot-needs-clarification`).
+With no diff to the code these tests exercise, "confirm no regression" is
+satisfied by re-running the existing suite, which is green (see Re-run
+results above). No new test cases were added because the task scope was
+explicitly to re-run the existing file, not author new coverage for
+pointer PR numbers #29/#31 (those are incident-log PR numbers on the
+`qf-studio/pointer` repo, not entities represented in this test file).
+


### PR DESCRIPTION
## Summary
Automated PR created by Pilot for task GH-4441.

Closes #4441

## Changes
Re-ran `internal/autopilot/gh4384_ci_watcher_test.go` after the GH-4415 investigation wave (GH-4436/#4443, GH-4438, GH-4439, GH-4440) to confirm the fresh-event-stream path that pointer PRs #29/#31 rely on still behaves correctly. All GH-4384 cases pass unchanged, and the full `internal/autopilot` suite + `go build ./...` are clean.

No production code under `internal/autopilot` changed as part of the GH-4415 wave (per GH-4436/GH-4439's findings that restore and fresh-registration share the same poll path, and GH-4438's proposed patch was never merged), so this is documented as a NO-OP with evidence in `.agent/tasks/gh-4441.md`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/autopilot/... -run TestCIMonitor_AutoDiscoveryCompletion_GH4384 -v` — PASS
- [x] `go test ./internal/autopilot/... -run TestController_ActionsOnlyRepo_AdvancesWaitingCIToCIPassed_GH4384 -v` — PASS
- [x] `go test ./internal/autopilot/...` — full package suite PASS