### PR TITLE
GH-4404: fix(executor): successful completion never recorded in executions ledger — poller re-picks done task at next generation, duplicate-PR class (pointer GH-16)

### DIFF
--- a/.agent/sops/quality/pr-exists-overrides-terminal-status.md
+++ b/.agent/sops/quality/pr-exists-overrides-terminal-status.md
@@ -1,0 +1,71 @@
+# SOP: a delivered PR is ground truth — it must outrank any later non-completed classification
+
+**Category:** Quality / execution-ledger correctness
+**Implemented:** 2026-07-18
+**Source incident:** GH-4404 (pointer GH-16/GH-15 — poller re-picked a task
+whose PR was already open and risked a duplicate-PR dispatch), one causal
+chain with GH-4407 (intent judge's truncated-diff false veto)
+
+## Problem
+
+`ExecutionLifecycle.Classify` (`internal/executor/lifecycle.go`) derives an
+execution's terminal status from `TerminalStatus(result)` (or `execErr`
+directly). Nothing in that derivation consulted whether a PR had actually
+been created. On pointer GH-16, a run completed and opened PR #18, but
+something downstream of delivery — GH-4407's truncated-diff intent-judge
+veto is the incident that exposed this, though the invariant below holds
+regardless of which downstream signal causes it — still classified the
+attempt as non-completed. The ledger row landed "failed" while the PR sat
+open on GitHub. `HasTerminalCompletion` (which requires `status='completed'`
+plus a PR/commit) correctly read that row as "not done," so the poller
+re-dispatched the issue at the next claim generation — a full re-execution
+of a task whose PR already existed, i.e. the exact duplicate-PR class
+TASK-407/#4349 was built to prevent, reached through a different door.
+
+## Root cause
+
+The classification pipeline trusted whatever the *last* signal said
+(intent-judge verdict, self-review, an error string) as the final word on
+"was this done," instead of treating GitHub PR existence as authoritative.
+Any advisory/soft check that runs after a PR is created can, by construction,
+produce this disagreement unless something explicitly checks for delivery
+evidence first.
+
+## Fix
+
+`ExecutionLifecycle.Classify` now promotes a non-completed classification to
+`ExecStatusCompleted` whenever `result.PRUrl != ""` — **unless** the caller
+passed an explicit `override` status. The override escape hatch matters:
+epic.go's stranded-work guard (`executeSubIssuesTracked`) forces `failed` for
+a sub-issue that has commits but **no PR** — the mirror case, which never
+collides with this fix since it has no PRUrl to promote on. If a future
+caller ever needs to override *despite* a PR existing (e.g. a PR later found
+to be garbage), the override parameter already provides that escape hatch —
+don't try to special-case it inside the PR check itself.
+
+This lives in `Classify` (not `Persist`) so callers that record
+`execution_events` between `Classify` and `Persist` (GH-4259 ordering) see
+the corrected status too — the event ledger and the row status stay
+consistent.
+
+## Prevention
+
+Any new signal that can mark an execution non-completed *after* PR/commit
+creation (a new quality gate, a new judge, a new async check) must be
+evaluated against this invariant: **can this fire after delivery evidence
+exists?** If yes, it must not be allowed to make `HasTerminalCompletion`
+disagree with GitHub reality. Prefer feeding the signal in as an advisory
+warning (see `ExecutionResult.IntentWarning` — surfaced as a PR/issue
+comment, never as ledger status) over letting it drive terminal status
+directly, unless the signal specifically wants to invoke the `override`
+parameter with full knowledge of this invariant.
+
+## Test coverage
+
+- `TestExecutionLifecycle_Finish_PRExistsPromotesToCompleted` — the GH-4404
+  regression: a `Success: false` result with a PRUrl set still resolves to
+  `completed`, and `HasTerminalCompletion` reports the row as done.
+- `TestExecutionLifecycle_Finish_OverrideWinsOverPRSelfHeal` — explicit
+  override still wins over the PR self-heal.
+- `TestExecutionLifecycle_Finish_Override` (pre-existing) — the mirror case,
+  commits with no PR, still gets a caller-forced `failed`.

