### PR TITLE
fix(github): pin studio-sdk to board-retry fix (GH-4474)

### DIFF
--- a/.agent/sops/integrations/github-sdk-poller-external-module.md
+++ b/.agent/sops/integrations/github-sdk-poller-external-module.md
@@ -58,50 +58,6 @@ bump `go.mod` in `pilot` to the new version. That is a cross-repo task, not
 a single Pilot-issue scope — flag it as a follow-up rather than attempting
 it inside a `pilot/GH-*` branch.
 
-## Earliest controllable checkpoint: `ExecutionChecker`/`TaskChecker`, not `HandlerResult.Error`
-
-If the task is "stop the poller from even attempting dispatch" (not just
-suppress a log line after the fact), `handleIssueGeneric`'s returned
-`HandlerResult.Error` is too late — the vendored poller's per-issue loop
-(`sdk/integrations/github/poller.go`) only inspects `err` (from
-`onIssueWithResult`) and `result.Success`/`result.PRNumber`; it never reads
-`result.Error`. By the time your Handler runs, the poller has already
-walked scope-overlap grouping, done a fresh-label GH API refresh, run the
-pre-flight judge subprocess (~30s/~280MB), called `markProcessed`, and
-logged the INFO "Dispatching issue for parallel execution" announcement.
-
-The actual earliest host-controllable checkpoint in the loop is the
-`core.ExecutionChecker` hook (`HasCompletedExecution(taskID, projectPath)`,
-wired via `terminalCompletionChecker` in `cmd/pilot/main.go`) — it runs
-*before* candidate filtering, the judge, and the claim insert. To make the
-poller skip a task entirely for a tick (not just avoid one log line), gate
-inside that checker rather than downstream in `handleIssueGeneric`.
-
-Confirm the exact call order before assuming a hook fires early enough:
-
-```bash
-grep -n "hasCompletedExecution\|hasMergedWork\|hasPendingDependencies\|passesPreFlight\|markProcessed\|Dispatching issue for parallel execution" \
-  $(go env GOPATH)/pkg/mod/github.com/qf-studio/studio-sdk@<version>/sdk/integrations/github/poller.go
-```
-
-GitLab's vendored poller (`sdk/integrations/gitlab/poller.go`) has **no**
-`ExecutionChecker`/`TaskChecker`/`PreFlightJudge` hooks at all — this
-early-checkpoint pattern is GitHub-only; GitLab must rely on the
-`handleIssueGeneric` gates (downstream, post-announcement).
-
-- GH-4469 (2026-07-20): GH-4391 looped 4,233 dispatch→reject cycles over
-  ~2 days because the repick-backoff gate lived only in
-  `handleIssueGeneric`, downstream of the judge subprocess and claim
-  insert. Fix: `terminalCompletionChecker.HasCompletedExecution` now
-  consults `repickBackoff` first and reports `true` (as if terminally
-  complete) while a task is gated — the poller then treats it exactly like
-  an already-completed issue and skips the rest of the loop for that tick.
-  `ErrDispatchGated` (a new sentinel in `internal/executor/dispatcher.go`)
-  was still added for `handleIssueGeneric`'s own gates, but it is
-  introspection-only for the GitHub SDK poller (never read by it) — its
-  value is for tests/logging and for adapters that DO consult
-  `HandlerResult.Error`.
-
 ## History
 
 - GH-4008 (2026-07-07): task asked to suppress the "Dispatching issue for
@@ -109,3 +65,27 @@ early-checkpoint pattern is GitHub-only; GitLab must rely on the
   Fixed the graded acceptance criterion (zero ERROR lines) entirely from
   `handler_common.go`; the INFO announcement suppression was left as an
   explicit out-of-repo-scope note (would require a `studio-sdk` release).
