### PR TITLE
fix(dispatch): poller respects repick backoff, killing the 30s dispatch-reject loop

### DIFF
--- a/.agent/sops/integrations/github-sdk-poller-external-module.md
+++ b/.agent/sops/integrations/github-sdk-poller-external-module.md
@@ -58,6 +58,50 @@ bump `go.mod` in `pilot` to the new version. That is a cross-repo task, not
 a single Pilot-issue scope — flag it as a follow-up rather than attempting
 it inside a `pilot/GH-*` branch.
 
+## Earliest controllable checkpoint: `ExecutionChecker`/`TaskChecker`, not `HandlerResult.Error`
+
+If the task is "stop the poller from even attempting dispatch" (not just
+suppress a log line after the fact), `handleIssueGeneric`'s returned
+`HandlerResult.Error` is too late — the vendored poller's per-issue loop
+(`sdk/integrations/github/poller.go`) only inspects `err` (from
+`onIssueWithResult`) and `result.Success`/`result.PRNumber`; it never reads
+`result.Error`. By the time your Handler runs, the poller has already
+walked scope-overlap grouping, done a fresh-label GH API refresh, run the
+pre-flight judge subprocess (~30s/~280MB), called `markProcessed`, and
+logged the INFO "Dispatching issue for parallel execution" announcement.
+
+The actual earliest host-controllable checkpoint in the loop is the
+`core.ExecutionChecker` hook (`HasCompletedExecution(taskID, projectPath)`,
+wired via `terminalCompletionChecker` in `cmd/pilot/main.go`) — it runs
+*before* candidate filtering, the judge, and the claim insert. To make the
+poller skip a task entirely for a tick (not just avoid one log line), gate
+inside that checker rather than downstream in `handleIssueGeneric`.
+
+Confirm the exact call order before assuming a hook fires early enough:
+
+```bash
+grep -n "hasCompletedExecution\|hasMergedWork\|hasPendingDependencies\|passesPreFlight\|markProcessed\|Dispatching issue for parallel execution" \
+  $(go env GOPATH)/pkg/mod/github.com/qf-studio/studio-sdk@<version>/sdk/integrations/github/poller.go
+```
+
+GitLab's vendored poller (`sdk/integrations/gitlab/poller.go`) has **no**
+`ExecutionChecker`/`TaskChecker`/`PreFlightJudge` hooks at all — this
+early-checkpoint pattern is GitHub-only; GitLab must rely on the
+`handleIssueGeneric` gates (downstream, post-announcement).
+
+- GH-4469 (2026-07-20): GH-4391 looped 4,233 dispatch→reject cycles over
+  ~2 days because the repick-backoff gate lived only in
+  `handleIssueGeneric`, downstream of the judge subprocess and claim
+  insert. Fix: `terminalCompletionChecker.HasCompletedExecution` now
+  consults `repickBackoff` first and reports `true` (as if terminally
+  complete) while a task is gated — the poller then treats it exactly like
+  an already-completed issue and skips the rest of the loop for that tick.
+  `ErrDispatchGated` (a new sentinel in `internal/executor/dispatcher.go`)
+  was still added for `handleIssueGeneric`'s own gates, but it is
+  introspection-only for the GitHub SDK poller (never read by it) — its
+  value is for tests/logging and for adapters that DO consult
+  `HandlerResult.Error`.
+
 ## History
 
 - GH-4008 (2026-07-07): task asked to suppress the "Dispatching issue for

--- a/.agent/tasks/gh-4469.md
+++ b/.agent/tasks/gh-4469.md
@@ -1,0 +1,84 @@
+# GH-4469
+
+**Created:** 2026-07-20
+
+## Problem
+
+GitHub Issue GH-4469: Poller must respect repick backoff — kill the 30s dispatch→reject loop
+
+# TASK-413: Poller must respect repick backoff — kill the 30s dispatch→reject loop
+
+**Created**: 2026-07-19 · **Status**: 📋 Ready for dispatch · **Last Updated**: 2026-07-19
+
+## Problem (observed 2026-07-17 → 2026-07-19, GH-4391 on the founder box)
+
+After a task hits the repick hard cap (or any dispatcher-side gate), the
+GitHub poller keeps re-picking it **every ~30s poll tick, forever**:
+
+```
+Dispatching issue for parallel execution … number=4391
+Execution failed without PR, unmarking for retry … number=4391   (<1s later)
+```
+
+Measured damage over ~2 days for ONE task: **4,233 loop cycles**, each
+burning (a) a board-sync GraphQL call, (b) REST calls for the issue fetch,
+(c) every other cycle a pre-flight intent-judge subprocess (~30s runtime,
+~280MB RSS, killed on context deadline), and (d) an `execution_claims`
+INSERT — GH-4391 accumulated **15 claim generations (0–14)** with zero
+executions. This loop was a substantial contributor to the user-aggregate
+GitHub rate-pool exhaustion that, among other things, killed the 07-18
+release-train tick.
+
+Mechanism: the dispatcher correctly rejects the task pre-claim (backoff /
+hard-cap gate in `repick_backoff` + stalled-row check), but the poller
+treats every rejection as a transient failure — "unmarking for retry" —
+and re-picks on the next tick. The gate and the poller disagree about
+whose state is authoritative.
+
+## Deliverables
+
+1. **Poller consults backoff before dispatching**: when a task's
+   `repick_backoff.next_allowed_at` is in the future (or its latest
+   execution row is terminal-stalled at cap), the poller must SKIP the
+   issue for the tick — no dispatch attempt, no judge run, no board-sync
+   write, no claim insert. Cheapest available check first.
+2. **Distinguish gate-rejection from real failure** in the dispatch result:
+   a typed sentinel (e.g. `ErrDispatchGated`) so "Execution failed without
+   PR, unmarking for retry" is only logged for genuine failures. Gated
+   skips log at DEBUG once per backoff window, not per tick.
+3. **No claim-generation churn on gated dispatch**: gate must be evaluated
+   before the claim insert (GH-4391's 15 stale generations came from this).
+4. **Loop breaker alert**: if the same task is dispatched-and-rejected ≥10
+   consecutive times regardless of cause, emit one WARNING alert naming the
+   task and stop retrying until operator action or backoff expiry — never
+   silently loop for days.
+5. Table-driven tests: gated task skipped (no judge/claim/board calls —
+   assert via mocks), gate expiry resumes dispatch, sentinel logging, loop
+   breaker fires once at threshold.
+
+## Constraints
+
+- Do NOT change hard-cap semantics themselves (#4455 owns cap counting).
+- Backoff store (`repick_backoff` schema: key, consecutive_drops,
+  next_allowed_at, updated_at) unchanged.
+- Poller behavior for healthy tasks unchanged.
+
+## Acceptance
+
+- [ ] A backoff-gated task produces zero API calls / judge runs / claim
+      rows until `next_allowed_at`
+- [ ] Real dispatch failures still unmark-for-retry exactly as today
+- [ ] ≥10 consecutive rejections → single WARNING alert + stop
+- [ ] Tests green, lint clean
+
+## Refs
+
+- Incident: GH-4391 loop, 4,233 cycles 07-17→07-19, 15 claim generations
+- Pitfall memory: `hard-cap-rearm-in-memory-gate` (4-step manual re-arm this
+  task makes unnecessary)
+- #4455 (repick hard-cap counting), #4372 (gen-0 re-claim), GH-4391
+  (rate-budget client — complementary; this task removes the loop that
+  burns the budget, that task makes the budget survivable)
+
+## Acceptance Criteria
+

--- a/cmd/pilot/handler_common.go
+++ b/cmd/pilot/handler_common.go
@@ -102,7 +102,7 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 	if deps.Dispatcher != nil && deps.Dispatcher.IsActive(taskID, projectPath) {
 		logging.WithComponent("dispatch").Debug("Task already queued or running, skipping dispatch",
 			slog.String("task_id", taskID))
-		return &HandlerResult{Success: false, BranchName: task.Branch}, nil
+		return &HandlerResult{Success: false, BranchName: task.Branch, Error: executor.ErrDispatchGated}, nil
 	}
 
 	// GH-4376: per-issue backoff — a task that was recently dropped (claim
@@ -121,7 +121,7 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 	if deps.Dispatcher != nil && !repickBackoff.allow(backoffKey) {
 		logging.WithComponent("dispatch").Debug("task in repick backoff window, skipping dispatch",
 			slog.String("task_id", taskID))
-		return &HandlerResult{Success: false, BranchName: task.Branch}, nil
+		return &HandlerResult{Success: false, BranchName: task.Branch, Error: executor.ErrDispatchGated}, nil
 	}
 
 	// GH-4376/GH-4350: independent terminal-completion re-check at the shared
@@ -144,7 +144,8 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 			if deps.Metrics != nil {
 				deps.Metrics.RecordPollerSkipped(repickMetricsRepo(task), skipreason.ReasonRepickStormBackoff)
 			}
-			return &HandlerResult{Success: false, BranchName: task.Branch}, nil
+			fireLoopBreakerAlert(deps, taskID, title, projectPath, consecutive)
+			return &HandlerResult{Success: false, BranchName: task.Branch, Error: executor.ErrDispatchGated}, nil
 		}
 	}
 
