### PR TITLE
fix(board): external-merge path never syncs card to Done

### DIFF
--- a/.agent/tasks/gh-4475.md
+++ b/.agent/tasks/gh-4475.md
@@ -1,0 +1,26 @@
+# GH-4475
+
+**Created:** 2026-07-20
+
+## Problem
+
+GitHub Issue GH-4475: fix(board): external-merge path never syncs card to Done
+
+Found 2026-07-20 during GH-4472 canary (pointer#107 / PR pointer#108).
+
+## Context
+
+When a Pilot PR is merged externally (human merge — routine while Slack approval is unroutable, #4431, and Actions-only repos stall at waiting_ci, #4384), the autopilot handler closes the issue and deletes the branch but never writes the board Done status. Log 12:25:37–40Z: "PR merged externally" -> "closed issue after external merge" -> "deleted branch" -> "PR removed from tracking" — no board sync. Card stayed In Review until moved by hand.
+
+## Fix
+
+The external-merge handling in the autopilot controller should invoke the same board Done sync as the internal merge path (per-repo ProjectBoardSync is available since GH-4472). Same for externally-closed-unmerged (-> failed status).
+
+## Acceptance
+
+- Externally merged Pilot PR moves its issue card to the configured done status.
+- Externally closed (unmerged) PR moves the card to the failed status.
+- Covered by controller tests alongside the existing external-merge cases.
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -5260,6 +5260,16 @@ func (c *Controller) checkExternalMergeOrClose(ctx context.Context, prState *PRS
 			}
 		}
 
+		// GH-4475: Sync board card to "Done" column on external merge, same as
+		// the internal merge path (line ~2472). Without this the card stays
+		// stuck in "In Review" until moved by hand — the issue/branch/PR
+		// bookkeeping above all ran, but the board itself was never told.
+		if c.boardSync != nil && prState.IssueNodeID != "" && c.doneStatus != "" {
+			if err := c.boardSync.UpdateProjectItemStatus(ctx, prState.IssueNodeID, c.doneStatus); err != nil {
+				c.log.Warn("board sync on external merge failed", "pr", prState.PRNumber, "error", err)
+			}
+		}
+
 		// GH-411: Trigger release for externally merged PRs if auto-release is enabled
 		if c.releaseConfigured() && prState.Stage != StageReleasing {
 			action, scopeKey, _ := c.releaseActionFor(ctx, prState.IssueNumber)
@@ -5319,6 +5329,16 @@ func (c *Controller) checkExternalMergeOrClose(ctx context.Context, prState *PRS
 
 		c.log.Info("PR closed externally, removing from tracking", "pr", prState.PRNumber)
 		c.notifyExternalClose(ctx, prState)
+
+		// GH-4475: Sync board card to the failed status on external close
+		// (unmerged) — mirrors the Done sync above for external merge, and
+		// the failStatus syncs used on internal execution failures.
+		if c.boardSync != nil && prState.IssueNodeID != "" && c.failStatus != "" {
+			if err := c.boardSync.UpdateProjectItemStatus(ctx, prState.IssueNodeID, c.failStatus); err != nil {
+				c.log.Warn("board sync on external close failed", "pr", prState.PRNumber, "error", err)
+			}
+		}
+
 		c.removePR(prState.PRNumber)
 		return true
 	}

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -1590,6 +1590,107 @@ func TestController_CheckExternalClose(t *testing.T) {
 	}
 }
 
+// TestController_CheckExternalMerge_BoardSync verifies GH-4475: checkExternalMergeOrClose
+// syncs the board card to doneStatus for an externally-merged PR, the same way the
+// internal merge path (handleMerged) does. Before this fix the external-merge branch
+// closed the issue, deleted the branch, and removed tracking but never touched the board.
+func TestController_CheckExternalMerge_BoardSync(t *testing.T) {
+	const issueNodeID = "IssueNodeID_extmerge"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/pulls/42":
+			resp := github.PullRequest{
+				Number:  42,
+				State:   "closed",
+				Merged:  true,
+				HTMLURL: "https://github.com/owner/repo/pull/42",
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.CIPollInterval = 10 * time.Millisecond
+
+	mock := &mockBoardSyncer{}
+	c := NewController(cfg, ghClient, nil, "owner", "repo",
+		withBoardSyncerForTest(mock, "Done", "Failed", "In Review", "In Dev"))
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc123", "pilot/GH-10", issueNodeID)
+	// OnPRCreated itself fires a reviewStatus sync — reset so we only observe
+	// the external-merge sync under test.
+	mock.calls = nil
+
+	c.processAllPRs(context.Background())
+
+	if len(mock.calls) != 1 {
+		t.Fatalf("board sync calls = %d, want 1 (externally-merged PR card should move to Done)", len(mock.calls))
+	}
+	if mock.calls[0].issueNodeID != issueNodeID {
+		t.Errorf("board sync issueNodeID = %q, want %q", mock.calls[0].issueNodeID, issueNodeID)
+	}
+	if mock.calls[0].statusName != "Done" {
+		t.Errorf("board sync statusName = %q, want %q", mock.calls[0].statusName, "Done")
+	}
+}
+
+// TestController_CheckExternalClose_BoardSync verifies GH-4475: checkExternalMergeOrClose
+// syncs the board card to failStatus for an externally-closed (unmerged) PR.
+func TestController_CheckExternalClose_BoardSync(t *testing.T) {
+	const issueNodeID = "IssueNodeID_extclose"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/pulls/42":
+			resp := github.PullRequest{
+				Number:  42,
+				State:   "closed",
+				Merged:  false,
+				HTMLURL: "https://github.com/owner/repo/pull/42",
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/repos/owner/repo/issues/10":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"node_id": issueNodeID})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.CIPollInterval = 10 * time.Millisecond
+
+	mock := &mockBoardSyncer{}
+	c := NewController(cfg, ghClient, nil, "owner", "repo",
+		withBoardSyncerForTest(mock, "Done", "Failed", "In Review", "In Dev"))
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc123", "pilot/GH-10", issueNodeID)
+	// OnPRCreated itself fires a reviewStatus sync — reset so we only observe
+	// the external-close sync under test.
+	mock.calls = nil
+
+	c.processAllPRs(context.Background())
+
+	if len(mock.calls) != 1 {
+		t.Fatalf("board sync calls = %d, want 1 (externally-closed PR card should move to Failed)", len(mock.calls))
+	}
+	if mock.calls[0].issueNodeID != issueNodeID {
+		t.Errorf("board sync issueNodeID = %q, want %q", mock.calls[0].issueNodeID, issueNodeID)
+	}
+	if mock.calls[0].statusName != "Failed" {
+		t.Errorf("board sync statusName = %q, want %q", mock.calls[0].statusName, "Failed")
+	}
+}
+
 func TestController_CheckExternalMergeOrClose_OpenPR(t *testing.T) {
 	// Test that open PRs are processed normally
 	ciCheckCalled := false


### PR DESCRIPTION
## Summary
- `checkExternalMergeOrClose` closed the issue, deleted the branch, and dropped PR tracking on an externally-merged/closed Pilot PR, but never called the Projects V2 board sync — so the card stayed stuck in "In Review" until moved by hand (found during GH-4472 canary, pointer#107/PR pointer#108).
- External merge now syncs the card to `doneStatus`, mirroring the internal `handleMerged` path (controller.go:2472).
- External close (unmerged) now syncs the card to `failStatus`, mirroring the existing execution-failure board syncs.
- Both are gated the same way as every other board-sync call site: `boardSync != nil && IssueNodeID != "" && status != ""` — no-op when board sync isn't configured for the repo.

Closes GH-4475.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/autopilot/...` (full package, incl. new tests)
- [x] New tests: `TestController_CheckExternalMerge_BoardSync`, `TestController_CheckExternalClose_BoardSync` — verify the board sync call fires with the correct `issueNodeID`/status on each path
- [x] `gofmt -l` clean