--- a/.agent/tasks/gh-4404.md
+++ b/.agent/tasks/gh-4404.md
@@ -1,0 +1,69 @@
+# GH-4404
+
+**Created:** 2026-07-18
+
+## Problem
+
+GitHub Issue GH-4404: fix(executor): successful completion never recorded in executions ledger — poller re-picks done task at next generation, duplicate-PR class (pointer GH-16)
+
+## Symptom
+
+Dispatcher logged a successful completion for pointer GH-16 at 2026-07-17T10:13:56Z:
+
+```
+msg="Task completed successfully" component=dispatcher project=.../pointer task_id=GH-16 duration=11m2s pr_url=https://github.com/qf-studio/pointer/pull/18
+```
+
+but the executions ledger has **no row for that run**. GH-16 history (rowid DESC): `3806 queued 11:10:43`, `3759 failed 09:28:00` — nothing between. The ~10:02Z execution that produced PR #18 never got a ledger row (or its row was never transitioned/persisted).
+
+## Consequence
+
+At 11:10:43Z the poller re-dispatched issue #16 and the dispatcher re-picked it:
+
+```
+msg="dispatch re-pick: prior claim was terminal but task is not done — claiming next generation for retry" task_id=GH-16 generation=8
+```
+
+"task is not done" is derived from the ledger, which is missing the completion → a task with an open PR (#18) is queued for full re-execution → duplicate-PR class that TASK-407 (#4349) was built to kill. The poller's "Skipping re-dispatch — completed execution exists" guard (works for GH-85) can't fire because the completed row doesn't exist.
+
+## Where to look
+
+- Whatever path handled GH-16's ~10:02Z run wrote dispatcher-level success but not an `ExecutionLifecycle` terminal transition — audit against TASK-404's `Begin/Transition/Finish` inventory (`internal/executor/lifecycle.go`); this looks like a create-or-finish site that bypasses it, possibly on a retry-after-failed-claim path (prior GH-16 rows were all `failed`, gen 7).
+- Ledger evidence on box DB: `SELECT rowid,task_id,status,datetime(created_at) FROM executions WHERE task_id='GH-16' ORDER BY rowid DESC LIMIT 6;`
+
+## Refs
+
+- TASK-404 (lifecycle chokepoint), TASK-407/#4349 (admission claim), #4392 (dead-owner rows), #4394 (repick backoff — adjacent but distinct: this is a correctness gap, not a pacing gap)
+
+## Root cause (pinned via issue-comment forensics, 2026-07-17)
+
+Not a lifecycle-bypass (no create/finish site skips `ExecutionLifecycle`).
+Box forensics on the live daemon (see issue comments) traced the sequence:
+executor logged `Task completed` 10:09:50Z → intent judge vetoed at
+10:12:27Z (truncated-diff false veto, #4407) → the execution's terminal
+classification landed non-completed → the dispatcher still logged "Task
+completed successfully" 10:13:56Z because PR #18 already existed. #4404 and
+#4407 are one causal chain: truncation → false veto → a terminal status that
+disagreed with GitHub reality despite a real PR → poller re-pick at gen+1.
+
+## Fix
+
+`ExecutionLifecycle.Classify` (`internal/executor/lifecycle.go`) now treats
+a non-empty `result.PRUrl` as ground truth: any non-completed classification
+is promoted to `completed` unless the caller passed an explicit `override`
+(epic.go's stranded-work override is the mirror case — commits with no PR —
+and never collides with this). This closes the gap regardless of which
+downstream signal (intent judge or otherwise) produces the disagreement.
+Full writeup: `.agent/sops/quality/pr-exists-overrides-terminal-status.md`.
+
+## Acceptance Criteria
+
+- [x] A `Finish`/`Classify` call whose result carries a PR URL persists as
+      `completed` and is counted done by `HasTerminalCompletion`, even when
+      `TerminalStatus` alone would classify it as failed/declined/etc.
+      (`TestExecutionLifecycle_Finish_PRExistsPromotesToCompleted`)
+- [x] An explicit caller override (epic.go's stranded-work case) still wins
+      over the PR self-heal (`TestExecutionLifecycle_Finish_OverrideWinsOverPRSelfHeal`,
+      pre-existing `TestExecutionLifecycle_Finish_Override`)
+- [x] `go test -race ./internal/executor/...` green
+

--- a/internal/executor/lifecycle.go
+++ b/internal/executor/lifecycle.go
@@ -178,6 +178,26 @@ func (l *ExecutionLifecycle) Classify(result *ExecutionResult, execErr error, ov
 			outcome.Error = result.Error
 		}
 	}
+
+	// GH-4404: a PR is ground truth that work was delivered. Something
+	// downstream of PR creation — an intent-judge veto arriving after
+	// delivery (#4407's truncated-diff false-veto is the incident that
+	// exposed this), or any other terminal-but-not-completed signal — can
+	// still classify the attempt as failed/declined/etc. Left uncorrected,
+	// that write makes HasTerminalCompletion disagree with GitHub reality:
+	// the row reads "not done" while the PR sits open, so the poller
+	// re-picks the task and re-executes it from scratch — the duplicate-PR
+	// class TASK-407 was built to prevent, reached by a different door
+	// (pointer GH-16/GH-15). Promote to completed whenever a PR exists,
+	// unless the caller supplied an explicit override — epic.go's
+	// stranded-work override is the mirror case (commits with NO PR,
+	// deliberately kept non-completed so the issue stays open for
+	// recovery) and never collides with this: it never has a PRUrl to
+	// promote on.
+	if outcome.Status != ExecStatusCompleted && len(override) == 0 && result != nil && result.PRUrl != "" {
+		outcome = FinishOutcome{Status: ExecStatusCompleted}
+	}
+
 	if len(override) > 0 {
 		outcome.Status = override[0]
 	}

--- a/internal/executor/lifecycle_test.go
+++ b/internal/executor/lifecycle_test.go
@@ -216,6 +216,99 @@ func TestExecutionLifecycle_Finish_Override(t *testing.T) {
 	}
 }
 
+// TestExecutionLifecycle_Finish_PRExistsPromotesToCompleted is the GH-4404
+// regression test: pointer GH-16/GH-15 re-picked a task whose PR was already
+// open because something downstream of PR creation (an intent-judge veto
+// arriving after delivery — #4407's truncated-diff false-veto is the
+// incident that exposed this) classified the attempt as a non-completed
+// terminal status. That write made HasTerminalCompletion disagree with
+// GitHub reality (a real PR existed but the row read "not done"), so the
+// poller re-picked the task and risked a duplicate PR. A PR is ground truth
+// that work was delivered, so Classify/Finish must promote to completed
+// whenever result.PRUrl is non-empty, regardless of what TerminalStatus
+// would otherwise classify the result as.
+func TestExecutionLifecycle_Finish_PRExistsPromotesToCompleted(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GH-16", ProjectPath: "/tmp/project"}
+	lifecycle := NewExecutionLifecycle(store)
+	execID, err := lifecycle.Begin(task, ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	result := &ExecutionResult{
+		TaskID:  task.ID,
+		Success: false, // e.g. an intent-judge veto arriving after the PR was created
+		Error:   "intent judge vetoed: diff appears to be missing implementation",
+		PRUrl:   "https://github.com/qf-studio/pointer/pull/18",
+	}
+
+	if classified := TerminalStatus(result); classified != "failed" {
+		t.Fatalf("test setup invalid: expected TerminalStatus to classify as failed without the PR-exists guard, got %q", classified)
+	}
+
+	outcome, err := lifecycle.Finish(execID, result, nil, 11*time.Minute)
+	if err != nil {
+		t.Fatalf("Finish failed: %v", err)
+	}
+	if outcome.Status != ExecStatusCompleted {
+		t.Errorf("expected outcome status %q, got %q", ExecStatusCompleted, outcome.Status)
+	}
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("failed to load execution: %v", err)
+	}
+	if exec.Status != string(ExecStatusCompleted) {
+		t.Errorf("expected status %q, got %q", ExecStatusCompleted, exec.Status)
+	}
+	if exec.PRUrl != result.PRUrl {
+		t.Errorf("expected pr_url to be persisted, got %+v", exec)
+	}
+
+	done, err := store.HasTerminalCompletion(task.ID, task.ProjectPath)
+	if err != nil {
+		t.Fatalf("HasTerminalCompletion: %v", err)
+	}
+	if !done {
+		t.Error("expected HasTerminalCompletion to count the PR-delivered row as done — a false 'not done' here is exactly what let the poller re-pick and risk a duplicate PR")
+	}
+}
+
+// TestExecutionLifecycle_Finish_OverrideWinsOverPRSelfHeal verifies the
+// GH-4404 PR-exists self-heal never overrides an explicit caller override —
+// epic.go's stranded-work override (executeSubIssuesTracked) must still be
+// able to force a non-completed status even if, hypothetically, a PRUrl were
+// present, since the caller's override reflects context (e.g. the PR itself
+// being invalid/abandoned) that Classify cannot see from result alone.
+func TestExecutionLifecycle_Finish_OverrideWinsOverPRSelfHeal(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GH-17", ProjectPath: "/tmp/project"}
+	lifecycle := NewExecutionLifecycle(store)
+	execID, err := lifecycle.Begin(task, ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	result := &ExecutionResult{
+		TaskID:  task.ID,
+		Success: false,
+		PRUrl:   "https://github.com/qf-studio/pointer/pull/19",
+	}
+
+	outcome, err := lifecycle.Finish(execID, result, nil, time.Second, ExecStatusFailed)
+	if err != nil {
+		t.Fatalf("Finish failed: %v", err)
+	}
+	if outcome.Status != ExecStatusFailed {
+		t.Errorf("expected explicit override to win over PR self-heal, got %q", outcome.Status)
+	}
+}
+
 // TestExecutionLifecycle_Begin_EmptyTitle_BackfillsViaUpdateExecutionTitle is
 // the GH-4281 integration test for the Begin+UpdateExecutionTitle round trip:
 // a caller that starts an execution before a title is resolvable (Begin with


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4404.

Closes #4404

## Changes

GitHub Issue GH-4404: fix(executor): successful completion never recorded in executions ledger — poller re-picks done task at next generation, duplicate-PR class (pointer GH-16)

## Symptom

Dispatcher logged a successful completion for pointer GH-16 at 2026-07-17T10:13:56Z:

```
msg="Task completed successfully" component=dispatcher project=.../pointer task_id=GH-16 duration=11m2s pr_url=https://github.com/qf-studio/pointer/pull/18
```

but the executions ledger has **no row for that run**. GH-16 history (rowid DESC): `3806 queued 11:10:43`, `3759 failed 09:28:00` — nothing between. The ~10:02Z execution that produced PR #18 never got a ledger row (or its row was never transitioned/persisted).

## Consequence

At 11:10:43Z the poller re-dispatched issue #16 and the dispatcher re-picked it:

```
msg="dispatch re-pick: prior claim was terminal but task is not done — claiming next generation for retry" task_id=GH-16 generation=8
```

"task is not done" is derived from the ledger, which is missing the completion → a task with an open PR (#18) is queued for full re-execution → duplicate-PR class that TASK-407 (#4349) was built to kill. The poller's "Skipping re-dispatch — completed execution exists" guard (works for GH-85) can't fire because the completed row doesn't exist.

## Where to look

- Whatever path handled GH-16's ~10:02Z run wrote dispatcher-level success but not an `ExecutionLifecycle` terminal transition — audit against TASK-404's `Begin/Transition/Finish` inventory (`internal/executor/lifecycle.go`); this looks like a create-or-finish site that bypasses it, possibly on a retry-after-failed-claim path (prior GH-16 rows were all `failed`, gen 7).
- Ledger evidence on box DB: `SELECT rowid,task_id,status,datetime(created_at) FROM executions WHERE task_id='GH-16' ORDER BY rowid DESC LIMIT 6;`

## Refs

- TASK-404 (lifecycle chokepoint), TASK-407/#4349 (admission claim), #4392 (dead-owner rows), #4394 (repick backoff — adjacent but distinct: this is a correctness gap, not a pacing gap)