### PR TITLE
GH-4454: fix(dispatcher): repick hard cap counts restart churn + operator cancels as failures — wedged head issue then starves lane via scope-overlap defer (7h silent idle)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -184,6 +184,7 @@
 | Cooldown periods | ✅ | alerts | - | `alerts.defaults.cooldown` | Avoid spam |
 | PagerDuty escalation | ✅ | alerts | - | - | Auto-escalate after 3 retries (v0.38.0, GH-848) |
 | Deadlock detector | ✅ | autopilot | - | - | Alert after 1h with no progress on PR (v0.38.0, GH-849) |
+| Lane-starvation detector | ✅ | autopilot/alerts | - | `alerts.rules[].condition.lane_starvation_poll_cycles` | Alert when a project lane has open non-blocked pilot-labeled issues but 0 queued/running executions for N consecutive poll cycles (default 3, cooldown 30m) — catches wedged/stalled issues that never produce a PR or execution row for the other health checks to watch (v2.241.2, GH-4454) |
 | Alert dispatch metrics | ✅ | alerts/gateway | - | - | alerts_fired_total, alert_delivery_total, alert_events_dropped_total, alert_queue_depth on /metrics (TASK-332) |
 | Rate limit detection | ✅ | executor | - | - | Detect GitHub API rate limits, pause + resume at reset time (v0.34.0) |
 | GitHub token fallback + live validation | ✅ | cmd/pilot, health | `pilot doctor` | `adapters.github.token` | config → `GITHUB_TOKEN` env → `gh auth token` fallback; authenticated startup check logs ERROR + fires `config_error` alert on a dead/expired token (GH-3718) |

--- a/.agent/tasks/archive/gh-4454-1.md
+++ b/.agent/tasks/archive/gh-4454-1.md
@@ -1,0 +1,23 @@
+# GH-4454-1
+
+**Created:** 2026-07-18
+
+## Problem
+
+## Subtask 1 of 4
+
+**Parent Task:** GH-4454 - fix(dispatcher): repick hard cap counts restart churn + operator cancels as failures — wedged head issue then starves lane via scope-overlap defer (7h silent idle)
+
+## Objective
+
+Boot reconciliation (GH-4403) must clear/decrement `repick_backoff` for rows IT stalls — a daemon restart is not evidence the task can't succeed.
+
+## Context
+
+This is part of a larger task that has been decomposed for better execution.
+Focus on this specific objective. Other subtasks will handle the remaining work.
+
+
+
+## Acceptance Criteria
+

--- a/.agent/tasks/archive/gh-4454-2.md
+++ b/.agent/tasks/archive/gh-4454-2.md
@@ -1,0 +1,23 @@
+# GH-4454-2
+
+**Created:** 2026-07-18
+
+## Problem
+
+## Subtask 2 of 4
+
+**Parent Task:** GH-4454 - fix(dispatcher): repick hard cap counts restart churn + operator cancels as failures — wedged head issue then starves lane via scope-overlap defer (7h silent idle)
+
+## Objective
+
+Operator-cancelled rows (`status='cancelled'`) must not count toward the repick hard cap.
+
+## Context
+
+This is part of a larger task that has been decomposed for better execution.
+Focus on this specific objective. Other subtasks will handle the remaining work.
+
+
+
+## Acceptance Criteria
+

--- a/.agent/tasks/archive/gh-4454-3.md
+++ b/.agent/tasks/archive/gh-4454-3.md
@@ -1,0 +1,23 @@
+# GH-4454-3
+
+**Created:** 2026-07-18
+
+## Problem
+
+## Subtask 3 of 4
+
+**Parent Task:** GH-4454 - fix(dispatcher): repick hard cap counts restart churn + operator cancels as failures — wedged head issue then starves lane via scope-overlap defer (7h silent idle)
+
+## Objective
+
+Scope-overlap deferral must not defer behind an issue whose latest execution is hard-cap `stalled` — treat it as not-dispatched (or surface it), otherwise one wedged head issue starves every overlapping issue silently.
+
+## Context
+
+This is part of a larger task that has been decomposed for better execution.
+Focus on this specific objective. Other subtasks will handle the remaining work.
+
+
+
+## Acceptance Criteria
+

--- a/.agent/tasks/archive/gh-4454-4.md
+++ b/.agent/tasks/archive/gh-4454-4.md
@@ -1,0 +1,24 @@
+# GH-4454-4
+
+**Created:** 2026-07-18
+
+## Problem
+
+## Subtask 4 of 4
+
+**Parent Task:** GH-4454 - fix(dispatcher): repick hard cap counts restart churn + operator cancels as failures — wedged head issue then starves lane via scope-overlap defer (7h silent idle)
+
+## Objective
+
+Alert when a project lane has open labeled issues but 0 queued/running executions for >N poll cycles (lane-starvation detector).
+
+## Context
+
+This is part of a larger task that has been decomposed for better execution.
+Focus on this specific objective. Other subtasks will handle the remaining work.
+
+**Note:** This is the final subtask. Ensure all previous subtasks are complete before finishing.
+
+
+## Acceptance Criteria
+

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -664,6 +664,12 @@ Examples:
 
 							// GH-1870: Board sync option for gateway autopilot controller.
 							var gwBoardOpts []autopilot.ControllerOption
+							// GH-4454: match the polling-path pilot-label wiring so the
+							// lane-starvation reconciler searches the same trigger label
+							// the webhook/legacy poller watches for.
+							if cfg.Adapters.GitHub.PilotLabel != "" {
+								gwBoardOpts = append(gwBoardOpts, autopilot.WithPilotLabel(cfg.Adapters.GitHub.PilotLabel))
+							}
 							if cfg.Adapters.GitHub.ProjectBoard != nil && cfg.Adapters.GitHub.ProjectBoard.Enabled {
 								bs := githubSDK.NewProjectBoardSync(apGHClient, toSDKProjectBoardConfig(cfg.Adapters.GitHub.ProjectBoard), parts[0])
 								statuses := cfg.Adapters.GitHub.ProjectBoard.GetStatuses()
@@ -699,6 +705,9 @@ Examples:
 							// wiring further down).
 							if gwDispatcher != nil {
 								gwAutopilotController.SetDispatcherLiveness(gwDispatcher)
+								// GH-4454: project-scoped queued/running count for the
+								// lane-starvation reconciler.
+								gwAutopilotController.SetLaneQueueStatus(gwDispatcher)
 							}
 						}
 					}
@@ -1592,6 +1601,14 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 
 			// GH-1870: Build board sync option for autopilot controllers.
 			var autopilotBoardOpts []autopilot.ControllerOption
