### PR TITLE
fix(autopilot): re-validate CI at the merge chokepoint, rescind stale approval on regression

### DIFF
--- a/.agent/tasks/gh-4477.md
+++ b/.agent/tasks/gh-4477.md
@@ -1,0 +1,25 @@
+# GH-4477
+
+**Created:** 2026-07-20
+
+## Problem
+
+GitHub Issue GH-4477: fix(autopilot): stale ci_status=success at awaiting_approval — late check failure after handleCIPassed is never rescinded
+
+Known-unfiled bug (nearly merged a red PR via #4466, 2026-07-19).
+
+## Context
+
+Once `handleCIPassed` transitions a PR to `awaiting_approval`, `ci_status=success` is frozen. If a check subsequently fails (re-run, late-reporting check, new commit-status), the stored state still says success — approval is not rescinded and auto-merge would trust the stale value and merge a red PR.
+
+## Fix
+
+Re-validate CI state at the merge decision point (post-approval, pre-merge) rather than trusting the frozen `ci_status`; on regression, transition back to `waiting_ci`/failed and notify. This is the `handleCIPassed` chokepoint (scope_guard escalate-only pattern applies).
+
+## Acceptance
+
+- PR at awaiting_approval whose check flips to failure does not merge; stage regresses and the approval request is cancelled/refreshed.
+- Controller test covering the late-failure race.
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2393,6 +2393,26 @@ func (c *Controller) shouldDeferIssueClose(ctx context.Context, issueNum, prNum 
 }
 
 func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error {
+	// GH-4477: re-validate CI live at the merge chokepoint instead of trusting
+	// the ci_status frozen by handleCIPassed/handleWaitingCI. Once a PR
+	// reaches StageAwaitApproval, ci_status is never touched again — a
+	// re-run or a late-reporting check that flips to failure during the
+	// (human, potentially long) approval wait left the stale "success" value
+	// in place with nothing to rescind it, and nearly merged a red PR
+	// (#4466, 2026-07-19). Fail-open on a transient API error here (mirrors
+	// the size-floor/scope-drift gates in handleCIPassed) — only a definitive
+	// CIFailure regresses the PR; we must not block a legitimate merge on a
+	// flaky status-check call.
+	if c.ciMonitor != nil {
+		status, err := c.ciMonitor.CheckCI(ctx, prState.HeadSHA)
+		if err != nil {
+			c.log.Warn("handleMerging: CI re-validation failed, proceeding with frozen ci_status (fail-open)",
+				"pr", prState.PRNumber, "sha", ShortSHA(prState.HeadSHA), "error", err)
+		} else if status == CIFailure {
+			return c.rescindApprovalOnCIRegression(ctx, prState, status)
+		}
+	}
+
 	prState.MergeAttempts++
 
 	c.log.Info("handleMerging: attempting merge",
@@ -2550,6 +2570,46 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 			}
 		}
 	}
+
+	return nil
+}
+
+// rescindApprovalOnCIRegression handles a CI regression discovered at the
+// handleMerging chokepoint (GH-4477): the PR was escalated to
+// StageAwaitApproval on a since-stale ci_status=success and CI has now
+// failed. This refuses the merge, un-freezes ci_status, cancels/clears the
+// approval so a re-escalation can't fast-track past a fresh gate on the old
+// decision, and routes back to StageCIFailed to reuse the existing
+// CI-failure pipeline (continuation-issue creation, notification, iteration
+// limits) rather than duplicating it here.
+func (c *Controller) rescindApprovalOnCIRegression(ctx context.Context, prState *PRState, status CIStatus) error {
+	c.log.Warn("handleMerging: CI regressed since approval — refusing to merge a red PR",
+		"pr", prState.PRNumber,
+		"stale_ci_status", prState.CIStatus,
+		"revalidated_status", status,
+	)
+
+	// Cancel any outstanding approval request (e.g. a pending Slack/Telegram
+	// approval message) and clear the recorded decision. Without clearing
+	// ApprovalDecision, a future re-escalation of this same PR would hit
+	// handleAwaitApproval's "decision already recorded" path and skip
+	// straight back to StageMerging on the stale "approved" decision instead
+	// of waiting for a fresh one.
+	if c.approvalMgr != nil && prState.ApprovalRequestID != "" {
+		taskID := fmt.Sprintf("GH-%d", prState.IssueNumber)
+		if prState.IssueNumber == 0 {
+			taskID = fmt.Sprintf("PR-%d", prState.PRNumber)
+		}
+		c.approvalMgr.CancelPending(ctx, taskID)
+	}
+	prState.ApprovalRequestID = ""
+	prState.ApprovalDecision = ""
+	prState.ApprovalRequestedAt = time.Time{}
+	prState.EscalationReason = ""
+
+	prState.CIStatus = status
+	prState.Stage = StageCIFailed
+	c.metrics.RecordCIRun("fail")
 
 	return nil
 }