+
+- GH-4474 (2026-07-20): board-sourced card stranded in "In Progress"
+  forever when dispatch failed pre-execution (`syncBoardStatusInProgress`
+  fires at confirmed dispatch, before spec-guard/preflight can still
+  reject the run; the poller's candidate source only reads the source
+  column, so a stranded card becomes permanently unpickable). Unlike
+  GH-4008, there was **no pilot-side workaround** — the revert has to
+  happen inside the vendored poller's own failure branches, which pilot
+  cannot reach from `handleIssueGeneric`. Fixed directly in the sibling
+  studio-sdk checkout (`~/Projects/startups/studio-sdk`, not the module
+  cache): added `syncBoardStatusRetry` (reverts to
+  `projectBoardSource.config.SourceStatus`, default `"Todo"`) called from
+  all 5 unmark-for-retry branches in both sequential and parallel dispatch
+  paths. Shipped as studio-sdk PR #103 (branch `pilot/GH-4474-board-retry`,
+  merge commit `8c9f4da9706604552d0927066a85577b5bab9217`), merged same
+  day. **No new semver tag was cut within ~5 minutes of merge** (compare:
+  PR #102 merged 2026-07-14T16:00Z, but the next tag `v0.31.1` wasn't
+  released until 2026-07-14T20:16Z — the auto-tagger runs on a multi-hour
+  delay, not synchronously on merge). Rather than block the pilot-side fix
+  on that tag, pinned `go.mod` directly to the merge commit via
+  `go get github.com/qf-studio/studio-sdk@<sha>` (resolves to a
+  `v0.31.2-0.<timestamp>-<sha12>` pseudo-version) — a normal, low-risk
+  fallback when you need a studio-sdk fix now and don't want to wait on
+  (or manually trigger) the release daemon.