@@ -217,6 +218,12 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 	// 6. Dispatch via dispatcher OR direct execute via runner
 	var result *executor.ExecutionResult
 	var execErr error
+	// gatedDrop marks the execID=="" branch below (GH-4372 duplicate/terminal
+	// drop) so the final HandlerResult can carry executor.ErrDispatchGated
+	// (GH-4469) without disturbing the existing execErr-driven monitor/alert
+	// side effects in steps 7-9, which intentionally treat this path as
+	// "nothing to wait for" rather than a failure.
+	var gatedDrop bool
 
 	if deps.Dispatcher != nil {
 		execID, qErr := deps.Dispatcher.QueueTask(ctx, task)
@@ -252,6 +259,8 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 			if deps.Metrics != nil {
 				deps.Metrics.RecordPollerSkipped(repickMetricsRepo(task), skipreason.ReasonRepickStormBackoff)
 			}
+			fireLoopBreakerAlert(deps, taskID, title, projectPath, consecutive)
+			gatedDrop = true
 		} else {
 			// GH-4394 subtask 2: a repick (Dispatcher.beginWithGenerationRetry
 			// claiming execution_claims generation > 0 because the prior claim
@@ -360,10 +369,16 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 	}
 
 	// 10. Build and return HandlerResult
+	hrErr := execErr
+	if hrErr == nil && gatedDrop {
+		// GH-4469: distinguish "dropped a duplicate/terminal pickup" from a
+		// genuine execution failure for anything that inspects HandlerResult.
+		hrErr = executor.ErrDispatchGated
+	}
 	hr := &HandlerResult{
 		Success:    execErr == nil && result != nil && result.Success,
 		BranchName: task.Branch,
-		Error:      execErr,
+		Error:      hrErr,
 		Result:     result,
 	}
 	if result != nil {
@@ -391,6 +406,35 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 	}
 
 	return hr, execErr
+}
+
+// fireLoopBreakerAlert emits AlertTypeDispatchLoopBreaker exactly once per
+// storm — the tick where consecutive first reaches repickLoopBreakerThreshold
+// (GH-4469). consecutive strictly increases while a task keeps dropping and
+// is reset by repickBackoff.recordSuccess on the first genuine dispatch, so
+// comparing for equality (rather than >=) fires the alert once without
+// needing separate dedup state; a nil AlertsEngine (e.g. in tests without one
+// wired) is a no-op.
+func fireLoopBreakerAlert(deps HandlerDeps, taskID, title, projectPath string, consecutive int) {
+	if consecutive != repickLoopBreakerThreshold {
+		return
+	}
+	logging.WithComponent("dispatch").Warn(
+		"dispatch loop breaker: task rejected 10+ consecutive times, stopping until operator action or backoff expiry",
+		slog.String("task_id", taskID), slog.Int("consecutive_drops", consecutive))
+	if deps.AlertsEngine == nil {
+		return
+	}
+	deps.AlertsEngine.ProcessEvent(alerts.Event{
+		Type:      alerts.EventTypeDispatchLoopBreaker,
+		TaskID:    taskID,
+		TaskTitle: title,
+		Project:   projectPath,
+		Metadata: map[string]string{
+			"consecutive_drops": fmt.Sprintf("%d", consecutive),
+		},
+		Timestamp: time.Now(),
+	})
 }
 
 // repickMetricsRepo returns the repo label to record repick-storm skips

