### PR TITLE
fix(autopilot): per-project CI-checks override, fixing pointer#108 forever-pending CI (GH-4478)

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "updated": "2026-07-18T13:50:00+00:00",
+  "updated": "2026-07-20T13:00:00+00:00",
   "nodes": {
     "concepts": {
       "pilot-architecture": {
@@ -3151,6 +3151,16 @@
           "dispatcher",
           "dispatch"
         ]
+      },
+      "global-required-checks-leak-across-projects": {
+        "type": "pitfall",
+        "summary": "Global autopilot.required_checks/ci_checks allowlist is shared by every project controller; a repo whose check-run names differ polls waiting_ci forever with all checks green (qf-studio/pointer#108 repro) — fixed by per-project ProjectCIChecksOverride overlay (GH-4478)",
+        "file": ".agent/knowledge/memories/pitfalls/global-required-checks-leak-across-projects.md",
+        "concepts": [
+          "autopilot",
+          "ci",
+          "github"
+        ]
       }
     }
   },
@@ -4902,10 +4912,10 @@
       "decomposer-narrative-bullets-as-subtask-boundaries"
     ]
   },
-  "last_updated": "2026-07-20T11:25:47.452793+00:00",
+  "last_updated": "2026-07-20T13:00:00+00:00",
   "stats": {
-    "total_nodes": 271,
+    "total_nodes": 272,
     "total_edges": 234,
-    "memory_count": 171
+    "memory_count": 172
   }
 }

