### PR TITLE
GH-4423: fix(executor,memory): terminal-status writes lack CAS — stale reaper can fail completed rows (TOCTOU + merged-only PR evidence); add store-level guard + open-PR liveness

### DIFF
--- a/.agent/tasks/gh-4423.md
+++ b/.agent/tasks/gh-4423.md
@@ -1,0 +1,31 @@
+# GH-4423
+
+**Created:** 2026-07-18
+
+## Problem
+
+GitHub Issue GH-4423: fix(executor,memory): terminal-status writes lack CAS — stale reaper can fail completed rows (TOCTOU + merged-only PR evidence); add store-level guard + open-PR liveness
+
+## Context
+
+Static-analysis findings from tracing completed→failed flip paths (navigator-research, 2026-07-17). Not the cause of today's GH-4387 flip (that was the guarded GH-3818/D10 reclassify path reacting to a closed PR), but two adjacent unguarded paths WILL cause silent terminal-status corruption under the right timing.
+
+## Finding 1: stale-running reaper can fail a completed execution (TOCTOU + merged-only evidence)
+
+`recoverStaleRunningTasks` (internal/executor/dispatcher.go:293–397): candidate selection is `status='running' AND older than 30m` — a legitimately long task is a candidate for every 5-min tick past 30m. Guards run in-loop (`HasCompletedExecution` → `hasLiveWorker` → `staleRunningMergedPRCheck`, which includes a **GitHub API round-trip**), then the final write at dispatcher.go:388 is a blind `UpdateExecutionStatus(id,'failed',...)` with **no re-check of current status** — if the task completes inside that window, the completed row gets stamped failed. Additionally `staleRunningMergedPRCheck` only recognizes a **merged** PR as evidence of shipped work; "open PR in waiting_ci" — the normal state for minutes-to-hours — reads as "no merge evidence". Same pattern at dispatcher.go:524 (stale-queued reap).
+
+## Finding 2: no store-layer CAS for terminal statuses
+
+`store.UpdateExecutionStatus` (store.go:1863) and `MarkExecutionCompleted` (store.go:2241) are blind `WHERE id=?` writes. Only `ResolveOrphanedRunningExecution` (`AND status='running'`) and `ReclassifyCompletionAsFailed` (`AND status='completed' ...`) are guarded. `ExecutionLifecycle.Transition/Persist` (lifecycle.go:144/215) inherit the blindness — a duplicate `Finish` overwrites a terminal state silently (this is also how today's GH-16 completion write vanished-in-plain-sight class stays invisible: terminal→terminal writes neither blocked nor logged).
+
+## Fix sketch (chokepoint, not call sites)
+
+1. Add CAS semantics to the store: `UpdateExecutionStatusIfCurrent(id, new, allowedCurrent...)` or a forbidden-set variant; route dispatcher.go:388/:524 and lifecycle.Transition through it. Terminal→terminal attempts: reject + ERROR log with both states (evidence for #4404-class debugging).
+2. Extend `staleRunningMergedPRCheck` (dispatcher.go:360–381) to treat an OPEN PR on the task branch as liveness evidence, not just merged.
+
+## Refs
+
+- #4404 (vanished completion class), #4403 (boot reconciliation — same family), TASK-404 (lifecycle chokepoint), #4417 (sweep liveness fix, autopilot side).
+
+## Acceptance Criteria
+

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -517,13 +517,36 @@ func (d *Dispatcher) recoverStaleRunningTasks() int {
 			continue
 		}
 
+		// GH-4423: a merged PR isn't the only liveness evidence a branch can
+		// carry — an OPEN PR (the normal state for minutes-to-hours while CI
+		// runs or a reviewer is pending) means the worker already shipped its
+		// deliverable and is simply waiting, not orphaned. Without this check,
+		// any task whose PR review outlasts StaleRunningThreshold got marked
+		// failed on every 5-minute reap tick past that point.
+		if openURL, openErr := staleRunningOpenPRCheck(d.ctx, exec.ProjectPath, branch); openErr == nil && openURL != "" {
+			d.log.Info("Stale running task's branch has an open PR; treating as live, not orphaned",
+				slog.String("execution_id", exec.ID),
+				slog.String("task_id", exec.TaskID),
+				slog.String("pr_url", openURL),
+			)
+			continue
+		}
+
 		d.log.Warn("Marking stale running task as failed",
 			slog.String("execution_id", exec.ID),
 			slog.String("task_id", exec.TaskID),
 			slog.Time("created_at", exec.CreatedAt),
 		)
-		if err := d.store.UpdateExecutionStatus(exec.ID, "failed", "stale running task recovered (orphaned worker)"); err != nil {
+		// GH-4423: CAS-guarded — if this row completed in the gap between the
+		// evidence gathered above and this write (the reaper's own TOCTOU
+		// window), the write is rejected instead of clobbering the completed
+		// row. The store already logs the rejection at ERROR with both states.
+		applied, err := d.store.UpdateExecutionStatusIfNotTerminal(exec.ID, "failed", "stale running task recovered (orphaned worker)")
+		if err != nil {
 			d.log.Error("Failed to mark stale running task", slog.String("id", exec.ID), slog.Any("error", err))
+		} else if !applied {
+			d.log.Warn("Skipped marking stale running task failed — row reached a terminal status during reap (GH-4423 CAS guard)",
+				slog.String("execution_id", exec.ID), slog.String("task_id", exec.TaskID))
 		} else {
 			resetCount++
 			// GH-4101: without this, the terminal transition a restart forces on an
@@ -586,6 +609,22 @@ var staleRunningMergedPRCheck = func(ctx context.Context, projectPath, branch st
 		return "", nil
 	}
 	return NewGitOperations(projectPath).FindMergedPRByBranch(ctx, branch)
+}
+
+// staleRunningOpenPRCheck reports the URL of an OPEN PR for branch in
+// projectPath, or "" if none exists. GH-4423: an open PR is liveness evidence
+// just like a merged one — it's the normal state for minutes-to-hours while
+// CI runs or a reviewer is pending, not evidence of an orphaned worker.
+// staleRunningMergedPRCheck alone only recognized a MERGED PR, so a task
+// legitimately waiting on an open PR past StaleRunningThreshold got no credit
+// here and was marked failed on the very next reap tick. Mirrors
+// staleRunningMergedPRCheck's test-mode short-circuit; tests override this
+// var directly.
+var staleRunningOpenPRCheck = func(ctx context.Context, projectPath, branch string) (string, error) {
+	if testing.Testing() {
+		return "", nil
+	}
+	return NewGitOperations(projectPath).FindOpenPRByBranch(ctx, branch)
 }
 
 // mergedPRPreflightCheck reports the URL of a merged PR for a queued task's
@@ -677,8 +716,17 @@ func (d *Dispatcher) recoverStaleQueuedTasks() int {
 		// every project with queued rows a worker, so reaching here means the
 		// project genuinely has none (e.g. removed from config), not that a
 		// normal restart failed to reconnect it.
-		if err := d.store.UpdateExecutionStatus(exec.ID, "failed", "queued task orphaned by restart; project no longer configured"); err != nil {
+		//
+		// GH-4423: CAS-guarded — same TOCTOU window as the stale-running reap
+		// above; if this row went terminal between the guards above and this
+		// write, the write is rejected instead of clobbering it (the store
+		// already logs both states at ERROR).
+		applied, err := d.store.UpdateExecutionStatusIfNotTerminal(exec.ID, "failed", "queued task orphaned by restart; project no longer configured")
+		if err != nil {
 			d.log.Error("Failed to mark stale queued task", slog.String("id", exec.ID), slog.Any("error", err))
+		} else if !applied {
+			d.log.Warn("Skipped marking stale queued task failed — row reached a terminal status during reap (GH-4423 CAS guard)",
+				slog.String("execution_id", exec.ID), slog.String("task_id", exec.TaskID))
 		} else {
 			resetCount++
 			// GH-4101: mirrors the stale-running event above — the audit trail must

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -1041,6 +1041,131 @@ func TestRecoverStaleRunningTasks_MarksFailedWhenNoMergedPR(t *testing.T) {
 	}
 }
 
+// TestRecoverStaleRunningTasks_SkipsWhenOpenPRExists is the GH-4423 regression
+// test for finding 1's second half: an OPEN PR on the task's branch — the
+// normal state for minutes-to-hours while CI/review runs — must be treated as
+// liveness evidence exactly like a merged PR, not "no evidence" that gets the
+// row marked failed. Before this fix, staleRunningMergedPRCheck alone
+// couldn't see this and any task whose review outlasted StaleRunningThreshold
+// got marked failed on the next reap tick despite already having shipped a PR.
+func TestRecoverStaleRunningTasks_SkipsWhenOpenPRExists(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	exec := &memory.Execution{ID: "exec-open-pr-run", TaskID: "GH-4423-E", ProjectPath: "/project-open-pr", Status: "running"}
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("failed to save execution: %v", err)
+	}
+
+	origMergedCheck := staleRunningMergedPRCheck
+	staleRunningMergedPRCheck = func(_ context.Context, _, _ string) (string, error) { return "", nil }
+	defer func() { staleRunningMergedPRCheck = origMergedCheck }()
+
+	const openPRURL = "https://github.com/qf-studio/pilot/pull/4422"
+	origOpenCheck := staleRunningOpenPRCheck
+	staleRunningOpenPRCheck = func(_ context.Context, projectPath, branch string) (string, error) {
+		if projectPath == "/project-open-pr" && branch == "pilot/GH-4423-E" {
+			return openPRURL, nil
+		}
+		return "", nil
+	}
+	defer func() { staleRunningOpenPRCheck = origOpenCheck }()
+
+	config := &DispatcherConfig{StaleRunningThreshold: 0, StaleQueuedThreshold: 0, StaleRecoveryInterval: time.Hour}
+	dispatcher := NewDispatcher(store, NewRunner(), config)
+
+	resetCount := dispatcher.recoverStaleRunningTasks()
+	if resetCount != 0 {
+		t.Errorf("expected resetCount=0 (open PR is liveness, not a reap), got %d", resetCount)
+	}
+
+	got, err := store.GetExecution("exec-open-pr-run")
+	if err != nil {
+		t.Fatalf("failed to get execution: %v", err)
+	}
+	if got.Status != "running" {
+		t.Errorf("expected row with an open PR to remain 'running' (not failed/completed), got %q", got.Status)
+	}
+
+	events, err := store.ListExecutionEvents("exec-open-pr-run")
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("expected no execution events for a skipped (still-live) row, got %d: %+v", len(events), events)
+	}
+}
+
+// TestRecoverStaleRunningTasks_CASRejectsRaceWithCompletion is the GH-4423
+// regression test for finding 1's TOCTOU: if the row's own worker completes
+// it for real in the gap between the reaper's evidence-gathering
+// (staleRunningMergedPRCheck's GitHub round trip here) and the reaper's final
+// "mark failed" write, that final write must be rejected instead of
+// silently stamping the completed row failed. The merged-PR-check override
+// below simulates the race by completing the row as a side effect, mirroring
+// a concurrent writer finishing the task mid-reap.
+func TestRecoverStaleRunningTasks_CASRejectsRaceWithCompletion(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	exec := &memory.Execution{ID: "exec-race-run", TaskID: "GH-4423-F", ProjectPath: "/project-race", Status: "running"}
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("failed to save execution: %v", err)
+	}
+
+	const racingPRURL = "https://github.com/qf-studio/pilot/pull/4424"
+
+	origMergedCheck := staleRunningMergedPRCheck
+	staleRunningMergedPRCheck = func(_ context.Context, _, _ string) (string, error) {
+		// Simulate the real worker completing this exact row for real,
+		// concurrently with this reap tick's evidence-gathering — the row is
+		// now genuinely 'completed' by the time the reaper reaches its final
+		// write below, but this check itself reports "no merge evidence"
+		// (mirroring the check having run before the race landed).
+		if err := store.MarkExecutionCompleted("exec-race-run", racingPRURL, "cafefeed", 1234); err != nil {
+			t.Fatalf("failed to simulate racing completion: %v", err)
+		}
+		return "", nil
+	}
+	defer func() { staleRunningMergedPRCheck = origMergedCheck }()
+
+	origOpenCheck := staleRunningOpenPRCheck
+	staleRunningOpenPRCheck = func(_ context.Context, _, _ string) (string, error) { return "", nil }
+	defer func() { staleRunningOpenPRCheck = origOpenCheck }()
+
+	config := &DispatcherConfig{StaleRunningThreshold: 0, StaleQueuedThreshold: 0, StaleRecoveryInterval: time.Hour}
+	dispatcher := NewDispatcher(store, NewRunner(), config)
+
+	resetCount := dispatcher.recoverStaleRunningTasks()
+	if resetCount != 0 {
+		t.Errorf("expected resetCount=0 — the CAS guard must reject the failed-write, got %d", resetCount)
+	}
+
+	got, err := store.GetExecution("exec-race-run")
+	if err != nil {
+		t.Fatalf("failed to get execution: %v", err)
+	}
+	if got.Status != "completed" {
+		t.Errorf("expected the racing completion to survive the reap ('completed'), got %q (error=%q)", got.Status, got.Error)
+	}
+	if got.PRUrl != racingPRURL {
+		t.Errorf("expected pr_url from the racing completion to survive, got %q", got.PRUrl)
+	}
+
+	// The reaper must not have recorded a stale_running-failed audit event
+	// over the real completion — only evidence of the reap's own outcome
+	// (none, since the write was rejected) may exist.
+	events, err := store.ListExecutionEvents("exec-race-run")
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+	for _, e := range events {
+		if e.Stage == memory.StageFailed {
+			t.Errorf("expected no stale_running-failed event over a racing completion, got %+v", e)
+		}
+	}
+}
+
 // TestRecoverStaleRunningTasks_WritesExecutionEvent verifies GH-4101: marking
 // a stale running task failed also writes an execution_events row, closing
 // the gap where a restart/orphan-driven terminal transition was invisible in

--- a/internal/executor/lifecycle.go
+++ b/internal/executor/lifecycle.go
@@ -137,11 +137,20 @@ func (l *ExecutionLifecycle) Begin(task *Task, initial Status, generation ...int
 
 // Transition moves execID to a non-terminal status (e.g. queued -> running).
 // Terminal moves go through Finish instead, which also persists metrics.
+//
+// GH-4423: routed through the CAS-guarded store write so a Transition racing
+// in after Finish already recorded a terminal status (e.g. a duplicate
+// dispatch resuming a worker for a row that already completed) is rejected
+// instead of silently resurrecting the row to a non-terminal status. A
+// rejection is not surfaced as an error here — the store already logs the
+// both-states evidence, and the caller has no terminal-vs-not distinction to
+// act on beyond what already happened to the row.
 func (l *ExecutionLifecycle) Transition(execID string, s Status) error {
 	if l.store == nil || execID == "" {
 		return nil
 	}
-	return l.store.UpdateExecutionStatus(execID, string(s))
+	_, err := l.store.UpdateExecutionStatusIfNotTerminal(execID, string(s))
+	return err
 }
 
 // FinishOutcome is what Finish computed and persisted, so callers can drive
@@ -224,15 +233,21 @@ func (l *ExecutionLifecycle) Persist(execID string, outcome FinishOutcome, resul
 		return nil
 	}
 
+	// GH-4423: both branches route through the CAS-guarded store writes — a
+	// duplicate Finish call (the same execID finished twice, e.g. a retried
+	// callback) can no longer silently overwrite a terminal status this row
+	// already reached. A rejected write returns err=nil here (the store
+	// already logged the both-states evidence); metrics are still saved
+	// below regardless, since they're informational and idempotent.
 	var statusErr error
 	if outcome.Status == ExecStatusCompleted {
 		var prURL, commitSHA string
 		if result != nil {
 			prURL, commitSHA = result.PRUrl, result.CommitSHA
 		}
-		statusErr = l.store.MarkExecutionCompleted(execID, prURL, commitSHA, duration.Milliseconds())
+		_, statusErr = l.store.MarkExecutionCompletedIfNotTerminal(execID, prURL, commitSHA, duration.Milliseconds())
 	} else {
-		statusErr = l.store.UpdateExecutionStatus(execID, string(outcome.Status), outcome.Error)
+		_, statusErr = l.store.UpdateExecutionStatusIfNotTerminal(execID, string(outcome.Status), outcome.Error)
 	}
 
 	if result != nil {

--- a/internal/executor/lifecycle_test.go
+++ b/internal/executor/lifecycle_test.go
@@ -92,6 +92,41 @@ func TestExecutionLifecycle_Transition_QueuedToRunning(t *testing.T) {
 	}
 }
 
+// TestExecutionLifecycle_Transition_RejectsWhenAlreadyTerminal is the GH-4423
+// regression test for finding 2: Transition must not resurrect a row that
+// already reached a terminal status back to a non-terminal one (e.g. a
+// duplicate/late dispatch resuming a worker for a row Finish already closed
+// out). The CAS guard in UpdateExecutionStatusIfNotTerminal rejects the
+// write silently (no error) — the terminal status must survive.
+func TestExecutionLifecycle_Transition_RejectsWhenAlreadyTerminal(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GH-4423-T1", ProjectPath: "/tmp/project"}
+	lifecycle := NewExecutionLifecycle(store)
+	execID, err := lifecycle.Begin(task, ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+	if _, err := lifecycle.Finish(execID, &ExecutionResult{TaskID: task.ID, Success: true, CommitSHA: "abc123"}, nil, time.Second); err != nil {
+		t.Fatalf("Finish failed: %v", err)
+	}
+
+	// A late/duplicate Transition call racing in after Finish already closed
+	// out the row must be rejected, not resurrect it to "running".
+	if err := lifecycle.Transition(execID, ExecStatusRunning); err != nil {
+		t.Fatalf("Transition on an already-terminal row should not error, got: %v", err)
+	}
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("failed to load execution: %v", err)
+	}
+	if exec.Status != string(ExecStatusCompleted) {
+		t.Errorf("expected terminal status to survive a late Transition, got %q", exec.Status)
+	}
+}
+
 // TestExecutionLifecycle_Finish_Success verifies the success path atomically
 // persists status/pr_url/commit_sha and saves metrics.
 func TestExecutionLifecycle_Finish_Success(t *testing.T) {
@@ -134,6 +169,53 @@ func TestExecutionLifecycle_Finish_Success(t *testing.T) {
 	}
 	if exec.TokensTotal != result.TokensTotal {
 		t.Errorf("expected metrics to be persisted: tokens_total = %d, want %d", exec.TokensTotal, result.TokensTotal)
+	}
+}
+
+// TestExecutionLifecycle_Finish_DuplicateCallRejectsSecondWrite is the GH-4423
+// regression test for finding 2: "a duplicate Finish overwrites a terminal
+// state silently". A second Finish call against an execID that already
+// reached a terminal status (e.g. a retried callback finishing the same
+// execution twice with a different outcome) must not overwrite the first,
+// genuine terminal status — Persist's CAS guard should reject the second
+// write instead.
+func TestExecutionLifecycle_Finish_DuplicateCallRejectsSecondWrite(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GH-4423-T2", ProjectPath: "/tmp/project"}
+	lifecycle := NewExecutionLifecycle(store)
+	execID, err := lifecycle.Begin(task, ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	firstResult := &ExecutionResult{
+		TaskID:    task.ID,
+		Success:   true,
+		PRUrl:     "https://github.com/qf-studio/pilot/pull/4423",
+		CommitSHA: "first-commit",
+	}
+	if _, err := lifecycle.Finish(execID, firstResult, nil, time.Second); err != nil {
+		t.Fatalf("first Finish failed: %v", err)
+	}
+
+	// A second, later Finish call for the same execID (e.g. a retried
+	// callback) reports a completely different outcome — this must not land.
+	secondResult := &ExecutionResult{TaskID: task.ID, Success: false, Error: "boom"}
+	if _, err := lifecycle.Finish(execID, secondResult, nil, time.Second); err != nil {
+		t.Fatalf("second Finish should not error even though its write is rejected, got: %v", err)
+	}
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("failed to load execution: %v", err)
+	}
+	if exec.Status != string(ExecStatusCompleted) {
+		t.Errorf("expected the FIRST Finish's terminal status to survive, got %q", exec.Status)
+	}
+	if exec.PRUrl != firstResult.PRUrl || exec.CommitSHA != firstResult.CommitSHA {
+		t.Errorf("expected the first Finish's pr_url/commit_sha to survive a duplicate call, got %+v", exec)
 	}
 }
 

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1884,6 +1884,48 @@ func (s *Store) GetQueuedTasksForProject(projectPath string, limit int) ([]*Exec
 	return executions, rows.Err()
 }
 
+// terminalExecutionStatuses are the statuses that make an executions row's
+// outcome final. Shared by UpdateExecutionStatus (which stamps completed_at
+// for any of these) and the CAS-guarded writes below (GH-4423): a guarded
+// write is rejected once the row's CURRENT status is already one of these,
+// so a terminal row can never be silently clobbered by a second terminal
+// write racing in after the first one landed.
+//
+// GH-4243 dead-API audit: "cancelled" is confirmed dead as a write value —
+// no production call site ever passes it to UpdateExecutionStatus,
+// MarkExecutionCompleted, or Begin/Transition/Finish (executor.Status has
+// no ExecStatusCancelled constant). It's kept in this terminal-state list
+// only defensively — matching monitor.go's separate in-memory TaskStatus
+// enum, which does have a StatusCancelled, and matching dispatcher.go's
+// WaitForExecution terminal-status switch, which reads "cancelled" as a
+// possible historical/manually-written value. Not removed since dropping
+// it would silently stop setting completed_at on that historical value.
+var terminalExecutionStatuses = []string{
+	"completed", "failed", "cancelled", "declined", "stalled", "no_op", "rate_limited", "infra", "skipped",
+}
+
+func isTerminalExecutionStatus(status string) bool {
+	for _, t := range terminalExecutionStatuses {
+		if status == t {
+			return true
+		}
+	}
+	return false
+}
+
+// notTerminalClause returns a "status NOT IN (?, ?, ...)" SQL fragment sized
+// to terminalExecutionStatuses, plus its matching bind args — the CAS guard
+// every UpdateExecutionStatusIfNotTerminal / MarkExecutionCompletedIfNotTerminal
+// write appends to its WHERE clause (GH-4423).
+func notTerminalClause() (string, []interface{}) {
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(terminalExecutionStatuses)), ",")
+	args := make([]interface{}, len(terminalExecutionStatuses))
+	for i, st := range terminalExecutionStatuses {
+		args[i] = st
+	}
+	return placeholders, args
+}
+
 // UpdateExecutionStatus updates the status of an execution record.
 // Optionally sets the error message if provided. Also sets completed_at for terminal states.
 func (s *Store) UpdateExecutionStatus(id, status string, errorMsg ...string) error {
@@ -1893,17 +1935,7 @@ func (s *Store) UpdateExecutionStatus(id, status string, errorMsg ...string) err
 	}
 
 	// Set completed_at for terminal states.
-	//
-	// GH-4243 dead-API audit: "cancelled" is confirmed dead as a write value —
-	// no production call site ever passes it to UpdateExecutionStatus,
-	// MarkExecutionCompleted, or Begin/Transition/Finish (executor.Status has
-	// no ExecStatusCancelled constant). It's kept in this terminal-state list
-	// only defensively — matching monitor.go's separate in-memory TaskStatus
-	// enum, which does have a StatusCancelled, and matching dispatcher.go's
-	// WaitForExecution terminal-status switch, which reads "cancelled" as a
-	// possible historical/manually-written value. Not removed since dropping
-	// it would silently stop setting completed_at on that historical value.
-	if status == "completed" || status == "failed" || status == "cancelled" || status == "declined" || status == "stalled" || status == "no_op" || status == "rate_limited" || status == "infra" || status == "skipped" {
+	if isTerminalExecutionStatus(status) {
 		return s.withRetry("UpdateExecutionStatus", func() error {
 			_, err := s.db.Exec(`
 				UPDATE executions
@@ -1937,6 +1969,86 @@ func (s *Store) UpdateExecutionStatus(id, status string, errorMsg ...string) err
 		`, status, errStr, id)
 		return err
 	})
+}
+
+// UpdateExecutionStatusIfNotTerminal is UpdateExecutionStatus's CAS-guarded
+// counterpart (GH-4423). It appends "AND status NOT IN (<terminalExecutionStatuses>)"
+// to the WHERE clause, so the write only lands while the row is still
+// non-terminal — once a row reaches a terminal status, this method can never
+// silently overwrite it with another write.
+//
+// This closes the TOCTOU in the stale-running/stale-queued reapers
+// (dispatcher.go): both gather evidence across several steps
+// (HasCompletedExecution, live-worker check, merged-PR check for the running
+// reap) and then used to write UpdateExecutionStatus(id, "failed", ...)
+// blind — if the row reached a terminal status (e.g. completed) in the gap
+// between evidence-gathering and that write, the completed row silently got
+// stamped failed. Routed through this guard instead, that write is now
+// rejected — logged at ERROR with both the attempted and actual status, so
+// the #4404/#4457-class debugging trail has evidence instead of a vanished
+// completion.
+//
+// Returns applied=false with err=nil when the guard rejected the write: this
+// is not a failure for the caller to retry or escalate — the row already
+// reached its true terminal state through another writer, and the rejection
+// itself has already been logged here.
+func (s *Store) UpdateExecutionStatusIfNotTerminal(id, status string, errorMsg ...string) (applied bool, err error) {
+	var errStr *string
+	if len(errorMsg) > 0 && errorMsg[0] != "" {
+		errStr = &errorMsg[0]
+	}
+
+	var setClause string
+	switch {
+	case isTerminalExecutionStatus(status):
+		setClause = "status = ?, error = COALESCE(?, error), completed_at = CURRENT_TIMESTAMP"
+	case status == "running":
+		setClause = "status = ?, error = COALESCE(?, error), started_at = CURRENT_TIMESTAMP"
+	default:
+		setClause = "status = ?, error = COALESCE(?, error)"
+	}
+
+	notTerminal, notTerminalArgs := notTerminalClause()
+
+	err = s.withRetry("UpdateExecutionStatusIfNotTerminal", func() error {
+		args := append([]interface{}{status, errStr, id}, notTerminalArgs...)
+		result, execErr := s.db.Exec(`
+			UPDATE executions
+			SET `+setClause+`
+			WHERE id = ? AND status NOT IN (`+notTerminal+`)
+		`, args...)
+		if execErr != nil {
+			return execErr
+		}
+		affected, raErr := result.RowsAffected()
+		if raErr != nil {
+			return raErr
+		}
+		applied = affected > 0
+		return nil
+	})
+	if err == nil && !applied {
+		s.logRejectedTerminalWrite("UpdateExecutionStatusIfNotTerminal", id, status)
+	}
+	return applied, err
+}
+
+// logRejectedTerminalWrite logs the ERROR evidence trail for a CAS write
+// rejected by UpdateExecutionStatusIfNotTerminal / MarkExecutionCompletedIfNotTerminal
+// (GH-4423): both the attempted status and the row's actual current status,
+// so a terminal->terminal collision leaves a trace instead of disappearing
+// silently.
+func (s *Store) logRejectedTerminalWrite(method, id, attemptedStatus string) {
+	var current string
+	if scanErr := s.db.QueryRow(`SELECT status FROM executions WHERE id = ?`, id).Scan(&current); scanErr != nil {
+		slog.Error("CAS-guarded write rejected but failed to read current status for evidence (GH-4423)",
+			slog.String("method", method), slog.String("execution_id", id),
+			slog.String("attempted_status", attemptedStatus), slog.Any("error", scanErr))
+		return
+	}
+	slog.Error("CAS-guarded write rejected: row already terminal (GH-4423)",
+		slog.String("method", method), slog.String("execution_id", id),
+		slog.String("attempted_status", attemptedStatus), slog.String("current_status", current))
 }
 
 // UpdateExecutionStatusByTaskID updates the status of the most recent execution
@@ -2277,6 +2389,45 @@ func (s *Store) MarkExecutionCompleted(id, prURL, commitSHA string, durationMs i
 		`, prURL, commitSHA, durationMs, id)
 		return err
 	})
+}
+
+// MarkExecutionCompletedIfNotTerminal is MarkExecutionCompleted's CAS-guarded
+// counterpart (GH-4423), scoped to the same "AND status NOT IN
+// (<terminalExecutionStatuses>)" guard as UpdateExecutionStatusIfNotTerminal.
+// ExecutionLifecycle.Persist's success branch routes through this so a
+// duplicate Finish call on an execution that already reached a terminal
+// status (e.g. a racing writer already recorded "failed") cannot silently
+// resurrect and overwrite it as "completed". Returns applied=false with
+// err=nil when the guard rejected the write — the rejection is already
+// logged (both attempted and actual status) by the time this returns.
+func (s *Store) MarkExecutionCompletedIfNotTerminal(id, prURL, commitSHA string, durationMs int64) (applied bool, err error) {
+	notTerminal, notTerminalArgs := notTerminalClause()
+
+	err = s.withRetry("MarkExecutionCompletedIfNotTerminal", func() error {
+		args := append([]interface{}{prURL, commitSHA, durationMs, id}, notTerminalArgs...)
+		result, execErr := s.db.Exec(`
+			UPDATE executions
+			SET status = 'completed',
+				pr_url = ?,
+				commit_sha = ?,
+				duration_ms = ?,
+				completed_at = CURRENT_TIMESTAMP
+			WHERE id = ? AND status NOT IN (`+notTerminal+`)
+		`, args...)
+		if execErr != nil {
+			return execErr
+		}
+		affected, raErr := result.RowsAffected()
+		if raErr != nil {
+			return raErr
+		}
+		applied = affected > 0
+		return nil
+	})
+	if err == nil && !applied {
+		s.logRejectedTerminalWrite("MarkExecutionCompletedIfNotTerminal", id, "completed")
+	}
+	return applied, err
 }
 
 // UpdateExecutionEffort records the resolved effort and complexity levels for a completed execution.

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -4446,6 +4446,136 @@ func TestResolveOrphanedRunningExecution_IdempotentOnAlreadyTerminalRow(t *testi
 	}
 }
 
+// TestUpdateExecutionStatusIfNotTerminal_AppliesFromNonTerminal verifies the
+// CAS guard's normal case: a write against a still-running row applies
+// exactly like plain UpdateExecutionStatus would. GH-4423.
+func TestUpdateExecutionStatusIfNotTerminal_AppliesFromNonTerminal(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_ = store.SaveExecution(&Execution{ID: "cas-running", TaskID: "GH-4423-A", ProjectPath: "/proj", Status: "running"})
+
+	applied, err := store.UpdateExecutionStatusIfNotTerminal("cas-running", "failed", "orphaned worker")
+	if err != nil {
+		t.Fatalf("UpdateExecutionStatusIfNotTerminal: %v", err)
+	}
+	if !applied {
+		t.Error("expected applied=true for a write against a non-terminal row")
+	}
+
+	exec, err := store.GetExecution("cas-running")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "failed" {
+		t.Errorf("expected status 'failed', got %q", exec.Status)
+	}
+	if exec.CompletedAt == nil {
+		t.Error("expected completed_at to be set for the terminal write")
+	}
+}
+
+// TestUpdateExecutionStatusIfNotTerminal_RejectsWhenAlreadyTerminal is the
+// GH-4423 regression test for the TOCTOU class this issue targets: a stale
+// reaper's blind failure-write must not clobber a row that already reached a
+// terminal status (e.g. completed) between the reaper's evidence-gathering
+// and its final write.
+func TestUpdateExecutionStatusIfNotTerminal_RejectsWhenAlreadyTerminal(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_ = store.SaveExecution(&Execution{
+		ID: "cas-completed", TaskID: "GH-4423-B", ProjectPath: "/proj",
+		Status: "completed", PRUrl: "https://github.com/org/repo/pull/99",
+	})
+
+	applied, err := store.UpdateExecutionStatusIfNotTerminal("cas-completed", "failed", "stale running task recovered (orphaned worker)")
+	if err != nil {
+		t.Fatalf("UpdateExecutionStatusIfNotTerminal: %v", err)
+	}
+	if applied {
+		t.Error("expected applied=false — row already terminal, write must be rejected")
+	}
+
+	exec, err := store.GetExecution("cas-completed")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "completed" {
+		t.Errorf("expected status to remain 'completed', got %q", exec.Status)
+	}
+	if exec.PRUrl != "https://github.com/org/repo/pull/99" {
+		t.Errorf("expected pr_url to remain stamped, got %q", exec.PRUrl)
+	}
+}
+
+// TestMarkExecutionCompletedIfNotTerminal_AppliesFromNonTerminal verifies the
+// CAS-guarded completion write applies normally against a running row. GH-4423.
+func TestMarkExecutionCompletedIfNotTerminal_AppliesFromNonTerminal(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_ = store.SaveExecution(&Execution{ID: "cas-mec-running", TaskID: "GH-4423-C", ProjectPath: "/proj", Status: "running"})
+
+	applied, err := store.MarkExecutionCompletedIfNotTerminal("cas-mec-running", "https://github.com/org/repo/pull/100", "abc123", 500)
+	if err != nil {
+		t.Fatalf("MarkExecutionCompletedIfNotTerminal: %v", err)
+	}
+	if !applied {
+		t.Error("expected applied=true for a write against a non-terminal row")
+	}
+
+	exec, err := store.GetExecution("cas-mec-running")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "completed" || exec.PRUrl != "https://github.com/org/repo/pull/100" {
+		t.Errorf("expected completed with pr_url stamped, got status=%q pr_url=%q", exec.Status, exec.PRUrl)
+	}
+}
+
+// TestMarkExecutionCompletedIfNotTerminal_RejectsWhenAlreadyTerminal verifies
+// a duplicate Finish call (ExecutionLifecycle.Persist's success branch) can't
+// resurrect and overwrite a row that already reached a different terminal
+// status (e.g. "failed" from a racing writer). GH-4423.
+func TestMarkExecutionCompletedIfNotTerminal_RejectsWhenAlreadyTerminal(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_ = store.SaveExecution(&Execution{ID: "cas-mec-failed", TaskID: "GH-4423-D", ProjectPath: "/proj", Status: "failed", Error: "boom"})
+
+	applied, err := store.MarkExecutionCompletedIfNotTerminal("cas-mec-failed", "https://github.com/org/repo/pull/101", "def456", 500)
+	if err != nil {
+		t.Fatalf("MarkExecutionCompletedIfNotTerminal: %v", err)
+	}
+	if applied {
+		t.Error("expected applied=false — row already terminal, write must be rejected")
+	}
+
+	exec, err := store.GetExecution("cas-mec-failed")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "failed" {
+		t.Errorf("expected status to remain 'failed', got %q", exec.Status)
+	}
+	if exec.PRUrl != "" {
+		t.Errorf("expected pr_url to remain empty, got %q", exec.PRUrl)
+	}
+}
+
 // TestSelfHealExecutionByPRURL_HealsMatchingRow verifies the pr_url-keyed
 // fallback heal used when a merged PR's issue number can't be resolved at
 // all. TASK-399/GH-4209.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4423.

Closes #4423

## Changes

GitHub Issue GH-4423: fix(executor,memory): terminal-status writes lack CAS — stale reaper can fail completed rows (TOCTOU + merged-only PR evidence); add store-level guard + open-PR liveness

## Context

Static-analysis findings from tracing completed→failed flip paths (navigator-research, 2026-07-17). Not the cause of today's GH-4387 flip (that was the guarded GH-3818/D10 reclassify path reacting to a closed PR), but two adjacent unguarded paths WILL cause silent terminal-status corruption under the right timing.

## Finding 1: stale-running reaper can fail a completed execution (TOCTOU + merged-only evidence)

`recoverStaleRunningTasks` (internal/executor/dispatcher.go:293–397): candidate selection is `status='running' AND older than 30m` — a legitimately long task is a candidate for every 5-min tick past 30m. Guards run in-loop (`HasCompletedExecution` → `hasLiveWorker` → `staleRunningMergedPRCheck`, which includes a **GitHub API round-trip**), then the final write at dispatcher.go:388 is a blind `UpdateExecutionStatus(id,'failed',...)` with **no re-check of current status** — if the task completes inside that window, the completed row gets stamped failed. Additionally `staleRunningMergedPRCheck` only recognizes a **merged** PR as evidence of shipped work; "open PR in waiting_ci" — the normal state for minutes-to-hours — reads as "no merge evidence". Same pattern at dispatcher.go:524 (stale-queued reap).

## Finding 2: no store-layer CAS for terminal statuses

`store.UpdateExecutionStatus` (store.go:1863) and `MarkExecutionCompleted` (store.go:2241) are blind `WHERE id=?` writes. Only `ResolveOrphanedRunningExecution` (`AND status='running'`) and `ReclassifyCompletionAsFailed` (`AND status='completed' ...`) are guarded. `ExecutionLifecycle.Transition/Persist` (lifecycle.go:144/215) inherit the blindness — a duplicate `Finish` overwrites a terminal state silently (this is also how today's GH-16 completion write vanished-in-plain-sight class stays invisible: terminal→terminal writes neither blocked nor logged).

## Fix sketch (chokepoint, not call sites)

1. Add CAS semantics to the store: `UpdateExecutionStatusIfCurrent(id, new, allowedCurrent...)` or a forbidden-set variant; route dispatcher.go:388/:524 and lifecycle.Transition through it. Terminal→terminal attempts: reject + ERROR log with both states (evidence for #4404-class debugging).
2. Extend `staleRunningMergedPRCheck` (dispatcher.go:360–381) to treat an OPEN PR on the task branch as liveness evidence, not just merged.

## Refs

- #4404 (vanished completion class), #4403 (boot reconciliation — same family), TASK-404 (lifecycle chokepoint), #4417 (sweep liveness fix, autopilot side).