--- a/cmd/pilot/handler_common_test.go
+++ b/cmd/pilot/handler_common_test.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/qf-studio/pilot/internal/adapters/azuredevops"
 	"github.com/qf-studio/pilot/internal/adapters/github"
 	"github.com/qf-studio/pilot/internal/adapters/gitlab"
+	"github.com/qf-studio/pilot/internal/alerts"
 	"github.com/qf-studio/pilot/internal/budget"
 	"github.com/qf-studio/pilot/internal/executor"
 	"github.com/qf-studio/pilot/internal/memory"
@@ -509,6 +511,235 @@ func TestHandleIssueGeneric_RepickDoesNotClearBackoff(t *testing.T) {
 	}
 	if !found || consecutive != 1 {
 		t.Errorf("expected persisted repick backoff consecutive_drops=1 after the re-pick, got found=%v consecutive=%d", found, consecutive)
+	}
+}
+
+// TestHandleIssueGeneric_GatedReturns_CarryErrDispatchGated is the GH-4469
+// deliverable-2 regression test: every one of handleIssueGeneric's
+// pre-dispatch admission gates must set HandlerResult.Error to
+// executor.ErrDispatchGated (checkable via errors.Is), so anything that
+// inspects the result can distinguish "the dispatcher intentionally declined
+// this tick" from a genuine execution failure — even though the vendored
+// github SDK poller itself doesn't consult this field (GH-4469's fix for that
+// path is gating earlier, at terminalCompletionChecker).
+func TestHandleIssueGeneric_GatedReturns_CarryErrDispatchGated(t *testing.T) {
+	t.Run("IsActive dedup gate", func(t *testing.T) {
+		dispatcher := newHandlerTestDispatcher(t)
+		taskID := "GH-4469-ACTIVE"
+		projectPath := "/tmp/pilot-gh-4469-active-does-not-exist"
+		task := &executor.Task{ID: taskID, Title: "t", Branch: "pilot/" + taskID, ProjectPath: projectPath}
+
+		// Queue the task once so IsActive reports true on the next check.
+		if _, err := dispatcher.QueueTask(context.Background(), task); err != nil {
+			t.Fatalf("setup QueueTask failed: %v", err)
+		}
+
+		deps := HandlerDeps{Dispatcher: dispatcher, Monitor: executor.NewMonitor(), ProjectPath: projectPath}
+		info := IssueInfo{TaskID: taskID, Title: "t", Adapter: "github", LogMark: "▸"}
+
+		hr, err := handleIssueGeneric(context.Background(), deps, info, task)
+		if err != nil {
+			t.Fatalf("expected nil error, got: %v", err)
+		}
+		if !errors.Is(hr.Error, executor.ErrDispatchGated) {
+			t.Errorf("expected hr.Error to wrap executor.ErrDispatchGated, got: %v", hr.Error)
+		}
+	})
+
+	t.Run("repick backoff window gate", func(t *testing.T) {
+		dispatcher := newHandlerTestDispatcher(t)
+		taskID := "GH-4469-BACKOFF"
+		projectPath := "/tmp/pilot-gh-4469-backoff-does-not-exist"
+		backoffKey := repickBackoffKey(projectPath, taskID)
+		t.Cleanup(func() { repickBackoff.recordSuccess(backoffKey) })
+		repickBackoff.setPersister(dispatcher)
+		repickBackoff.recordDrop(backoffKey)
+
+		deps := HandlerDeps{Dispatcher: dispatcher, Monitor: executor.NewMonitor(), ProjectPath: projectPath}
+		info := IssueInfo{TaskID: taskID, Title: "t", Adapter: "github", LogMark: "▸"}
+		task := &executor.Task{ID: taskID, Title: "t", Branch: "pilot/" + taskID, ProjectPath: projectPath}
+
+		hr, err := handleIssueGeneric(context.Background(), deps, info, task)
+		if err != nil {
+			t.Fatalf("expected nil error, got: %v", err)
+		}
+		if !errors.Is(hr.Error, executor.ErrDispatchGated) {
+			t.Errorf("expected hr.Error to wrap executor.ErrDispatchGated, got: %v", hr.Error)
+		}
+	})
+
+	t.Run("terminal completion re-check gate", func(t *testing.T) {
+		taskID := "GH-4469-TERMINAL"
+		projectPath := "/tmp/pilot-gh-4469-terminal-does-not-exist"
+		backoffKey := repickBackoffKey(projectPath, taskID)
+		t.Cleanup(func() { repickBackoff.recordSuccess(backoffKey) })
+
+		store, err := memory.NewStore(t.TempDir())
+		if err != nil {
+			t.Fatalf("NewStore failed: %v", err)
+		}
+		t.Cleanup(func() { _ = store.Close() })
+		dispatcher2 := executor.NewDispatcher(store, executor.NewRunner(), nil)
+		if err := dispatcher2.Start(context.Background()); err != nil {
+			t.Fatalf("failed to start dispatcher: %v", err)
+		}
+		t.Cleanup(dispatcher2.Stop)
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-gh-4469-terminal", TaskID: taskID, ProjectPath: projectPath,
+			Status: "completed", PRUrl: "https://github.com/qf-studio/pilot-canary-sandbox/pull/1",
+		}); err != nil {
+			t.Fatalf("failed to seed completed execution: %v", err)
+		}
+
+		deps := HandlerDeps{Dispatcher: dispatcher2, Monitor: executor.NewMonitor(), ProjectPath: projectPath}
+		info := IssueInfo{TaskID: taskID, Title: "t", Adapter: "github", LogMark: "▸"}
+		task := &executor.Task{ID: taskID, Title: "t", Branch: "pilot/" + taskID, ProjectPath: projectPath}
+
+		hr, hErr := handleIssueGeneric(context.Background(), deps, info, task)
+		if hErr != nil {
+			t.Fatalf("expected nil error, got: %v", hErr)
+		}
+		if !errors.Is(hr.Error, executor.ErrDispatchGated) {
+			t.Errorf("expected hr.Error to wrap executor.ErrDispatchGated, got: %v", hr.Error)
+		}
+	})
+}
+
+// testAlertChannel is a minimal alerts.Channel implementation that records
+// every alert it receives, for tests that need to observe what
+// handleIssueGeneric's AlertsEngine actually dispatched.
+type testAlertChannel struct {
+	mu     sync.Mutex
+	alerts []alerts.Alert
+}
+
+func (c *testAlertChannel) Name() string { return "test-channel" }
+func (c *testAlertChannel) Type() string { return "webhook" }
+func (c *testAlertChannel) Send(_ context.Context, alert *alerts.Alert) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.alerts = append(c.alerts, *alert)
+	return nil
+}
+func (c *testAlertChannel) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.alerts)
+}
+
+// waitForAlertCount polls until ch has recorded at least n alerts or the
+// timeout elapses (alerts.Engine.ProcessEvent is asynchronous).
+func waitForAlertCount(t *testing.T, ch *testAlertChannel, n int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if ch.count() >= n {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d alert(s), got %d", n, ch.count())
+}
+
+// TestHandleIssueGeneric_LoopBreakerAlert_FiresOnceAtThreshold is the GH-4469
+// deliverable-4 regression test: repeatedly hitting the same gate (here, the
+// terminal-completion re-check) must fire exactly one
+// AlertTypeDispatchLoopBreaker WARNING when the consecutive-drop count first
+// reaches repickLoopBreakerThreshold (10) — not before, and not again on
+// every subsequent tick past it.
+func TestHandleIssueGeneric_LoopBreakerAlert_FiresOnceAtThreshold(t *testing.T) {
+	taskID := "GH-4469-LOOP-BREAKER"
+	projectPath := "/tmp/pilot-gh-4469-loop-breaker-does-not-exist"
+	backoffKey := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(backoffKey) })
+
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	d2 := executor.NewDispatcher(store, executor.NewRunner(), nil)
+	if err := d2.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	t.Cleanup(d2.Stop)
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "exec-gh-4469-loop-breaker", TaskID: taskID, ProjectPath: projectPath,
+		Status: "completed", PRUrl: "https://github.com/qf-studio/pilot-canary-sandbox/pull/1",
+	}); err != nil {
+		t.Fatalf("failed to seed completed execution: %v", err)
+	}
+
+	config := &alerts.AlertConfig{
+		Enabled: true,
+		Channels: []alerts.ChannelConfig{
+			{Name: "test-channel", Type: "webhook", Enabled: true},
+		},
+		Rules: []alerts.AlertRule{
+			{
+				Name:     "dispatch_loop_breaker",
+				Type:     alerts.AlertTypeDispatchLoopBreaker,
+				Enabled:  true,
+				Severity: alerts.SeverityWarning,
+				Channels: []string{"test-channel"},
+				Cooldown: 0,
+			},
+		},
+	}
+	testCh := &testAlertChannel{}
+	alertDispatcher := alerts.NewDispatcher(config)
+	alertDispatcher.RegisterChannel(testCh)
+	engine := alerts.NewEngine(config, alerts.WithDispatcher(alertDispatcher))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := engine.Start(ctx); err != nil {
+		t.Fatalf("failed to start alerts engine: %v", err)
+	}
+
+	deps := HandlerDeps{Dispatcher: d2, Monitor: executor.NewMonitor(), ProjectPath: projectPath, AlertsEngine: engine}
+	info := IssueInfo{TaskID: taskID, Title: "loop breaker", Adapter: "github", LogMark: "▸"}
+	task := &executor.Task{ID: taskID, Title: "loop breaker", Branch: "pilot/" + taskID, ProjectPath: projectPath}
+
+	forceExpire := func() {
+		repickBackoff.mu.Lock()
+		if e, ok := repickBackoff.entries[backoffKey]; ok {
+			e.nextAllowedAt = time.Now().Add(-time.Second)
+		}
+		repickBackoff.mu.Unlock()
+	}
+
+	// Drive 9 drops (simulating 9 prior poll ticks each ~30s+ apart) — no
+	// alert expected yet.
+	for i := 0; i < 9; i++ {
+		if i > 0 {
+			forceExpire()
+		}
+		if _, err := handleIssueGeneric(context.Background(), deps, info, task); err != nil {
+			t.Fatalf("drop %d: unexpected error: %v", i+1, err)
+		}
+	}
+	if got := testCh.count(); got != 0 {
+		t.Fatalf("expected 0 alerts before reaching the threshold, got %d", got)
+	}
+
+	// 10th consecutive drop: must fire exactly one alert.
+	forceExpire()
+	if _, err := handleIssueGeneric(context.Background(), deps, info, task); err != nil {
+		t.Fatalf("10th drop: unexpected error: %v", err)
+	}
+	waitForAlertCount(t, testCh, 1, 2*time.Second)
+	if got := testCh.count(); got != 1 {
+		t.Fatalf("expected exactly 1 alert at the threshold, got %d", got)
+	}
+
+	// An 11th drop must not fire a second alert.
+	forceExpire()
+	if _, err := handleIssueGeneric(context.Background(), deps, info, task); err != nil {
+		t.Fatalf("11th drop: unexpected error: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if got := testCh.count(); got != 1 {
+		t.Fatalf("expected still exactly 1 alert past the threshold, got %d", got)
 	}
 }
 

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -3188,11 +3188,32 @@ func (s storeTaskChecker) IsTaskQueued(taskID string) bool {
 // executor.HasTerminalCompletion is the same broadened "done" definition
 // dispatcher.go's own pickup guard (hasTerminalSuccessLedger) uses, so both
 // re-arm points agree.
+//
+// GH-4469: this is also the earliest host-controllable checkpoint in the
+// vendored github SDK poller's per-issue candidate loop
+// (studio-sdk/sdk/integrations/github/poller.go: hasCompletedExecution runs
+// before scope-grouping, the fresh-label GH API refresh, the pre-flight judge
+// subprocess, markProcessed, board-sync, and the dispatch/claim-insert
+// itself). GH-4391 looped 4,233 times over two days because the ONLY existing
+// gate was inside handleIssueGeneric (cmd/pilot/handler_common.go), which the
+// poller only reaches AFTER already paying for the judge run and board-sync
+// write — a rejection there still cost the full cycle every ~30s. Consulting
+// the repick backoff here, before any of that, makes a backoff-gated task
+// look identical to an already-completed one to the poller: it's skipped via
+// recordSkip(ReasonCompletedExecution) with zero further API calls, judge
+// runs, or claim rows until next_allowed_at passes.
 type terminalCompletionChecker struct {
 	store *memory.Store
 }
 
 func (c terminalCompletionChecker) HasCompletedExecution(taskID, projectPath string) (bool, error) {
+	if gated, shouldLog := repickBackoff.gateStatus(repickBackoffKey(projectPath, taskID)); gated {
+		if shouldLog {
+			logging.WithComponent("dispatch").Debug("task in repick backoff window, skipping poller candidacy entirely",
+				slog.String("task_id", taskID))
+		}
+		return true, nil
+	}
 	return executor.HasTerminalCompletion(c.store, taskID, projectPath)
 }
 

--- a/cmd/pilot/repick_backoff.go
+++ b/cmd/pilot/repick_backoff.go
@@ -22,12 +22,27 @@ const (
 	// repickBackoffMaxShift caps backoff growth at base * 2^5 = base * 32.
 	repickBackoffMaxShift      = 5
 	repickBackoffWarnThreshold = 5 // consecutive drops before escalating to WARN
+
+	// repickLoopBreakerThreshold is the consecutive-drop count (GH-4469) at
+	// which handleIssueGeneric fires a single WARNING alert naming the task,
+	// on top of the ordinary Warn-level log escalation at
+	// repickBackoffWarnThreshold. By this point the exponential backoff has
+	// already been capped (repickBackoffMaxShift) for several drops, so the
+	// task is being silently re-offered every ~16 minutes rather than every
+	// 30s — still worth paging an operator about, since GH-4391 accumulated
+	// this pattern for two days before anyone noticed.
+	repickLoopBreakerThreshold = 10
 )
 
 // repickBackoffEntry tracks one task_id/project_path pair's cooldown state.
 type repickBackoffEntry struct {
 	consecutiveDrops int
 	nextAllowedAt    time.Time
+	// gateLogged records whether the current backoff window has already
+	// emitted its once-per-window DEBUG "gated" log line (GH-4469 deliverable
+	// 2) — set by gateStatus, cleared once nextAllowedAt passes so the next
+	// window logs exactly once again.
+	gateLogged bool
 }
 
 // repickBackoffPersister durably mirrors the tracker's in-memory entries
@@ -107,6 +122,30 @@ func (t *repickBackoffTracker) allow(key string) bool {
 		}
 	}
 	return !time.Now().Before(e.nextAllowedAt)
