### PR TITLE
GH-4460: fix(autopilot): capture failing CI step log tail for continuation issues

### DIFF
--- a/.agent/tasks/gh-4460.md
+++ b/.agent/tasks/gh-4460.md
@@ -1,0 +1,10 @@
+# GH-4460
+
+**Created:** 2026-07-18
+
+## Problem
+
+Separable sub-defect that made every GH-4415 continuation (4444/4446/4449/4453) bounce at preflight with 'provide only runner setup information.' In internal/autopilot/ci_monitor.go / feedback_loop.go (and, if the raw fetch lives there, internal/adapters/github/client.go), replace the current whole-job / head-of-log capture with a failing-step-tail extraction: for each failed check, resolve to the specific failing step (GitHub check-run annotations + jobs API), fetch that step's log, and take the last N lines (e.g. 200) plus a heading. Include a permalink to the raw log per failed check as a fallback. When multiple checks fail, emit one excerpt per failed check, capped to a total body budget so the continuation issue body stays under GitHub's issue-body limit. Ensure the continuation issue body is self-contained (repro command / commit SHA / failed-check names + tail excerpts) so preflight has enough signal to admit it. Add fixture-based tests (canned check-run + job payloads) verifying the extractor returns the failing step's tail, not the runner-setup preamble, and a body-assembly test verifying multiple failures fit under the budget with excerpts intact. Independent of subtasks 1 & 2 in logic, but sequenced last because subtask 2's CI-fail escalate path is the safety net that catches this defect while it's being fixed — if subtask 3 lands first without subtask 2, a truncated-log continuation still risks a destructive close under the old rung.
+
+## Acceptance Criteria
+

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -664,6 +664,10 @@ Examples:
 
 							// GH-1870: Board sync option for gateway autopilot controller.
 							var gwBoardOpts []autopilot.ControllerOption
+							// GH-4460: the in-tree client exposes the jobs/annotations APIs the
+							// studio-sdk client doesn't yet — wire it so CI-failure excerpts
+							// resolve to the actual failing step instead of a whole-job tail.
+							gwBoardOpts = append(gwBoardOpts, autopilot.WithStepLogClient(ghClient))
 							// GH-4454: match the polling-path pilot-label wiring so the
 							// lane-starvation reconciler searches the same trigger label
 							// the webhook/legacy poller watches for.
@@ -1601,6 +1605,10 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 
 			// GH-1870: Build board sync option for autopilot controllers.
 			var autopilotBoardOpts []autopilot.ControllerOption
+			// GH-4460: the in-tree client exposes the jobs/annotations APIs the
+			// studio-sdk client doesn't yet — wire it so CI-failure excerpts
+			// resolve to the actual failing step instead of a whole-job tail.
+			autopilotBoardOpts = append(autopilotBoardOpts, autopilot.WithStepLogClient(ghClient))
 			// GH-4454: every controller's lane-starvation reconciler needs the
 			// same trigger label the GitHub SDK poller watches for
 			// (poller_github.go resolves this identically: ghCfg.PilotLabel,

