### PR TITLE
fix(upgrade): preflight binary writability and fail loudly on self-upgrade

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-19 (v2.151.0)
+**Last Updated:** 2026-07-17 (v2.151.0)
 
 ## Legend
 
@@ -455,6 +455,7 @@
 | Project add wizard | ✅ | cli | `pilot project add` (no flags) | - | gh CLI auth, repo picker, token seeding; `--no-wizard` for CI (GH-3017, v2.187.1) |
 | Shell completion | ✅ | main | `pilot completion` | - | bash/zsh/fish |
 | Zip archive support | ✅ | upgrade | - | - | Windows self-upgrade handles .zip archives |
+| Self-upgrade writability preflight | ✅ | upgrade | - | - | Upgrade() probes binary dir before downloading; typed ErrBinaryNotWritable (dir+uid+hint); ERROR log + service_unhealthy alert on auto-upgrade failure; download progress logging throttled to ≥1s/10% steps (GH-4468) |
 | Pipeline hardening | ✅ | executor | - | - | 4 correctness checks: constants, parity, coverage, dropped features (v1.10.0, GH-1321) |
 | Pre-commit hooks | ✅ | - | `make install-hooks` | - | Git hooks for secret scanning + lint |
 | Qwen Code bug fixes | ✅ | executor | `--backend qwen` | - | 5x pricing correction, CLI version check, session_not_found handling (v1.9.2, GH-1316) |

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -2933,6 +2933,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 					if err := hotUpgrader.PerformHotUpgrade(ctx, info.LatestRelease, upgradeCfg); err != nil {
 						program.Send(dashboard.NotifyUpgradeComplete(false, err.Error())())
 						program.Send(dashboard.AddLog(fmt.Sprintf("✗ upgrade failed: %v", err))())
+						reportUpgradeFailure(alertsEngine, version, info.Latest, err)
 					} else {
 						// On Unix, process is replaced and this line is never reached.
 						// On Windows, hot restart is not supported — binary is installed

--- a/cmd/pilot/upgrade.go
+++ b/cmd/pilot/upgrade.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/signal"
 	"strings"
@@ -15,8 +16,41 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
+	"github.com/qf-studio/pilot/internal/alerts"
 	"github.com/qf-studio/pilot/internal/upgrade"
 )
+
+// reportUpgradeFailure makes a self-upgrade failure loud (GH-4468): before
+// this, the auto-upgrade path only logged progress at INFO and a failure
+// left no ERROR line and no alert — an operator found out from the TUI hours
+// after the fact. Logs at ERROR with the full error, then raises a
+// service_unhealthy alert (severity WARNING — a failed self-upgrade is not
+// itself availability-affecting) through the alerts engine if one is wired,
+// mirroring the existing self-upgrade-staleness alert (GH-3790).
+func reportUpgradeFailure(alertsEngine *alerts.Engine, currentVersion, targetVersion string, err error) {
+	slog.Error("self-upgrade failed",
+		slog.String("current_version", currentVersion),
+		slog.String("target_version", targetVersion),
+		slog.Any("error", err),
+	)
+
+	if alertsEngine == nil {
+		return
+	}
+
+	alertsEngine.ProcessEvent(alerts.Event{
+		Type:      alerts.EventTypeConfigError,
+		TaskID:    "self-upgrade",
+		TaskTitle: "Self-upgrade failed",
+		Error:     err.Error(),
+		Metadata: map[string]string{
+			"check":           "self_upgrade_failed",
+			"current_version": currentVersion,
+			"target_version":  targetVersion,
+		},
+		Timestamp: time.Now(),
+	})
+}
 
 // confirmPromptTimeout bounds how long the upgrade confirmation prompt waits
 // for input before giving up, so an unattended/non-interactive invocation