+			// GH-4454: every controller's lane-starvation reconciler needs the
+			// same trigger label the GitHub SDK poller watches for
+			// (poller_github.go resolves this identically: ghCfg.PilotLabel,
+			// defaulting to "pilot" — WithPilotLabel leaves it unset when
+			// PilotLabel is empty, so NewController's own default applies).
+			if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.PilotLabel != "" {
+				autopilotBoardOpts = append(autopilotBoardOpts, autopilot.WithPilotLabel(cfg.Adapters.GitHub.PilotLabel))
+			}
 			if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.ProjectBoard != nil && cfg.Adapters.GitHub.ProjectBoard.Enabled {
 				owner := ""
 				if parts := strings.SplitN(cfg.Adapters.GitHub.Repo, "/", 2); len(parts) == 2 {
@@ -2268,6 +2285,10 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 	if dispatcher != nil {
 		for _, ctrl := range autopilotControllers {
 			ctrl.SetDispatcherLiveness(dispatcher)
+			// GH-4454: wire the project-scoped queued/running count the
+			// lane-starvation reconciler needs, unconditionally alongside the
+			// liveness signal above.
+			ctrl.SetLaneQueueStatus(dispatcher)
 		}
 	}
 

--- a/internal/alerts/engine.go
+++ b/internal/alerts/engine.go
@@ -128,6 +128,13 @@ const (
 	// did not produce its expected release tag, so a stalled release
 	// pipeline doesn't go unnoticed.
 	EventTypeReleaseMissing EventType = "release_missing"
+
+	// Lane starvation events (GH-4454): fired every poll cycle a project
+	// lane has open pilot-labeled issues but zero queued/running executions.
+	// Metadata carries repo, project_path, open_issue_count, and
+	// poll_cycles_starved (the running streak) — see
+	// autopilot.Controller.reconcileLaneStarvation, the sole emitter.
+	EventTypeLaneStarvation EventType = "lane_starvation"
 )
 
 const (
@@ -360,6 +367,8 @@ func (e *Engine) handleEvent(ctx context.Context, event Event) {
 		e.handleConfigError(ctx, event)
 	case EventTypeReleaseMissing:
 		e.handleReleaseMissing(ctx, event)
+	case EventTypeLaneStarvation:
+		e.handleLaneStarvation(ctx, event)
 	case EventTypeBudgetExceeded, EventTypeBudgetWarning:
 		e.handleBudgetEvent(ctx, event)
 	case EventTypeAutopilotMetrics:
@@ -561,6 +570,40 @@ func (e *Engine) handleReleaseMissing(ctx context.Context, event Event) {
 			message := fmt.Sprintf("Release missing for %s: expected tag %s after PR #%s was merged",
 				event.Metadata["repo"], event.Metadata["tag"], event.Metadata["pr"])
 			alert := e.createAlert(rule, event, message)
+			e.fireAlert(ctx, rule, alert)
+		}
+	}
+}
+
+// handleLaneStarvation fires AlertTypeLaneStarvation rules when a project
+// lane's poll_cycles_starved streak (GH-4454, emitted by
+// autopilot.Controller.reconcileLaneStarvation every poll cycle the lane
+// looks starved) reaches RuleCondition.LaneStarvationPollCycles. The emitting
+// side does no threshold filtering of its own — mirroring
+// handleAutopilotMetrics's ownership of FailedQueueThreshold/PRStuckTimeout —
+// so a rule override here takes effect without any autopilot-side change.
+func (e *Engine) handleLaneStarvation(ctx context.Context, event Event) {
+	streak := 0
+	if v, ok := event.Metadata["poll_cycles_starved"]; ok {
+		_, _ = fmt.Sscanf(v, "%d", &streak)
+	}
+	openIssues := event.Metadata["open_issue_count"]
+	repo := event.Metadata["repo"]
+
+	for _, rule := range e.config.Rules {
+		if !rule.Enabled || rule.Type != AlertTypeLaneStarvation {
+			continue
+		}
+
+		threshold := rule.Condition.LaneStarvationPollCycles
+		if threshold <= 0 {
+			threshold = 3
+		}
+
+		if streak >= threshold && e.shouldFire(rule) {
+			alert := e.createAlert(rule, event,
+				fmt.Sprintf("Lane %s has %s open pilot-labeled issue(s) but nothing queued/running for %d consecutive poll cycles",
+					repo, openIssues, streak))
 			e.fireAlert(ctx, rule, alert)
 		}
 	}

--- a/internal/alerts/engine_test.go
+++ b/internal/alerts/engine_test.go
@@ -1273,6 +1273,228 @@ func TestHandleReleaseMissing(t *testing.T) {
 	})
 }
 
+// TestHandleLaneStarvation covers the GH-4454 lane-starvation rule: the
+// emitting side (autopilot.Controller.reconcileLaneStarvation) does no
+// threshold filtering of its own and sends the raw streak on every starved
+// tick, so handleLaneStarvation alone is responsible for comparing that
+// streak against RuleCondition.LaneStarvationPollCycles and respecting
+// cooldown — mirroring TestHandleReleaseMissing above.
+func TestHandleLaneStarvation(t *testing.T) {
+	newEvent := func(repo, openIssues, streak string) Event {
+		return Event{
+			Type: EventTypeLaneStarvation,
+			Metadata: map[string]string{
+				"repo":                repo,
+				"project_path":        "/proj",
+				"open_issue_count":    openIssues,
+				"poll_cycles_starved": streak,
+			},
+			Timestamp: time.Now(),
+		}
+	}
+
+	t.Run("below threshold does not fire", func(t *testing.T) {
+		config := &AlertConfig{
+			Enabled: true,
+			Channels: []ChannelConfig{
+				{Name: "test-channel", Type: "webhook", Enabled: true},
+			},
+			Rules: []AlertRule{
+				{
+					Name:      "lane_starvation",
+					Type:      AlertTypeLaneStarvation,
+					Enabled:   true,
+					Condition: RuleCondition{LaneStarvationPollCycles: 3},
+					Severity:  SeverityWarning,
+					Channels:  []string{"test-channel"},
+					Cooldown:  0,
+				},
+			},
+		}
+
+		mockCh := newMockChannel("test-channel", "webhook")
+		dispatcher := NewDispatcher(config)
+		dispatcher.RegisterChannel(mockCh)
+		engine := NewEngine(config, WithDispatcher(dispatcher))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = engine.Start(ctx)
+
+		engine.ProcessEvent(newEvent("qf-studio/pilot", "2", "2"))
+		engine.flushForTest()
+
+		if got := len(mockCh.getAlerts()); got != 0 {
+			t.Errorf("expected 0 alerts below threshold, got %d", got)
+		}
+	})
+
+	t.Run("at threshold fires with repo/open-issue/streak in message", func(t *testing.T) {
+		config := &AlertConfig{
+			Enabled: true,
+			Channels: []ChannelConfig{
+				{Name: "test-channel", Type: "webhook", Enabled: true},
+			},
+			Rules: []AlertRule{
+				{
+					Name:      "lane_starvation",
+					Type:      AlertTypeLaneStarvation,
+					Enabled:   true,
+					Condition: RuleCondition{LaneStarvationPollCycles: 3},
+					Severity:  SeverityWarning,
+					Channels:  []string{"test-channel"},
+					Cooldown:  0,
+				},
+			},
+		}
+
+		mockCh := newMockChannel("test-channel", "webhook")
+		dispatcher := NewDispatcher(config)
+		dispatcher.RegisterChannel(mockCh)
+		engine := NewEngine(config, WithDispatcher(dispatcher))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = engine.Start(ctx)
+
+		engine.ProcessEvent(newEvent("qf-studio/pilot", "2", "3"))
+		waitForAlerts(t, mockCh, 1, 2*time.Second)
+
+		got := mockCh.getAlerts()
+		if len(got) != 1 {
+			t.Fatalf("expected 1 alert at threshold, got %d", len(got))
+		}
+		if got[0].Type != AlertTypeLaneStarvation {
+			t.Errorf("expected alert type %s, got %s", AlertTypeLaneStarvation, got[0].Type)
+		}
+		if !strings.Contains(got[0].Message, "qf-studio/pilot") ||
+			!strings.Contains(got[0].Message, "2") ||
+			!strings.Contains(got[0].Message, "3") {
+			t.Errorf("expected alert message to mention repo/open-issue-count/streak, got %q", got[0].Message)
+		}
+	})
+
+	t.Run("disabled rule does not fire", func(t *testing.T) {
+		config := &AlertConfig{
+			Enabled: true,
+			Channels: []ChannelConfig{
+				{Name: "test-channel", Type: "webhook", Enabled: true},
+			},
+			Rules: []AlertRule{
+				{
+					Name:      "lane_starvation",
+					Type:      AlertTypeLaneStarvation,
+					Enabled:   false, // Disabled
+					Condition: RuleCondition{LaneStarvationPollCycles: 3},
+					Severity:  SeverityWarning,
+					Channels:  []string{"test-channel"},
+					Cooldown:  0,
+				},
+			},
+		}
+
+		mockCh := newMockChannel("test-channel", "webhook")
+		dispatcher := NewDispatcher(config)
+		dispatcher.RegisterChannel(mockCh)
+		engine := NewEngine(config, WithDispatcher(dispatcher))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = engine.Start(ctx)
+
+		engine.ProcessEvent(newEvent("qf-studio/pilot", "2", "5"))
+		engine.flushForTest()
+
+		if got := len(mockCh.getAlerts()); got != 0 {
+			t.Errorf("expected 0 alerts (rule disabled), got %d", got)
+		}
+	})
+
+	t.Run("zero LaneStarvationPollCycles falls back to default of 3", func(t *testing.T) {
+		config := &AlertConfig{
+			Enabled: true,
+			Channels: []ChannelConfig{
+				{Name: "test-channel", Type: "webhook", Enabled: true},
+			},
+			Rules: []AlertRule{
+				{
+					Name:     "lane_starvation",
+					Type:     AlertTypeLaneStarvation,
+					Enabled:  true,
+					Severity: SeverityWarning,
+					Channels: []string{"test-channel"},
+					Cooldown: 0,
+					// Condition.LaneStarvationPollCycles left unset (zero value).
+				},
+			},
+		}
+
+		mockCh := newMockChannel("test-channel", "webhook")
+		dispatcher := NewDispatcher(config)
+		dispatcher.RegisterChannel(mockCh)
+		engine := NewEngine(config, WithDispatcher(dispatcher))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = engine.Start(ctx)
+
+		// Streak of 2 should NOT fire against the default threshold of 3.
+		engine.ProcessEvent(newEvent("qf-studio/pilot", "1", "2"))
+		engine.flushForTest()
+		if got := len(mockCh.getAlerts()); got != 0 {
+			t.Errorf("expected 0 alerts below default threshold, got %d", got)
+		}
+
+		// Streak of 3 should fire.
+		engine.ProcessEvent(newEvent("qf-studio/pilot", "1", "3"))
+		waitForAlerts(t, mockCh, 1, 2*time.Second)
+		if got := len(mockCh.getAlerts()); got != 1 {
+			t.Errorf("expected 1 alert at default threshold, got %d", got)
+		}
+	})
+
+	t.Run("cooldown suppresses repeat fires", func(t *testing.T) {
+		config := &AlertConfig{
+			Enabled: true,
+			Channels: []ChannelConfig{
+				{Name: "test-channel", Type: "webhook", Enabled: true},
+			},
+			Rules: []AlertRule{
+				{
+					Name:      "lane_starvation",
+					Type:      AlertTypeLaneStarvation,
+					Enabled:   true,
+					Condition: RuleCondition{LaneStarvationPollCycles: 3},
+					Severity:  SeverityWarning,
+					Channels:  []string{"test-channel"},
+					Cooldown:  30 * time.Minute,
+				},
+			},
+		}
+
+		mockCh := newMockChannel("test-channel", "webhook")
+		dispatcher := NewDispatcher(config)
+		dispatcher.RegisterChannel(mockCh)
+		engine := NewEngine(config, WithDispatcher(dispatcher))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = engine.Start(ctx)
+
+		engine.ProcessEvent(newEvent("qf-studio/pilot", "2", "3"))
+		waitForAlerts(t, mockCh, 1, 2*time.Second)
+
+		// Next poll cycle's streak (4) is still within cooldown and must be
+		// suppressed even though it's further past threshold.
+		engine.ProcessEvent(newEvent("qf-studio/pilot", "2", "4"))
+		engine.flushForTest()
+
+		if got := len(mockCh.getAlerts()); got != 1 {
+			t.Errorf("expected 1 alert (second suppressed by cooldown), got %d", got)
+		}
+	})
+}
+
 func TestEngine_ChannelAcceptsSeverity(t *testing.T) {
 	config := &AlertConfig{Enabled: true}
 	engine := NewEngine(config)

--- a/internal/alerts/types.go
+++ b/internal/alerts/types.go
@@ -52,6 +52,11 @@ const (
 	// Release monitoring (GH-3952): a merged pilot/GH-* PR that never
 	// produced its expected release tag.
 	AlertTypeReleaseMissing AlertType = "release_missing"
+
+	// Lane-starvation detection (GH-4454): a project lane has open
+	// pilot-labeled issues but nothing queued/running for too many
+	// consecutive poll cycles.
+	AlertTypeLaneStarvation AlertType = "lane_starvation"
 )
 
 // Alert represents an alert event
@@ -108,6 +113,9 @@ type RuleCondition struct {
 
 	// Escalation conditions (GH-848)
 	EscalationRetries int `yaml:"escalation_retries"` // Failures before escalation (default 3)
+
+	// Lane-starvation detection (GH-4454)
+	LaneStarvationPollCycles int `yaml:"lane_starvation_poll_cycles"` // Consecutive idle poll cycles before firing (default 3)
 }
 
 // AlertConfig holds the main alerting configuration
@@ -366,6 +374,19 @@ func defaultRules() []AlertRule {
 			Channels:    []string{},
 			Cooldown:    30 * time.Minute,
 			Description: "Alert when a merged PR did not produce its expected release tag",
+		},
+		// Lane-starvation detection (GH-4454)
+		{
+			Name:    "lane_starvation",
+			Type:    AlertTypeLaneStarvation,
+			Enabled: true,
+			Condition: RuleCondition{
+				LaneStarvationPollCycles: 3,
+			},
+			Severity:    SeverityWarning,
+			Channels:    []string{},
+			Cooldown:    30 * time.Minute,
+			Description: "Alert when a project lane has open pilot-labeled issues but nothing queued/running for too many poll cycles",
 		},
 	}
 }