--- a/internal/adapters/github/jobs.go
+++ b/internal/adapters/github/jobs.go
@@ -1,0 +1,76 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// WorkflowJob represents a single GitHub Actions job within a workflow run,
+// including its per-step status/conclusion breakdown.
+//
+// GH-4460: the studio-sdk GitHub client (used by autopilot's CIMonitor for
+// the check-runs list and whole-job log fetch) does not expose the jobs API,
+// so this in-tree client supplies it. For check runs created by GitHub
+// Actions, the check-run ID and the job ID are the same numeric ID — see
+// ListCheckRuns/GetJobLogs, which already rely on that equivalence.
+type WorkflowJob struct {
+	ID         int64     `json:"id"`
+	RunID      int64     `json:"run_id"`
+	Name       string    `json:"name"`
+	Status     string    `json:"status"`               // queued, in_progress, completed
+	Conclusion string    `json:"conclusion,omitempty"` // success, failure, cancelled, timed_out, ...
+	HTMLURL    string    `json:"html_url,omitempty"`
+	Steps      []JobStep `json:"steps"`
+}
+
+// JobStep is one step within a WorkflowJob.
+type JobStep struct {
+	Name        string `json:"name"`
+	Status      string `json:"status"`               // queued, in_progress, completed
+	Conclusion  string `json:"conclusion,omitempty"` // success, failure, cancelled, skipped, ...
+	Number      int    `json:"number"`
+	StartedAt   string `json:"started_at,omitempty"`
+	CompletedAt string `json:"completed_at,omitempty"`
+}
+
+// GetWorkflowJob fetches a single GitHub Actions job by ID, including its
+// per-step breakdown.
+// Uses GET /repos/{owner}/{repo}/actions/jobs/{job_id}.
+// GH-4460: the step list is what lets a CI-failure excerpt point at the
+// actual failing step instead of the whole job's log, which starts with
+// runner-provisioning preamble that preflight rejected as "only runner setup
+// information" (root cause of the GH-4415 continuation-issue bounce chain).
+func (c *Client) GetWorkflowJob(ctx context.Context, owner, repo string, jobID int64) (*WorkflowJob, error) {
+	path := fmt.Sprintf("/repos/%s/%s/actions/jobs/%d", owner, repo, jobID)
+	var job WorkflowJob
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &job); err != nil {
+		return nil, err
+	}
+	return &job, nil
+}
+
+// CheckRunAnnotation is a single annotation attached to a check run, e.g. a
+// compiler error or lint failure GitHub surfaces inline against a file/line.
+// GH-4460: used as a fallback signal for check runs that are not backed by a
+// GitHub Actions job (e.g. third-party Checks-API integrations), where
+// GetWorkflowJob has nothing to resolve.
+type CheckRunAnnotation struct {
+	Path            string `json:"path"`
+	StartLine       int    `json:"start_line"`
+	EndLine         int    `json:"end_line"`
+	AnnotationLevel string `json:"annotation_level"` // notice, warning, failure
+	Message         string `json:"message"`
+	Title           string `json:"title,omitempty"`
+}
+
+// GetCheckRunAnnotations fetches annotations for a check run.
+// Uses GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations.
+func (c *Client) GetCheckRunAnnotations(ctx context.Context, owner, repo string, checkRunID int64) ([]CheckRunAnnotation, error) {
+	path := fmt.Sprintf("/repos/%s/%s/check-runs/%d/annotations?per_page=50", owner, repo, checkRunID)
+	var result []CheckRunAnnotation
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/internal/autopilot/ci_failure_excerpt.go
+++ b/internal/autopilot/ci_failure_excerpt.go
@@ -1,0 +1,172 @@
+package autopilot
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	ghadapter "github.com/qf-studio/pilot/internal/adapters/github"
+)
+
+// failedCheckExcerptMaxLines is how many trailing lines of a failing step's
+// log to keep per check (GH-4460). Large enough to show the actual
+// assertion/panic/compiler-error plus a few lines of surrounding context,
+// without dragging in the job's runner-provisioning preamble.
+const failedCheckExcerptMaxLines = 200
+
+// failedCheckExcerptBudgetChars caps the total size of the multi-check
+// failing-step excerpt bundle embedded in a continuation issue body, so a
+// PR with several failing checks still produces a body comfortably under
+// GitHub's issue-body limit (65536 chars).
+//
+// GH-4460: every GH-4415 continuation (4444/4446/4449/4453) bounced at
+// preflight with "provide only runner setup information" because the old
+// GetFailedCheckLogs concatenated whole job logs and then hard-truncated
+// the combined blob to 2000 chars from the head — on a multi-check failure
+// the first check's runner-setup preamble alone could consume the entire
+// budget before the actual failure line was ever reached.
+const failedCheckExcerptBudgetChars = 12000
+
+// ciExcerptSentinel prefixes a logs string that is already a pre-assembled,
+// budget-capped bundle of per-check failing-step excerpts (see
+// CIMonitor.GetFailedCheckExcerpts / AssembleFailureExcerptsBody), so
+// FeedbackLoop.generateBody can skip the single-blob marker search in
+// extractFailureExcerpt — which is designed for one raw log blob and would
+// otherwise misfire against multi-check output (no --- FAIL:/panic: marker
+// sits at the top level of the bundle, so it would fall through to a
+// last-N-lines fallback and clobber earlier checks' excerpts).
+const ciExcerptSentinel = "<!-- gh4460:step-excerpt-bundle -->\n"
+
+// jobLogLineTimestampRe matches the leading RFC3339-nanosecond timestamp
+// GitHub Actions prefixes on every raw job-log line, e.g.
+// "2026-07-18T10:13:56.1234567Z Run go test ./...".
+var jobLogLineTimestampRe = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z) `)
+
+// FailingStepExcerpt is one failed check's extracted evidence: the tail of
+// its actual failing step (not the whole job), plus a permalink fallback.
+type FailingStepExcerpt struct {
+	CheckName    string
+	StepName     string // empty when step-level resolution wasn't possible
+	Tail         string
+	PermalinkURL string
+	Source       string // "step", "annotations", or "job" — which fallback tier produced Tail
+}
+
+// resolveFailingStep returns the step that actually caused the job to fail,
+// as opposed to a later step GitHub marks "cancelled" once the job aborts.
+// A step with conclusion "failure" is the primary signal; "timed_out" is the
+// fallback for jobs killed by a step-level timeout.
+func resolveFailingStep(steps []ghadapter.JobStep) (ghadapter.JobStep, bool) {
+	for _, s := range steps {
+		if s.Conclusion == "failure" {
+			return s, true
+		}
+	}
+	for _, s := range steps {
+		if s.Conclusion == "timed_out" {
+			return s, true
+		}
+	}
+	return ghadapter.JobStep{}, false
+}
+
+// sliceLogByStepWindow returns the lines of jobLog whose leading timestamp
+// falls within [step.StartedAt, step.CompletedAt]. This slices a job's
+// combined raw log down to one step's output without depending on GitHub
+// Actions' internal ##[group] formatting, which isn't guaranteed stable
+// across runner versions.
+func sliceLogByStepWindow(jobLog string, step ghadapter.JobStep) (string, bool) {
+	if step.StartedAt == "" || step.CompletedAt == "" {
+		return "", false
+	}
+	start, err := time.Parse(time.RFC3339Nano, step.StartedAt)
+	if err != nil {
+		return "", false
+	}
+	end, err := time.Parse(time.RFC3339Nano, step.CompletedAt)
+	if err != nil {
+		return "", false
+	}
+
+	lines := strings.Split(jobLog, "\n")
+	matched := make([]string, 0, len(lines))
+	for _, line := range lines {
+		m := jobLogLineTimestampRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		ts, err := time.Parse(time.RFC3339Nano, m[1])
+		if err != nil {
+			continue
+		}
+		if !ts.Before(start) && !ts.After(end) {
+			matched = append(matched, line)
+		}
+	}
+	if len(matched) == 0 {
+		return "", false
+	}
+	return strings.Join(matched, "\n"), true
+}
+
+// tailLines returns the last n lines of s (or all of s when it has n lines
+// or fewer).
+func tailLines(s string, n int) string {
+	lines := strings.Split(s, "\n")
+	if len(lines) <= n {
+		return s
+	}
+	return strings.Join(lines[len(lines)-n:], "\n")
+}
+
+// AssembleFailureExcerptsBody renders a list of per-check failing-step
+// excerpts into one self-contained block — heading, tail excerpt, and a
+// permalink fallback per check — capped to maxTotalChars total. The budget
+// is split evenly across excerpts up front so one oversized excerpt can't
+// starve the others out of the body entirely (GH-4460).
+func AssembleFailureExcerptsBody(excerpts []FailingStepExcerpt, maxTotalChars int) string {
+	if len(excerpts) == 0 {
+		return ""
+	}
+
+	perExcerptBudget := maxTotalChars / len(excerpts)
+
+	var sb strings.Builder
+	for i, ex := range excerpts {
+		if i > 0 {
+			sb.WriteString("\n\n")
+		}
+
+		heading := fmt.Sprintf("=== %s ===", ex.CheckName)
+		if ex.StepName != "" {
+			heading = fmt.Sprintf("=== %s \u2014 failing step: %s ===", ex.CheckName, ex.StepName)
+		}
+		sb.WriteString(heading)
+		sb.WriteString("\n")
+
+		tail := ex.Tail
+		if strings.TrimSpace(tail) == "" {
+			tail = "(no log output captured)"
+		}
+
+		permalinkLine := ""
+		if ex.PermalinkURL != "" {
+			permalinkLine = "\nFull log: " + ex.PermalinkURL
+		}
+
+		// Reserve room for the heading and permalink so the *total* rendered
+		// block for this check — not just the tail — respects its share of
+		// the budget.
+		overhead := len(heading) + 1 + len(permalinkLine)
+		tailBudget := perExcerptBudget - overhead
+		const minTailBudget = 200 // always keep a minimum useful slice
+		if tailBudget < minTailBudget {
+			tailBudget = minTailBudget
+		}
+		sb.WriteString(truncateKeepingTail(tail, tailBudget))
+		sb.WriteString(permalinkLine)
+	}
+
+	return sb.String()
+}

--- a/internal/autopilot/ci_failure_excerpt_test.go
+++ b/internal/autopilot/ci_failure_excerpt_test.go
@@ -1,0 +1,373 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	ghadapter "github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// Canned job log: two steps. Step 1 is the runner-setup preamble GitHub
+// Actions always emits first; step 2 is the actual test run that failed.
+// Every line is prefixed with an RFC3339-nanosecond timestamp, matching
+// GitHub's raw job-log format, so sliceLogByStepWindow can carve out the
+// failing step from the combined blob using the steps' StartedAt/CompletedAt.
+const gh4460FixtureJobLog = `2026-07-18T10:00:00.0000000Z Current runner version: '2.319.1'
+2026-07-18T10:00:00.1000000Z Runner Image Provisioner
+2026-07-18T10:00:00.2000000Z Operating System
+2026-07-18T10:00:00.3000000Z Runner Image
+2026-07-18T10:00:00.4000000Z ##[group]Job defaults
+2026-07-18T10:00:00.5000000Z ##[endgroup]
+2026-07-18T10:00:05.0000000Z ##[group]Run go test ./...
+2026-07-18T10:00:05.1000000Z Run go test ./...
+2026-07-18T10:00:06.0000000Z --- FAIL: TestForecastMonthlyBurn (0.00s)
+2026-07-18T10:00:06.1000000Z     forecast_test.go:42: expected 1200, got 1100
+2026-07-18T10:00:06.2000000Z FAIL
+2026-07-18T10:00:06.3000000Z FAIL	github.com/qf-studio/pilot/internal/forecast	0.004s
+2026-07-18T10:00:06.4000000Z ##[error]Process completed with exit code 1.
+`
+
+func gh4460FixtureSteps() []ghadapter.JobStep {
+	return []ghadapter.JobStep{
+		{
+			Name:        "Set up job",
+			Status:      "completed",
+			Conclusion:  "success",
+			Number:      1,
+			StartedAt:   "2026-07-18T10:00:00.0000000Z",
+			CompletedAt: "2026-07-18T10:00:04.9000000Z",
+		},
+		{
+			Name:        "Run go test ./...",
+			Status:      "completed",
+			Conclusion:  "failure",
+			Number:      2,
+			StartedAt:   "2026-07-18T10:00:05.0000000Z",
+			CompletedAt: "2026-07-18T10:00:06.4000000Z",
+		},
+	}
+}
+
+// gh4460TestServer builds one httptest.Server that answers both the
+// studio-sdk client's endpoints (check-runs list, job log fetch) and the
+// in-tree client's endpoints (jobs API, check-run annotations), so a single
+// CIMonitor wired with both clients (as production does via
+// WithStepLogClient) can be exercised end-to-end against canned fixtures.
+type gh4460ServerOpts struct {
+	// jobStatus, when non-zero, overrides the HTTP status returned by the
+	// in-tree jobs-API endpoint (e.g. http.StatusNotFound to simulate a
+	// check run that isn't backed by a GitHub Actions job).
+	jobStatus int
+	// annotations, when non-nil, is served by the check-run annotations
+	// endpoint.
+	annotations []ghadapter.CheckRunAnnotation
+}
+
+func gh4460NewTestServer(t *testing.T, checkRuns []github.CheckRun, opts gh4460ServerOpts) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/abc123/check-runs":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.CheckRunsResponse{
+				TotalCount: len(checkRuns),
+				CheckRuns:  checkRuns,
+			})
+		case r.URL.Path == "/repos/owner/repo/actions/jobs/100/logs":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(gh4460FixtureJobLog))
+		case r.URL.Path == "/repos/owner/repo/actions/jobs/101/logs":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(strings.ReplaceAll(gh4460FixtureJobLog, "TestForecastMonthlyBurn", "TestOtherThing")))
+		case r.URL.Path == "/repos/owner/repo/actions/jobs/100":
+			if opts.jobStatus != 0 {
+				w.WriteHeader(opts.jobStatus)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(ghadapter.WorkflowJob{
+				ID:     100,
+				Name:   "test",
+				Status: "completed",
+				Steps:  gh4460FixtureSteps(),
+			})
+		case r.URL.Path == "/repos/owner/repo/actions/jobs/101":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(ghadapter.WorkflowJob{
+				ID:     101,
+				Name:   "lint",
+				Status: "completed",
+				Steps:  gh4460FixtureSteps(),
+			})
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/check-runs/") && strings.HasSuffix(r.URL.Path, "/annotations"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(opts.annotations)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// TestCIMonitor_GetFailedCheckExcerpts_ResolvesFailingStep verifies that when
+// a StepLogClient is wired, the excerpt for a failed check is the tail of
+// the actual failing step ("Run go test ./..."), not the runner-setup
+// preamble ("Set up job") that GH-4415's continuations kept bouncing on.
+func TestCIMonitor_GetFailedCheckExcerpts_ResolvesFailingStep(t *testing.T) {
+	server := gh4460NewTestServer(t, []github.CheckRun{
+		{ID: 100, Name: "test", Status: "completed", Conclusion: "failure", DetailsURL: "https://github.com/owner/repo/runs/100"},
+	}, gh4460ServerOpts{})
+	defer server.Close()
+
+	sdkClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	adapterClient := ghadapter.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	monitor := NewCIMonitor(sdkClient, "owner", "repo", DefaultConfig())
+	monitor.SetStepLogClient(adapterClient)
+
+	body := monitor.GetFailedCheckExcerpts(context.Background(), "abc123")
+
+	if body == "" {
+		t.Fatal("expected non-empty excerpt body")
+	}
+	if !strings.Contains(body, "TestForecastMonthlyBurn") {
+		t.Errorf("expected failing step's actual failure content, got:\n%s", body)
+	}
+	if !strings.Contains(body, "forecast_test.go:42") {
+		t.Errorf("expected failing assertion line, got:\n%s", body)
+	}
+	if strings.Contains(body, "Current runner version") || strings.Contains(body, "Runner Image Provisioner") {
+		t.Errorf("excerpt should not contain runner-setup preamble, got:\n%s", body)
+	}
+	if !strings.Contains(body, "failing step: Run go test ./...") {
+		t.Errorf("expected heading to name the failing step, got:\n%s", body)
+	}
+	if !strings.Contains(body, "https://github.com/owner/repo/runs/100") {
+		t.Errorf("expected permalink fallback in body, got:\n%s", body)
+	}
+}
+
+// TestCIMonitor_GetFailedCheckExcerpts_FallsBackToAnnotations verifies the
+// second fallback tier: when the jobs API can't resolve a failing step (here,
+// a 404 simulating a check run with no GitHub Actions job/step breakdown —
+// e.g. a third-party Checks-API integration), buildFailingStepExcerpt falls
+// back to failure-level check-run annotations instead of the whole job log.
+func TestCIMonitor_GetFailedCheckExcerpts_FallsBackToAnnotations(t *testing.T) {
+	server := gh4460NewTestServer(t, []github.CheckRun{
+		{ID: 100, Name: "test", Status: "completed", Conclusion: "failure", DetailsURL: "https://github.com/owner/repo/runs/100"},
+	}, gh4460ServerOpts{
+		jobStatus: http.StatusNotFound,
+		annotations: []ghadapter.CheckRunAnnotation{
+			{Path: "forecast.go", StartLine: 42, AnnotationLevel: "failure", Message: "expected 1200, got 1100"},
+			{Path: "forecast.go", StartLine: 10, AnnotationLevel: "notice", Message: "consider caching this"},
+		},
+	})
+	defer server.Close()
+
+	sdkClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	adapterClient := ghadapter.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	monitor := NewCIMonitor(sdkClient, "owner", "repo", DefaultConfig())
+	monitor.SetStepLogClient(adapterClient)
+
+	excerpt := monitor.buildFailingStepExcerpt(context.Background(), github.CheckRun{
+		ID: 100, Name: "test", Conclusion: "failure", DetailsURL: "https://github.com/owner/repo/runs/100",
+	})
+
+	if excerpt.Source != "annotations" {
+		t.Fatalf("Source = %q, want %q", excerpt.Source, "annotations")
+	}
+	if !strings.Contains(excerpt.Tail, "expected 1200, got 1100") {
+		t.Errorf("expected failure-level annotation message, got: %q", excerpt.Tail)
+	}
+	if strings.Contains(excerpt.Tail, "consider caching this") {
+		t.Errorf("non-failure-level annotation should be excluded, got: %q", excerpt.Tail)
+	}
+}
+
+// TestCIMonitor_GetFailedCheckExcerpts_FallsBackToWholeJobWithoutStepLogClient
+// verifies the third fallback tier: when no StepLogClient is wired at all
+// (e.g. an older Controller wiring, or SetStepLogClient was never called),
+// buildFailingStepExcerpt still produces a useful tail — just the whole
+// job's last N lines rather than the isolated failing step.
+func TestCIMonitor_GetFailedCheckExcerpts_FallsBackToWholeJobWithoutStepLogClient(t *testing.T) {
+	server := gh4460NewTestServer(t, []github.CheckRun{
+		{ID: 100, Name: "test", Status: "completed", Conclusion: "failure", DetailsURL: "https://github.com/owner/repo/runs/100"},
+	}, gh4460ServerOpts{})
+	defer server.Close()
+
+	sdkClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	monitor := NewCIMonitor(sdkClient, "owner", "repo", DefaultConfig())
+	// Deliberately do not call SetStepLogClient.
+
+	body := monitor.GetFailedCheckExcerpts(context.Background(), "abc123")
+
+	if body == "" {
+		t.Fatal("expected non-empty excerpt body")
+	}
+	// The fixture log is short enough that tailLines(_, 200) keeps everything,
+	// including the preamble — this tier is a fallback, not a fix, for checks
+	// with no wired StepLogClient. What matters is it still surfaces the
+	// actual failure line rather than truncating before reaching it.
+	if !strings.Contains(body, "TestForecastMonthlyBurn") {
+		t.Errorf("expected whole-job tail to still include the failure, got:\n%s", body)
+	}
+}
+
+// TestCIMonitor_GetFailedCheckExcerpts_MultipleFailuresFitBudget is the
+// multi-check body-assembly test: two failing checks, each independently
+// resolved to their failing step, both need to survive
+// failedCheckExcerptBudgetChars intact — this is the defect GH-4460 fixes,
+// where one check's preamble used to consume the whole budget before a
+// second check's content was ever reached.
+func TestCIMonitor_GetFailedCheckExcerpts_MultipleFailuresFitBudget(t *testing.T) {
+	server := gh4460NewTestServer(t, []github.CheckRun{
+		{ID: 100, Name: "test", Status: "completed", Conclusion: "failure", DetailsURL: "https://github.com/owner/repo/runs/100"},
+		{ID: 101, Name: "lint", Status: "completed", Conclusion: "failure", DetailsURL: "https://github.com/owner/repo/runs/101"},
+		{ID: 102, Name: "build", Status: "completed", Conclusion: "success"},
+	}, gh4460ServerOpts{})
+	defer server.Close()
+
+	sdkClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	adapterClient := ghadapter.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	monitor := NewCIMonitor(sdkClient, "owner", "repo", DefaultConfig())
+	monitor.SetStepLogClient(adapterClient)
+
+	body := monitor.GetFailedCheckExcerpts(context.Background(), "abc123")
+
+	if len(body) > failedCheckExcerptBudgetChars+len(ciExcerptSentinel) {
+		t.Errorf("body length = %d, want <= %d (budget + sentinel)", len(body), failedCheckExcerptBudgetChars+len(ciExcerptSentinel))
+	}
+	if !strings.Contains(body, "=== test") {
+		t.Errorf("expected 'test' check heading, got:\n%s", body)
+	}
+	if !strings.Contains(body, "=== lint") {
+		t.Errorf("expected 'lint' check heading, got:\n%s", body)
+	}
+	if strings.Contains(body, "=== build") {
+		t.Errorf("passing 'build' check should not be included, got:\n%s", body)
+	}
+	if !strings.Contains(body, "TestForecastMonthlyBurn") {
+		t.Errorf("expected 'test' check's failure content, got:\n%s", body)
+	}
+	if !strings.Contains(body, "TestOtherThing") {
+		t.Errorf("expected 'lint' check's failure content, got:\n%s", body)
+	}
+}
+
+// TestAssembleFailureExcerptsBody_MultipleFailuresFitBudget is a direct,
+// HTTP-free unit test of the assembly step: given oversized excerpts for
+// several checks, the combined body must stay within maxTotalChars while
+// every check's heading and some of its content survives — no single
+// excerpt should be able to starve the others out of the budget.
+func TestAssembleFailureExcerptsBody_MultipleFailuresFitBudget(t *testing.T) {
+	longTail := strings.Repeat("line of failure output\n", 500) // ~11500 chars, alone exceeds the budget below
+
+	excerpts := []FailingStepExcerpt{
+		{CheckName: "test", StepName: "Run go test ./...", Tail: longTail, PermalinkURL: "https://example.com/test"},
+		{CheckName: "lint", StepName: "Run golangci-lint", Tail: longTail, PermalinkURL: "https://example.com/lint"},
+		{CheckName: "build", StepName: "Run go build", Tail: longTail, PermalinkURL: "https://example.com/build"},
+	}
+
+	const budget = 3000
+	body := AssembleFailureExcerptsBody(excerpts, budget)
+
+	if len(body) > budget+500 {
+		// Small slack: headings/permalinks/minTailBudget floors can push
+		// slightly over an evenly-split budget on tiny budgets; the point of
+		// this assertion is "roughly capped", not exact-to-the-byte.
+		t.Errorf("body length = %d, want roughly <= %d", len(body), budget)
+	}
+	for _, name := range []string{"test", "lint", "build"} {
+		if !strings.Contains(body, "=== "+name) {
+			t.Errorf("expected heading for %q to survive budget capping, got:\n%s", name, body)
+		}
+	}
+	for _, url := range []string{"https://example.com/test", "https://example.com/lint", "https://example.com/build"} {
+		if !strings.Contains(body, url) {
+			t.Errorf("expected permalink %q to survive budget capping, got:\n%s", url, body)
+		}
+	}
+}
+
+// TestAssembleFailureExcerptsBody_Empty verifies the no-failures case returns
+// an empty string, so GetFailedCheckExcerpts's sentinel-prefix step can
+// correctly detect "nothing to report" and skip the CI Error Logs section.
+func TestAssembleFailureExcerptsBody_Empty(t *testing.T) {
+	if got := AssembleFailureExcerptsBody(nil, failedCheckExcerptBudgetChars); got != "" {
+		t.Errorf("AssembleFailureExcerptsBody(nil) = %q, want empty", got)
+	}
+}
+
+func TestResolveFailingStep(t *testing.T) {
+	t.Run("prefers failure over cancelled", func(t *testing.T) {
+		steps := []ghadapter.JobStep{
+			{Name: "Set up job", Conclusion: "success"},
+			{Name: "Run tests", Conclusion: "failure"},
+			{Name: "Upload artifacts", Conclusion: "cancelled"},
+		}
+		step, found := resolveFailingStep(steps)
+		if !found {
+			t.Fatal("expected a failing step to be found")
+		}
+		if step.Name != "Run tests" {
+			t.Errorf("step.Name = %q, want %q", step.Name, "Run tests")
+		}
+	})
+
+	t.Run("falls back to timed_out when no failure step", func(t *testing.T) {
+		steps := []ghadapter.JobStep{
+			{Name: "Set up job", Conclusion: "success"},
+			{Name: "Run long test", Conclusion: "timed_out"},
+			{Name: "Upload artifacts", Conclusion: "cancelled"},
+		}
+		step, found := resolveFailingStep(steps)
+		if !found {
+			t.Fatal("expected the timed_out step to be found")
+		}
+		if step.Name != "Run long test" {
+			t.Errorf("step.Name = %q, want %q", step.Name, "Run long test")
+		}
+	})
+
+	t.Run("no signal returns false", func(t *testing.T) {
+		steps := []ghadapter.JobStep{
+			{Name: "Set up job", Conclusion: "success"},
+			{Name: "Upload artifacts", Conclusion: "cancelled"},
+		}
+		if _, found := resolveFailingStep(steps); found {
+			t.Error("expected no failing step to be found")
+		}
+	})
+}
+
+func TestSliceLogByStepWindow(t *testing.T) {
+	step := ghadapter.JobStep{
+		Name:        "Run go test ./...",
+		StartedAt:   "2026-07-18T10:00:05.0000000Z",
+		CompletedAt: "2026-07-18T10:00:06.4000000Z",
+	}
+
+	window, ok := sliceLogByStepWindow(gh4460FixtureJobLog, step)
+	if !ok {
+		t.Fatal("expected a matching window")
+	}
+	if !strings.Contains(window, "TestForecastMonthlyBurn") {
+		t.Errorf("expected window to contain the failure, got:\n%s", window)
+	}
+	if strings.Contains(window, "Current runner version") {
+		t.Errorf("expected window to exclude the preamble, got:\n%s", window)
+	}
+
+	t.Run("missing timestamps returns false", func(t *testing.T) {
+		if _, ok := sliceLogByStepWindow(gh4460FixtureJobLog, ghadapter.JobStep{Name: "no timestamps"}); ok {
+			t.Error("expected false when step has no StartedAt/CompletedAt")
+		}
+	})
+}

--- a/internal/autopilot/ci_monitor.go
+++ b/internal/autopilot/ci_monitor.go
@@ -9,8 +9,22 @@ import (
 	"sync"
 	"time"
 
+	ghadapter "github.com/qf-studio/pilot/internal/adapters/github"
 	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 )
+
+// StepLogClient is the minimal in-tree GitHub client surface CIMonitor needs
+// to resolve a failed check run down to its actual failing step (GH-4460):
+// the jobs API for the step breakdown, and check-run annotations as a
+// fallback for check runs that aren't backed by a GitHub Actions job (e.g.
+// third-party Checks-API integrations report annotations but have no
+// job/step breakdown). This is deliberately a separate, in-tree client
+// (internal/adapters/github) rather than the studio-sdk client CIMonitor
+// otherwise uses — the SDK does not yet expose the jobs/annotations APIs.
+type StepLogClient interface {
+	GetWorkflowJob(ctx context.Context, owner, repo string, jobID int64) (*ghadapter.WorkflowJob, error)
+	GetCheckRunAnnotations(ctx context.Context, owner, repo string, checkRunID int64) ([]ghadapter.CheckRunAnnotation, error)
+}
 
 // CIMonitor watches GitHub CI status for PRs.
 type CIMonitor struct {
@@ -21,6 +35,11 @@ type CIMonitor struct {
 	waitTimeout    time.Duration
 	requiredChecks []string
 	log            *slog.Logger
+
+	// stepLogClient is optional (GH-4460). When unset, GetFailedCheckExcerpts
+	// falls back to whole-job-log tails instead of resolving the specific
+	// failing step.
+	stepLogClient StepLogClient
 
 	// CI checks configuration (auto-discovery)
 	ciChecks *CIChecksConfig
@@ -116,6 +135,13 @@ func NewCIMonitor(ghClient *github.Client, owner, repo string, cfg *Config) *CIM
 		discoveryStart:   make(map[string]time.Time),
 		log:              startupLog,
 	}
+}
+
+// SetStepLogClient injects the in-tree GitHub client used to resolve a
+// failed check run down to its specific failing step (GH-4460). Optional:
+// without it, GetFailedCheckExcerpts falls back to whole-job-log tails.
+func (m *CIMonitor) SetStepLogClient(c StepLogClient) {
+	m.stepLogClient = c
 }
 
 // WaitForCI polls until all required checks complete or timeout.
@@ -594,6 +620,101 @@ func (m *CIMonitor) GetFailedCheckLogs(ctx context.Context, sha string, maxLen i
 		result = result[:maxLen]
 	}
 	return result
+}
+
+// GetFailedCheckExcerpts fetches, for each failed check run on sha, the tail
+// of its actual failing step (GH-4460) rather than the whole job log, and
+// assembles them into a single budget-capped, self-contained block: a
+// heading, the tail excerpt, and a permalink fallback per check. Returns ""
+// when there are no in-scope failed checks or the check-run list can't be
+// fetched.
+//
+// This replaces GetFailedCheckLogs in the fix-issue creation path: that
+// method's small maxLen (2000 chars, applied to the head of the *combined*
+// blob) let one check's runner-setup preamble consume the entire budget
+// before the real failure line was ever reached, which is what made every
+// GH-4415 continuation (4444/4446/4449/4453) bounce at preflight with
+// "provide only runner setup information".
+func (m *CIMonitor) GetFailedCheckExcerpts(ctx context.Context, sha string) string {
+	checkRuns, err := m.ghClient.ListCheckRuns(ctx, m.owner, m.repo, sha)
+	if err != nil {
+		m.log.Warn("failed to list check runs for excerpt fetch", "sha", ShortSHA(sha), "error", err)
+		return ""
+	}
+
+	var excerpts []FailingStepExcerpt
+	for _, run := range checkRuns.CheckRuns {
+		if run.Conclusion != github.ConclusionFailure {
+			continue
+		}
+		if !m.isScopedCheck(run.Name) {
+			continue
+		}
+		excerpts = append(excerpts, m.buildFailingStepExcerpt(ctx, run))
+	}
+
+	body := AssembleFailureExcerptsBody(excerpts, failedCheckExcerptBudgetChars)
+	if body == "" {
+		return ""
+	}
+	return ciExcerptSentinel + body
+}
+
+// buildFailingStepExcerpt resolves one failed check run down to its actual
+// failing step and returns the trailing lines of that step's log. It falls
+// through progressively coarser signal when the finer one is unavailable:
+//  1. jobs API step breakdown + timestamp-sliced job log tail (GitHub
+//     Actions-backed checks — the common case)
+//  2. check-run annotations (checks posted directly via the Checks API by
+//     third-party CI apps have no job/step breakdown at all)
+//  3. whole job log, last N lines (old behavior, still an improvement over
+//     the previous head-of-combined-blob truncation)
+func (m *CIMonitor) buildFailingStepExcerpt(ctx context.Context, run github.CheckRun) FailingStepExcerpt {
+	excerpt := FailingStepExcerpt{
+		CheckName:    run.Name,
+		PermalinkURL: run.DetailsURL,
+	}
+
+	if m.stepLogClient != nil {
+		job, jobErr := m.stepLogClient.GetWorkflowJob(ctx, m.owner, m.repo, run.ID)
+		if jobErr != nil {
+			m.log.Debug("jobs API lookup failed, falling back", "check", run.Name, "id", run.ID, "error", jobErr)
+		} else if step, found := resolveFailingStep(job.Steps); found {
+			if jobLog, logErr := m.ghClient.GetJobLogs(ctx, m.owner, m.repo, run.ID); logErr == nil {
+				if window, ok := sliceLogByStepWindow(jobLog, step); ok {
+					excerpt.StepName = step.Name
+					excerpt.Tail = tailLines(window, failedCheckExcerptMaxLines)
+					excerpt.Source = "step"
+					return excerpt
+				}
+			}
+		}
+
+		if anns, annErr := m.stepLogClient.GetCheckRunAnnotations(ctx, m.owner, m.repo, run.ID); annErr == nil {
+			var sb strings.Builder
+			for _, a := range anns {
+				if a.AnnotationLevel != "failure" {
+					continue
+				}
+				fmt.Fprintf(&sb, "%s:%d: %s\n", a.Path, a.StartLine, a.Message)
+			}
+			if sb.Len() > 0 {
+				excerpt.Tail = sb.String()
+				excerpt.Source = "annotations"
+				return excerpt
+			}
+		}
+	}
+
+	// Fallback: whole job log, tail only (still better than head-of-log).
+	jobLog, err := m.ghClient.GetJobLogs(ctx, m.owner, m.repo, run.ID)
+	if err != nil {
+		m.log.Warn("failed to fetch logs for check run", "check", run.Name, "id", run.ID, "error", err)
+		return excerpt
+	}
+	excerpt.Tail = tailLines(jobLog, failedCheckExcerptMaxLines)
+	excerpt.Source = "job"
+	return excerpt
 }
 
 // GetCheckLogs fetches logs for all completed, in-scope check runs for sha and

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -238,6 +238,19 @@ func WithProjectPath(path string) ControllerOption {
 	}
 }
 
+// WithStepLogClient wires the in-tree GitHub client (internal/adapters/github)
+// CIMonitor uses to resolve a failed check run down to its actual failing
+// step via the jobs API + check-run annotations (GH-4460). The studio-sdk
+// client passed as ghClient does not yet expose those APIs, so this is a
+// second, narrower client sharing the same token. Optional: without it,
+// CI-failure excerpts fall back to whole-job-log tails instead of the
+// specific failing step.
+func WithStepLogClient(c2 StepLogClient) ControllerOption {
+	return func(c *Controller) {
+		c.stepLogClient = c2
+	}
+}
+
 // WithReleaseOverride wires a per-project release config overlay (GH-3930)
 // for this controller's repo. Nil is a no-op. NewController applies the
 // overlay (ProjectReleaseConfig.Apply) against the resolved global/env
@@ -385,6 +398,13 @@ type Controller struct {
 	// GH-4454.
 	pilotLabel string
 
+	// stepLogClient is the optional in-tree GitHub client CIMonitor uses to
+	// resolve a failed check run down to its actual failing step via the
+	// jobs API + check-run annotations (GH-4460). Wired into c.ciMonitor
+	// after construction (see WithStepLogClient); nil means
+	// GetFailedCheckExcerpts falls back to whole-job-log tails.
+	stepLogClient StepLogClient
+
 	// laneStarvationStreak counts consecutive reconcileLaneStarvation poll
 	// cycles this lane has had open (non-blocked) pilot-labeled issues with
 	// zero queued/running executions, guarded by mu. Reset to 0 the moment
@@ -501,6 +521,9 @@ func NewController(cfg *Config, ghClient *github.Client, approvalMgr *approval.M
 	}
 
 	c.ciMonitor = NewCIMonitor(ghClient, owner, repo, cfg)
+	if c.stepLogClient != nil {
+		c.ciMonitor.SetStepLogClient(c.stepLogClient)
+	}
 	c.autoMerger = NewAutoMerger(ghClient, approvalMgr, c.ciMonitor, owner, repo, cfg)
 	c.feedbackLoop = NewFeedbackLoop(ghClient, owner, repo, cfg)
 
@@ -1851,7 +1874,9 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 
 	// GH-1567: Fetch actual CI error logs to include in fix issues.
 	// This prevents Pilot from having to rediscover errors by running linter/tests itself.
-	ciLogs := c.ciMonitor.GetFailedCheckLogs(ctx, prState.HeadSHA, 2000)
+	// GH-4460: failing-step-tail excerpts (not whole-job/head-of-log) so the
+	// continuation issue body is self-contained enough to pass preflight.
+	ciLogs := c.ciMonitor.GetFailedCheckExcerpts(ctx, prState.HeadSHA)
 
 	issueNum, err := c.feedbackLoop.CreateFailureIssue(ctx, prState, FailureCIPreMerge, failedChecks, ciLogs, iteration+1)
 	if err != nil {
@@ -2889,7 +2914,8 @@ func (c *Controller) handlePostMergeCI(ctx context.Context, prState *PRState) er
 		c.log.Warn("post-merge CI failed", "pr", prState.PRNumber, "sha", ShortSHA(mainSHA))
 		failedChecks, _ := c.ciMonitor.GetFailedChecks(ctx, mainSHA)
 		// GH-1567: Fetch CI error logs for post-merge failures too.
-		ciLogs := c.ciMonitor.GetFailedCheckLogs(ctx, mainSHA, 2000)
+		// GH-4460: failing-step-tail excerpts, see the matching comment above.
+		ciLogs := c.ciMonitor.GetFailedCheckExcerpts(ctx, mainSHA)
 
 		// GH-4312: port the pre-merge cascade/size guards (~:1502-1593) to the
 		// post-merge path. Post-merge failures normally start a new lineage

--- a/internal/autopilot/feedback_loop.go
+++ b/internal/autopilot/feedback_loop.go
@@ -333,7 +333,18 @@ func (f *FeedbackLoop) generateBody(prState *PRState, failureType FailureType, f
 	if logs != "" {
 		sb.WriteString("<details><summary>CI Error Logs</summary>\n\n")
 		sb.WriteString("```\n")