--- a/cmd/pilot/upgrade_failure_test.go
+++ b/cmd/pilot/upgrade_failure_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/alerts"
+)
+
+// mockAlertChannel is a minimal alerts.Channel implementation for asserting
+// that reportUpgradeFailure's alerts.Event actually reaches a channel via
+// the real Engine/Dispatcher, not just that ProcessEvent was called.
+type mockAlertChannel struct {
+	mu     sync.Mutex
+	name   string
+	alerts []*alerts.Alert
+}
+
+func newMockAlertChannel(name string) *mockAlertChannel {
+	return &mockAlertChannel{name: name}
+}
+
+func (m *mockAlertChannel) Name() string { return m.name }
+func (m *mockAlertChannel) Type() string { return "webhook" }
+
+func (m *mockAlertChannel) Send(_ context.Context, alert *alerts.Alert) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.alerts = append(m.alerts, alert)
+	return nil
+}
+
+func (m *mockAlertChannel) getAlerts() []*alerts.Alert {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]*alerts.Alert, len(m.alerts))
+	copy(out, m.alerts)
+	return out
+}
+
+func waitForMockAlerts(t *testing.T, ch *mockAlertChannel, n int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if len(ch.getAlerts()) >= n {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d alert(s), got %d", n, len(ch.getAlerts()))
+}
+
+// TestReportUpgradeFailure_EmitsAlert is the GH-4468 "loud failure" contract:
+// a failed self-upgrade must reach a real alert channel (severity WARNING)
+// through the same service_unhealthy rule path the self-upgrade-staleness
+// check (GH-3790) already uses, not just log at ERROR.
+func TestReportUpgradeFailure_EmitsAlert(t *testing.T) {
+	config := &alerts.AlertConfig{
+		Enabled: true,
+		Channels: []alerts.ChannelConfig{
+			{Name: "test-channel", Type: "webhook", Enabled: true},
+		},
+		Rules: []alerts.AlertRule{
+			{
+				Name:     "service-unhealthy",
+				Type:     alerts.AlertTypeServiceUnhealthy,
+				Enabled:  true,
+				Severity: alerts.SeverityWarning,
+				Channels: []string{"test-channel"},
+				Cooldown: 0,
+			},
+		},
+	}
+
+	mockCh := newMockAlertChannel("test-channel")
+	dispatcher := alerts.NewDispatcher(config)
+	dispatcher.RegisterChannel(mockCh)
+
+	engine := alerts.NewEngine(config, alerts.WithDispatcher(dispatcher))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := engine.Start(ctx); err != nil {
+		t.Fatalf("engine.Start() error = %v", err)
+	}
+
+	upgradeErr := errors.New("binary directory /usr/local/bin is not writable by uid 1000: permission denied")
+	reportUpgradeFailure(engine, "v2.242.0", "v2.243.0", upgradeErr)
+
+	waitForMockAlerts(t, mockCh, 1, 2*time.Second)
+	got := mockCh.getAlerts()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(got))
+	}
+	if got[0].Type != alerts.AlertTypeServiceUnhealthy {
+		t.Errorf("alert type = %s, want %s", got[0].Type, alerts.AlertTypeServiceUnhealthy)
+	}
+	if got[0].Severity != alerts.SeverityWarning {
+		t.Errorf("alert severity = %s, want %s", got[0].Severity, alerts.SeverityWarning)
+	}
+	if !strings.Contains(got[0].Message, "not writable") {
+		t.Errorf("alert message = %q, want it to include the upgrade error detail", got[0].Message)
+	}
+}
+
+// TestReportUpgradeFailure_NoMatchingRule confirms the call is a no-op (no
+// panic, no delivery attempt) when alerting is configured but no
+// service_unhealthy rule exists — mirrors the engine's existing
+// "unmatched rule drops silently" behavior.
+func TestReportUpgradeFailure_NoMatchingRule(t *testing.T) {
+	config := &alerts.AlertConfig{
+		Enabled:  true,
+		Channels: []alerts.ChannelConfig{{Name: "test-channel", Type: "webhook", Enabled: true}},
+		Rules:    []alerts.AlertRule{},
+	}
+
+	mockCh := newMockAlertChannel("test-channel")
+	dispatcher := alerts.NewDispatcher(config)
+	dispatcher.RegisterChannel(mockCh)
+
+	engine := alerts.NewEngine(config, alerts.WithDispatcher(dispatcher))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := engine.Start(ctx); err != nil {
+		t.Fatalf("engine.Start() error = %v", err)
+	}
+
+	reportUpgradeFailure(engine, "v2.242.0", "v2.243.0", errors.New("boom"))
+
+	time.Sleep(100 * time.Millisecond)
+	if got := len(mockCh.getAlerts()); got != 0 {
+		t.Errorf("expected no alerts without a matching rule, got %d", got)
+	}
+}
+
+// TestReportUpgradeFailure_NilEngineDoesNotPanic covers the daemon startup
+// path where alertsEngine can be nil (alerting disabled/misconfigured) —
+// reportUpgradeFailure must still log and simply skip alerting.
+func TestReportUpgradeFailure_NilEngineDoesNotPanic(t *testing.T) {
+	reportUpgradeFailure(nil, "v2.242.0", "v2.243.0", errors.New("boom"))
+}

