### PR TITLE
chore(deps): bump studio-sdk to 7d17e124 (GH-4491)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/qf-studio/grom v0.2.0
-	github.com/qf-studio/studio-sdk v0.31.2-0.20260720133718-8c9f4da97066
+	github.com/qf-studio/studio-sdk v0.31.2-0.20260721122825-7d17e12412ff
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2
 	github.com/wailsapp/wails/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/qf-studio/grom v0.2.0 h1:EefLLr794KGk8ihdpKBgJnmSyUc//b/n8zZ77VbeuXY=
 github.com/qf-studio/grom v0.2.0/go.mod h1:YVihqE0treA2091TLNhGWvGi5+vMYv/ZBlAlX7Mr/JI=
-github.com/qf-studio/studio-sdk v0.31.2-0.20260720133718-8c9f4da97066 h1:G5eeVCljbF6gtWz4472pVdK05n8eDhnMcOyt48kUG68=
-github.com/qf-studio/studio-sdk v0.31.2-0.20260720133718-8c9f4da97066/go.mod h1:M/uFBeXsPAtsrO7wiIgE/GgWzfw80ftW6BrQUIOwxUM=
+github.com/qf-studio/studio-sdk v0.31.2-0.20260721122825-7d17e12412ff h1:/6HwOixbjOSRj1XZ5R7jh4WcGqA1xU5yA7scbgxX+1Y=
+github.com/qf-studio/studio-sdk v0.31.2-0.20260721122825-7d17e12412ff/go.mod h1:M/uFBeXsPAtsrO7wiIgE/GgWzfw80ftW6BrQUIOwxUM=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
## Summary
- Bumps `github.com/qf-studio/studio-sdk` from `v0.31.2-0.20260720133718-8c9f4da97066` to `v0.31.2-0.20260721122825-7d17e12412ff`, activating the SDK-side unsourced-issue detection (project_source, skip-reason plumbing) from studio-sdk PR #104.
- Second half of #4488; daemon-side wiring (board_source_audit, controller, metrics) already landed in #4489.

## Scope
go.mod / go.sum only — no feature changes. No SDK API shift required a compile fix; `cmd/pilot/github_sdk_bridge.go` and `internal/autopilot/board_source_audit.go` resolve cleanly against the bumped version.

## Test plan
- [x] `make build` green
- [x] `make test` green (full suite)
- [x] `go vet ./cmd/pilot/... ./internal/autopilot/...` clean

Closes GH-4491