-		sb.WriteString(extractFailureExcerpt(logs, maxCIErrorExcerptChars))
+		if bundle, ok := strings.CutPrefix(logs, ciExcerptSentinel); ok {
+			// GH-4460: logs is already a pre-assembled, budget-capped bundle
+			// of per-check failing-step excerpts (CIMonitor.GetFailedCheckExcerpts).
+			// Re-running the single-blob marker search below would misfire —
+			// there's no top-level --- FAIL:/panic: marker in a multi-check
+			// bundle — and its last-N-lines fallback would clobber earlier
+			// checks' excerpts. Assembly already respects the char budget, so
+			// this truncation is a defensive no-op in the normal case.
+			sb.WriteString(truncateKeepingTail(bundle, maxCIErrorExcerptChars))
+		} else {
+			sb.WriteString(extractFailureExcerpt(logs, maxCIErrorExcerptChars))
+		}
 		sb.WriteString("\n```\n\n")
 		sb.WriteString("</details>\n\n")
 	}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4460.

Closes #4460

## Changes

Separable sub-defect that made every GH-4415 continuation (4444/4446/4449/4453) bounce at preflight with 'provide only runner setup information.' In internal/autopilot/ci_monitor.go / feedback_loop.go (and, if the raw fetch lives there, internal/adapters/github/client.go), replace the current whole-job / head-of-log capture with a failing-step-tail extraction: for each failed check, resolve to the specific failing step (GitHub check-run annotations + jobs API), fetch that step's log, and take the last N lines (e.g. 200) plus a heading. Include a permalink to the raw log per failed check as a fallback. When multiple checks fail, emit one excerpt per failed check, capped to a total body budget so the continuation issue body stays under GitHub's issue-body limit. Ensure the continuation issue body is self-contained (repro command / commit SHA / failed-check names + tail excerpts) so preflight has enough signal to admit it. Add fixture-based tests (canned check-run + job payloads) verifying the extractor returns the failing step's tail, not the runner-setup preamble, and a body-assembly test verifying multiple failures fit under the budget with excerpts intact. Independent of subtasks 1 & 2 in logic, but sequenced last because subtask 2's CI-fail escalate path is the safety net that catches this defect while it's being fixed — if subtask 3 lands first without subtask 2, a truncated-log continuation still risks a destructive close under the old rung.