--- a/internal/upgrade/hot.go
+++ b/internal/upgrade/hot.go
@@ -38,6 +38,53 @@ func DefaultHotUpgradeConfig() *HotUpgradeConfig {
 	}
 }
 
+// progressLogHygieneInterval is the minimum gap between two INFO-level
+// "upgrade progress" log lines for the same run, unless a 10% boundary or
+// the 0%/100% endpoints are crossed. downloadAsset reports progress on every
+// 32KB chunk — for a ~30MB release that's roughly a thousand callbacks in a
+// few hundred milliseconds, which without throttling turns into hundreds of
+// log lines per second (GH-4468 incident: daemon.log was too noisy to
+// contain the one ERROR line that mattered).
+const progressLogHygieneInterval = time.Second
+
+// progressLogThrottle decides whether a given progress update is significant
+// enough to log at INFO. It does not gate the OnProgress callback itself —
+// UI consumers (the TUI progress bar) still get every update; only the log
+// line is throttled.
+type progressLogThrottle struct {
+	clock   clock
+	started bool
+	lastAt  time.Time
+	lastPct int
+}
+
+func newProgressLogThrottle(clk clock) *progressLogThrottle {
+	if clk == nil {
+		clk = realClock{}
+	}
+	return &progressLogThrottle{clock: clk}
+}
+
+// shouldLog reports whether pct should produce a log line, then (if so)
+// records it as the new baseline. Always logs the first call and the
+// 0%/100% endpoints so start and completion are never dropped.
+func (t *progressLogThrottle) shouldLog(pct int) bool {
+	now := t.clock.Now()
+
+	log := !t.started ||
+		pct <= 0 || pct >= 100 ||
+		pct/10 != t.lastPct/10 ||
+		now.Sub(t.lastAt) >= progressLogHygieneInterval
+
+	if log {
+		t.started = true
+		t.lastAt = now
+		t.lastPct = pct
+	}
+
+	return log
+}
+
 // NewHotUpgrader creates a new HotUpgrader instance
 func NewHotUpgrader(currentVersion string, taskChecker TaskChecker) (*HotUpgrader, error) {
 	graceful, err := NewGracefulUpgrader(currentVersion, taskChecker)
@@ -66,8 +113,11 @@ func (h *HotUpgrader) PerformHotUpgrade(ctx context.Context, release *Release, c
 
 	currentVersion := h.graceful.GetUpgrader().currentVersion
 
+	logThrottle := newProgressLogThrottle(nil)
 	progress := func(pct int, msg string) {
-		slog.Info("upgrade progress", slog.Int("percent", pct), slog.String("msg", msg))
+		if logThrottle.shouldLog(pct) {
+			slog.Info("upgrade progress", slog.Int("percent", pct), slog.String("msg", msg))
+		}
 		if cfg.OnProgress != nil {
 			cfg.OnProgress(pct, msg)
 		}

--- a/internal/upgrade/hot_test.go
+++ b/internal/upgrade/hot_test.go
@@ -322,3 +322,118 @@ func TestCanHotRestart(t *testing.T) {
 		t.Error("CanHotRestart() = false, want true on Unix")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// progressLogThrottle (GH-4468: download progress logging hygiene)
+// ---------------------------------------------------------------------------
+
+func TestNewProgressLogThrottle_NilClockDefaultsToReal(t *testing.T) {
+	th := newProgressLogThrottle(nil)
+	if _, ok := th.clock.(realClock); !ok {
+		t.Errorf("expected realClock default when nil is passed, got %T", th.clock)
+	}
+}
+
+func TestProgressLogThrottle_ShouldLog_TableDriven(t *testing.T) {
+	tests := []struct {
+		name  string
+		calls []int // sequence of pct values, no simulated time elapsed between calls
+		want  []bool
+	}{
+		{
+			name:  "first call always logs",
+			calls: []int{5},
+			want:  []bool{true},
+		},
+		{
+			name:  "same decile suppressed after first log",
+			calls: []int{5, 6, 7, 9},
+			want:  []bool{true, false, false, false},
+		},
+		{
+			name:  "crossing a 10% boundary logs",
+			calls: []int{5, 12, 12, 23},
+			want:  []bool{true, true, false, true},
+		},
+		{
+			name:  "0% and 100% always log",
+			calls: []int{0, 0, 50, 100, 100},
+			want:  []bool{true, true, true, true, true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fc := newFakeClock(time.Now())
+			th := newProgressLogThrottle(fc)
+			for i, pct := range tt.calls {
+				got := th.shouldLog(pct)
+				if got != tt.want[i] {
+					t.Errorf("call #%d shouldLog(%d) = %v, want %v", i, pct, got, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestProgressLogThrottle_ElapsedTimeReopensSameDecile verifies the ≥1s
+// escape hatch: even without crossing a 10% boundary, once the hygiene
+// interval has passed the next update logs again.
+func TestProgressLogThrottle_ElapsedTimeReopensSameDecile(t *testing.T) {
+	fc := newFakeClock(time.Now())
+	th := newProgressLogThrottle(fc)
+
+	if !th.shouldLog(11) {
+		t.Fatal("first call should log")
+	}
+	if th.shouldLog(15) {
+		t.Fatal("same decile with no elapsed time should be suppressed")
+	}
+
+	// Advance the clock past the hygiene interval without crossing a decile.
+	<-fc.After(progressLogHygieneInterval)
+
+	if !th.shouldLog(16) {
+		t.Error("same decile after the hygiene interval elapsed should log")
+	}
+}
+
+// TestProgressLogThrottle_DoesNotGateCallback confirms the throttle is only
+// a logging decision — PerformHotUpgrade must still forward every update to
+// cfg.OnProgress so the TUI progress bar stays smooth.
+func TestProgressLogThrottle_DoesNotGateCallback(t *testing.T) {
+	tc := &NoOpTaskChecker{}
+	h, _ := newTestHotUpgrader(t, tc)
+
+	newBinary := []byte(strings.Repeat("x", 200*1024)) // large enough for multiple 32KB chunks
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(newBinary)
+	}))
+	defer server.Close()
+
+	h.graceful.upgrader.httpClient = server.Client()
+
+	release := &Release{
+		TagName: "v2.0.0",
+		Assets: []Asset{
+			{
+				Name:               fmt.Sprintf("pilot-%s-%s", runtime.GOOS, runtime.GOARCH),
+				BrowserDownloadURL: server.URL + "/pilot",
+				Size:               int64(len(newBinary)),
+			},
+		},
+	}
+
+	var callbackCount int
+	cfg := &HotUpgradeConfig{
+		OnProgress: func(pct int, msg string) {
+			callbackCount++
+		},
+	}
+
+	_ = h.PerformHotUpgrade(context.Background(), release, cfg)
+
+	if callbackCount < 2 {
+		t.Errorf("expected multiple OnProgress callbacks despite log throttling, got %d", callbackCount)
+	}
+}

--- a/internal/upgrade/preflight_test.go
+++ b/internal/upgrade/preflight_test.go
@@ -1,0 +1,191 @@
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// checkBinaryWritable / ErrBinaryNotWritable (GH-4468)
+// ---------------------------------------------------------------------------
+
+func TestCheckBinaryWritable_WritableDir(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := checkBinaryWritable(dir); err != nil {
+		t.Fatalf("checkBinaryWritable() error = %v, want nil for a writable dir", err)
+	}
+
+	// The probe file must not be left behind.
+	if _, err := os.Stat(filepath.Join(dir, upgradeProbeFilename)); !os.IsNotExist(err) {
+		t.Errorf("probe file was not cleaned up (stat err = %v)", err)
+	}
+}
+
+func TestCheckBinaryWritable_UnwritableDir(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root — permission checks are bypassed")
+	}
+
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(dir, 0755) }() // let t.TempDir() clean up
+
+	err := checkBinaryWritable(dir)
+	if err == nil {
+		t.Fatal("checkBinaryWritable() error = nil, want error for an unwritable dir")
+	}
+
+	var notWritable *ErrBinaryNotWritable
+	if !errors.As(err, &notWritable) {
+		t.Fatalf("expected *ErrBinaryNotWritable, got %T: %v", err, err)
+	}
+	if notWritable.Dir != dir {
+		t.Errorf("Dir = %q, want %q", notWritable.Dir, dir)
+	}
+	if notWritable.UID != os.Getuid() {
+		t.Errorf("UID = %d, want %d", notWritable.UID, os.Getuid())
+	}
+	if notWritable.Err == nil {
+		t.Error("Err should wrap the underlying OS error")
+	}
+}
+
+func TestErrBinaryNotWritable_Error(t *testing.T) {
+	err := &ErrBinaryNotWritable{Dir: "/usr/local/bin", UID: 1000, Err: os.ErrPermission}
+	msg := err.Error()
+
+	for _, want := range []string{"/usr/local/bin", "1000", "relocate"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("Error() = %q, missing %q", msg, want)
+		}
+	}
+}
+
+func TestErrBinaryNotWritable_Unwrap(t *testing.T) {
+	underlying := os.ErrPermission
+	err := &ErrBinaryNotWritable{Dir: "/usr/local/bin", UID: 1000, Err: underlying}
+
+	if !errors.Is(err, os.ErrPermission) {
+		t.Error("errors.Is(err, os.ErrPermission) = false, want true (Unwrap should expose Err)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Upgrade() preflight integration: must fail before any network call
+// ---------------------------------------------------------------------------
+
+func TestUpgrade_PreflightBlocksBeforeDownload(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root — permission checks are bypassed")
+	}
+
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "pilot")
+	if err := os.WriteFile(binPath, []byte("old-binary"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(dir, 0755) }()
+
+	downloadHit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		downloadHit = true
+		_, _ = w.Write([]byte("new-binary"))
+	}))
+	defer server.Close()
+
+	u := &Upgrader{
+		currentVersion:      "1.0.0",
+		httpClient:          server.Client(),
+		binaryPath:          binPath,
+		backupPath:          binPath + BackupSuffix,
+		prepareForExecution: func(string) error { return nil },
+	}
+
+	release := &Release{
+		TagName: "v2.0.0",
+		Assets: []Asset{
+			{
+				Name:               fmt.Sprintf("pilot-%s-%s", runtime.GOOS, runtime.GOARCH),
+				BrowserDownloadURL: server.URL + "/pilot",
+				Size:               10,
+			},
+		},
+	}
+
+	err := u.Upgrade(context.Background(), release, nil)
+	if err == nil {
+		t.Fatal("Upgrade() error = nil, want *ErrBinaryNotWritable")
+	}
+
+	var notWritable *ErrBinaryNotWritable
+	if !errors.As(err, &notWritable) {
+		t.Fatalf("expected *ErrBinaryNotWritable, got %T: %v", err, err)
+	}
+	if notWritable.Dir != dir {
+		t.Errorf("Dir = %q, want %q", notWritable.Dir, dir)
+	}
+
+	if downloadHit {
+		t.Error("Upgrade() hit the download server despite an unwritable binary dir — preflight should abort first")
+	}
+}
+
+// TestUpgrade_PreflightPassesForWritableDir is the control case: with a
+// writable dir, Upgrade() proceeds past the preflight and completes normally
+// (mirrors TestUpgrade_EndToEnd but asserts specifically that the new
+// preflight step doesn't regress the happy path).
+func TestUpgrade_PreflightPassesForWritableDir(t *testing.T) {
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "pilot")
+	if err := os.WriteFile(binPath, []byte("old-binary"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	newBinary := []byte("new-binary-v2")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(newBinary)
+	}))
+	defer server.Close()
+
+	u := &Upgrader{
+		currentVersion:      "1.0.0",
+		httpClient:          server.Client(),
+		binaryPath:          binPath,
+		backupPath:          binPath + BackupSuffix,
+		prepareForExecution: func(string) error { return nil },
+	}
+
+	release := &Release{
+		TagName: "v2.0.0",
+		Assets: []Asset{
+			{
+				Name:               fmt.Sprintf("pilot-%s-%s", runtime.GOOS, runtime.GOARCH),
+				BrowserDownloadURL: server.URL + "/pilot",
+				Size:               int64(len(newBinary)),
+			},
+		},
+	}
+
+	if err := u.Upgrade(context.Background(), release, nil); err != nil {
+		t.Fatalf("Upgrade() error = %v, want nil for a writable dir", err)
+	}
+
+	got, _ := os.ReadFile(binPath)
+	if string(got) != string(newBinary) {
+		t.Errorf("installed content = %q, want %q", got, newBinary)
+	}
+}

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -167,8 +167,65 @@ func ReleasesBehind(releases []Release, currentVersion string) int {
 	return count
 }
 
+// ErrBinaryNotWritable is returned by Upgrade when the process cannot write
+// to the directory holding the binary — e.g. a root-owned binary with the
+// daemon running as a non-root user. Detected via a preflight probe before
+// any download happens (GH-4468: previously this only surfaced as an EACCES
+// from createBackup() after a ~30MB download had already completed, with no
+// ERROR log or alert marking the failure).
+type ErrBinaryNotWritable struct {
+	// Dir is the binary's containing directory that failed the write probe.
+	Dir string
+	// UID is the process's effective user id (-1 on platforms without one,
+	// e.g. Windows).
+	UID int
+	// Err is the underlying OS error from the probe.
+	Err error
+}
+
+func (e *ErrBinaryNotWritable) Error() string {
+	return fmt.Sprintf(
+		"binary directory %s is not writable by uid %d: %v — relocate the binary to a directory this user owns, or fix ownership/permissions on %s",
+		e.Dir, e.UID, e.Err, e.Dir,
+	)
+}
+
+func (e *ErrBinaryNotWritable) Unwrap() error {
+	return e.Err
+}
+
+// upgradeProbeFilename is the throwaway file checkBinaryWritable creates and
+// removes to confirm write access without touching the real binary/backup.
+const upgradeProbeFilename = ".pilot-upgrade-probe"
+
+// checkBinaryWritable verifies the process can create, write, and delete a
+// file in dir — the same access createBackup() and installBinary() will need
+// later in the flow. Called as a preflight so a doomed upgrade fails in
+// microseconds instead of after downloading the full release asset.
+func checkBinaryWritable(dir string) error {
+	probePath := filepath.Join(dir, upgradeProbeFilename)
+
+	f, err := os.OpenFile(probePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return &ErrBinaryNotWritable{Dir: dir, UID: os.Getuid(), Err: err}
+	}
+	_ = f.Close()
+
+	if err := os.Remove(probePath); err != nil {
+		return &ErrBinaryNotWritable{Dir: dir, UID: os.Getuid(), Err: err}
+	}
+
+	return nil
+}
+
 // Upgrade downloads and installs the latest version
 func (u *Upgrader) Upgrade(ctx context.Context, release *Release, onProgress func(pct int, msg string)) error {
+	// Preflight: fail loud before spending time/bandwidth on a download that
+	// can never be installed (GH-4468).
+	if err := checkBinaryWritable(filepath.Dir(u.binaryPath)); err != nil {
+		return err
+	}
+
 	// Find appropriate asset for current platform
 	asset := u.findAsset(release)
 	if asset == nil {


### PR DESCRIPTION
## Summary
- `Upgrade()` now preflights write access to `dir(binaryPath)` (create+delete a probe file) before downloading the release asset; an unwritable dir returns typed `ErrBinaryNotWritable{Dir, UID, Err}` naming the dir, uid, and remediation hint.
- The auto-upgrade call site (dashboard hot-upgrade loop in `cmd/pilot/main.go`) now logs `level=ERROR` with the full error and fires a `service_unhealthy` alert (severity WARNING) via `reportUpgradeFailure`, mirroring the GH-3790 self-upgrade-staleness alert pattern.
- Download progress logging in the hot-upgrade path is throttled to ≥1s intervals / 10% steps (plus always at 0%/100%) instead of one INFO line per 32KB chunk — the OnProgress callback to the TUI is unaffected, only the slog line is throttled.

Fixes the root cause of the 2026-07-19 v2.242.0 auto-upgrade failure on the founder box: a root-owned binary in a root-owned directory with the daemon running as `ec2-user` failed silently 70% through the upgrade with no ERROR log and no alert.

Closes GH-4468.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/upgrade/...` — new preflight tests (writable/unwritable dir, typed error, no network call on preflight failure) + progress-log-throttle table-driven tests
- [x] `go test ./cmd/pilot/...` — new `reportUpgradeFailure` tests asserting ERROR log + alert delivery through a real `alerts.Engine`/`Dispatcher`/mock channel, nil-engine no-op, no-matching-rule no-op
- [x] `gofmt -l` clean on all touched files