--- a/internal/alerts/types_test.go
+++ b/internal/alerts/types_test.go
@@ -64,6 +64,8 @@ func TestDefaultRules(t *testing.T) {
 		AlertTypeEscalation: {"escalation", true},
 		// Release monitoring (GH-3952)
 		AlertTypeReleaseMissing: {"release_missing", true},
+		// Lane-starvation detection (GH-4454)
+		AlertTypeLaneStarvation: {"lane_starvation", true},
 	}
 
 	if len(rules) != len(expectedRules) {

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -138,6 +138,18 @@ type DispatcherLiveness interface {
 	GetRunningTaskIDs() []string
 }
 
+// LaneQueueStatus reports how many tasks are queued or actively running for
+// a single project lane right now. GH-4454: DispatcherLiveness above only
+// exposes task IDs across every project a Dispatcher drives, which cannot
+// tell "this repo's lane is empty" from "this repo's lane's tasks just don't
+// happen to be running this instant" — the lane-starvation reconciler needs
+// a project-scoped count instead. Satisfied by *executor.Dispatcher.
+type LaneQueueStatus interface {
+	// QueuedOrRunningCount returns the number of tasks queued or being
+	// processed for projectPath. Zero means the lane is currently idle.
+	QueuedOrRunningCount(projectPath string) int
+}
+
 // EvalStore persists eval tasks extracted from merged PRs.
 type EvalStore interface {
 	SaveEvalTask(task *memory.EvalTask) error
@@ -204,6 +216,17 @@ func WithMemoryStore(s *memory.Store) ControllerOption {
 	}
 }
 
+// WithPilotLabel overrides the trigger label reconcileLaneStarvation searches
+// open issues for (GH-4454). Empty (the zero value / unset) falls back to
+// github.LabelPilot ("pilot") in NewController — pass this only when
+// adapters.github.pilot_label deviates from the default, mirroring
+// poller_github.go's own ghCfg.PilotLabel resolution.
+func WithPilotLabel(label string) ControllerOption {
+	return func(c *Controller) {
+		c.pilotLabel = label
+	}
+}
+
 // WithProjectPath sets the filesystem project path used to scope execution
 // self-heal (SelfHealExecutionAfterMerge) to this project's rows. It MUST match
 // the value the executor stored in executions.project_path — an absolute fs path
@@ -259,6 +282,7 @@ type Controller struct {
 	notifier         Notifier
 	monitor          TaskMonitor        // GH-1336: sync dashboard state on merge
 	dispatcherLive   DispatcherLiveness // GH-4412: always-on live-worker signal (unlike monitor, dashboard-only)
+	laneQueueStatus  LaneQueueStatus    // GH-4454: project-scoped queued/running count for lane-starvation detection
 	boardSync        projectBoardSyncer
 	doneStatus       string
 	failStatus       string
@@ -355,6 +379,18 @@ type Controller struct {
 	// alertedMissingReleases (GH-3991).
 	alertedStaleScopes map[string]bool
 
+	// pilotLabel is the trigger label reconcileLaneStarvation searches open
+	// issues for (default github.LabelPilot = "pilot", overridable via
+	// WithPilotLabel to match a non-default adapters.github.pilot_label).
+	// GH-4454.
+	pilotLabel string
+
+	// laneStarvationStreak counts consecutive reconcileLaneStarvation poll
+	// cycles this lane has had open (non-blocked) pilot-labeled issues with
+	// zero queued/running executions, guarded by mu. Reset to 0 the moment
+	// either condition clears. GH-4454.
+	laneStarvationStreak int
+
 	// alertedPersistFailures deduplicates pr_persist_failed alerts per PR
 	// number, guarded by mu — same rationale as alertedMissingReleases: a
 	// wedged PR retries every tick, and without this map the alerts engine's
@@ -444,6 +480,13 @@ func NewController(cfg *Config, ghClient *github.Client, approvalMgr *approval.M
 	// running them first is safe.
 	for _, opt := range opts {
 		opt(c)
+	}
+
+	// GH-4454: default the lane-starvation trigger label to the SDK's own
+	// "pilot" constant when WithPilotLabel was never applied, matching
+	// poller_github.go's ghCfg.PilotLabel fallback.
+	if c.pilotLabel == "" {
+		c.pilotLabel = github.LabelPilot
 	}
 
 	c.ciMonitor = NewCIMonitor(ghClient, owner, repo, cfg)
@@ -731,6 +774,14 @@ func (c *Controller) SetMonitor(m TaskMonitor) {
 // whenever an executor.Dispatcher exists.
 func (c *Controller) SetDispatcherLiveness(d DispatcherLiveness) {
 	c.dispatcherLive = d
+}
+
+// SetLaneQueueStatus wires the project-scoped queued/running count the
+// lane-starvation reconciler needs. GH-4454: like SetDispatcherLiveness,
+// callers should wire this unconditionally whenever an executor.Dispatcher
+// exists — reconcileLaneStarvation is a no-op (skips silently) while nil.
+func (c *Controller) SetLaneQueueStatus(s LaneQueueStatus) {
+	c.laneQueueStatus = s
 }
 
 // SetStateStore sets the persistent state store for crash recovery.
@@ -4766,6 +4817,9 @@ func (c *Controller) Run(ctx context.Context) error {
 			// orphaned by a manual tag push that bypassed the release train)
 			// whose PR is, in fact, already merged and tagged.
 			c.reconcileReleaseBackfill(ctx)
+			// GH-4454: poll-cycle lane-starvation sweep — this project's lane
+			// has open pilot-labeled issues but nothing queued/running.
+			c.reconcileLaneStarvation(ctx)
 		case <-ticker.C:
 			c.processAllPRs(ctx)
 

--- a/internal/autopilot/lane_starvation.go
+++ b/internal/autopilot/lane_starvation.go
@@ -1,0 +1,87 @@
+package autopilot
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/alerts"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// reconcileLaneStarvation is the poll-cycle lane-starvation sweep (GH-4454).
+// It's distinct from every other health check in this package — deadlock
+// detection, PR-stuck-waiting-CI, failed-queue-depth — because those all
+// require an active PR or execution to exist in the first place before they
+// can measure lack of progress against it. This detector catches the case
+// where NOTHING is even in flight for a lane that still has open, actionable
+// work: a wedged head issue stuck behind studio-sdk's scope-overlap defer, a
+// repick-hard-cap-stalled issue nobody re-armed, a crashed/misconfigured
+// poller, or a dispatcher that silently stopped picking up this project —
+// none of which leave a PR or execution row behind for the existing alerts to
+// watch (GH-4454: exactly this starved a lane for 7h with no alert firing).
+//
+// It lists this repo's open issues carrying the trigger label (c.pilotLabel,
+// default "pilot"), excludes any already parked with pilot-blocked (a
+// deliberately-parked backlog — e.g. the repick-hard-cap stall label this
+// same parent task's earlier subtask applies — is a known, intentional idle
+// state, not starvation), and compares the remainder against
+// laneQueueStatus.QueuedOrRunningCount for this project's lane. Every tick the
+// lane looks starved, the in-memory streak counter increments and an event is
+// emitted with the running streak as metadata; every tick it doesn't, the
+// streak resets to 0 and no event fires. The alerts engine's lane_starvation
+// rule (handleLaneStarvation) — not this method — decides whether the streak
+// has crossed RuleCondition.LaneStarvationPollCycles and is due (cooldown),
+// mirroring how handleAutopilotMetrics owns FailedQueueThreshold/PRStuckTimeout
+// instead of the emitting side pre-filtering.
+func (c *Controller) reconcileLaneStarvation(ctx context.Context) {
+	if c.alertsEngine == nil || c.laneQueueStatus == nil {
+		return
+	}
+
+	issues, err := c.ghClient.ListIssues(ctx, c.owner, c.repo, &github.ListIssuesOptions{
+		Labels: []string{c.pilotLabel},
+		State:  github.StateOpen,
+	})
+	if err != nil {
+		c.log.Warn("reconcileLaneStarvation: failed to list open pilot-labeled issues",
+			slog.String("repo", c.repoKey()), slog.Any("error", err))
+		return
+	}
+
+	actionable := 0
+	for _, issue := range issues {
+		if github.HasLabel(issue, github.LabelBlocked) {
+			continue
+		}
+		actionable++
+	}
+
+	if actionable == 0 || c.laneQueueStatus.QueuedOrRunningCount(c.projectPath) > 0 {
+		c.mu.Lock()
+		c.laneStarvationStreak = 0
+		c.mu.Unlock()
+		return
+	}
+
+	c.mu.Lock()
+	c.laneStarvationStreak++
+	streak := c.laneStarvationStreak
+	c.mu.Unlock()
+
+	c.log.Debug("reconcileLaneStarvation: lane idle with open actionable issues",
+		slog.String("repo", c.repoKey()), slog.Int("streak", streak), slog.Int("open_issues", actionable))
+
+	c.alertsEngine.ProcessEvent(alerts.Event{
+		Type:      alerts.EventTypeLaneStarvation,
+		Project:   c.repoKey(),
+		Timestamp: time.Now(),
+		Metadata: map[string]string{
+			"repo":                c.repoKey(),
+			"project_path":        c.projectPath,
+			"open_issue_count":    fmt.Sprintf("%d", actionable),
+			"poll_cycles_starved": fmt.Sprintf("%d", streak),
+		},
+	})
+}

--- a/internal/autopilot/lane_starvation_test.go
+++ b/internal/autopilot/lane_starvation_test.go
@@ -1,0 +1,221 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/alerts"
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// laneStarvationFakeIssue describes one open issue served by the fake GitHub
+// server used across TestReconcileLaneStarvation subtests.
+type laneStarvationFakeIssue struct {
+	number int
+	labels []string
+}
+
+// laneStarvationServer serves GET /repos/owner/repo/issues (what ListIssues
+// calls) with the given issues on page 1 and an empty page thereafter, so
+// ListIssues's pagination loop terminates after a single round-trip.
+func laneStarvationServer(t *testing.T, issues []laneStarvationFakeIssue) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("page") != "" && r.URL.Query().Get("page") != "1" {
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Issue{})
+			return
+		}
+
+		out := make([]github.Issue, 0, len(issues))
+		for _, iss := range issues {
+			labels := make([]github.Label, 0, len(iss.labels))
+			for _, name := range iss.labels {
+				labels = append(labels, github.Label{Name: name})
+			}
+			out = append(out, github.Issue{Number: iss.number, State: github.StateOpen, Labels: labels})
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(out)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// fakeLaneQueueStatus is a minimal LaneQueueStatus stub for tests, keyed by
+// project path.
+type fakeLaneQueueStatus struct {
+	counts map[string]int
+}
+
+func (f *fakeLaneQueueStatus) QueuedOrRunningCount(projectPath string) int {
+	return f.counts[projectPath]
+}
+
+func newLaneStarvationController(t *testing.T, issues []laneStarvationFakeIssue) (*Controller, *fakeAlertSink, *fakeLaneQueueStatus) {
+	t.Helper()
+	server := laneStarvationServer(t, issues)
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithProjectPath("/proj"))
+
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+	lqs := &fakeLaneQueueStatus{counts: map[string]int{}}
+	c.SetLaneQueueStatus(lqs)
+
+	return c, sink, lqs
+}
+
+// TestReconcileLaneStarvation_NoEngineOrQueueStatus verifies the sweep is a
+// silent no-op (GH-4454: SetAlertsEngine/SetLaneQueueStatus are both
+// optional wiring) when either dependency was never configured.
+func TestReconcileLaneStarvation_NoEngineOrQueueStatus(t *testing.T) {
+	server := laneStarvationServer(t, []laneStarvationFakeIssue{{number: 1}})
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithProjectPath("/proj"))
+	c.reconcileLaneStarvation(context.Background())
+	if c.laneStarvationStreak != 0 {
+		t.Errorf("expected streak to stay 0 with no alertsEngine/laneQueueStatus wired, got %d", c.laneStarvationStreak)
+	}
+
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+	c.reconcileLaneStarvation(context.Background())
+	if len(sink.events) != 0 {
+		t.Errorf("expected no events with laneQueueStatus still nil, got %d", len(sink.events))
+	}
+}
+
+// TestReconcileLaneStarvation_NoOpenIssues verifies a lane with zero open
+// pilot-labeled issues never trips the detector, and resets any prior streak.
+func TestReconcileLaneStarvation_NoOpenIssues(t *testing.T) {
+	c, sink, _ := newLaneStarvationController(t, nil)
+	c.laneStarvationStreak = 5
+
+	c.reconcileLaneStarvation(context.Background())
+
+	if c.laneStarvationStreak != 0 {
+		t.Errorf("expected streak reset to 0 with no open issues, got %d", c.laneStarvationStreak)
+	}
+	if len(sink.events) != 0 {
+		t.Errorf("expected no event with no open issues, got %d", len(sink.events))
+	}
+}
+
+// TestReconcileLaneStarvation_AllBlocked verifies issues carrying
+// pilot-blocked (a deliberately-parked backlog, e.g. GH-4454's own
+// repick-hard-cap stall label) are excluded from the actionable count and do
+// not trip starvation.
+func TestReconcileLaneStarvation_AllBlocked(t *testing.T) {
+	c, sink, _ := newLaneStarvationController(t, []laneStarvationFakeIssue{
+		{number: 1, labels: []string{github.LabelPilot, github.LabelBlocked}},
+		{number: 2, labels: []string{github.LabelPilot, github.LabelBlocked}},
+	})
+
+	c.reconcileLaneStarvation(context.Background())
+
+	if c.laneStarvationStreak != 0 {
+		t.Errorf("expected streak to stay 0 when every open issue is pilot-blocked, got %d", c.laneStarvationStreak)
+	}
+	if len(sink.events) != 0 {
+		t.Errorf("expected no event when every open issue is pilot-blocked, got %d", len(sink.events))
+	}
+}
+
+// TestReconcileLaneStarvation_LaneBusy verifies open actionable issues do not
+// trip starvation while the lane still has something queued or running.
+func TestReconcileLaneStarvation_LaneBusy(t *testing.T) {
+	c, sink, lqs := newLaneStarvationController(t, []laneStarvationFakeIssue{
+		{number: 1, labels: []string{github.LabelPilot}},
+	})
+	lqs.counts["/proj"] = 1
+
+	c.reconcileLaneStarvation(context.Background())
+
+	if c.laneStarvationStreak != 0 {
+		t.Errorf("expected streak to stay 0 while the lane is busy, got %d", c.laneStarvationStreak)
+	}
+	if len(sink.events) != 0 {
+		t.Errorf("expected no event while the lane is busy, got %d", len(sink.events))
+	}
+}
+
+// TestReconcileLaneStarvation_Starved verifies open actionable issues with
+// nothing queued/running increments the streak and emits an event carrying
+// the running streak plus open issue count as metadata (GH-4454) — every
+// tick, not just once the Engine's threshold is crossed, since the Engine
+// (not this method) owns the fire/cooldown decision.
+func TestReconcileLaneStarvation_Starved(t *testing.T) {
+	c, sink, _ := newLaneStarvationController(t, []laneStarvationFakeIssue{
+		{number: 1, labels: []string{github.LabelPilot}},
+		{number: 2, labels: []string{github.LabelPilot}},
+	})
+
+	c.reconcileLaneStarvation(context.Background())
+
+	if c.laneStarvationStreak != 1 {
+		t.Errorf("expected streak 1 after first starved tick, got %d", c.laneStarvationStreak)
+	}
+	if len(sink.events) != 1 {
+		t.Fatalf("expected 1 event after first starved tick, got %d", len(sink.events))
+	}
+	ev := sink.events[0]
+	if ev.Type != alerts.EventTypeLaneStarvation {
+		t.Errorf("expected event type %s, got %s", alerts.EventTypeLaneStarvation, ev.Type)
+	}
+	if ev.Metadata["poll_cycles_starved"] != "1" {
+		t.Errorf("expected poll_cycles_starved=1, got %s", ev.Metadata["poll_cycles_starved"])
+	}
+	if ev.Metadata["open_issue_count"] != "2" {
+		t.Errorf("expected open_issue_count=2, got %s", ev.Metadata["open_issue_count"])
+	}
+	if ev.Metadata["project_path"] != "/proj" {
+		t.Errorf("expected project_path=/proj, got %s", ev.Metadata["project_path"])
+	}
+	if ev.Metadata["repo"] != "owner/repo" {
+		t.Errorf("expected repo=owner/repo, got %s", ev.Metadata["repo"])
+	}
+
+	// A second consecutive starved tick increments the streak again.
+	c.reconcileLaneStarvation(context.Background())
+	if c.laneStarvationStreak != 2 {
+		t.Errorf("expected streak 2 after second starved tick, got %d", c.laneStarvationStreak)
+	}
+	if len(sink.events) != 2 {
+		t.Fatalf("expected 2 events after second starved tick, got %d", len(sink.events))
+	}
+	if sink.events[1].Metadata["poll_cycles_starved"] != "2" {
+		t.Errorf("expected poll_cycles_starved=2 on second tick, got %s", sink.events[1].Metadata["poll_cycles_starved"])
+	}
+}
+
+// TestReconcileLaneStarvation_RecoveryResetsStreak verifies the streak resets
+// to 0 the moment the lane stops looking starved (either the queue gains
+// work or the open-issue backlog clears), matching the documented
+// increment-while-starved/reset-otherwise contract.
+func TestReconcileLaneStarvation_RecoveryResetsStreak(t *testing.T) {
+	c, sink, lqs := newLaneStarvationController(t, []laneStarvationFakeIssue{
+		{number: 1, labels: []string{github.LabelPilot}},
+	})
+
+	c.reconcileLaneStarvation(context.Background())
+	if c.laneStarvationStreak != 1 {
+		t.Fatalf("expected streak 1 after starved tick, got %d", c.laneStarvationStreak)
+	}
+
+	lqs.counts["/proj"] = 1
+	c.reconcileLaneStarvation(context.Background())
+	if c.laneStarvationStreak != 0 {
+		t.Errorf("expected streak reset to 0 once the lane picks up work, got %d", c.laneStarvationStreak)
+	}
+	if len(sink.events) != 1 {
+		t.Errorf("expected no additional event once recovered, got %d total", len(sink.events))
+	}
+}

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -881,6 +881,27 @@ func repickBackoffKey(projectPath, taskID string) string {
 	return projectPath + "|" + taskID
 }
 
+// priorClaimWasOperatorCancelled reports whether (taskID, projectPath)'s
+// currently claimed execution — the one nextRetryGeneration just examined to
+// grant this retry — has status "cancelled". There is no in-repo call site
+// that writes "cancelled" (see store.go's UpdateExecutionStatus comment); it
+// is a value an operator sets by hand (direct DB write) to unblock a wedged
+// head-of-queue task. GH-4454 subtask 2: that manual intervention must not
+// be treated as a failure by beginWithGenerationRetry's hard-cap accounting.
+// Errors are treated as "not cancelled" — the caller falls through to the
+// ordinary backoff/hard-cap path, which is the safe default.
+func (d *Dispatcher) priorClaimWasOperatorCancelled(taskID, projectPath string) bool {
+	_, execID, found, err := d.store.LatestClaimGeneration(taskID, projectPath)
+	if err != nil || !found {
+		return false
+	}
+	exec, err := d.store.GetExecution(execID)
+	if err != nil {
+		return false
+	}
+	return exec.Status == "cancelled"
+}
+
 // nextRetryGeneration inspects the highest execution_claims generation
 // currently held for (taskID, projectPath) and reports whether a fresh
 // Begin(..., generation+1) is warranted (GH-4372). Three outcomes:
@@ -966,6 +987,44 @@ func (d *Dispatcher) beginWithGenerationRetry(task *Task, initial Status) (strin
 		return "", nil
 	}
 
+	backoffKey := repickBackoffKey(task.ProjectPath, task.ID)
+
+	// GH-4454 subtask 2: an operator manually cancelling a wedged
+	// head-of-queue execution to unblock the lane is not evidence the task
+	// can't succeed — unlike a genuine failure, it's deliberate human
+	// intervention. Left uncounted-for, each cancel-and-repick cycle still
+	// grew the SAME consecutiveDrops counter a real failure would, so an
+	// operator trying to rescue a wedged task tripped
+	// dispatcherRepickHardCap on their own unblock attempts and permanently
+	// stalled the very task they were trying to save (GH-4454: 7h silent
+	// idle after a wedged head issue starved its lane). Clear any
+	// accumulated backoff state and grant the retry immediately, without
+	// consulting or growing the hard-cap counter.
+	if d.priorClaimWasOperatorCancelled(task.ID, task.ProjectPath) {
+		if err := d.ClearRepickBackoffState(backoffKey); err != nil {
+			d.log.Warn("failed to clear repick backoff state for operator-cancelled claim",
+				slog.String("task_id", task.ID),
+				slog.String("project", task.ProjectPath),
+				slog.Any("error", err))
+		}
+		retryExecID, retryErr := lifecycle.Begin(task, initial, gen)
+		if retryErr == nil {
+			d.log.Info("dispatch re-pick: prior claim was operator-cancelled — claiming next generation without counting toward repick hard cap",
+				slog.String("task_id", task.ID),
+				slog.String("project", task.ProjectPath),
+				slog.Int("generation", gen),
+			)
+			return retryExecID, nil
+		}
+		if errors.Is(retryErr, ErrClaimLost) {
+			// Race: another channel claimed generation gen between our
+			// decision and this Begin call — drop it, same as any other
+			// duplicate pickup.
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to save retry execution: %w", retryErr)
+	}
+
 	// GH-4394 subtask 2: cmd/pilot's per-issue backoff (#4385) only gates
 	// whether handleIssueGeneric calls QueueTask at all — it has no
 	// visibility into a repick decided *inside* this call, and QueueTask's
@@ -985,7 +1044,6 @@ func (d *Dispatcher) beginWithGenerationRetry(task *Task, initial Status) (strin
 	// config-registered values, identical for a canary or a real project) and
 	// never inspects IsCanary. See
 	// TestDispatcher_BeginWithGenerationRetry_ThrottlesCanaryProjectSameAsRegular.
-	backoffKey := repickBackoffKey(task.ProjectPath, task.ID)
 	consecutiveDrops, nextAllowedAt, found, boErr := d.RepickBackoffState(backoffKey)
 	if boErr != nil {
 		d.log.Warn("failed to read repick backoff state — dropping retry to be safe",

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -1443,6 +1443,31 @@ func (d *Dispatcher) GetRunningTaskIDs() []string {
 	return ids
 }
 
+// QueuedOrRunningCount returns the number of tasks currently queued or being
+// processed for projectPath — the same live/store-backed signals
+// GetWorkerStatus exposes, collapsed to one int for a single project. A
+// project with no live worker at all (nothing ever dispatched, or the worker
+// drained its queue and exited) returns 0, which is itself the "nothing in
+// flight" signal the lane-starvation detector needs (GH-4454): a project
+// lane can have open pilot-labeled issues on GitHub while never having had a
+// worker created for it here, e.g. every candidate issue is stuck behind a
+// scope-overlap defer or a repick-hard-cap-stalled head issue.
+func (d *Dispatcher) QueuedOrRunningCount(projectPath string) int {
+	d.mu.RLock()
+	worker, ok := d.workers[projectPath]
+	d.mu.RUnlock()
+	if !ok {
+		return 0
+	}
+
+	status := worker.Status()
+	count := status.QueuedCount
+	if status.IsProcessing {
+		count++
+	}
+	return count
+}
+
 // GetExecutionStatus returns the current status of an execution.
 func (d *Dispatcher) GetExecutionStatus(execID string) (*memory.Execution, error) {
 	return d.store.GetExecution(execID)

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -203,7 +203,11 @@ func (d *Dispatcher) Start(ctx context.Context) error {
 // reconcileOrphanedExecutions transitions every claimed, non-terminal
 // ("queued" or "running") execution row found at boot to "stalled", freeing
 // its execution_claims generation lock so nextRetryGeneration can hand out a
-// generation+1 retry on the next dispatch attempt (GH-4392).
+// generation+1 retry on the next dispatch attempt (GH-4392). Every row it
+// stalls also has its repick_backoff state cleared (GH-4454) — a daemon
+// restart is not evidence the task can't succeed, so the retry this stall
+// enables must not inherit a consecutive-drop count inflated by restart
+// churn rather than genuine failures.
 //
 // Incident context: nextRetryGeneration (GH-4372) only advances the
 // generation when the claimed execution it finds is in a TERMINAL status —
@@ -296,6 +300,25 @@ func (d *Dispatcher) reconcileOrphanedExecutions() int {
 		}
 		reconciled++
 		d.recordExecutionEvent(exec.ID, memory.StageStalled, "orphaned queued/running execution reconciled at daemon boot (dead pre-restart owner, GH-4392)")
+
+		// GH-4454: a daemon restart is not evidence the task can't succeed —
+		// but the "stalled" status this loop just wrote is exactly the
+		// terminal-but-not-done claim nextRetryGeneration looks for, so the
+		// very next dispatch attempt repicks it and beginWithGenerationRetry
+		// treats that repick as one more consecutive drop toward
+		// dispatcherRepickHardCap. Left alone, repeated restarts (or one
+		// restart on top of pre-existing real drops) push a perfectly healthy
+		// task over the hard cap on restart churn alone, permanently stalling
+		// it via stallTaskAfterRepickHardCap for a reason that has nothing to
+		// do with the task itself. Clear any accumulated backoff state here so
+		// the retry this stall enables starts a fresh consecutive-drop count
+		// instead of inheriting one inflated by the restart.
+		backoffKey := repickBackoffKey(exec.ProjectPath, exec.TaskID)
+		if err := d.ClearRepickBackoffState(backoffKey); err != nil {
+			d.log.Warn("failed to clear repick backoff state for boot-stalled execution",
+				slog.String("execution_id", exec.ID), slog.String("task_id", exec.TaskID),
+				slog.String("project", exec.ProjectPath), slog.Any("error", err))
+		}
 	}
 
 	if reconciled > 0 {

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -1152,6 +1152,7 @@ func (d *Dispatcher) stallTaskAfterRepickHardCap(task *Task, gen, consecutiveDro
 		slog.Int("hard_cap", dispatcherRepickHardCap),
 		slog.Int("generation", gen),
 	)
+	d.surfaceStalledIssue(task, reason)
 	if d.runner != nil {
 		d.runner.EmitAlertEvent(AlertEvent{
 			Type:      AlertEventTypeTaskFailed,
@@ -1166,6 +1167,64 @@ func (d *Dispatcher) stallTaskAfterRepickHardCap(task *Task, gen, consecutiveDro
 			},
 			Timestamp: time.Now(),
 		})
+	}
+}
+
+// surfaceStalledIssue labels a repick-hard-cap-stalled task's GitHub issue
+// pilot-blocked (removing pilot-failed/pilot-in-progress) and posts an
+// explanatory comment — GH-4454 subtask 3.
+//
+// Why this matters: studio-sdk's GitHub poller groups open "pilot"-labeled
+// issues by shared directory reference (scope overlap) and, within each
+// group, dispatches only the OLDEST issue every poll tick, deferring every
+// other issue in that group. That grouping/ordering has no visibility into
+// this dispatcher's independent repick_backoff hard cap — it re-admits a
+// pilot-failed issue as a candidate via its own separate retry counter,
+// unaware the store-side execution behind it was already stalled above.
+// Being the oldest issue in its scope cluster, the stalled head keeps
+// winning the dispatch slot on every tick, silently starving every issue
+// that shares its scope forever (GH-4454: 7h idle after exactly this). The
+// poller DOES unconditionally exclude any issue carrying pilot-blocked from
+// its candidate list before scope grouping ever runs, so applying that label
+// here removes the stalled issue from contention entirely and lets the
+// next-oldest overlapping issue through instead of silently starving.
+//
+// Best-effort and GitHub-only: a labeling/comment failure is logged, not
+// fatal — the store-side "stalled" status the caller already wrote is the
+// durable source of truth regardless of whether this side channel succeeds.
+func (d *Dispatcher) surfaceStalledIssue(task *Task, reason string) {
+	if task.SourceAdapter != "" && task.SourceAdapter != "github" {
+		return
+	}
+	issueNum := strings.TrimPrefix(task.ID, "GH-")
+	if task.SourceIssueID != "" {
+		issueNum = task.SourceIssueID
+	}
+	if issueNum == "" {
+		return
+	}
+	var parsed int
+	if _, err := fmt.Sscanf(issueNum, "%d", &parsed); err != nil || parsed <= 0 {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(d.ctx, 30*time.Second)
+	defer cancel()
+
+	comment := fmt.Sprintf(
+		"Pilot stopped retrying (repick hard cap): %s\n\n"+
+			"Labeled `pilot-blocked` so this issue stops winning scope-overlap "+
+			"dispatch priority over sibling issues that touch the same files. "+
+			"To re-arm after fixing the underlying blocker:\n```\ngh issue edit %d --remove-label pilot-blocked --remove-label pilot-failed --add-label pilot-retry-ready\n```",
+		reason, parsed,
+	)
+	if err := ghIssueComment(ctx, task.ProjectPath, issueNum, comment); err != nil {
+		d.log.Warn("stalled-issue surfacing: failed to post comment",
+			slog.String("task_id", task.ID), slog.Any("error", err))
+	}
+	if err := ghEditLabels(ctx, task.ProjectPath, issueNum, []string{"pilot-blocked"}, []string{"pilot-failed", "pilot-in-progress"}); err != nil {
+		d.log.Warn("stalled-issue surfacing: failed to update labels",
+			slog.String("task_id", task.ID), slog.Any("error", err))
 	}
 }
 

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -3054,6 +3054,75 @@ func TestDispatcher_BeginWithGenerationRetry_ThrottledWithinBackoffWindow(t *tes
 	}
 }
 
+// TestDispatcher_BeginWithGenerationRetry_OperatorCancelBypassesHardCap is
+// the GH-4454 subtask 2 acceptance test: an operator-cancelled claim
+// (status="cancelled", the manual-intervention value used to unblock a
+// wedged head-of-queue task — see priorClaimWasOperatorCancelled) must not
+// be treated as a failure by the hard-cap accounting. Even with the
+// persisted consecutive-drop count already AT dispatcherRepickHardCap,
+// beginWithGenerationRetry must still grant the retry (not stall the task
+// or raise an alert) and must clear the backoff state instead of growing
+// it — otherwise an operator's own cancel-to-unblock attempts permanently
+// stall the very task they were trying to save.
+func TestDispatcher_BeginWithGenerationRetry_OperatorCancelBypassesHardCap(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GH-4454-CANCEL", ProjectPath: "/project-cancel", Title: "Operator-cancelled task"}
+	runner := NewRunner()
+	processor := &fakeAlertProcessor{}
+	runner.SetAlertProcessor(processor)
+	dispatcher := NewDispatcher(store, runner, nil)
+	key := repickBackoffKey(task.ProjectPath, task.ID)
+
+	// Already at the hard cap — if this repick were treated like an ordinary
+	// failure-driven retry, it would trip stallTaskAfterRepickHardCap.
+	if err := dispatcher.SetRepickBackoffState(key, dispatcherRepickHardCap, time.Now().Add(-time.Minute)); err != nil {
+		t.Fatalf("SetRepickBackoffState: %v", err)
+	}
+
+	execID, err := NewExecutionLifecycle(store).Begin(task, ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("setup Begin: %v", err)
+	}
+	// Operator-cancelled, not failed — the manual-intervention value that
+	// must be exempted from the hard-cap counter.
+	if err := store.UpdateExecutionStatus(execID, "cancelled"); err != nil {
+		t.Fatalf("setup: failed to mark generation 0 as cancelled: %v", err)
+	}
+
+	freshTask := &Task{ID: task.ID, ProjectPath: task.ProjectPath, Title: task.Title}
+	retryExecID, err := dispatcher.beginWithGenerationRetry(freshTask, ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("beginWithGenerationRetry: %v", err)
+	}
+	if retryExecID == "" {
+		t.Fatal("expected the operator-cancelled repick to succeed despite the hard cap being reached")
+	}
+
+	if genCheck, _, found, err := store.LatestClaimGeneration(task.ID, task.ProjectPath); err != nil {
+		t.Fatalf("LatestClaimGeneration: %v", err)
+	} else if !found || genCheck != 1 {
+		t.Errorf("expected a generation-1 claim after the operator-cancelled repick, found=%v generation=%d", found, genCheck)
+	}
+
+	if len(processor.events) != 0 {
+		t.Fatalf("expected no hard-cap alert for an operator-cancelled repick, got %d: %+v", len(processor.events), processor.events)
+	}
+
+	if stalledExec, err := store.GetExecution(execID); err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	} else if stalledExec.Status == "stalled" {
+		t.Error("expected the operator-cancelled execution to be left alone, not marked stalled")
+	}
+
+	if _, _, found, err := dispatcher.RepickBackoffState(key); err != nil {
+		t.Fatalf("RepickBackoffState: %v", err)
+	} else if found {
+		t.Error("expected the operator-cancelled repick to clear backoff state instead of growing it")
+	}
+}
+
 // TestDispatcher_BeginWithGenerationRetry_HardCapStallsInsteadOfRetrying is
 // the GH-4394 subtask 5 acceptance test: exponential backoff alone (subtask
 // 2/3) never stops a doomed task from retrying — it only slows the interval

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -3201,6 +3201,110 @@ func TestDispatcher_BeginWithGenerationRetry_HardCapStallsInsteadOfRetrying(t *t
 	}
 }
 
+// TestDispatcher_StallTaskAfterRepickHardCap_SurfacesStalledIssue is the
+// GH-4454 subtask 3 regression test: reaching the repick hard cap must label
+// the task's GitHub issue pilot-blocked (dropping pilot-failed/
+// pilot-in-progress) instead of leaving it eligible to keep winning
+// studio-sdk's scope-overlap dispatch grouping — a stalled head issue that
+// keeps winning its scope cluster silently starves every sibling issue that
+// touches the same files (the "7h silent idle" in GH-4454's title).
+func TestDispatcher_StallTaskAfterRepickHardCap_SurfacesStalledIssue(t *testing.T) {
+	fakeBin := t.TempDir()
+	logFile := filepath.Join(t.TempDir(), "gh-calls.log")
+	script := filepath.Join(fakeBin, "gh")
+	content := "#!/bin/sh\n" + `echo "$@" >> "` + logFile + `"` + "\nexit 0\n"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	origPATH := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+origPATH)
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	projectDir := t.TempDir()
+	task := &Task{ID: "GH-9001", ProjectPath: projectDir, Title: "Wedged head issue", SourceAdapter: "github"}
+	runner := NewRunner()
+	dispatcher := NewDispatcher(store, runner, nil)
+
+	execID, err := NewExecutionLifecycle(store).Begin(task, ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("setup Begin: %v", err)
+	}
+	if err := store.UpdateExecutionStatus(execID, "failed"); err != nil {
+		t.Fatalf("setup: failed to mark generation 0 as failed: %v", err)
+	}
+
+	dispatcher.stallTaskAfterRepickHardCap(task, 0, dispatcherRepickHardCap)
+
+	stalledExec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if stalledExec.Status != "stalled" {
+		t.Fatalf("expected execution stalled, got %q", stalledExec.Status)
+	}
+
+	logBytes, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("expected gh CLI to be invoked, but log file missing: %v", err)
+	}
+	calls := string(logBytes)
+	if !strings.Contains(calls, "issue comment 9001") {
+		t.Errorf("expected a comment posted to issue 9001, got calls:\n%s", calls)
+	}
+	if !strings.Contains(calls, "issue edit 9001") {
+		t.Errorf("expected a label edit on issue 9001, got calls:\n%s", calls)
+	}
+	if !strings.Contains(calls, "--add-label pilot-blocked") {
+		t.Errorf("expected pilot-blocked to be added, got calls:\n%s", calls)
+	}
+	if !strings.Contains(calls, "--remove-label pilot-failed") {
+		t.Errorf("expected pilot-failed to be removed, got calls:\n%s", calls)
+	}
+	if !strings.Contains(calls, "--remove-label pilot-in-progress") {
+		t.Errorf("expected pilot-in-progress to be removed, got calls:\n%s", calls)
+	}
+}
+
+// TestDispatcher_StallTaskAfterRepickHardCap_NonGitHubTaskSkipsGHCLI ensures
+// the GH-4454 subtask 3 surfacing logic only shells out for GitHub-sourced
+// tasks — mirrors postTitleRejectionEscalation's existing adapter guard so a
+// Linear/GitLab/Jira task never triggers a `gh` CLI call it can't act on.
+func TestDispatcher_StallTaskAfterRepickHardCap_NonGitHubTaskSkipsGHCLI(t *testing.T) {
+	fakeBin := t.TempDir()
+	logFile := filepath.Join(t.TempDir(), "gh-calls.log")
+	script := filepath.Join(fakeBin, "gh")
+	content := "#!/bin/sh\n" + `echo "$@" >> "` + logFile + `"` + "\nexit 0\n"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	origPATH := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+origPATH)
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	projectDir := t.TempDir()
+	task := &Task{ID: "GL-42", ProjectPath: projectDir, Title: "Non-GitHub task", SourceAdapter: "gitlab"}
+	runner := NewRunner()
+	dispatcher := NewDispatcher(store, runner, nil)
+
+	execID, err := NewExecutionLifecycle(store).Begin(task, ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("setup Begin: %v", err)
+	}
+	if err := store.UpdateExecutionStatus(execID, "failed"); err != nil {
+		t.Fatalf("setup: failed to mark generation 0 as failed: %v", err)
+	}
+
+	dispatcher.stallTaskAfterRepickHardCap(task, 0, dispatcherRepickHardCap)
+
+	if _, err := os.ReadFile(logFile); err == nil {
+		t.Error("expected no gh CLI invocation for a non-GitHub task")
+	}
+}
+
 // TestDispatcher_BeginWithGenerationRetry_HardCapIsIdempotent covers the
 // GH-4394 subtask 5 quiet-repeat requirement: once a task has been stalled by
 // the hard cap, subsequent poll ticks that reach the same gate (e.g. after

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -2825,6 +2825,53 @@ func TestDispatcher_ReconcileOrphanedExecutions_Idempotent(t *testing.T) {
 	}
 }
 
+// TestDispatcher_ReconcileOrphanedExecutions_ClearsRepickBackoff is the
+// GH-4454 subtask 1 regression test: a daemon restart is not evidence a task
+// can't succeed, so boot reconciliation stalling a dead-owner row must clear
+// any repick_backoff state already accumulated for that task — otherwise the
+// generation+1 retry this stall enables inherits a consecutive-drop count
+// inflated by restart churn instead of genuine failures, pushing the task
+// toward dispatcherRepickHardCap for reasons unrelated to the task itself.
+func TestDispatcher_ReconcileOrphanedExecutions_ClearsRepickBackoff(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GH-4454-BACKOFF", ProjectPath: "/project-boot-backoff"}
+	execID, err := NewExecutionLifecycle(store).Begin(task, ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("setup Begin: %v", err)
+	}
+
+	dispatcher := NewDispatcher(store, NewRunner(), nil)
+	key := repickBackoffKey(task.ProjectPath, task.ID)
+
+	// Simulate consecutive drops already accumulated BEFORE the restart (e.g.
+	// real repicks from a prior daemon lifetime), sitting one shy of the hard
+	// cap.
+	const preExistingDrops = dispatcherRepickHardCap - 1
+	if err := dispatcher.SetRepickBackoffState(key, preExistingDrops, time.Now().Add(-time.Minute)); err != nil {
+		t.Fatalf("setup SetRepickBackoffState: %v", err)
+	}
+
+	if reconciled := dispatcher.reconcileOrphanedExecutions(); reconciled != 1 {
+		t.Fatalf("expected 1 reconciled execution, got %d", reconciled)
+	}
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "stalled" {
+		t.Errorf("expected status 'stalled', got %q", exec.Status)
+	}
+
+	if _, _, found, err := dispatcher.RepickBackoffState(key); err != nil {
+		t.Fatalf("RepickBackoffState: %v", err)
+	} else if found {
+		t.Fatal("expected boot reconciliation to clear repick backoff state for the row it stalled, but state still exists")
+	}
+}
+
 // TestDispatcher_BootOrphanReconciliation_EnablesGenerationRetry is the
 // GH-4392 acceptance test: a dead daemon's claimed 'queued' row must not
 // wedge the task forever. After Dispatcher.Start's boot reconciliation

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -324,6 +324,84 @@ func TestDispatcher_GetRunningTaskIDs(t *testing.T) {
 	}
 }
 
+// TestDispatcher_QueuedOrRunningCount verifies the GH-4454 lane-starvation
+// signal: 0 for a project with no worker at all, the raw queued count for an
+// idle worker sitting on a backlog, +1 while a worker is actively processing,
+// and the sum of both when a worker is processing with more still queued.
+func TestDispatcher_QueuedOrRunningCount(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runner := NewRunner()
+	dispatcher := NewDispatcher(store, runner, nil)
+
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	// No worker for this project path at all.
+	if got := dispatcher.QueuedOrRunningCount("/proj-none"); got != 0 {
+		t.Errorf("expected 0 for a project with no worker, got %d", got)
+	}
+
+	log := slog.Default()
+
+	// Idle worker, no queued tasks in the store: 0.
+	idleWorker := NewProjectWorker("/proj-idle", store, runner, log)
+	dispatcher.mu.Lock()
+	dispatcher.workers["/proj-idle"] = idleWorker
+	dispatcher.mu.Unlock()
+
+	if got := dispatcher.QueuedOrRunningCount("/proj-idle"); got != 0 {
+		t.Errorf("expected 0 for an idle worker with no queued tasks, got %d", got)
+	}
+
+	// Worker actively processing, still no queued tasks: 1.
+	liveWorker := NewProjectWorker("/proj-live", store, runner, log)
+	liveWorker.processing.Store(true)
+	liveWorker.currentTaskID.Store("GH-4454")
+	dispatcher.mu.Lock()
+	dispatcher.workers["/proj-live"] = liveWorker
+	dispatcher.mu.Unlock()
+
+	if got := dispatcher.QueuedOrRunningCount("/proj-live"); got != 1 {
+		t.Errorf("expected 1 for a processing worker with no queued tasks, got %d", got)
+	}
+
+	// Worker with real queued rows backing it in the store, not processing:
+	// count matches the queue depth. Rows are written directly via
+	// SaveExecution (status "queued") rather than QueueTask, so no worker
+	// goroutine races this assertion by actually picking the task up.
+	for i := 0; i < 2; i++ {
+		exec := &memory.Execution{
+			ID:          fmt.Sprintf("TEST-QUEUED-%d", i),
+			TaskID:      fmt.Sprintf("TEST-QUEUED-%d", i),
+			ProjectPath: "/proj-queued",
+			Status:      "queued",
+			CreatedAt:   time.Now(),
+		}
+		if err := store.SaveExecution(exec); err != nil {
+			t.Fatalf("failed to save queued execution %d: %v", i, err)
+		}
+	}
+	queuedWorker := NewProjectWorker("/proj-queued", store, runner, log)
+	dispatcher.mu.Lock()
+	dispatcher.workers["/proj-queued"] = queuedWorker
+	dispatcher.mu.Unlock()
+
+	got := dispatcher.QueuedOrRunningCount("/proj-queued")
+	if got != 2 {
+		t.Errorf("expected 2 for a worker with 2 queued tasks and not processing, got %d", got)
+	}
+
+	// Same worker now also marked processing: queued count + 1.
+	queuedWorker.processing.Store(true)
+	if got := dispatcher.QueuedOrRunningCount("/proj-queued"); got != 3 {
+		t.Errorf("expected 3 for a worker with 2 queued tasks and processing, got %d", got)
+	}
+}
+
 func TestDispatcher_MultipleProjects(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()

--- a/internal/executor/title_rejection.go
+++ b/internal/executor/title_rejection.go
@@ -238,9 +238,20 @@ func ghIssueComment(ctx context.Context, dir, issueID, body string) error {
 }
 
 func ghAddLabels(ctx context.Context, dir, issueID string, labels []string) error {
+	return ghEditLabels(ctx, dir, issueID, labels, nil)
+}
+
+// ghEditLabels adds and removes GitHub issue labels via a single `gh issue
+// edit` call. Used by stallTaskAfterRepickHardCap (dispatcher.go, GH-4454
+// subtask 3) to swap pilot-failed/pilot-in-progress for pilot-blocked in one
+// shot, alongside ghAddLabels' add-only callers.
+func ghEditLabels(ctx context.Context, dir, issueID string, addLabels, removeLabels []string) error {
 	args := []string{"issue", "edit", issueID}
-	for _, l := range labels {
+	for _, l := range addLabels {
 		args = append(args, "--add-label", l)
+	}
+	for _, l := range removeLabels {
+		args = append(args, "--remove-label", l)
 	}
 	cmd := exec.CommandContext(ctx, "gh", args...)
 	if dir != "" {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4454.

Closes #4454

## Changes

GitHub Issue GH-4454: fix(dispatcher): repick hard cap counts restart churn + operator cancels as failures — wedged head issue then starves lane via scope-overlap defer (7h silent idle)

## Problem

Overnight 07-18 ~01:38Z→08:46Z the pilot lane sat completely idle (0 running, 0 queued) while 3 open labeled issues (GH-4401, GH-4404, GH-4423) waited — silent lane starvation, no alert.

## Chain

1. Three operator restarts on 07-17 (20:50Z, 23:02Z, 00:16Z) + operator row cancels each orphaned queued rows for GH-4393 and GH-4415. Every boot-reconciliation stall → re-pick incremented the `repick_backoff` counter (post-#4424, successful re-picks arm backoff too).
2. Counters crossed `dispatcherRepickHardCap` (5) and kept growing (observed 35–36) → both tasks marked `stalled`, "manual re-arm required". Neither task ever failed on its own merits post-rescope — the cap was consumed by restart churn and operator cancels.
3. The poller's scope-overlap dedup then deferred GH-4401/GH-4404/GH-4423 behind "dispatched=4393" on every tick — but 4393 was hard-cap-stalled and would never run again. Whole lane starved indefinitely.

## Fix

- [ ] Boot reconciliation (GH-4403) must clear/decrement `repick_backoff` for rows IT stalls — a daemon restart is not evidence the task can't succeed.
- [ ] Operator-cancelled rows (`status='cancelled'`) must not count toward the repick hard cap.
- [ ] Scope-overlap deferral must not defer behind an issue whose latest execution is hard-cap `stalled` — treat it as not-dispatched (or surface it), otherwise one wedged head issue starves every overlapping issue silently.
- [ ] Alert when a project lane has open labeled issues but 0 queued/running executions for >N poll cycles (lane-starvation detector).

## Evidence

- `repick_backoff` rows at 08:46Z: `…|GH-4393` drops=36 next_allowed 09:00Z; `…|GH-4415` drops=36 (cleared manually 08:5xZ as re-arm)
- Ledger GH-4393: stalled 23:17:57Z "repick backoff hard cap reached: 35 consecutive failed re-picks (cap=5)"
- daemon.log 08:44–08:46Z: repeating `Deferring issue due to overlapping scope with older issue` number=4401/4404/4423 dispatched=4393
- Overnight window: last real outcome 01:38Z, then nothing until manual re-arm

## Refs

Related: #4394 (backoff design), #4403 (boot reconciliation), #4392 (orphan rows), GH-4392/GH-44 prior hard-cap manual re-arms