+}
+
+// gateStatus reports whether key is currently within its backoff window
+// (gated) and, if so, whether the caller should emit its once-per-window
+// DEBUG log line (GH-4469 deliverable 2) — true only the first time
+// gateStatus observes this window as gated, false on every subsequent poll
+// tick until the window expires and a new one begins.
+func (t *repickBackoffTracker) gateStatus(key string) (gated bool, shouldLog bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	e, ok := t.entries[key]
+	if !ok {
+		e = t.hydrateLocked(key)
+		if e == nil {
+			return false, false
+		}
+	}
+	if time.Now().Before(e.nextAllowedAt) {
+		shouldLog = !e.gateLogged
+		e.gateLogged = true
+		return true, shouldLog
+	}
+	e.gateLogged = false
+	return false, false
 }
 
 // recordDrop registers a dropped pickup for key, extending its backoff window

--- a/cmd/pilot/repick_backoff_test.go
+++ b/cmd/pilot/repick_backoff_test.go
@@ -216,6 +216,90 @@ func TestRepickBackoffTracker_HydratesFromPersisterAfterRestart(t *testing.T) {
 	}
 }
 
+// TestRepickBackoffTracker_GateStatus_LogsOncePerWindow is the GH-4469
+// deliverable-2 regression test: gateStatus must report shouldLog=true only
+// on the FIRST observation of a given backoff window, so
+// terminalCompletionChecker.HasCompletedExecution logs its DEBUG "gated" line
+// once per window instead of once per ~30s poll tick for the entire
+// (potentially 16-minute) cooldown.
+func TestRepickBackoffTracker_GateStatus_LogsOncePerWindow(t *testing.T) {
+	tr := newRepickBackoffTracker()
+	key := "proj|GH-4391"
+
+	// No drop recorded yet — not gated.
+	if gated, shouldLog := tr.gateStatus(key); gated || shouldLog {
+		t.Fatalf("expected a never-seen key to be ungated with no log, got gated=%v shouldLog=%v", gated, shouldLog)
+	}
+
+	tr.recordDrop(key)
+
+	gated, shouldLog := tr.gateStatus(key)
+	if !gated || !shouldLog {
+		t.Fatalf("expected first gateStatus check after a drop to be gated=true shouldLog=true, got gated=%v shouldLog=%v", gated, shouldLog)
+	}
+
+	// Subsequent checks within the same window must not re-log.
+	for i := 0; i < 3; i++ {
+		gated, shouldLog = tr.gateStatus(key)
+		if !gated {
+			t.Fatalf("check %d: expected key to remain gated within its backoff window", i)
+		}
+		if shouldLog {
+			t.Fatalf("check %d: expected shouldLog=false for repeat checks within the same window", i)
+		}
+	}
+}
+
+// TestRepickBackoffTracker_GateStatus_ResetsLogFlagOnNewWindow verifies that
+// once a backoff window expires, the next drop's new window logs once again
+// rather than staying permanently silenced from the prior window.
+func TestRepickBackoffTracker_GateStatus_ResetsLogFlagOnNewWindow(t *testing.T) {
+	tr := newRepickBackoffTracker()
+	key := "proj|GH-4391b"
+
+	tr.recordDrop(key)
+	if gated, shouldLog := tr.gateStatus(key); !gated || !shouldLog {
+		t.Fatalf("expected first window to be gated+logged, got gated=%v shouldLog=%v", gated, shouldLog)
+	}
+
+	// Force the window to have already elapsed.
+	tr.mu.Lock()
+	tr.entries[key].nextAllowedAt = time.Now().Add(-time.Second)
+	tr.mu.Unlock()
+
+	if gated, shouldLog := tr.gateStatus(key); gated || shouldLog {
+		t.Fatalf("expected an elapsed window to report ungated with no log, got gated=%v shouldLog=%v", gated, shouldLog)
+	}
+
+	// A fresh drop starts a new window that must log once again.
+	tr.recordDrop(key)
+	if gated, shouldLog := tr.gateStatus(key); !gated || !shouldLog {
+		t.Fatalf("expected the new window to be gated+logged again, got gated=%v shouldLog=%v", gated, shouldLog)
+	}
+}
+
+// TestRepickBackoffTracker_GateStatus_HydratesFromPersister verifies a fresh
+// tracker (simulating a restart) whose map has never seen the key still
+// correctly reports it as gated when the persister holds a live cooldown —
+// mirroring TestRepickBackoffTracker_HydratesFromPersisterAfterRestart but
+// for the gate-check path terminalCompletionChecker uses.
+func TestRepickBackoffTracker_GateStatus_HydratesFromPersister(t *testing.T) {
+	key := "proj|GH-4391c"
+	persist := &fakeRepickBackoffPersister{
+		consecutiveDrops: 2,
+		nextAllowedAt:    time.Now().Add(5 * time.Minute),
+		found:            true,
+	}
+
+	tr := newRepickBackoffTracker()
+	tr.setPersister(persist)
+
+	gated, shouldLog := tr.gateStatus(key)
+	if !gated || !shouldLog {
+		t.Fatalf("expected a restarted tracker to hydrate the persisted cooldown as gated+logged, got gated=%v shouldLog=%v", gated, shouldLog)
+	}
+}
+
 // TestRepickBackoffTracker_RecordSuccessClearsPersister verifies
 // recordSuccess clears the persister's state, not just the in-memory map —
 // otherwise a restart right after a successful dispatch would rehydrate the