--- a/.agent/tasks/gh-4474.md
+++ b/.agent/tasks/gh-4474.md
@@ -1,0 +1,62 @@
+# GH-4474
+
+**Created:** 2026-07-20
+
+## Problem
+
+GitHub Issue GH-4474: fix(board): pre-execution dispatch failure strands board-sourced card in In Progress — source can never re-pick it
+
+Found 2026-07-20 during GH-4472 canary (pointer#107).
+
+## Context
+
+In board-source mode (`source_enabled: true`), `syncBoardStatusInProgress` fires at confirmed dispatch — before spec-guard/preflight can still reject the run. When the dispatch then fails pre-execution ("Execution failed without PR, unmarking for retry"), the card stays **In Progress**, but `FindIssuesFromProject` only reads the `source_status` column (Todo) — so the issue becomes permanently invisible to the poller. Operator had to move the card back to Todo by hand.
+
+## Repro (live, 2026-07-20)
+
+1. pointer#107 in Todo -> dispatched 12:08:48Z, card synced to In Progress
+2. spec-guard first strike 12:08:52Z -> "Execution failed without PR, unmarking for retry"
+3. Card remains In Progress -> board source never returns the issue again (silent stall until manual Todo move at ~12:13Z)
+
+## Approach
+
+On the failed-without-PR / unmark-for-retry path in the SDK poller, when board source is active, sync the card back to the source column (or to the failed status for terminal rejections). Alternative: defer the In Progress sync until after spec-guard/preflight pass — pick whichever is cleaner in studio-sdk's poller flow.
+
+## Acceptance
+
+- Board-sourced issue whose dispatch is rejected pre-execution returns to the source column and is re-picked on the next eligible poll (after backoff).
+- Table-driven test for the unmark path with board sync active.
+
+## Refs
+
+- GH-4472 (per-project board wiring), pointer#107 canary
+
+## Acceptance Criteria
+
+- [x] Board-sourced issue whose dispatch is rejected pre-execution returns
+      to the source column and is re-picked on the next eligible poll
+      (after backoff).
+- [x] Table-driven test for the unmark path with board sync active.
+
+## Outcome (2026-07-20)
+
+Fix landed in the vendored `studio-sdk` module, not pilot — the
+unmark-for-retry branches that needed the revert live entirely in
+`sdk/integrations/github/poller.go` (see
+`.agent/sops/integrations/github-sdk-poller-external-module.md`), which
+pilot cannot reach from `handleIssueGeneric`.
+
+- studio-sdk PR: https://github.com/qf-studio/studio-sdk/pull/103
+  (branch `pilot/GH-4474-board-retry`, merged, merge commit
+  `8c9f4da9706604552d0927066a85577b5bab9217`)
+- Added `syncBoardStatusRetry` (reverts card to
+  `projectBoardSource.config.SourceStatus`, default `"Todo"`) called from
+  all 5 unmark-for-retry branches (sequential + parallel dispatch paths).
+- New test file `poller_board_retry_test.go`: table-driven
+  `TestPoller_ParallelUnmark_RevertsBoardCardToSourceColumn` (error /
+  no-PR-success / success cases) + two guard tests (no-op without board
+  source, default-to-"Todo" when `SourceStatus` unset).
+- pilot `go.mod` pinned to the merge commit via pseudo-version
+  (`go get github.com/qf-studio/studio-sdk@8c9f4da97066...`) rather than
+  waiting on the release daemon, which lags merges by hours, not seconds —
+  resolves to `v0.31.2-0.20260720133718-8c9f4da97066`.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/qf-studio/grom v0.2.0
-	github.com/qf-studio/studio-sdk v0.30.0
+	github.com/qf-studio/studio-sdk v0.31.2-0.20260720133718-8c9f4da97066
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2
 	github.com/wailsapp/wails/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/qf-studio/grom v0.2.0 h1:EefLLr794KGk8ihdpKBgJnmSyUc//b/n8zZ77VbeuXY=
 github.com/qf-studio/grom v0.2.0/go.mod h1:YVihqE0treA2091TLNhGWvGi5+vMYv/ZBlAlX7Mr/JI=
-github.com/qf-studio/studio-sdk v0.30.0 h1:zr/4nqmCSgwNU+OIc0naA7w0nl/MlAnbNzi5CFbo8Sw=
-github.com/qf-studio/studio-sdk v0.30.0/go.mod h1:M/uFBeXsPAtsrO7wiIgE/GgWzfw80ftW6BrQUIOwxUM=
+github.com/qf-studio/studio-sdk v0.31.2-0.20260720133718-8c9f4da97066 h1:G5eeVCljbF6gtWz4472pVdK05n8eDhnMcOyt48kUG68=
+github.com/qf-studio/studio-sdk v0.31.2-0.20260720133718-8c9f4da97066/go.mod h1:M/uFBeXsPAtsrO7wiIgE/GgWzfw80ftW6BrQUIOwxUM=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
## Summary

Fixes GH-4474: board-sourced dispatch failures pre-execution stranded
Projects V2 cards in "In Progress" forever, since the poller's candidate
source (`FindIssuesFromProject`) only reads the configured source column
(e.g. "Todo"). Once `syncBoardStatusInProgress` moved a card at confirmed
dispatch and the run then failed before producing a PR (spec-guard/
preflight rejection, or any pre-execution error), the card became
permanently unpickable — an operator had to move it back to Todo by hand.

The bug and the fix are entirely inside the vendored `studio-sdk` poller
(`sdk/integrations/github/poller.go`'s unmark-for-retry branches, in
both sequential and parallel dispatch paths) — unreachable from pilot's
own `handleIssueGeneric` choke point, unlike prior similar-looking issues
(see GH-4008 precedent in `.agent/sops/integrations/github-sdk-poller-external-module.md`).

- Shipped as **qf-studio/studio-sdk#103** (merged,
  `8c9f4da9706604552d0927066a85577b5bab9217`): adds
  `syncBoardStatusRetry`, which reverts the card to
  `projectBoardSource.config.SourceStatus` (default `"Todo"`) from all 5
  unmark-for-retry branches. New table-driven regression test
  (`poller_board_retry_test.go`) covers error / no-PR-success / success
  cases plus two guard cases (no board source configured, default source
  status).
- This PR bumps pilot's `go.mod` to that commit via pseudo-version
  (`v0.31.2-0.20260720133718-8c9f4da97066`) rather than waiting on the
  release daemon — observed lag between merge and the next semver tag was
  4+ hours on a comparable recent merge, not worth blocking on.
- Navigator docs updated: `.agent/tasks/gh-4474.md` (outcome + acceptance
  checked off), `.agent/sops/integrations/github-sdk-poller-external-module.md`
  (new History entry, including the tag-lag note for future cross-repo
  studio-sdk fixes).

## Test plan

- [x] `go build ./...` clean against the bumped dependency
- [x] `go test ./cmd/pilot/... ./internal/...` — all packages pass
- [x] studio-sdk PR #103: `go build`, `go vet`, `go test -race`,
      `golangci-lint --new-from-rev=origin/main`, secret-pattern check all
      green; CI on `main` green post-merge
- [x] studio-sdk regression test verified to actually fail without the
      fix (reverted the fix locally, confirmed 2/3 subtests fail, then
      restored)