--- a/.agent/knowledge/memories/pitfalls/global-required-checks-leak-across-projects.md
+++ b/.agent/knowledge/memories/pitfalls/global-required-checks-leak-across-projects.md
@@ -1,0 +1,73 @@
+---
+name: global-required-checks-leak-across-projects
+description: A single global autopilot.required_checks/ci_checks allowlist is shared by every project controller — a repo whose check-run names differ polls waiting_ci forever even with all checks green; fixed by a per-project ProjectCIChecksOverride (GH-4478)
+type: pitfall
+---
+
+# Global `required_checks` leaks across every project controller — silent forever-pending CI
+
+**What happened (live repro 2026-07-20, qf-studio/pointer#108):** all three
+check-runs (`integration`, `go`, `web`) completed SUCCESS by 12:20:25Z, but
+`autopilot_pr_state` stayed `stage=waiting_ci, ci_status=pending` for
+4-6 minutes / ≥8 consecutive polls — not a timing artifact. GH-4384/#4408
+(auto-discovery vs. combined-status fallback) was confirmed working correctly
+and was NOT the cause; the bug was upstream of that logic.
+
+## Root cause
+
+`cmd/pilot/main.go` constructs every project's `autopilot.Controller` with
+the SAME `*autopilot.Config` pointer
+(`cfg.Orchestrator.Autopilot`). `NewCIMonitor` picks its polling branch by
+precedence: `cfg.CIChecks.Required` (GH-4307) → `cfg.RequiredChecks` (GH-4333,
+forces `mode=manual`) → auto-discovery. Production has a global
+`required_checks: [test, lint]` (tuned for the qf-studio/pilot repo's own CI
+job names). That list applied to the `pointer` controller too, so
+`checkRequiredChecks` seeded a `requiredStatus` map keyed on `test`/`lint`
+and never saw a live check-run whose `Name` matched — `aggregateStatus`
+returns the `CIPending` zero-value forever, no matter how green the actual
+checks are. `Release`, `ProjectBoard` (GH-4472) and `Quality` all already had
+a per-project overlay for exactly this global-vs-per-repo class of bug;
+`RequiredChecks`/`CIChecks` did not.
+
+## Fix
+
+`internal/autopilot.ProjectCIChecksOverride` (nil-inherits-global, mirrors
+`ProjectReleaseConfig`), wired via `autopilot.WithCIChecksOverride(...)`
+`ControllerOption`, applied inside `NewController` as a shallow-copy overlay
+of `cfg` **before** `NewCIMonitor` is constructed — never mutate the shared
+global `cfg` in place, or the overlay itself becomes a cross-controller leak.
+Config surface: `ProjectConfig.CIChecks *autopilot.ProjectCIChecksOverride`
+(`ci_checks:` block under a project entry in `~/.pilot/config.yaml`).
+
+**Deploy note:** this PR is code-only. The live `pointer` project entry in
+production `config.yaml` still needs an operator to add its own `ci_checks:
+{required_checks: [...]}` (or `required_checks: []` to fall through to
+auto-discovery) — a config + restart step, out of scope for the code fix.
+
+## Diagnostic signature
+
+`stage=waiting_ci` / `ci_status=pending` that never clears despite
+`gh pr checks <n>` (or the GitHub UI) showing all green, on a repo whose CI
+job names don't literally match the global `required_checks`/`ci_checks.required`
+list. Check `checkRequiredChecks` is the branch being taken (log line
+`discovered CI checks ... mode=manual`) before assuming it's another
+GH-4384-class combined-status issue.
+
+## Recommended approach
+
+For any "CI watcher stuck pending with green checks" report: (1) confirm via
+`daemon.log` which polling branch fired (`mode=manual` vs `mode=auto`) for
+the repo/SHA in question — per mem-159, pull ground truth (log + actual
+config.yaml + real check-run names) before filing from code-reading alone;
+(2) if `mode=manual`, diff the live check-run names against the effective
+`required_checks`/`ci_checks.required` list for THAT repo, not just the
+global block; (3) any new global-vs-per-project autopilot config field should
+get an overlay from day one (see `Release`/`ProjectBoard` precedent) rather
+than being retrofitted after a live incident.
+
+## Related
+
+- Files: internal/autopilot/ci_monitor.go, internal/autopilot/controller.go,
+  internal/autopilot/types.go, internal/config/config.go, cmd/pilot/main.go
+- Refs: #4384, #4408, #4415, GH-4472 (ProjectBoard, same overlay pattern)
+- [[hard-cap-rearm-in-memory-gate]] (same mem-159 ground-truth-first discipline)

--- a/.agent/tasks/gh-4478.md
+++ b/.agent/tasks/gh-4478.md
@@ -1,0 +1,34 @@
+# GH-4478
+
+**Created:** 2026-07-20
+
+## Problem
+
+GitHub Issue GH-4478: fix(autopilot): CI watcher still reports pending after all check-runs green (GH-4384 incomplete) — live repro pointer#108
+
+Live repro 2026-07-20 on v2.242.0-8-gb3216f27 (which contains the #4408 fix for GH-4384).
+
+## Context
+
+pointer#108 (branch pilot/GH-107, sha f671620):
+
+- 12:18:46Z stage pr_created -> waiting_ci; 12:18:57Z "CI checks discovered" checks=[integration go web]
+- All three check-runs completed SUCCESS by **12:20:25Z** (API: integration 12:19:17, web 12:20:07, go 12:20:25)
+- autopilot_pr_state still `stage=waiting_ci, ci_status=pending` at ~12:24Z and ~12:26Z — 4–6 min and ~10 poll cycles after green
+- PR was then merged externally at 12:25:37Z, so the stall window observed is bounded, but ≥8 consecutive polls failing to see green check-runs is not a timing artifact
+
+## Approach
+
+Trace the pointer controller's CI poll path on this repro: `internal/autopilot/ci_monitor.go` polls check-runs (post-#4408), so find why the poll result never reached `autopilot_pr_state` — candidates: discovery mode=manual list pinning to required-checks that never match, per-repo controller polling the wrong owner/repo/sha after the GH-4472 wiring, success result computed but transition gated elsewhere. Add a regression test in the style of gh4384_ci_watcher_test.go reproducing green-check-runs-but-pending.
+
+## Acceptance
+
+- A PR whose check-runs are all green transitions waiting_ci -> ci_passed within one poll interval, on an Actions-only repo (no legacy commit statuses).
+- Regression test covering this repro shape.
+
+## Refs
+
+- #4384, #4408 (prior fix), #4415 (restore ci poll), GH-4472 (per-project wiring, in case of interaction)
+
+## Acceptance Criteria
+

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1645,8 +1645,15 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 					// GH-4472: default repo resolves project override → global fallback.
 					ctrlOpts = append(ctrlOpts, projectBoardControllerOpts(apGHClient, cfg, cfg.Adapters.GitHub.Repo, parts[0], true)...)
 					// GH-3931: apply the per-project release overlay (GH-3930) when configured.
-					if proj := cfg.FindProjectByRepo(cfg.Adapters.GitHub.Repo); proj != nil && proj.Release != nil {
-						ctrlOpts = append(ctrlOpts, autopilot.WithReleaseOverride(proj.Release))
+					if proj := cfg.FindProjectByRepo(cfg.Adapters.GitHub.Repo); proj != nil {
+						if proj.Release != nil {
+							ctrlOpts = append(ctrlOpts, autopilot.WithReleaseOverride(proj.Release))
+						}
+						// GH-4478: apply the per-project CI-checks overlay when configured;
+						// nil is a no-op (inherits the global required-checks/CI-checks).
+						if proj.CIChecks != nil {
+							ctrlOpts = append(ctrlOpts, autopilot.WithCIChecksOverride(proj.CIChecks))
+						}
 					}
 					controller := autopilot.NewController(
 						cfg.Orchestrator.Autopilot,
@@ -1700,6 +1707,13 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 							slog.String("repo", repoFullName),
 						)
 					}
+				}
+				// GH-4478: apply the per-project CI-checks overlay when configured;
+				// nil is a no-op (inherits the global required-checks/CI-checks) —
+				// unlike Release, there's no "opt-in" warning here since inheriting
+				// the global CI-checks config was always the pre-existing behavior.
+				if proj.CIChecks != nil {
+					ctrlOpts = append(ctrlOpts, autopilot.WithCIChecksOverride(proj.CIChecks))
 				}
 				controller := autopilot.NewController(
 					cfg.Orchestrator.Autopilot,

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -281,6 +281,21 @@ func WithReleaseNotOptedIn() ControllerOption {
 	}
 }
 
+// WithCIChecksOverride wires a per-project CI-checks / required-checks
+// overlay (GH-4478) for this controller's repo. Nil is a no-op. Without
+// this, every controller's CIMonitor is built from the single global
+// Config.RequiredChecks / Config.CIChecks — fine for the default repo
+// (adapters.github.repo), which that config is tuned for, but silently
+// wrong for any other project whose check-run names differ (see
+// ProjectCIChecksOverride doc for the qf-studio/pointer#108 repro). Must be
+// applied before NewController constructs c.ciMonitor — see the options
+// loop at the top of NewController.
+func WithCIChecksOverride(o *ProjectCIChecksOverride) ControllerOption {
+	return func(c *Controller) {
+		c.projectCIChecks = o
+	}
+}
+
 // Controller orchestrates the autopilot loop for PR processing.
 // It manages the state machine: PR created → CI check → merge → post-merge CI → feedback loop.
 type Controller struct {
@@ -358,6 +373,13 @@ type Controller struct {
 	// (GH-4001). Only affects the "resolved release policy" log source tag —
 	// resolvedReleaseCfg is already forced disabled either way.
 	releaseNotOptedIn bool
+
+	// projectCIChecks is the per-project CI-checks / required-checks overlay
+	// (GH-4478), wired via WithCIChecksOverride. Nil = no project-level
+	// override — this controller's CIMonitor is built from the global
+	// Config.RequiredChecks / Config.CIChecks, same as before this option
+	// existed. Applied once during NewController, before c.ciMonitor is built.
+	projectCIChecks *ProjectCIChecksOverride
 
 	// resolvedReleaseCfg is the effective release config computed once in
 	// NewController: env-scoped config wins over global, then projectRelease
@@ -520,7 +542,24 @@ func NewController(cfg *Config, ghClient *github.Client, approvalMgr *approval.M
 		c.pilotLabel = github.LabelPilot
 	}
 
-	c.ciMonitor = NewCIMonitor(ghClient, owner, repo, cfg)
+	// GH-4478: apply the per-project CI-checks overlay (if any) on a shallow
+	// copy of cfg before constructing CIMonitor, rather than mutating cfg
+	// itself — cfg is the single shared Config.Orchestrator.Autopilot object
+	// every controller in cmd/pilot/main.go is constructed with, so mutating
+	// it in place would leak this project's overlay onto every other
+	// controller's CIMonitor too (the exact class of bug this overlay fixes).
+	ciMonitorCfg := cfg
+	if c.projectCIChecks != nil {
+		overlay := *cfg
+		if c.projectCIChecks.RequiredChecks != nil {
+			overlay.RequiredChecks = c.projectCIChecks.RequiredChecks
+		}
+		if c.projectCIChecks.CIChecks != nil {
+			overlay.CIChecks = c.projectCIChecks.CIChecks
+		}
+		ciMonitorCfg = &overlay
+	}
+	c.ciMonitor = NewCIMonitor(ghClient, owner, repo, ciMonitorCfg)
 	if c.stepLogClient != nil {
 		c.ciMonitor.SetStepLogClient(c.stepLogClient)
 	}

--- a/internal/autopilot/gh4478_ci_checks_leak_test.go
+++ b/internal/autopilot/gh4478_ci_checks_leak_test.go
@@ -1,0 +1,163 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestCIMonitor_MismatchedGlobalRequiredChecks_GH4478 is the CIMonitor-level
+// regression test for GH-4478: qf-studio/pointer#108 stayed at
+// stage=waiting_ci, ci_status=pending for 4-6 minutes / ~10 poll cycles after
+// all three of its check-runs ("integration", "go", "web") completed SUCCESS.
+// Root cause: the production config's global required_checks: [test, lint]
+// (tuned for the qf-studio/pilot repo's own CI job names) applied to every
+// controller, including pointer's. checkRequiredChecks seeds a
+// requiredStatus map from cfg.RequiredChecks and only flips an entry to
+// success when a live check-run's Name matches one of those allowlisted
+// names — a total name mismatch means aggregateStatus never observes
+// anything but the CIPending zero-value, no matter how green the actual
+// check-runs are.
+func TestCIMonitor_MismatchedGlobalRequiredChecks_GH4478(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/qf-studio/pointer/commits/f671620/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 3,
+				CheckRuns: []github.CheckRun{
+					{Name: "integration", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+					{Name: "go", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+					{Name: "web", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	// Global config, as deployed in production: required_checks tuned for a
+	// different repo (qf-studio/pilot's own "test"/"lint" jobs).
+	cfg := DefaultConfig()
+	cfg.RequiredChecks = []string{"test", "lint"}
+
+	monitor := NewCIMonitor(ghClient, "qf-studio", "pointer", cfg)
+
+	status, err := monitor.CheckCI(context.Background(), "f671620")
+	if err != nil {
+		t.Fatalf("CheckCI() error = %v", err)
+	}
+	if status != CIPending {
+		t.Fatalf("CheckCI() = %s, want %s — demonstrates the bug: a global required_checks list with no matching check-run names must aggregate to pending (never success), even though every actual check-run on the SHA is green", status, CIPending)
+	}
+
+	// Now prove the fix: a per-project override with the correct check names
+	// (or an empty list, falling through to auto-discovery) resolves the same
+	// SHA to success.
+	overrideCfg := *cfg
+	overrideCfg.RequiredChecks = []string{"integration", "go", "web"}
+	overriddenMonitor := NewCIMonitor(ghClient, "qf-studio", "pointer", &overrideCfg)
+
+	status, err = overriddenMonitor.CheckCI(context.Background(), "f671620")
+	if err != nil {
+		t.Fatalf("overridden CheckCI() error = %v", err)
+	}
+	if status != CISuccess {
+		t.Errorf("overridden CheckCI() = %s, want %s — a required_checks list matching this repo's actual check-run names must resolve to success", status, CISuccess)
+	}
+}
+
+// TestController_ProjectCIChecksOverride_GH4478 is the controller-level
+// acceptance test for GH-4478, in the style of
+// TestController_ActionsOnlyRepo_AdvancesWaitingCIToCIPassed_GH4384. It
+// builds two controllers sharing the SAME global *Config (mirroring
+// cmd/pilot/main.go passing cfg.Orchestrator.Autopilot by pointer to every
+// controller): one for the default repo the global required_checks list is
+// tuned for, and one for a "pointer"-shaped repo whose check-run names never
+// match that list. Without WithCIChecksOverride, the pointer controller's PR
+// is stuck at waiting_ci forever despite green check-runs — reproducing the
+// live pointer#108 stall. With WithCIChecksOverride wired (the GH-4478 fix,
+// mirroring the WithReleaseOverride/ProjectReleaseConfig pattern), it
+// transitions to ci_passed within a single poll.
+func TestController_ProjectCIChecksOverride_GH4478(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/qf-studio/pointer/commits/f671620/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 3,
+				CheckRuns: []github.CheckRun{
+					{Name: "integration", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+					{Name: "go", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+					{Name: "web", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	// Single shared global Config, exactly as main.go threads
+	// cfg.Orchestrator.Autopilot by pointer into every controller.
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.RequiredChecks = []string{"test", "lint"}
+
+	ghPR := &github.PullRequest{
+		Number: 108,
+		Head:   github.PRRef{SHA: "f671620"},
+		Base:   github.PRRef{Ref: "main"},
+	}
+
+	newPointerControllerState := func(c *Controller) {
+		c.mu.Lock()
+		c.activePRs[108] = &PRState{
+			PRNumber: 108,
+			HeadSHA:  "f671620",
+			Stage:    StageWaitingCI,
+		}
+		c.mu.Unlock()
+	}
+
+	t.Run("without override: stuck at waiting_ci despite all check-runs green", func(t *testing.T) {
+		c := NewController(cfg, ghClient, nil, "qf-studio", "pointer")
+		newPointerControllerState(c)
+
+		ctx := context.Background()
+		if err := c.ProcessPR(ctx, 108, ghPR); err != nil {
+			t.Fatalf("ProcessPR error = %v", err)
+		}
+		pr, _ := c.GetPRState(108)
+		if pr.Stage != StageWaitingCI {
+			t.Fatalf("stage = %s, want %s (sanity: this sub-test documents the bug, not the fix)", pr.Stage, StageWaitingCI)
+		}
+	})
+
+	t.Run("with WithCIChecksOverride: advances to ci_passed within one poll", func(t *testing.T) {
+		override := &ProjectCIChecksOverride{RequiredChecks: []string{"integration", "go", "web"}}
+		c := NewController(cfg, ghClient, nil, "qf-studio", "pointer", WithCIChecksOverride(override))
+		newPointerControllerState(c)
+
+		ctx := context.Background()
+		if err := c.ProcessPR(ctx, 108, ghPR); err != nil {
+			t.Fatalf("ProcessPR error = %v", err)
+		}
+		pr, _ := c.GetPRState(108)
+		if pr.Stage != StageCIPassed {
+			t.Fatalf("stage = %s, want %s — the per-project override must let this repo's own check-run names resolve CI status instead of the mismatched global required_checks list", pr.Stage, StageCIPassed)
+		}
+	})
+}

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -234,6 +234,33 @@ type CIChecksConfig struct {
 	DiscoveryGracePeriod time.Duration `yaml:"discovery_grace_period"`
 }
 
+// ProjectCIChecksOverride lets a per-project controller override the global
+// CI-checks / required-checks allowlist (GH-4478). Nil fields inherit from
+// the global Config.RequiredChecks / Config.CIChecks. Mirrors the
+// ProjectReleaseConfig overlay pattern (GH-3930) — without an overlay, every
+// project controller shared Config.Orchestrator.Autopilot's single global
+// required_checks list (same object passed to every NewController call in
+// cmd/pilot/main.go), so a repo whose check-run names differ from the
+// default repo's allowlist polled waiting_ci forever: checkRequiredChecks
+// only flips an entry when a live check run's name matches one of the
+// allowlisted names, so a total name mismatch aggregates to CIPending
+// indefinitely — never CISuccess, never CIFailure — even once every actual
+// check run on the SHA is green. Confirmed live: qf-studio/pointer#108
+// (checks "integration"/"go"/"web" all SUCCESS by 12:20:25Z) stayed
+// waiting_ci/pending because the global required_checks: [test, lint] —
+// tuned for the qf-studio/pilot repo's own CI job names — silently applied
+// to the pointer controller too.
+type ProjectCIChecksOverride struct {
+	// RequiredChecks overrides the legacy Config.RequiredChecks allowlist for
+	// this project. Nil (omitted) inherits the global list; an explicit
+	// empty slice disables the legacy allowlist for this project so it falls
+	// through to CIChecks/auto-discovery instead of the global manual list.
+	RequiredChecks []string `yaml:"required_checks,omitempty"`
+
+	// CIChecks overrides Config.CIChecks wholesale for this project when set.
+	CIChecks *CIChecksConfig `yaml:"ci_checks,omitempty"`
+}
+
 // defaultEnvironments returns built-in environment configs matching legacy behavior.
 func defaultEnvironments() map[string]*EnvironmentConfig {
 	return map[string]*EnvironmentConfig{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -254,6 +254,14 @@ type ProjectConfig struct {
 	// Config.Orchestrator.Autopilot's global and per-environment release
 	// blocks.
 	Release *autopilot.ProjectReleaseConfig `yaml:"release,omitempty"`
+	// CIChecks overlays the global required-checks / CI-checks allowlist for
+	// this project (GH-4478). Without it, every project controller shares
+	// Config.Orchestrator.Autopilot's single global RequiredChecks/CIChecks —
+	// fine for the default repo those names are tuned for, but a project
+	// whose check-run names differ polls waiting_ci forever (checkRequiredChecks
+	// only flips CISuccess when a live run's name matches an allowlisted name).
+	// Unset fields inherit from the global config.
+	CIChecks *autopilot.ProjectCIChecksOverride `yaml:"ci_checks,omitempty"`
 	// Canary marks this project as a synthetic sandbox (e.g. the TASK-379 V8
 	// canary workflow) rather than real work (GH-4240). Executions dispatched
 	// for a canary project are still fully persisted and event-logged — the


### PR DESCRIPTION
## Summary

- Fixes GH-4478: live repro on qf-studio/pointer#108 — all three check-runs (`integration`, `go`, `web`) completed SUCCESS by 12:20:25Z, but `autopilot_pr_state` stayed `stage=waiting_ci, ci_status=pending` for 4-6 minutes / ≥8 consecutive polls, not a timing artifact.
- Root cause: `cmd/pilot/main.go` constructs every project's `autopilot.Controller` with the SAME `*autopilot.Config` pointer (`cfg.Orchestrator.Autopilot`). Production's global `required_checks: [test, lint]` (tuned for qf-studio/pilot's own CI job names) silently applied to the `pointer` controller too. `checkRequiredChecks` seeds a `requiredStatus` map from that global list and only flips an entry when a live check-run's `Name` matches — total name mismatch aggregates to `CIPending` forever, no matter how green the actual checks are. GH-4384/#4408 (auto-discovery vs. combined-status) was verified correct and unrelated — this bug is upstream, in which `CIMonitor` polling branch gets selected.
- Fix: `ProjectCIChecksOverride` (mirrors the existing `ProjectReleaseConfig`/`ProjectBoard` per-project overlay pattern), wired via `WithCIChecksOverride`, applied as a shallow-copy overlay of `cfg` inside `NewController` before `CIMonitor` is built — never mutates the shared global `cfg` in place. New `ci_checks:` block under a project's `~/.pilot/config.yaml` entry (nil = inherit global, unchanged behavior).
- Adds `.agent/knowledge/memories/pitfalls/global-required-checks-leak-across-projects.md` documenting this class of bug (global-config-leaking-across-projects), indexed in the knowledge graph.

## Test plan

- [x] `internal/autopilot/gh4478_ci_checks_leak_test.go`: `TestCIMonitor_MismatchedGlobalRequiredChecks_GH4478` reproduces the bug at the `CIMonitor` level (mismatched global `required_checks` → `CIPending` forever despite green check-runs) and proves the override resolves it to `CISuccess`.
- [x] `TestController_ProjectCIChecksOverride_GH4478`: controller-level acceptance test with two controllers sharing one global `*Config` (mirroring `main.go`) — without the override the PR is stuck at `waiting_ci`; with `WithCIChecksOverride` wired it advances to `ci_passed` within one poll.
- [x] `go build ./...`, `go vet ./...` clean.
- [x] `go test ./internal/autopilot/... ./internal/config/... ./cmd/pilot/...` — all pass, including existing GH-4384 regression tests (unaffected).
- [x] Knowledge-graph drift gate (`scripts/check-graph.py`) passes.

**Deploy note (out of scope for this PR):** production's `pointer` project entry in `config.yaml` still needs an operator to add its own `ci_checks: {required_checks: [...]}` (or `required_checks: []` to fall through to auto-discovery) plus a daemon restart — this PR only ships the code-level capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)