--- a/cmd/pilot/terminal_completion_checker_test.go
+++ b/cmd/pilot/terminal_completion_checker_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// newTerminalCompletionCheckerTestStore creates a real on-disk store (no
+// completed execution rows seeded), matching production schema, for tests
+// that need to distinguish "gated by repick backoff" from "genuinely has a
+// terminal completion" — both return true from HasCompletedExecution, but for
+// different reasons, and only the DB-backed path proves the distinction.
+func newTerminalCompletionCheckerTestStore(t *testing.T) *memory.Store {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "pilot-test-terminal-checker-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp failed: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// TestTerminalCompletionChecker_GatedByBackoff_SkipsWithoutStoreLookup is the
+// GH-4469 deliverable-1/3 core regression test: this is the exact hook wired
+// as the vendored github SDK poller's ExecutionChecker
+// (studio-sdk/sdk/integrations/github/poller.go hasCompletedExecution), the
+// EARLIEST checkpoint in its per-issue candidate loop — running before
+// scope-grouping, the fresh-label GH API refresh, the pre-flight judge
+// subprocess, markProcessed, board-sync, and the dispatch/claim-insert. A
+// task with NO completed execution row would ordinarily report false here;
+// once its repick backoff key is gated, HasCompletedExecution must report
+// true anyway so the poller treats it exactly like an already-completed
+// issue and skips the entire rest of the expensive loop.
+func TestTerminalCompletionChecker_GatedByBackoff_SkipsWithoutStoreLookup(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	checker := terminalCompletionChecker{store: store}
+
+	taskID := "GH-4391"
+	projectPath := "/tmp/pilot-gh-4469-gate-test-does-not-exist"
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+
+	// Sanity: with no backoff armed and no completed row, this must be false.
+	done, err := checker.HasCompletedExecution(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if done {
+		t.Fatal("expected false for a task with neither a completed row nor an armed backoff")
+	}
+
+	// Arm the backoff (simulating a prior dropped pickup) and verify the
+	// checker now reports true — the poller-visible signal for "skip this
+	// tick" — even though there is still no completed execution row.
+	repickBackoff.recordDrop(key)
+
+	done, err = checker.HasCompletedExecution(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("unexpected error while gated: %v", err)
+	}
+	if !done {
+		t.Fatal("expected HasCompletedExecution to report true while the repick backoff is armed, so the poller skips this candidate entirely")
+	}
+}
+
+// TestTerminalCompletionChecker_GateExpiry_ResumesNormalCheck verifies that
+// once the backoff window has elapsed, HasCompletedExecution falls back to
+// the real terminal-completion check instead of remaining stuck reporting
+// true forever.
+func TestTerminalCompletionChecker_GateExpiry_ResumesNormalCheck(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	checker := terminalCompletionChecker{store: store}
+
+	taskID := "GH-4391-EXPIRE"
+	projectPath := "/tmp/pilot-gh-4469-gate-expiry-test-does-not-exist"
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+
+	repickBackoff.recordDrop(key)
+	if done, _ := checker.HasCompletedExecution(taskID, projectPath); !done {
+		t.Fatal("expected the task to be gated immediately after a drop")
+	}
+
+	// Force the window to have already elapsed, as if next_allowed_at passed.
+	repickBackoff.mu.Lock()
+	repickBackoff.entries[key].nextAllowedAt = time.Now().Add(-time.Second)
+	repickBackoff.mu.Unlock()
+
+	done, err := checker.HasCompletedExecution(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("unexpected error after gate expiry: %v", err)
+	}
+	if done {
+		t.Fatal("expected the gate to expire and fall back to the real (false) terminal-completion check")
+	}
+}
+
+// TestTerminalCompletionChecker_GenuineCompletion_StillReportsTrue verifies
+// GH-4469's new gate does not regress the pre-existing GH-4347 behavior: a
+// task with a real completed execution row must still report true even with
+// no backoff involved at all.
+func TestTerminalCompletionChecker_GenuineCompletion_StillReportsTrue(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	checker := terminalCompletionChecker{store: store}
+
+	taskID := "GH-4391-GENUINE"
+	projectPath := "/tmp/pilot-gh-4469-genuine-completion-does-not-exist"
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "exec-gh-4469-genuine", TaskID: taskID, ProjectPath: projectPath,
+		Status: "completed", PRUrl: "https://github.com/qf-studio/pilot-canary-sandbox/pull/1",
+	}); err != nil {
+		t.Fatalf("failed to seed completed execution: %v", err)
+	}
+
+	done, err := checker.HasCompletedExecution(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !done {
+		t.Fatal("expected a genuinely completed task to still report true")
+	}
+}

--- a/internal/alerts/engine.go
+++ b/internal/alerts/engine.go
@@ -135,6 +135,13 @@ const (
 	// poll_cycles_starved (the running streak) — see
 	// autopilot.Controller.reconcileLaneStarvation, the sole emitter.
 	EventTypeLaneStarvation EventType = "lane_starvation"
+
+	// Dispatch loop breaker events (GH-4469): fired exactly once by
+	// handleIssueGeneric (cmd/pilot/handler_common.go) when a task's
+	// consecutive dispatch-and-reject count reaches repickLoopBreakerThreshold
+	// (10) — regardless of whether the rejections were backoff gates or
+	// genuine failures. Metadata carries task_id and consecutive_drops.
+	EventTypeDispatchLoopBreaker EventType = "dispatch_loop_breaker"
 )
 
 const (
@@ -369,6 +376,8 @@ func (e *Engine) handleEvent(ctx context.Context, event Event) {
 		e.handleReleaseMissing(ctx, event)
 	case EventTypeLaneStarvation:
 		e.handleLaneStarvation(ctx, event)
+	case EventTypeDispatchLoopBreaker:
+		e.handleDispatchLoopBreaker(ctx, event)
 	case EventTypeBudgetExceeded, EventTypeBudgetWarning:
 		e.handleBudgetEvent(ctx, event)
 	case EventTypeAutopilotMetrics:
@@ -604,6 +613,25 @@ func (e *Engine) handleLaneStarvation(ctx context.Context, event Event) {
 			alert := e.createAlert(rule, event,
 				fmt.Sprintf("Lane %s has %s open pilot-labeled issue(s) but nothing queued/running for %d consecutive poll cycles",
 					repo, openIssues, streak))
+			e.fireAlert(ctx, rule, alert)
+		}
+	}
+}
+
+// handleDispatchLoopBreaker fires AlertTypeDispatchLoopBreaker rules when a
+// task's consecutive dispatch-and-reject count reaches the caller's
+// threshold (GH-4469). The caller (handleIssueGeneric) already computed and
+// gated on the exact threshold before emitting this event, so — like
+// handleReleaseMissing — no Condition-based counting happens here.
+func (e *Engine) handleDispatchLoopBreaker(ctx context.Context, event Event) {
+	for _, rule := range e.config.Rules {
+		if !rule.Enabled {
+			continue
+		}
+		if rule.Type == AlertTypeDispatchLoopBreaker && e.shouldFire(rule) {
+			message := fmt.Sprintf("Task %s has been dispatched-and-rejected %s consecutive times without completing — stopping until operator action or backoff expiry",
+				event.TaskID, event.Metadata["consecutive_drops"])
+			alert := e.createAlert(rule, event, message)
 			e.fireAlert(ctx, rule, alert)
 		}
 	}

--- a/internal/alerts/engine_test.go
+++ b/internal/alerts/engine_test.go
@@ -1273,6 +1273,107 @@ func TestHandleReleaseMissing(t *testing.T) {
 	})
 }
 
+// TestHandleDispatchLoopBreaker covers the GH-4469 loop-breaker rule: the
+// emitting side (handleIssueGeneric, cmd/pilot/handler_common.go) does its
+// own threshold counting (fires exactly once, at consecutive drop == 10) and
+// sends a single event, so this test only needs to verify the event turns
+// into exactly one alert carrying the task and consecutive-drops metadata —
+// mirroring TestHandleReleaseMissing above.
+func TestHandleDispatchLoopBreaker(t *testing.T) {
+	t.Run("fires with task_id and consecutive_drops metadata", func(t *testing.T) {
+		config := &AlertConfig{
+			Enabled: true,
+			Channels: []ChannelConfig{
+				{Name: "test-channel", Type: "webhook", Enabled: true},
+			},
+			Rules: []AlertRule{
+				{
+					Name:     "dispatch_loop_breaker",
+					Type:     AlertTypeDispatchLoopBreaker,
+					Enabled:  true,
+					Severity: SeverityWarning,
+					Channels: []string{"test-channel"},
+					Cooldown: 0,
+				},
+			},
+		}
+
+		mockCh := newMockChannel("test-channel", "webhook")
+		dispatcher := NewDispatcher(config)
+		dispatcher.RegisterChannel(mockCh)
+
+		engine := NewEngine(config, WithDispatcher(dispatcher))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = engine.Start(ctx)
+
+		engine.ProcessEvent(Event{
+			Type:   EventTypeDispatchLoopBreaker,
+			TaskID: "GH-4391",
+			Metadata: map[string]string{
+				"consecutive_drops": "10",
+			},
+			Timestamp: time.Now(),
+		})
+
+		waitForAlerts(t, mockCh, 1, 2*time.Second)
+		alerts := mockCh.getAlerts()
+		if len(alerts) != 1 {
+			t.Fatalf("expected 1 alert, got %d", len(alerts))
+		}
+		if alerts[0].Type != AlertTypeDispatchLoopBreaker {
+			t.Errorf("expected alert type %s, got %s", AlertTypeDispatchLoopBreaker, alerts[0].Type)
+		}
+		if !strings.Contains(alerts[0].Message, "GH-4391") || !strings.Contains(alerts[0].Message, "10") {
+			t.Errorf("expected alert message to mention the task and consecutive-drop count, got %q", alerts[0].Message)
+		}
+	})
+
+	t.Run("disabled rule does not fire", func(t *testing.T) {
+		config := &AlertConfig{
+			Enabled: true,
+			Channels: []ChannelConfig{
+				{Name: "test-channel", Type: "webhook", Enabled: true},
+			},
+			Rules: []AlertRule{
+				{
+					Name:     "dispatch_loop_breaker",
+					Type:     AlertTypeDispatchLoopBreaker,
+					Enabled:  false,
+					Severity: SeverityWarning,
+					Channels: []string{"test-channel"},
+					Cooldown: 0,
+				},
+			},
+		}
+
+		mockCh := newMockChannel("test-channel", "webhook")
+		dispatcher := NewDispatcher(config)
+		dispatcher.RegisterChannel(mockCh)
+
+		engine := NewEngine(config, WithDispatcher(dispatcher))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = engine.Start(ctx)
+
+		engine.ProcessEvent(Event{
+			Type:   EventTypeDispatchLoopBreaker,
+			TaskID: "GH-4391",
+			Metadata: map[string]string{
+				"consecutive_drops": "10",
+			},
+			Timestamp: time.Now(),
+		})
+		engine.flushForTest()
+
+		if got := len(mockCh.getAlerts()); got != 0 {
+			t.Errorf("expected 0 alerts (rule disabled), got %d", got)
+		}
+	})
+}
+
 // TestHandleLaneStarvation covers the GH-4454 lane-starvation rule: the
 // emitting side (autopilot.Controller.reconcileLaneStarvation) does no
 // threshold filtering of its own and sends the raw streak on every starved

--- a/internal/alerts/types.go
+++ b/internal/alerts/types.go
@@ -57,6 +57,12 @@ const (
 	// pilot-labeled issues but nothing queued/running for too many
 	// consecutive poll cycles.
 	AlertTypeLaneStarvation AlertType = "lane_starvation"
+
+	// Dispatch loop breaker (GH-4469): the same task has been
+	// dispatched-and-rejected (gated or genuinely failed) 10+ consecutive
+	// times without ever completing — see repickLoopBreakerThreshold in
+	// cmd/pilot/repick_backoff.go, GH-4391's 4,233-cycle incident.
+	AlertTypeDispatchLoopBreaker AlertType = "dispatch_loop_breaker"
 )
 
 // Alert represents an alert event
@@ -387,6 +393,20 @@ func defaultRules() []AlertRule {
 			Channels:    []string{},
 			Cooldown:    30 * time.Minute,
 			Description: "Alert when a project lane has open pilot-labeled issues but nothing queued/running for too many poll cycles",
+		},
+		// Dispatch loop breaker (GH-4469): caller (handleIssueGeneric) does its
+		// own threshold counting via repickLoopBreakerThreshold and fires the
+		// event exactly once per storm (at consecutive drop == 10), so no
+		// Condition field is needed here — mirrors release_missing.
+		{
+			Name:        "dispatch_loop_breaker",
+			Type:        AlertTypeDispatchLoopBreaker,
+			Enabled:     true,
+			Condition:   RuleCondition{},
+			Severity:    SeverityWarning,
+			Channels:    []string{},
+			Cooldown:    30 * time.Minute,
+			Description: "Alert when a task is dispatched-and-rejected 10+ consecutive times without ever completing",
 		},
 	}
 }

