### PR TITLE
fix(release): retry scheduleReleaseTick on transient failure, alert on exhaustion

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -3170,6 +3170,25 @@
           "executor",
           "dispatcher"
         ]
+      },
+      "release-tick-retry-with-backoff-and-alert": {
+        "type": "pattern",
+        "summary": "on_schedule release-train scheduleReleaseTick now retries a transient GitHub failure (rate limit/5xx/network) every 15-30m for up to 6h past the scheduled time via scheduleReleaseTickWithRetry before firing a release_tick_failed alert, instead of forfeiting the whole day (GH-4476)",
+        "file": ".agent/knowledge/memories/patterns/release-tick-retry-with-backoff-and-alert.md",
+        "concepts": [
+          "autopilot",
+          "release",
+          "alerts"
+        ]
+      },
+      "sqlite-memory-dsn-serializes-to-one-conn": {
+        "type": "pitfall",
+        "summary": "NewStateStoreFromPath(\":memory:\") test stores need db.SetMaxOpenConns(1) -- modernc.org/sqlite in-memory DBs are private per pooled connection, so concurrent goroutines can see an unmigrated \"no such table\" database (GH-4476)",
+        "file": ".agent/knowledge/memories/pitfalls/sqlite-memory-dsn-serializes-to-one-conn.md",
+        "concepts": [
+          "autopilot",
+          "testing"
+        ]
       }
     }
   },
@@ -4923,8 +4942,8 @@
   },
   "last_updated": "2026-07-20T13:00:00+00:00",
   "stats": {
-    "total_nodes": 272,
+    "total_nodes": 274,
     "total_edges": 234,
-    "memory_count": 172
+    "memory_count": 174
   }
 }

--- a/.agent/knowledge/memories/patterns/release-tick-retry-with-backoff-and-alert.md
+++ b/.agent/knowledge/memories/patterns/release-tick-retry-with-backoff-and-alert.md
@@ -1,0 +1,58 @@
+---
+name: release-tick-retry-with-backoff-and-alert
+description: scheduleReleaseTick (on_schedule release train) now retries a transient GitHub failure every 15-30m for up to 6h past the scheduled time before giving up and firing a release_tick_failed alert
+type: pattern
+---
+
+# Release-train tick retry with bounded backoff + loud-failure alert (GH-4476)
+
+## Problem
+
+`startScheduleRelease`'s cron callback fired `scheduleReleaseTick` exactly
+once at the scheduled time with no retry. The 2026-07-18 16:00 Europe/Berlin
+tick hit a GitHub 403 (user-aggregate rate pool) on the very first API call
+(`repoHasAnyTag` → `GetLatestRelease`) and the whole day's release train was
+silently forfeited — the existing "missed tick" recovery
+(`recoverMissedTrainTick`) only covers the daemon being *down* at tick time,
+not the tick running and failing.
+
+## Fix (internal/autopilot/scope_schedule.go)
+
+1. `scheduleReleaseTick` now returns `(releaseTickOutcome, error)` instead of
+   silently `return`-ing on every early-exit path. Three outcomes:
+   - `releaseTickSucceeded` — enqueued a train.
+   - `releaseTickSkipped` — a legitimate no-op (nothing merged yet, empty
+     train, no resolvable member PRs). **Not retried** — retrying can't
+     produce merged PRs that don't exist.
+   - `releaseTickFailed` — a transient GitHub API failure (repoHasAnyTag,
+     firstReleaseTrainMembers, GetCurrentVersionForRepo, CompareCommits all
+     wrap their error into this outcome). **Retried.**
+2. `scheduleReleaseTickWithRetry` wraps the cron callback and
+   `recoverMissedTrainTick`'s call site. It runs the tick once synchronously;
+   on `releaseTickFailed` it spawns `retryReleaseTick` in a goroutine so the
+   caller returns immediately.
+3. `retryReleaseTick` loops until `scheduledAt.Add(releaseTickRetryWindow)`
+   (6h), waiting `releaseTickRetryMinInterval..releaseTickRetryMaxInterval`
+   (15-30m) between attempts — preferring a `*github.RateLimitError`'s own
+   `RetryAfter` (from `Retry-After`/`X-RateLimit-Reset`) over the default
+   interval, clamped to the same bounds. `ctx.Done()` (daemon shutdown) exits
+   the loop without alerting, since a restart re-attempts via
+   `recoverMissedTrainTick` anyway.
+4. Exhausted retries call `fireReleaseTickFailedAlert`, which logs `ERROR`
+   and — mirroring `fireReleaseMissingAlert`'s existing pattern — fires a
+   `release_tick_failed` event through `c.alertsEngine` (or logs a second
+   `ERROR` if `SetAlertsEngine` was never called).
+
+## Testability
+
+`releaseTickRetryMinInterval`/`releaseTickRetryMaxInterval`/
+`releaseTickRetryWindow` are **package-level `var`s, not `const`s**,
+specifically so tests can shrink them to milliseconds instead of a real test
+run waiting out real minutes/hours. See
+`internal/autopilot/scope_schedule_retry_test.go`'s `withShortRetryTiming`
+helper.
+
+## Related pitfall
+
+Writing the retry tests surfaced a pre-existing SQLite test-store gotcha —
+see `sqlite-memory-dsn-serializes-to-one-conn` pitfall memory.