--- a/internal/autopilot/gh4477_test.go
+++ b/internal/autopilot/gh4477_test.go
@@ -1,0 +1,175 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/approval"
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestHandleMerging_LateCIFailure_RescindsApproval is the GH-4477 regression
+// test: once handleCIPassed transitions a PR to StageAwaitApproval,
+// ci_status is frozen at "success" and never rechecked. If a check
+// subsequently flips to failure (re-run, late-reporting check) while the PR
+// sits in the (now-approved) StageMerging stage, the frozen ci_status must
+// not be trusted — the PR nearly merged red via #4466 (2026-07-19).
+//
+// This asserts the merge chokepoint (handleMerging) re-validates CI live: on
+// a since-regressed check it must not call the merge API, must un-freeze
+// ci_status, must regress the stage instead of merging, and must clear/cancel
+// the stale approval so a future re-escalation can't fast-track past a fresh
+// approval gate on the old "approved" decision.
+func TestHandleMerging_LateCIFailure_RescindsApproval(t *testing.T) {
+	var mergeCalled bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/sha77/check-runs" && r.Method == http.MethodGet:
+			// Live re-check now reports a failing check run, even though
+			// prState.CIStatus is still frozen at CISuccess from the earlier
+			// handleCIPassed transition.
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "test", Status: "completed", Conclusion: "failure"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/pulls/77/merge" && r.Method == http.MethodPut:
+			mergeCalled = true
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]bool{"merged": true})
+
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvProd
+
+	mgr := approval.NewManager(nil)
+	c := NewController(cfg, ghClient, mgr, "owner", "repo")
+
+	c.mu.Lock()
+	c.activePRs[77] = &PRState{
+		PRNumber:            77,
+		PRURL:               "https://github.com/owner/repo/pull/77",
+		IssueNumber:         30,
+		BranchName:          "pilot/GH-30",
+		HeadSHA:             "sha77",
+		Stage:               StageMerging,
+		CIStatus:            CISuccess, // frozen "success" from handleCIPassed
+		EscalationReason:    "environments.prod.require_approval=true",
+		ApprovalRequestID:   "req-77",
+		ApprovalDecision:    string(approval.DecisionApproved),
+		ApprovalRequestedAt: time.Now().Add(-5 * time.Minute),
+		CreatedAt:           time.Now(),
+	}
+	c.mu.Unlock()
+
+	if err := c.ProcessPR(context.Background(), 77, nil); err != nil {
+		t.Fatalf("ProcessPR returned error: %v", err)
+	}
+
+	if mergeCalled {
+		t.Error("merge API was called — a red PR must never be merged on stale ci_status")
+	}
+
+	pr, ok := c.GetPRState(77)
+	if !ok {
+		t.Fatal("PR state missing after ProcessPR")
+	}
+	if pr.Stage != StageCIFailed {
+		t.Errorf("Stage = %s, want %s (stage must regress on late CI failure)", pr.Stage, StageCIFailed)
+	}
+	if pr.CIStatus != CIFailure {
+		t.Errorf("CIStatus = %s, want %s (frozen success must be un-frozen)", pr.CIStatus, CIFailure)
+	}
+	if pr.ApprovalRequestID != "" {
+		t.Errorf("ApprovalRequestID = %q, want empty (stale approval request must be cancelled)", pr.ApprovalRequestID)
+	}
+	if pr.ApprovalDecision != "" {
+		t.Errorf("ApprovalDecision = %q, want empty (stale approved decision must not fast-track a future re-approval)", pr.ApprovalDecision)
+	}
+}
+
+// TestHandleMerging_CIStillPassing_ProceedsToMerge is the control case for
+// GH-4477: when the live re-check still reports success, handleMerging must
+// proceed to merge as before — the new re-validation must not block a
+// legitimately green PR.
+func TestHandleMerging_CIStillPassing_ProceedsToMerge(t *testing.T) {
+	var mergeCalled bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/sha88/check-runs" && r.Method == http.MethodGet:
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "test", Status: "completed", Conclusion: "success"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/pulls/88/merge" && r.Method == http.MethodPut:
+			mergeCalled = true
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]bool{"merged": true})
+
+		case r.URL.Path == "/repos/owner/repo/issues/40/labels" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Label{})
+
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	c.mu.Lock()
+	c.activePRs[88] = &PRState{
+		PRNumber:    88,
+		PRURL:       "https://github.com/owner/repo/pull/88",
+		IssueNumber: 40,
+		BranchName:  "pilot/GH-40",
+		HeadSHA:     "sha88",
+		Stage:       StageMerging,
+		CIStatus:    CISuccess,
+		CreatedAt:   time.Now(),
+	}
+	c.mu.Unlock()
+
+	if err := c.ProcessPR(context.Background(), 88, nil); err != nil {
+		t.Fatalf("ProcessPR returned error: %v", err)
+	}
+
+	if !mergeCalled {
+		t.Error("merge API was not called — a still-green PR must proceed to merge")
+	}
+
+	pr, ok := c.GetPRState(88)
+	if !ok {
+		t.Fatal("PR state missing after ProcessPR")
+	}
+	if pr.Stage != StageMerged {
+		t.Errorf("Stage = %s, want %s", pr.Stage, StageMerged)
+	}
+}


### PR DESCRIPTION
## Summary
- `handleCIPassed` freezes `prState.CIStatus = success` when a PR escalates to `awaiting_approval` and never touches it again. A re-run or a late-reporting check that flips to failure while the PR sits waiting on human approval left that stale value in place with nothing to rescind it — this nearly merged a red PR via #4466 (2026-07-19).
- `handleMerging` (the actual pre-merge chokepoint) now re-validates CI live via `ciMonitor.CheckCI` immediately before attempting the merge. On a definitive `CIFailure`:
  - the merge API is never called
  - `ci_status` is un-frozen to the revalidated value
  - any pending approval request is cancelled (`approvalMgr.CancelPending`) and the recorded decision/request fields are cleared, so a future re-escalation can't fast-track past a fresh approval gate on the stale "approved" decision
  - the PR regresses to `StageCIFailed`, reusing the existing CI-failure pipeline (continuation-issue creation, notification, iteration limits) instead of duplicating it
- Fails open on a transient CI-check API error (mirrors the existing size-floor/scope-drift escalate-only gates in `handleCIPassed`) — only a definitive failure blocks the merge.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/autopilot/...` (full package, including two new regression tests: late-failure-rescinds-approval and still-green-proceeds-to-merge control case)
- [x] `go test ./...` (full repo)
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/autopilot/...`