--- a/internal/alerts/types_test.go
+++ b/internal/alerts/types_test.go
@@ -66,6 +66,8 @@ func TestDefaultRules(t *testing.T) {
 		AlertTypeReleaseMissing: {"release_missing", true},
 		// Lane-starvation detection (GH-4454)
 		AlertTypeLaneStarvation: {"lane_starvation", true},
+		// Dispatch loop breaker (GH-4469)
+		AlertTypeDispatchLoopBreaker: {"dispatch_loop_breaker", true},
 	}
 
 	if len(rules) != len(expectedRules) {

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -23,6 +23,20 @@ import (
 // error text (GH-4008).
 var ErrTaskAlreadyActive = errors.New("task already queued or running")
 
+// ErrDispatchGated marks a HandlerResult produced by one of handleIssueGeneric's
+// pre-dispatch admission gates (already-active dedup, repick backoff window,
+// terminal-completion re-check) rather than a genuine execution failure
+// (GH-4469). Every adapter wrapper forwards HandlerResult.Error into its
+// result struct unchanged, so anything that CAN inspect the error (in-tree
+// pollers, tests, future adapters) can use errors.Is(err, ErrDispatchGated) to
+// tell "the dispatcher intentionally declined this tick" apart from "the
+// execution actually failed" instead of inferring it from Success/PRNumber
+// alone. Note the vendored github SDK poller's own unmark decision does not
+// consult this field at all (it only looks at Success/PRNumber) — for that
+// path GH-4469's fix is gating earlier, at terminalCompletionChecker (see
+// cmd/pilot/main.go), so the gated tick never reaches handleIssueGeneric.
+var ErrDispatchGated = errors.New("dispatch gated: pre-dispatch admission check declined this tick")
+
 // terminalExecutionStatuses is every execution status WaitForExecution and
 // the GH-4372 retry decider both treat as "finished" — the execution is no
 // longer in flight, regardless of whether it succeeded. Kept as the single


### PR DESCRIPTION
## Summary

- GH-4391 looped **4,233 dispatch-and-reject cycles** over ~2 days: after hitting the repick hard cap, the GitHub poller re-picked the task every ~30s forever, each cycle burning a board-sync GraphQL call, REST calls, a ~30s/280MB pre-flight judge subprocess (every other cycle), and an `execution_claims` INSERT.
- Root cause: the only repick-backoff gate lived in `handleIssueGeneric`, which the vendored GitHub SDK poller reaches only *after* paying for the judge run, board-sync write, and claim insert.
- Fix: gate at `terminalCompletionChecker.HasCompletedExecution` (`core.ExecutionChecker`) instead — the earliest host-controllable checkpoint in the poller's per-issue loop, running before scope-grouping, the fresh-label GH API refresh, the judge subprocess, `markProcessed`, board-sync, and the claim insert. A backoff-gated task now looks identical to an already-completed one to the poller and is skipped for the tick with zero further API/judge/claim cost.
- Added `ErrDispatchGated` sentinel (distinguishes gate-rejection from genuine failure for anything that inspects `HandlerResult.Error`), once-per-backoff-window DEBUG logging (`repickBackoffTracker.gateStatus`), and a `dispatch_loop_breaker` WARNING alert that fires exactly once when a task hits 10 consecutive dispatch-and-reject cycles.
- GitLab's vendored poller has no equivalent `ExecutionChecker` hook, so this early-checkpoint fix is GitHub-only; the sentinel + loop-breaker alert apply to all adapters via the shared `handleIssueGeneric` chokepoint. Documented in `.agent/sops/integrations/github-sdk-poller-external-module.md`.
- Hard-cap counting (#4455) and the `repick_backoff` schema are unchanged; healthy-task poller behavior is unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full suite green)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] New table-driven tests: gated task reports terminally-complete with zero real completion row (`TestTerminalCompletionChecker_GatedByBackoff_SkipsWithoutStoreLookup`), gate expiry resumes real check (`TestTerminalCompletionChecker_GateExpiry_ResumesNormalCheck`), genuine GH-4347 completion unaffected (`TestTerminalCompletionChecker_GenuineCompletion_StillReportsTrue`), `ErrDispatchGated` carried on all three `handleIssueGeneric` gate paths (`TestHandleIssueGeneric_GatedReturns_CarryErrDispatchGated`), loop-breaker alert fires exactly once at the 10th consecutive drop (`TestHandleIssueGeneric_LoopBreakerAlert_FiresOnceAtThreshold`), plus `gateStatus` once-per-window logging tests and `handleDispatchLoopBreaker` engine tests.

GH-4469