--- a/.agent/knowledge/memories/pitfalls/sqlite-memory-dsn-serializes-to-one-conn.md
+++ b/.agent/knowledge/memories/pitfalls/sqlite-memory-dsn-serializes-to-one-conn.md
@@ -1,0 +1,44 @@
+---
+name: sqlite-memory-dsn-serializes-to-one-conn
+description: NewStateStoreFromPath(":memory:") test stores need db.SetMaxOpenConns(1) — modernc.org/sqlite's in-memory database is private per-connection, so a second pooled connection sees an unmigrated "no such table" database under any concurrent access
+type: pitfall
+---
+
+# `sql.Open("sqlite", ":memory:")` is NOT shared across pooled connections
+
+**What happened (GH-4476, 2026-07-20):** a new test drove
+`scheduleReleaseTickWithRetry`'s retry goroutine (which persists via
+`StateStore` in a background goroutine) while the test's own goroutine
+polled `StateStore.GetScopeRelease` concurrently. The poll intermittently
+failed with `SQL logic error: no such table: autopilot_scope_release` even
+though the exact same store had just successfully migrated and written rows
+moments earlier from a different goroutine.
+
+## Root cause
+
+`internal/autopilot/state_store.go`'s `NewStateStoreFromPath` does
+`sql.Open("sqlite", path)` and lets `database/sql`'s default connection pool
+open more than one physical connection. For `modernc.org/sqlite`, a bare
+`":memory:"` DSN (no `?cache=shared`) gives **every connection its own
+private in-memory database** — `migrate()` runs on whichever connection the
+pool handed it first, and a second concurrent connection opens a brand-new,
+empty, unmigrated database. Every *sequential* test (open store → call →
+call → assert, all on one goroutine) happened to reuse the same pooled
+connection and never noticed; the first genuinely concurrent caller does.
+
+## Fix
+
+`NewStateStoreFromPath` now calls `db.SetMaxOpenConns(1)` right after
+`sql.Open`, pinning the pool to a single connection so `":memory:"` behaves
+as one logical database regardless of caller concurrency. This function is
+test-only (`NewStateStore(db)` is the production entry point with an
+externally-supplied `*sql.DB`), so this has zero production behavior change.
+
+## Prevention
+
+Any new test that exercises a `StateStore` (or other `":memory:"`-backed
+store) from more than one goroutine must confirm the store's constructor
+pins `SetMaxOpenConns(1)` — or use a shared-cache DSN
+(`file::memory:?cache=shared`) — before trusting concurrent reads/writes
+against it. A flaky "no such table" on a table you just successfully wrote
+to, with no schema changes in sight, is the diagnostic signature.

--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-20 (v2.151.0)
+**Last Updated:** 2026-07-17 (v2.151.0)
 
 ## Legend
 
@@ -132,7 +132,6 @@
 | Jira/Asana autopilot wire | ✅ | adapters | - | - | OnPRCreated + HeadSHA/BranchName for Jira + Asana (v1.19.0, GH-1397) |
 | GitHub Projects V2 Board | ✅ | adapters/github | - | `adapters.github.project_board` | GraphQL board sync: Review/Done/Failed columns (v2.30.0, PR #1863) |
 | GitHub Projects V2 Board Source | ✅ | adapters/github | - | `adapters.github.project_board.source_enabled` | Pull work FROM a board column (FindIssuesFromProject); opt-in via source_enabled/source_status (GH-3228) |
-| Per-project Projects V2 board | ✅ | config, cmd/pilot | - | `projects.<name>.github.project_board` | Unbinds board sync/source from the single default repo — each `projects[]` repo can carry its own board (`config.Config.ResolveProjectBoard`: project override → default-repo global fallback → none); wired into both the SDK poller (`poller_github.go`) and every autopilot controller construction site (`main.go`) (v2.242.0, GH-4472) |
 | Common Adapter Registry | ✅ | adapters | - | - | Unified Adapter interface, generic ProcessedStore table (v2.30.0, PR #1845) |
 | Linear workspace mode | ✅ | adapters/linear | - | `adapters.linear.projects` | Project-scoped routing via project_ids mapping for multi-project setups |
 | Plane.so state transitions | ✅ | adapters/plane | - | - | State transitions and PR comments on Plane.so issues (v2.25.0, PR #1843) |
@@ -415,6 +414,7 @@
 | Board sync tests | ✅ | adapters/github | - | - | ProjectBoardSync and ExecuteGraphQL unit tests (v2.30.0, PR #1865) |
 | CI context wiring | ✅ | autopilot | - | - | Wire proper CI context from autopilot controller (v2.52.0, PR #1981) |
 | PR stage execution-event audit trail | ✅ | autopilot | - | - | `Controller` writes `execution_events` rows (ci_passed/ci_failed/awaiting_approval/merged/released/failed) via `memory.Store.InsertExecutionEvent`; survives PR-state-row cleanup after merge since it keys off `executions.id` (GH-3847) |
+| Release train tick retry | ✅ | autopilot | - | - | `scheduleReleaseTickWithRetry` retries a failed `on_schedule` tick (rate limit/5xx/network) every 15-30m for up to 6h past the scheduled time before giving up, instead of forfeiting the whole day the way the 2026-07-18 403 did; exhausted retries fire a `release_tick_failed` alert via the alerts engine (GH-4476, v2.243.0) |
 
 ## Epic Management
 
@@ -590,7 +590,6 @@ quality:
 
 | Feature | Version | Package | Notes |
 |---------|---------|---------|-------|
-| Per-model taxonomy fix + issue-level-by-model gauges | v2.243.0+ | autopilot + memory + gateway | `GetLifetimeCounterBaselines`/hydrator no longer collapse declined/no_op/rate_limited/infra/skipped into `failed` for the per-model `pilot_executions_total{model,result}` baseline (same defect TASK-392/GH-4070 fixed for the headline rate, now applied to the per-model breakout); empty-`model_name` rows (zero-token, pre-GH-4041 or died-before-invoking-Claude) excluded entirely instead of bucketed under `model=unknown`. New `pilot_issues_shipped_by_model_total`/`pilot_issues_attempted_by_model_total` gauges (`Store.GetIssueLevelCountsByModel`, deduped by `task_id` within each model) give eventual per-model delivery next to the attempt-level counter, which reads far lower since every retry/rate-limit death is its own row (GH-4483) |
 | Issue-level success rate + rate_limited exclusion | v2.235.0+ | autopilot + memory + gateway | `pilot_issue_level_success_rate` / `pilot_issues_shipped_total` / `pilot_issues_attempted_total` dedupe by `task_id` across retries; `pilot_success_rate` now excludes `rate_limited` from the denominator; hydrator no longer folds declined/no_op/stalled/infra/skipped into `failed` (TASK-392 / GH-4070) |
 | Poller skip-by-reason counters | v2.150.0 | adapters/github | `pilot_poller_skipped/dispatched/deferred` Prometheus counters (TASK-293 / GH-3064) |
 | `WithRetry` centralized in `doRequest` | v2.150.0 | adapters/github | All GitHub client methods now get retry; `RecordAPIError` wired (TASK-294 / GH-3065) |

--- a/.agent/tasks/gh-4476.md
+++ b/.agent/tasks/gh-4476.md
@@ -1,0 +1,46 @@
+# GH-4476
+
+**Created:** 2026-07-20
+
+## Problem
+
+GitHub Issue GH-4476: fix(release): scheduleReleaseTick has no retry — one transient 403 at the scheduled time costs a full day
+
+Known-unfiled bug from 2026-07-18: the 16:00 Europe/Berlin release tick fired into a GitHub 403 (user-aggregate rate pool) and the train simply skipped the day — the 07-18 release was lost; next attempt was 07-19.
+
+## Context
+
+The release train scheduler fires `scheduleReleaseTick` once at the cron time. There is no retry/backoff around the tick's GitHub calls; any transient failure (403 rate-limit, 5xx, network) forfeits the run until the next scheduled day. The missed-train recovery only covers daemon-down-at-tick-time, not tick-ran-and-failed.
+
+## Fix
+
+Wrap the tick in bounded retries with backoff (e.g. every 15–30 min for up to N hours after the scheduled time), respecting rate-limit reset headers. A tick that ultimately fails should surface an alert, not silently skip.
+
+## Acceptance
+
+- Simulated 403 on first tick attempt → release succeeds on a later retry the same day.
+- Exhausted retries → loud alert (log ERROR + alert channel), not silence.
+
+## Acceptance Criteria
+
+- [x] Simulated 403 on first tick attempt → release succeeds on a later
+      retry the same day. Covered by
+      `TestScheduleReleaseTickWithRetry_SucceedsOnLaterRetry`.
+- [x] Exhausted retries → loud alert (log ERROR + alert channel), not
+      silence. Covered by
+      `TestScheduleReleaseTickWithRetry_ExhaustsRetriesFiresAlert`.
+
+## Implementation
+
+`internal/autopilot/scope_schedule.go`: `scheduleReleaseTick` now returns a
+`releaseTickOutcome` (`Succeeded` / `Skipped` / `Failed`) instead of only
+logging and returning. `scheduleReleaseTickWithRetry` wraps the cron
+callback and `recoverMissedTrainTick`'s call site; on `Failed` it retries in
+the background every 15-30 min (honoring a `*github.RateLimitError`'s
+Retry-After/X-RateLimit-Reset) for up to 6h past the scheduled time before
+calling `fireReleaseTickFailedAlert`, which logs ERROR and fires a
+`release_tick_failed` event via the alerts engine. See the
+`release-tick-retry-with-backoff-and-alert` pattern memory for details.
+
+Status: **Done.**
+

--- a/internal/autopilot/scope_schedule.go
+++ b/internal/autopilot/scope_schedule.go
@@ -2,12 +2,14 @@ package autopilot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/qf-studio/pilot/internal/alerts"
 	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 	"github.com/robfig/cron/v3"
 )
@@ -117,7 +119,7 @@ func (c *Controller) startScheduleRelease(ctx context.Context) {
 	cronInst := cron.New(cron.WithLocation(loc))
 	entryID, err := cronInst.AddFunc(rel.Schedule, func() {
 		scheduledAt := previousScheduledTime(schedule, time.Now().In(loc))
-		c.scheduleReleaseTick(ctx, scheduledAt)
+		c.scheduleReleaseTickWithRetry(ctx, scheduledAt)
 	})
 	if err != nil {
 		c.log.Error("startScheduleRelease: failed to register cron job",
@@ -180,8 +182,21 @@ func (c *Controller) recoverMissedTrainTick(ctx context.Context, rel *ReleaseCon
 	}
 
 	c.log.Warn("recovering missed train", "scheduled_at", prevScheduled.Format(time.RFC3339))
-	c.scheduleReleaseTick(ctx, prevScheduled)
+	c.scheduleReleaseTickWithRetry(ctx, prevScheduled)
 }
+
+// releaseTickOutcome classifies a scheduleReleaseTick result so
+// scheduleReleaseTickWithRetry knows whether to retry (GH-4476): a transient
+// GitHub API failure (releaseTickFailed) is retried, while success and a
+// legitimate no-op (nothing merged, empty train, no resolvable member PRs)
+// are both terminal and must not be retried.
+type releaseTickOutcome int
+
+const (
+	releaseTickSucceeded releaseTickOutcome = iota
+	releaseTickSkipped
+	releaseTickFailed
+)
 
 // scheduleReleaseTick batches everything merged since the last tag into one
 // scope-release carrier for Trigger "on_schedule" (GH-3993). scheduledAt is
@@ -190,14 +205,18 @@ func (c *Controller) recoverMissedTrainTick(ctx context.Context, rel *ReleaseCon
 // and a restart-recovered tick for the same slot always resolve to the same
 // key; enqueueScopeRelease's INSERT OR IGNORE then makes a double-fire for
 // the same slot exactly-once.
-func (c *Controller) scheduleReleaseTick(ctx context.Context, scheduledAt time.Time) {
+//
+// Returns releaseTickFailed (with the triggering error) for a transient
+// GitHub API failure so scheduleReleaseTickWithRetry can retry the tick
+// instead of forfeiting the day's release train (GH-4476).
+func (c *Controller) scheduleReleaseTick(ctx context.Context, scheduledAt time.Time) (releaseTickOutcome, error) {
 	rel := c.resolvedRelease()
 	branch := c.resolveMainBranchName()
 
 	hasTag, err := c.repoHasAnyTag(ctx, c.owner, c.repo)
 	if err != nil {
 		c.log.Warn("scheduleReleaseTick: failed to check for an existing tag, skipping this tick", "error", err)
-		return
+		return releaseTickFailed, err
 	}
 
 	var memberPRs []int
@@ -211,12 +230,12 @@ func (c *Controller) scheduleReleaseTick(ctx context.Context, scheduledAt time.T
 		memberPRs, err = c.firstReleaseTrainMembers(ctx, c.owner, c.repo)
 		if err != nil {
 			c.log.Warn("scheduleReleaseTick: failed to list merged PRs for first release, skipping this tick", "error", err)
-			return
+			return releaseTickFailed, err
 		}
 		if len(memberPRs) == 0 {
 			c.log.Debug("scheduleReleaseTick: no merged PRs yet, skipping first release",
 				"scheduled_at", scheduledAt.Format(time.RFC3339))
-			return
+			return releaseTickSkipped, nil
 		}
 		c.log.Info("scheduleReleaseTick: first release train — no prior tag, releasing entire merged history",
 			"repo", fmt.Sprintf("%s/%s", c.owner, c.repo),
@@ -227,7 +246,7 @@ func (c *Controller) scheduleReleaseTick(ctx context.Context, scheduledAt time.T
 		currentVersion, verErr := c.releaser.GetCurrentVersionForRepo(ctx, c.owner, c.repo)
 		if verErr != nil {
 			c.log.Warn("scheduleReleaseTick: failed to get current version, skipping this tick", "error", verErr)
-			return
+			return releaseTickFailed, verErr
 		}
 		lastTag := currentVersion.String(rel.TagPrefix)
 
@@ -235,12 +254,12 @@ func (c *Controller) scheduleReleaseTick(ctx context.Context, scheduledAt time.T
 		if cmpErr != nil {
 			c.log.Warn("scheduleReleaseTick: failed to compare commits, skipping this tick",
 				"last_tag", lastTag, "branch", branch, "error", cmpErr)
-			return
+			return releaseTickFailed, cmpErr
 		}
 		if len(commits) == 0 {
 			c.log.Debug("scheduleReleaseTick: empty train, skipping",
 				"last_tag", lastTag, "scheduled_at", scheduledAt.Format(time.RFC3339))
-			return
+			return releaseTickSkipped, nil
 		}
 
 		memberPRs = c.resolveTrainMemberPRs(ctx, commits)
@@ -248,13 +267,130 @@ func (c *Controller) scheduleReleaseTick(ctx context.Context, scheduledAt time.T
 			c.log.Warn("scheduleReleaseTick: no resolvable member PRs (direct-commit-only train), skipping — "+
 				"v1 limitation, the scope-release carrier requires a real merged PR",
 				"last_tag", lastTag, "commits", len(commits), "scheduled_at", scheduledAt.Format(time.RFC3339))
-			return
+			return releaseTickSkipped, nil
 		}
 	}
 
 	scopeKey := trainScopeKey(scheduledAt)
 	title := fmt.Sprintf("Release train %s", scheduledAt.Format("2006-01-02 15:04"))
 	c.enqueueScopeRelease(ctx, scopeKey, title, memberPRs)
+	return releaseTickSucceeded, nil
+}
+
+// releaseTickRetryMinInterval, releaseTickRetryMaxInterval, and
+// releaseTickRetryWindow bound scheduleReleaseTickWithRetry's backoff loop
+// (GH-4476): short enough between attempts that a transient outage doesn't
+// cost the release train its whole day, long enough not to hammer an
+// already-rate-limited API, and bounded overall so a permanently-broken tick
+// still gives up and alerts instead of retrying forever. Package-level vars
+// (not consts) so tests can shrink them instead of a real test run waiting
+// out real minutes/hours — see scope_schedule_retry_test.go.
+var (
+	// releaseTickRetryMinInterval is the default wait between retry attempts
+	// absent a rate-limit error's own Retry-After/X-RateLimit-Reset delay.
+	releaseTickRetryMinInterval = 15 * time.Minute
+	// releaseTickRetryMaxInterval caps any single retry wait, including one
+	// driven by a rate-limit header, so a runaway header value can't stall
+	// the loop for hours between attempts.
+	releaseTickRetryMaxInterval = 30 * time.Minute
+	// releaseTickRetryWindow bounds how long past the scheduled fire time
+	// the loop keeps retrying before giving up and firing a
+	// release_tick_failed alert. GH-4476: the 2026-07-18 16:00 Europe/Berlin
+	// tick hit a GitHub 403 and the train simply skipped the day with no
+	// retry at all — this window gives a same-day transient failure (rate
+	// limit, 5xx, network blip) room to clear before conceding the day.
+	releaseTickRetryWindow = 6 * time.Hour
+)
+
+// scheduleReleaseTickWithRetry runs scheduleReleaseTick and, on a transient
+// GitHub failure, retries with backoff for up to releaseTickRetryWindow past
+// scheduledAt instead of forfeiting the train until the next scheduled day
+// (GH-4476). The retry loop runs in its own goroutine so the cron callback
+// and recoverMissedTrainTick's synchronous call both return immediately;
+// ctx cancellation (daemon shutdown) stops the loop without firing the
+// exhausted-retries alert, since a restart already re-attempts the tick via
+// recoverMissedTrainTick.
+func (c *Controller) scheduleReleaseTickWithRetry(ctx context.Context, scheduledAt time.Time) {
+	outcome, err := c.scheduleReleaseTick(ctx, scheduledAt)
+	if outcome != releaseTickFailed {
+		return
+	}
+	go c.retryReleaseTick(ctx, scheduledAt, err)
+}
+
+// retryReleaseTick is scheduleReleaseTickWithRetry's backoff loop. Every
+// attempt's wait is releaseTickRetryMinInterval..releaseTickRetryMaxInterval,
+// preferring a rate-limit error's own Retry-After/X-RateLimit-Reset delay
+// (clamped to the same bounds) over the default interval so the retry
+// actually lands after the reported quota reset instead of guessing.
+func (c *Controller) retryReleaseTick(ctx context.Context, scheduledAt time.Time, firstErr error) {
+	deadline := scheduledAt.Add(releaseTickRetryWindow)
+	lastErr := firstErr
+	attempts := 1
+
+	for time.Now().Before(deadline) {
+		wait := releaseTickRetryMinInterval
+		var rlErr *github.RateLimitError
+		if errors.As(lastErr, &rlErr) && rlErr.RetryAfter > releaseTickRetryMinInterval {
+			wait = rlErr.RetryAfter
+		}
+		if wait > releaseTickRetryMaxInterval {
+			wait = releaseTickRetryMaxInterval
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(wait):
+		}
+
+		attempts++
+		outcome, err := c.scheduleReleaseTick(ctx, scheduledAt)
+		if outcome != releaseTickFailed {
+			if outcome == releaseTickSucceeded {
+				c.log.Info("scheduleReleaseTick: retry succeeded after a transient failure",
+					"scheduled_at", scheduledAt.Format(time.RFC3339), "attempts", attempts)
+			}
+			return
+		}
+		lastErr = err
+		c.log.Warn("scheduleReleaseTick: retry attempt failed, will retry",
+			"scheduled_at", scheduledAt.Format(time.RFC3339), "attempts", attempts, "error", err)
+	}
+
+	c.fireReleaseTickFailedAlert(scheduledAt, lastErr, attempts)
+}
+
+// fireReleaseTickFailedAlert fires a loud release_tick_failed alert (GH-4476)
+// once scheduleReleaseTickWithRetry has exhausted releaseTickRetryWindow of
+// retries without a successful (or legitimately-skipped) result. Mirrors
+// fireReleaseMissingAlert's alerts-engine-or-log-ERROR pattern so an
+// exhausted retry surfaces loudly instead of silently skipping the day's
+// release train the way the pre-GH-4476 bug did.
+func (c *Controller) fireReleaseTickFailedAlert(scheduledAt time.Time, lastErr error, attempts int) {
+	msg := fmt.Sprintf(
+		"release train tick scheduled for %s in %s/%s failed after %d attempt(s) over %s: %v — the release train did not run this cycle",
+		scheduledAt.Format(time.RFC3339), c.owner, c.repo, attempts, releaseTickRetryWindow, lastErr,
+	)
+	c.log.Error("scheduleReleaseTick: exhausted retries, giving up on this tick",
+		"scheduled_at", scheduledAt.Format(time.RFC3339), "attempts", attempts, "error", lastErr,
+	)
+
+	if c.alertsEngine == nil {
+		c.log.Error("release_tick_failed alert not delivered: SetAlertsEngine was never called",
+			"scheduled_at", scheduledAt.Format(time.RFC3339))
+		return
+	}
+	c.alertsEngine.ProcessEvent(alerts.Event{
+		Type:      alerts.EventType("release_tick_failed"),
+		Error:     msg,
+		Timestamp: time.Now(),
+		Metadata: map[string]string{
+			"repo":         c.owner + "/" + c.repo,
+			"scheduled_at": scheduledAt.Format(time.RFC3339),
+			"attempts":     strconv.Itoa(attempts),
+		},
+	})
 }
 
 // repoHasAnyTag reports whether owner/repo has at least one published

--- a/internal/autopilot/scope_schedule_retry_test.go
+++ b/internal/autopilot/scope_schedule_retry_test.go
@@ -1,0 +1,209 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/alerts"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// syncAlertSink is a mutex-protected alertSink recorder, used instead of the
+// plain fakeAlertSink (controller_test.go) wherever a background goroutine
+// (scheduleReleaseTickWithRetry's retry loop) may call ProcessEvent
+// concurrently with a test goroutine reading the recorded events.
+type syncAlertSink struct {
+	mu     sync.Mutex
+	events []alerts.Event
+}
+
+func (s *syncAlertSink) ProcessEvent(e alerts.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, e)
+}
+
+func (s *syncAlertSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.events)
+}
+
+func (s *syncAlertSink) first() alerts.Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.events[0]
+}
+
+// withShortRetryTiming shrinks the package-level retry backoff bounds for
+// the duration of a test, restoring the production defaults on cleanup.
+// GH-4476: the real bounds are 15-30 minutes over a 6h window, which a unit
+// test can't wait out — these vars exist specifically to be overridden here.
+func withShortRetryTiming(t *testing.T, minInterval, maxInterval, window time.Duration) {
+	t.Helper()
+	origMin, origMax, origWindow := releaseTickRetryMinInterval, releaseTickRetryMaxInterval, releaseTickRetryWindow
+	releaseTickRetryMinInterval = minInterval
+	releaseTickRetryMaxInterval = maxInterval
+	releaseTickRetryWindow = window
+	t.Cleanup(func() {
+		releaseTickRetryMinInterval = origMin
+		releaseTickRetryMaxInterval = origMax
+		releaseTickRetryWindow = origWindow
+	})
+}
+
+// rateLimitResponse writes a 403 response shaped like a GitHub primary
+// rate-limit hit (X-RateLimit-Remaining: 0), matching the studio-sdk client's
+// RateLimitError classification (GH-4476 repro: the 07-18 16:00 tick hit
+// exactly this response and the train skipped the day with no retry).
+func rateLimitResponse(w http.ResponseWriter) {
+	w.Header().Set("X-RateLimit-Remaining", "0")
+	w.WriteHeader(http.StatusForbidden)
+	_, _ = w.Write([]byte(`{"message":"API rate limit exceeded for user ID 123."}`))
+}
+
+// TestScheduleReleaseTickWithRetry_SucceedsOnLaterRetry covers the GH-4476
+// acceptance criterion: a simulated 403 on the first tick attempt must not
+// forfeit the day — a later retry within the window succeeds and enqueues
+// the train, and no exhausted-retries alert fires.
+func TestScheduleReleaseTickWithRetry_SucceedsOnLaterRetry(t *testing.T) {
+	withShortRetryTiming(t, 5*time.Millisecond, 10*time.Millisecond, 2*time.Second)
+
+	c1 := makeCommit("feat: add thing (#101)")
+	c1.SHA = "sha1"
+
+	var releaseLatestCalls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/releases/latest"):
+			if atomic.AddInt32(&releaseLatestCalls, 1) == 1 {
+				rateLimitResponse(w)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Release{TagName: "v1.0.0"})
+		case strings.HasSuffix(r.URL.Path, "/tags"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		case strings.Contains(r.URL.Path, "/compare/"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"commits": []*github.Commit{c1}})
+		case strings.Contains(r.URL.Path, "/pulls/"):
+			var num int
+			_, _ = fmtSscanIssueNum(strings.Replace(r.URL.Path, "/pulls/", "/issues/", 1), &num)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.PullRequest{Number: num, Merged: true})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	c, stateStore := newScheduleController(t, server.URL, "0 21 * * FRI")
+	sink := &syncAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	scheduledAt := time.Now()
+	c.scheduleReleaseTickWithRetry(context.Background(), scheduledAt)
+
+	scopeKey := trainScopeKey(scheduledAt)
+	deadline := time.Now().Add(2 * time.Second)
+	var row *ScopeRelease
+	for time.Now().Before(deadline) {
+		var err error
+		row, err = stateStore.GetScopeRelease("owner/repo", scopeKey)
+		if err != nil {
+			t.Fatalf("GetScopeRelease failed: %v", err)
+		}
+		if row != nil {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if row == nil {
+		t.Fatal("expected the train to be enqueued once the retry succeeded")
+	}
+	if calls := atomic.LoadInt32(&releaseLatestCalls); calls < 2 {
+		t.Errorf("expected at least 2 calls to /releases/latest (initial failure + retry), got %d", calls)
+	}
+	if n := sink.count(); n != 0 {
+		t.Errorf("expected no release_tick_failed alert when the retry eventually succeeds, got %d alert(s)", n)
+	}
+}
+
+// TestScheduleReleaseTickWithRetry_ExhaustsRetriesFiresAlert covers the
+// second GH-4476 acceptance criterion: a tick that fails every attempt for
+// the whole retry window must give up loudly — ERROR log plus an alert via
+// the alerts engine — instead of silently vanishing.
+func TestScheduleReleaseTickWithRetry_ExhaustsRetriesFiresAlert(t *testing.T) {
+	withShortRetryTiming(t, 5*time.Millisecond, 5*time.Millisecond, 40*time.Millisecond)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rateLimitResponse(w)
+	}))
+	defer server.Close()
+
+	c, stateStore := newScheduleController(t, server.URL, "0 21 * * FRI")
+	sink := &syncAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	scheduledAt := time.Now()
+	c.scheduleReleaseTickWithRetry(context.Background(), scheduledAt)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && sink.count() == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if n := sink.count(); n != 1 {
+		t.Fatalf("expected exactly 1 release_tick_failed alert, got %d", n)
+	}
+	event := sink.first()
+	if event.Type != alerts.EventType("release_tick_failed") {
+		t.Errorf("alert type = %q, want release_tick_failed", event.Type)
+	}
+	if event.Metadata["repo"] != "owner/repo" {
+		t.Errorf("alert repo metadata = %q, want owner/repo", event.Metadata["repo"])
+	}
+
+	rows, err := stateStore.ListScopeReleases("owner/repo", "pending", "releasing", "done", "failed")
+	if err != nil {
+		t.Fatalf("ListScopeReleases failed: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected no train row to be enqueued for a tick that never succeeded, got %d", len(rows))
+	}
+}
+
+// TestScheduleReleaseTickWithRetry_NonRetryableSkipDoesNotSpawnRetry covers
+// the negative case: a legitimate no-op (nothing merged yet) must not spawn
+// a retry loop or fire any alert — retrying can't produce merged PRs that
+// don't exist, and treating a quiet day as a failure would be alert noise.
+func TestScheduleReleaseTickWithRetry_NonRetryableSkipDoesNotSpawnRetry(t *testing.T) {
+	withShortRetryTiming(t, 5*time.Millisecond, 5*time.Millisecond, 40*time.Millisecond)
+
+	server := noTagScheduleTickServer(t, nil, nil)
+	defer server.Close()
+
+	c, _ := newScheduleController(t, server.URL, "0 21 * * FRI")
+	sink := &syncAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	scheduledAt := time.Now()
+	c.scheduleReleaseTickWithRetry(context.Background(), scheduledAt)
+
+	// Give any (incorrectly) spawned retry goroutine a chance to misbehave.
+	time.Sleep(80 * time.Millisecond)
+
+	if n := sink.count(); n != 0 {
+		t.Errorf("expected no alert for a legitimate skip (no merged PRs yet), got %d", n)
+	}
+}

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -36,6 +36,13 @@ func NewStateStoreFromPath(path string) (*StateStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
+	// modernc.org/sqlite's ":memory:" database is private per-connection, not
+	// shared across the pool — a second concurrent connection sees a fresh,
+	// unmigrated database ("no such table"). Test callers of this path are
+	// the only ones exercising this store from more than one goroutine (e.g.
+	// GH-4476's release-tick retry runs in a background goroutine), so pin
+	// the pool to a single connection to keep it one logical database.
+	db.SetMaxOpenConns(1)
 	if _, err := db.Exec("PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;"); err != nil {
 		return nil, fmt.Errorf("failed to set database pragmas: %w", err)
 	}


### PR DESCRIPTION
## Summary

- `scheduleReleaseTick` now classifies its outcome as Succeeded / Skipped / Failed instead of silently returning on every early-exit path, so a transient GitHub failure (rate limit/5xx/network) can be distinguished from a legitimate no-op.
- `scheduleReleaseTickWithRetry` wraps both the cron callback and `recoverMissedTrainTick`'s call site; on a `Failed` outcome it retries in the background every 15-30 min (honoring a `*github.RateLimitError`'s Retry-After/X-RateLimit-Reset) for up to 6h past the scheduled time.
- Exhausted retries fire a loud `release_tick_failed` alert (ERROR log + alerts engine event) instead of silently forfeiting the day's release, mirroring the existing `fireReleaseMissingAlert` pattern.

Fixes GH-4476 — the 2026-07-18 16:00 Europe/Berlin tick hit a GitHub 403 and the release train was silently skipped for the day with no retry and no alert.

## Test plan

- [x] `TestScheduleReleaseTickWithRetry_SucceedsOnLaterRetry` — simulated 403 on first attempt, succeeds on later retry same day
- [x] `TestScheduleReleaseTickWithRetry_ExhaustsRetriesFiresAlert` — persistent 403s exhaust retry window, fires exactly one `release_tick_failed` alert
- [x] `TestScheduleReleaseTickWithRetry_NonRetryableSkipDoesNotSpawnRetry` — legitimate no-op (no merged PRs) does not spawn a retry loop or alert
- [x] `go test -race ./internal/autopilot/...` and full `go test ./...` pass
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean