### PR TITLE
fix(executor): base-branch-aware memory-doc deletion guard (GH-4496)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -230,6 +230,7 @@
 | CI log pattern learning | ✅ | autopilot | - | - | Wire CI log learning into autopilot feedback loop (v2.50.0, PR #1977) |
 | Staticcheck S1011 fix | ✅ | memory | - | - | Replace loop with append for staticcheck compliance (v2.46.1, PR #1971) |
 | Execution stage ledger (data layer) | ✅ | memory | - | - | `execution_events` table + Stage enum, `InsertExecutionEvent`/`ListExecutionEvents`/`ListExecutionsForTask`; no consumers wired yet (TASK-379 C3, GH-3844, v2.208.0) |
+| Memory-doc deletion hard veto | ✅ | executor | - | - | `GitOperations.EnforceMemoryDocDeletionGuard`, wired into all 3 finalize/PR paths (`finalizeEpicBranchPR`, inline `executeWithOptions`, `finalizeDecomposedParentPR`): blocks push when a `.agent/knowledge/memories/**.md` deletion was graph-indexed on **baseBranch** (not just HEAD, so a commit that deletes the doc and its graph node together is still caught), unless the task explicitly names memory/knowledge-graph files. Also fixed `StripUnindexedMemoryDocs`/`RestoreDeletedIndexedMemoryDocs` to match indexed docs by slug/concept_index fallback and check every path field (not just the first present one), closing the false-negative that let an indexed doc through as "unindexed" (TASK-410 class, GH-4484/GH-4489/PR #4495, GH-4496) |
 
 ## Dashboard
 

--- a/.agent/tasks/gh-4496.md
+++ b/.agent/tasks/gh-4496.md
@@ -1,0 +1,33 @@
+# GH-4496
+
+**Created:** 2026-07-21
+
+## Problem
+
+GitHub Issue GH-4496: fix(executor): 'strip unindexed memory doc' pass deletes INDEXED docs and rides deletions into unrelated PRs — root cause of the TASK-410 memory-loss series
+
+## Evidence (three strikes in 26 hours, same mechanism)
+
+1. **#4484** (2026-07-20 19:32Z): deleted `claim-lost-drops-count-toward-hard-cap`, `global-required-checks-leak-across-projects`, `go-caches-on-root-volume-fill-disk` — all indexed in graph.json. Rode into main unnoticed; restored by 169787ee.
+2. **#4489** (2026-07-21 11:13Z): deleted `approvals-off-stage-auto-merge` (decision) + `require-approval-flip-doesnt-release-held-prs` (pitfall) — both indexed. Restored by c3413491.
+3. **PR #4495 branch, commit 78870958** (2026-07-21 15:32Z): explicit `chore(memory): strip unindexed memory doc(s) added during execution` deleted `board-sourced-repo-ignores-labeled-issues.md` — which IS indexed (node + edges + concept_index entries all present in the same branch's graph.json). The strip pass's own commit message claims GH-4286 compliance while destroying a compliant doc.
+
+## Defects
+
+- **Strip-pass index detection is wrong**: it judged an indexed doc unindexed (strike 3). Whatever it greps/parses in graph.json misses nodes under `nodes.memories.<slug>` (or compares against a stale/regenerated graph).
+- **Deletions ride into unrelated PRs**: executor worktrees produce commits whose diffs remove `.agent/knowledge/memories/**` files the task never touched (strikes 1–2). Likely cause: the worktree's graph/memory tooling regenerates or rebases state from a stale snapshot, then a cleanup pass deletes docs the regenerated graph no longer indexes.
+- **Drift gate asymmetry**: the gate caught strike 3 (dangling graph entries) but strikes 1–2 merged green — deleting file+keeping-node apparently passes on some paths. Gate must fail BOTH directions on every PR: indexed-but-missing AND present-but-unindexed, evaluated against the PR's own tree.
+
+## Fix
+
+1. Strip pass: parse graph.json properly (all node groups); never delete a doc whose slug appears anywhere in nodes/concept_index; log what it checked.
+2. Executor guard (TASK-410 series): refuse to commit deletions under `.agent/knowledge/memories/**` unless the task explicitly targets memory files — hard veto, not advisory.
+3. Drift gate: verify bidirectional consistency; add a regression test with a deleted-indexed file and an added-unindexed file.
+
+## Acceptance
+
+- Repro test: branch deletes an indexed memory file → gate red; strip pass run on a tree with indexed docs → zero deletions.
+- All three strike scenarios covered by tests.
+
+## Acceptance Criteria
+

--- a/internal/executor/git.go
+++ b/internal/executor/git.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -167,8 +168,106 @@ const (
 )
 
 // graphJSONPathFields are the node fields check-graph.py accepts as a memory
-// file reference, in the same priority order.
+// file reference. Unlike check-graph.py (which takes the first field present
+// and stops), the Go readers below check ALL of these per node — GH-4496
+// found the "stop at first field" shortcut can leave a resolvable path
+// ignored when a node carries more than one path-shaped field.
 var graphJSONPathFields = []string{"file", "path", "memory_file"}
+
+// memoryGraphDoc is the subset of .agent/knowledge/graph.json the executor's
+// memory-doc guards read: node groups (only "memories" carries file paths)
+// plus concept_index, which GH-4496 strike 3 showed can carry a memory doc's
+// slug even when no node's path field resolves cleanly.
+type memoryGraphDoc struct {
+	Nodes struct {
+		Memories map[string]map[string]any `json:"memories"`
+	} `json:"nodes"`
+	ConceptIndex map[string][]string `json:"concept_index"`
+}
+
+// loadMemoryGraph reads and parses .agent/knowledge/graph.json once for all
+// of the memory-doc guards below. Returns (nil, nil) when the file is
+// absent — a project without one has no drift gate to protect.
+func (g *GitOperations) loadMemoryGraph() (*memoryGraphDoc, error) {
+	raw, err := os.ReadFile(filepath.Join(g.projectPath, graphJSONRelPath))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read graph.json: %w", err)
+	}
+
+	var graph memoryGraphDoc
+	if err := json.Unmarshal(raw, &graph); err != nil {
+		return nil, fmt.Errorf("failed to parse graph.json: %w", err)
+	}
+	return &graph, nil
+}
+
+// loadMemoryGraphAtRef reads and parses graph.json as it existed at ref
+// (e.g. baseBranch), independent of whatever the current working tree/HEAD
+// holds. This matters for EnforceMemoryDocDeletionGuard: strikes 1-2 of the
+// TASK-410 series deleted a memory doc AND its graph.json node in the same
+// commit, so checking indexed-status against HEAD's graph.json (as
+// graphIndexedMemoryNodes does for the restore pass) sees no dangling
+// reference and misses it entirely. Checking against baseBranch's graph.json
+// instead answers the question that actually matters: was this doc part of
+// the curated knowledge graph before this branch touched it? Returns
+// (nil, nil) when graph.json didn't exist at ref.
+func (g *GitOperations) loadMemoryGraphAtRef(ctx context.Context, ref string) (*memoryGraphDoc, error) {
+	cmd := exec.CommandContext(ctx, "git", "show", ref+":"+graphJSONRelPath)
+	cmd.Dir = g.projectPath
+	raw, err := cmd.Output()
+	if err != nil {
+		// Most common cause: graph.json didn't exist at ref. Treat the same
+		// as "no graph to protect" rather than failing the guard closed.
+		return nil, nil
+	}
+
+	var graph memoryGraphDoc
+	if err := json.Unmarshal(raw, &graph); err != nil {
+		return nil, fmt.Errorf("failed to parse graph.json at %s: %w", ref, err)
+	}
+	return &graph, nil
+}
+
+// memorySlug returns a memory doc's graph-identity slug: its basename with
+// the .md extension stripped. Current-convention nodes key nodes.memories by
+// this slug directly; legacy nodes instead carry a path-shaped field whose
+// basename is this slug.
+func memorySlug(path string) string {
+	return strings.TrimSuffix(filepath.Base(path), ".md")
+}
+
+// indexedMemorySlugs returns every memory-doc slug that graph.json
+// references ANYWHERE: as a nodes.memories node ID (current convention), as
+// the basename of a node's file/path/memory_file field (regardless of
+// whether that field resolves to an existing path on disk), or as a value
+// inside concept_index. This is intentionally broader and more permissive
+// than resolving exact paths — GH-4496 strike 3 (PR #4495, commit 78870958)
+// deleted a doc whose node WAS present in nodes.memories with a correct
+// "file" field; whatever the strip pass's exact-path check missed, a
+// slug appearing anywhere in the graph must still veto deletion.
+func indexedMemorySlugs(graph *memoryGraphDoc) map[string]bool {
+	slugs := make(map[string]bool)
+	if graph == nil {
+		return slugs
+	}
+	for nodeID, node := range graph.Nodes.Memories {
+		slugs[nodeID] = true
+		for _, field := range graphJSONPathFields {
+			if rawPath, ok := node[field].(string); ok {
+				slugs[memorySlug(rawPath)] = true
+			}
+		}
+	}
+	for _, values := range graph.ConceptIndex {
+		for _, v := range values {
+			slugs[v] = true
+		}
+	}
+	return slugs
+}
 
 // addedMemoryDocs returns memory doc paths (relative to the repo root) added
 // between baseBranch and HEAD. Mirrors the file selection in
@@ -207,25 +306,16 @@ func (g *GitOperations) addedMemoryDocs(ctx context.Context, baseBranch string) 
 // whichever candidate exists on disk. Returns (nil, nil) when graph.json is
 // absent — a project without the file has no drift gate to protect.
 func (g *GitOperations) indexedMemoryPaths() (map[string]bool, error) {
-	raw, err := os.ReadFile(filepath.Join(g.projectPath, graphJSONRelPath))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to read graph.json: %w", err)
-	}
-
-	var graph struct {
-		Nodes struct {
-			Memories map[string]map[string]any `json:"memories"`
-		} `json:"nodes"`
-	}
-	if err := json.Unmarshal(raw, &graph); err != nil {
-		return nil, fmt.Errorf("failed to parse graph.json: %w", err)
+	graph, err := g.loadMemoryGraph()
+	if err != nil || graph == nil {
+		return nil, err
 	}
 
 	indexed := make(map[string]bool)
 	for _, node := range graph.Nodes.Memories {
+		// GH-4496: check every path-shaped field on the node, not just the
+		// first one present — a node carrying both a resolvable and a stale
+		// field must not have the resolvable one shadowed.
 		for _, field := range graphJSONPathFields {
 			rawPath, ok := node[field].(string)
 			if !ok {
@@ -241,9 +331,7 @@ func (g *GitOperations) indexedMemoryPaths() (map[string]bool, error) {
 				if rel, relErr := filepath.Rel(g.projectPath, candidate); relErr == nil {
 					indexed[filepath.ToSlash(rel)] = true
 				}
-				break
 			}
-			break
 		}
 	}
 	return indexed, nil
@@ -262,26 +350,51 @@ func (g *GitOperations) indexedMemoryPaths() (map[string]bool, error) {
 // execution's (project CLAUDE.md "Memory: Navigator only"), so an execution
 // that added one unindexed is out of its lane; stripping it here keeps the
 // rest of the diff intact instead of failing the whole task.
+//
+// GH-4496: a doc only counts as unindexed when BOTH the exact-path check
+// (indexedMemoryPaths) AND the slug-anywhere-in-the-graph check
+// (indexedMemorySlugs) come back negative — three strikes in 26 hours showed
+// the exact-path check alone can misjudge a genuinely indexed doc (strike 3,
+// PR #4495/commit 78870958, deleted a doc whose node had a correct "file"
+// field). Every doc considered and the verdict is logged so a future
+// misjudgment is diagnosable from the run log instead of only from a later
+// graph-vs-disk audit.
 func (g *GitOperations) StripUnindexedMemoryDocs(ctx context.Context, baseBranch string) ([]string, error) {
 	added, err := g.addedMemoryDocs(ctx, baseBranch)
 	if err != nil || len(added) == 0 {
 		return nil, err
 	}
 
-	indexed, err := g.indexedMemoryPaths()
+	graph, err := g.loadMemoryGraph()
 	if err != nil {
 		return nil, err
 	}
-	if indexed == nil {
+	if graph == nil {
 		// No graph.json in this project - nothing to reconcile against.
 		return nil, nil
 	}
 
+	indexed, err := g.indexedMemoryPaths()
+	if err != nil {
+		return nil, err
+	}
+	slugs := indexedMemorySlugs(graph)
+
 	var unindexed []string
 	for _, doc := range added {
-		if !indexed[doc] {
-			unindexed = append(unindexed, doc)
+		slug := memorySlug(doc)
+		byPath := indexed[doc]
+		bySlug := slugs[slug]
+		slog.Default().Debug("strip-unindexed-memory-docs: checked added doc",
+			slog.String("doc", doc),
+			slog.String("slug", slug),
+			slog.Bool("indexed_by_path", byPath),
+			slog.Bool("indexed_by_slug", bySlug),
+		)
+		if byPath || bySlug {
+			continue
 		}
+		unindexed = append(unindexed, doc)
 	}
 	if len(unindexed) == 0 {
 		return nil, nil
@@ -339,25 +452,14 @@ func (g *GitOperations) deletedMemoryDocs(ctx context.Context, baseBranch string
 // would always fail the case it exists to catch. Returns (nil, nil) when
 // graph.json is absent — no drift gate to protect.
 func (g *GitOperations) graphIndexedMemoryNodes() (map[string]string, error) {
-	raw, err := os.ReadFile(filepath.Join(g.projectPath, graphJSONRelPath))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to read graph.json: %w", err)
-	}
-
-	var graph struct {
-		Nodes struct {
-			Memories map[string]map[string]any `json:"memories"`
-		} `json:"nodes"`
-	}
-	if err := json.Unmarshal(raw, &graph); err != nil {
-		return nil, fmt.Errorf("failed to parse graph.json: %w", err)
+	graph, err := g.loadMemoryGraph()
+	if err != nil || graph == nil {
+		return nil, err
 	}
 
 	nodes := make(map[string]string)
 	for nodeID, node := range graph.Nodes.Memories {
+		// GH-4496: check every path-shaped field, not just the first present.
 		for _, field := range graphJSONPathFields {
 			rawPath, ok := node[field].(string)
 			if !ok {
@@ -369,7 +471,6 @@ func (g *GitOperations) graphIndexedMemoryNodes() (map[string]string, error) {
 			// never looked up. Mirrors indexedMemoryPaths' candidate order.
 			nodes[filepath.ToSlash(rawPath)] = nodeID
 			nodes[filepath.ToSlash(filepath.Join(".agent", "knowledge", rawPath))] = nodeID
-			break
 		}
 	}
 	return nodes, nil
@@ -455,6 +556,94 @@ func restoredPaths(docs []RestoredMemoryDoc) []string {
 		paths[i] = d.Path
 	}
 	return paths
+}
+
+// ErrMemoryDocDeletionVetoed is returned by EnforceMemoryDocDeletionGuard when
+// the branch still carries a net deletion of a pre-existing
+// .agent/knowledge/memories/**.md file after the strip/restore passes have
+// already run, and the task never said it was allowed to touch memory docs.
+var ErrMemoryDocDeletionVetoed = fmt.Errorf("execution deleted memory doc(s) outside its lane")
+
+// EnforceMemoryDocDeletionGuard is the GH-4496 hard-veto leg of the TASK-410
+// memory-loss series: it must run AFTER StripUnindexedMemoryDocs and
+// RestoreDeletedIndexedMemoryDocs, and reports any file under
+// .agent/knowledge/memories/ that is STILL net-deleted relative to
+// baseBranch AND was indexed in baseBranch's graph.json before this branch
+// touched it.
+//
+// The baseBranch check (not HEAD's current graph.json) is deliberate: in
+// strikes 1-2 of the TASK-410 series (GH-4484, GH-4489) the offending commit
+// deleted the memory doc AND its graph.json node together, so by the time
+// any HEAD-relative check runs there is no dangling reference left to
+// notice — the tree looks internally consistent even though it destroyed
+// curated knowledge. Checking against the graph as it stood on baseBranch
+// catches exactly that case. Deleting a doc that was never indexed on
+// baseBranch either (see TestFinalizeDecomposedParentPR_AllowsDeletingUnindexedMemoryDoc)
+// remains allowed — this guard is about protecting the graph's existing
+// knowledge, not blocking all memory-doc deletions outright.
+//
+// Unless allowMemoryChanges is true — the task itself explicitly targets
+// memory files — this is a hard veto (the caller must block push and fail
+// the run) rather than advisory-only, converting a silent-data-loss class
+// into a loud, reviewable failure.
+func (g *GitOperations) EnforceMemoryDocDeletionGuard(ctx context.Context, baseBranch string, allowMemoryChanges bool) ([]string, error) {
+	if allowMemoryChanges {
+		return nil, nil
+	}
+	deleted, err := g.deletedMemoryDocs(ctx, baseBranch)
+	if err != nil || len(deleted) == 0 {
+		return nil, err
+	}
+
+	baseGraph, err := g.loadMemoryGraphAtRef(ctx, baseBranch)
+	if err != nil {
+		return nil, err
+	}
+	if baseGraph == nil {
+		return nil, nil
+	}
+	baseSlugs := indexedMemorySlugs(baseGraph)
+
+	var vetoed []string
+	for _, doc := range deleted {
+		if baseSlugs[memorySlug(doc)] {
+			vetoed = append(vetoed, doc)
+		}
+	}
+	if len(vetoed) == 0 {
+		return nil, nil
+	}
+	return vetoed, fmt.Errorf("%w: %v", ErrMemoryDocDeletionVetoed, vetoed)
+}
+
+// memoryFileIntentKeywords are lower-cased substrings in a task's title or
+// description that indicate the task itself is expected to touch
+// .agent/knowledge/memories/** — e.g. a Navigator memory-authoring or
+// memory-tooling task — so EnforceMemoryDocDeletionGuard should not veto its
+// deletions.
+var memoryFileIntentKeywords = []string{
+	".agent/knowledge/memories",
+	"memory doc",
+	"memory-doc",
+	"knowledge graph",
+	"graph.json",
+}
+
+// taskExplicitlyTargetsMemoryFiles reports whether task's title or
+// description mentions the memory-doc/knowledge-graph system explicitly,
+// per memoryFileIntentKeywords. Used to scope EnforceMemoryDocDeletionGuard's
+// veto to executions that never said they needed to touch memory docs.
+func taskExplicitlyTargetsMemoryFiles(task *Task) bool {
+	if task == nil {
+		return false
+	}
+	haystack := strings.ToLower(task.Title + "\n" + task.Description)
+	for _, kw := range memoryFileIntentKeywords {
+		if strings.Contains(haystack, kw) {
+			return true
+		}
+	}
+	return false
 }
 
 // Push pushes the current branch to remote

--- a/internal/executor/git_test.go
+++ b/internal/executor/git_test.go
@@ -968,6 +968,64 @@ func TestStripUnindexedMemoryDocs(t *testing.T) {
 			t.Fatalf("stripped = %v, want none", stripped)
 		}
 	})
+
+	// GH-4496 strike 3 (PR #4495, commit 78870958): a doc whose node is
+	// keyed by its slug (current convention: no "file" field at all, just
+	// type/summary/concepts) was deleted because the exact-path check found
+	// nothing to resolve. The slug fallback must protect it.
+	t.Run("leaves a doc indexed only by node-ID slug alone", func(t *testing.T) {
+		run("checkout", base)
+		run("checkout", "-b", "pilot/GH-slug-indexed")
+
+		docRel := ".agent/knowledge/memories/pitfalls/board-sourced-repo-ignores-labeled-issues.md"
+		write(docRel, "# a pitfall indexed by convention, no file field")
+
+		graph := `{"nodes":{"memories":{"board-sourced-repo-ignores-labeled-issues":{"type":"pitfall","summary":"no file field, node id is the slug"}}}}`
+		write(".agent/knowledge/graph.json", graph)
+
+		run("add", docRel, ".agent/knowledge/graph.json")
+		run("commit", "-m", "docs: capture pitfall, indexed by node id only")
+
+		stripped, err := git.StripUnindexedMemoryDocs(ctx, base)
+		if err != nil {
+			t.Fatalf("StripUnindexedMemoryDocs failed: %v", err)
+		}
+		if len(stripped) != 0 {
+			t.Fatalf("stripped = %v, want none (doc is indexed by node id)", stripped)
+		}
+		if _, statErr := os.Stat(filepath.Join(dir, docRel)); statErr != nil {
+			t.Errorf("expected %s to remain, stat err = %v", docRel, statErr)
+		}
+	})
+
+	// GH-4496: a doc referenced only via concept_index (no matching node ID
+	// or file/path field at all) must still be protected — the strip pass
+	// must never delete a doc whose slug appears ANYWHERE in the graph.
+	t.Run("leaves a doc indexed only via concept_index alone", func(t *testing.T) {
+		run("checkout", base)
+		run("checkout", "-b", "pilot/GH-concept-indexed")
+
+		docRel := ".agent/knowledge/memories/pitfalls/mem_task_concept_only.md"
+		write(docRel, "# a pitfall referenced only from concept_index")
+
+		graph := `{"nodes":{"memories":{"mem-other":{"file":".agent/knowledge/memories/pitfalls/unrelated.md"}}},` +
+			`"concept_index":{"poller":["mem_task_concept_only"]}}`
+		write(".agent/knowledge/graph.json", graph)
+
+		run("add", docRel, ".agent/knowledge/graph.json")
+		run("commit", "-m", "docs: capture pitfall, indexed via concept_index only")
+
+		stripped, err := git.StripUnindexedMemoryDocs(ctx, base)
+		if err != nil {
+			t.Fatalf("StripUnindexedMemoryDocs failed: %v", err)
+		}
+		if len(stripped) != 0 {
+			t.Fatalf("stripped = %v, want none (doc is indexed via concept_index)", stripped)
+		}
+		if _, statErr := os.Stat(filepath.Join(dir, docRel)); statErr != nil {
+			t.Errorf("expected %s to remain, stat err = %v", docRel, statErr)
+		}
+	})
 }
 
 // TestRestoreDeletedIndexedMemoryDocs covers GH-4398: the restore leg of the
@@ -1162,6 +1220,155 @@ func TestRestoreDeletedIndexedMemoryDocs(t *testing.T) {
 			t.Fatalf("restored = %v, want none (no graph.json to protect)", restored)
 		}
 	})
+}
+
+// TestEnforceMemoryDocDeletionGuard covers GH-4496's hard-veto guard: run
+// AFTER StripUnindexedMemoryDocs/RestoreDeletedIndexedMemoryDocs, it must
+// refuse (return an error) any net deletion, relative to baseBranch, of a
+// .agent/knowledge/memories/**.md file that WAS graph-indexed on baseBranch
+// — unless the task explicitly targets memory files. It deliberately checks
+// baseBranch's graph.json rather than HEAD's: strikes 1-2 of the TASK-410
+// series (GH-4484, GH-4489) deleted the doc AND its graph.json node
+// together, so an indexed check against the current tree would see nothing
+// dangling and miss it. Deleting a doc that was never indexed on baseBranch
+// either must remain allowed (see
+// TestFinalizeDecomposedParentPR_AllowsDeletingUnindexedMemoryDoc) — this
+// guard protects existing knowledge, it doesn't ban all memory-doc
+// deletions outright.
+func TestEnforceMemoryDocDeletionGuard(t *testing.T) {
+	dir, _ := initTestRepo(t)
+	ctx := context.Background()
+	git := NewGitOperations(dir)
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	write := func(rel, content string) {
+		t.Helper()
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatalf("mkdir for %s: %v", rel, err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	docRel := ".agent/knowledge/memories/pitfalls/mem_task_preexisting.md"
+	write(docRel, "# a pre-existing, indexed doc on base")
+	write(".agent/knowledge/graph.json", `{"nodes":{"memories":{"mem-preexisting":{"file":"`+docRel+`"}}}}`)
+	run("add", docRel, ".agent/knowledge/graph.json")
+	run("commit", "-m", "chore: seed pre-existing indexed doc on base")
+	base, err := git.GetCurrentBranch(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentBranch failed: %v", err)
+	}
+
+	t.Run("vetoes a deletion when the task does not target memory files", func(t *testing.T) {
+		run("checkout", "-b", "pilot/GH-veto-deny")
+		run("rm", docRel)
+		// Strikes 1-2 shape: the node is removed from graph.json in the same
+		// commit that deletes the file, so a HEAD-relative indexed check
+		// would find nothing dangling. The guard must still catch this by
+		// checking baseBranch's graph.json.
+		write(".agent/knowledge/graph.json", `{"nodes":{"memories":{}}}`)
+		run("add", ".agent/knowledge/graph.json")
+		run("commit", "-m", "feat: unrelated change that also deleted a memory doc + its node")
+
+		vetoed, err := git.EnforceMemoryDocDeletionGuard(ctx, base, false)
+		if err == nil {
+			t.Fatal("expected EnforceMemoryDocDeletionGuard to veto the deletion, got nil error")
+		}
+		if !errors.Is(err, ErrMemoryDocDeletionVetoed) {
+			t.Errorf("expected ErrMemoryDocDeletionVetoed, got: %v", err)
+		}
+		if len(vetoed) != 1 || vetoed[0] != docRel {
+			t.Fatalf("vetoed = %v, want [%s]", vetoed, docRel)
+		}
+	})
+
+	t.Run("allows the deletion when the task explicitly targets memory files", func(t *testing.T) {
+		run("checkout", base)
+		run("checkout", "-b", "pilot/GH-veto-allow")
+		run("rm", docRel)
+		write(".agent/knowledge/graph.json", `{"nodes":{"memories":{}}}`)
+		run("add", ".agent/knowledge/graph.json")
+		run("commit", "-m", "chore(memory): intentionally remove a stale doc")
+
+		vetoed, err := git.EnforceMemoryDocDeletionGuard(ctx, base, true)
+		if err != nil {
+			t.Fatalf("expected no veto when allowMemoryChanges=true, got: %v", err)
+		}
+		if len(vetoed) != 0 {
+			t.Fatalf("vetoed = %v, want none", vetoed)
+		}
+	})
+
+	t.Run("allows a deletion of a doc that was never indexed on base", func(t *testing.T) {
+		run("checkout", base)
+		run("checkout", "-b", "pilot/GH-veto-unindexed")
+		unindexedRel := ".agent/knowledge/memories/pitfalls/mem_task_unindexed.md"
+		write(unindexedRel, "# never indexed")
+		run("add", unindexedRel)
+		run("commit", "-m", "chore: seed an unindexed doc")
+		run("rm", unindexedRel)
+		run("commit", "-m", "feat: unrelated change that deletes an unindexed doc")
+
+		vetoed, err := git.EnforceMemoryDocDeletionGuard(ctx, base, false)
+		if err != nil {
+			t.Fatalf("expected no veto for a doc never indexed on base, got: %v", err)
+		}
+		if len(vetoed) != 0 {
+			t.Fatalf("vetoed = %v, want none", vetoed)
+		}
+	})
+
+	t.Run("no-op when no memory docs were deleted", func(t *testing.T) {
+		run("checkout", base)
+		run("checkout", "-b", "pilot/GH-veto-noop")
+		write("internal/qux.go", "package qux")
+		run("add", "internal/qux.go")
+		run("commit", "-m", "feat: add qux")
+
+		vetoed, err := git.EnforceMemoryDocDeletionGuard(ctx, base, false)
+		if err != nil {
+			t.Fatalf("expected no veto, got: %v", err)
+		}
+		if len(vetoed) != 0 {
+			t.Fatalf("vetoed = %v, want none", vetoed)
+		}
+	})
+}
+
+// TestTaskExplicitlyTargetsMemoryFiles covers the keyword heuristic that
+// scopes EnforceMemoryDocDeletionGuard's veto (GH-4496): a task whose title
+// or description mentions the memory-doc/knowledge-graph system should not
+// have its memory-doc deletions vetoed.
+func TestTaskExplicitlyTargetsMemoryFiles(t *testing.T) {
+	cases := []struct {
+		name string
+		task *Task
+		want bool
+	}{
+		{"nil task", nil, false},
+		{"unrelated task", &Task{Title: "fix: dashboard queue card status", Description: "reconcile stuck cards"}, false},
+		{"title mentions memory doc", &Task{Title: "fix(memory): strip unindexed memory doc pass"}, true},
+		{"description mentions knowledge graph", &Task{Title: "chore", Description: "clean up the Knowledge Graph Drift Gate"}, true},
+		{"description mentions graph.json path", &Task{Title: "chore", Description: "touches .agent/knowledge/memories/pitfalls"}, true},
+		{"case-insensitive match", &Task{Title: "Chore: tidy GRAPH.JSON"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := taskExplicitlyTargetsMemoryFiles(tc.task); got != tc.want {
+				t.Errorf("taskExplicitlyTargetsMemoryFiles(%+v) = %v, want %v", tc.task, got, tc.want)
+			}
+		})
+	}
 }
 
 // TestCreateRecoveryRef verifies GH-3785's recovery-ref mechanism: a commit

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1659,6 +1659,23 @@ func (r *Runner) finalizeEpicBranchPR(ctx context.Context, task *Task, git *GitO
 		r.recordMemoryGuardRestoreEvents(task.LogExecutionID(), restored)
 	}
 
+	// GH-4496: hard veto — after strip+restore above, any memory doc still
+	// net-deleted vs baseBranch is a pre-existing, currently-unindexed doc an
+	// epic session deleted outside its lane. Three strikes in 26 hours showed
+	// advisory-only handling here lets deletions ride into unrelated PRs
+	// unnoticed; block the push instead.
+	if vetoed, vetoErr := git.EnforceMemoryDocDeletionGuard(ctx, baseBranch, taskExplicitlyTargetsMemoryFiles(task)); vetoErr != nil {
+		result.Success = false
+		result.Error = fmt.Sprintf("blocked: %v", vetoErr)
+		r.log.Warn("Vetoed memory doc deletion(s) outside epic branch's lane",
+			slog.String("task_id", task.ID),
+			slog.Any("files", vetoed),
+			slog.Any("error", vetoErr),
+		)
+		r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+		return
+	}
+
 	r.reportProgress(task.ID, "Creating PR", 96, "Pushing epic branch...")
 
 	// Push the parent branch. TASK-359: a real deliverable that fails to push is a
@@ -4182,6 +4199,24 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 				)
 			} else if len(restored) > 0 {
 				r.recordMemoryGuardRestoreEvents(task.LogExecutionID(), restored)
+			}
+
+			// GH-4496: hard veto — after strip+restore above, any memory doc
+			// still net-deleted vs baseBranch is a pre-existing,
+			// currently-unindexed doc this session deleted outside its lane.
+			// Three strikes in 26 hours showed advisory-only handling here
+			// lets deletions ride into unrelated PRs unnoticed; block the
+			// push instead.
+			if vetoed, vetoErr := git.EnforceMemoryDocDeletionGuard(ctx, baseBranch, taskExplicitlyTargetsMemoryFiles(task)); vetoErr != nil {
+				result.Success = false
+				result.Error = fmt.Sprintf("blocked: %v", vetoErr)
+				log.Warn("Vetoed memory doc deletion(s) outside branch's lane",
+					slog.String("task_id", task.ID),
+					slog.Any("files", vetoed),
+					slog.Any("error", vetoErr),
+				)
+				r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+				return result, nil
 			}
 
 			// Pre-push lint gate (GH-1376)

--- a/internal/executor/runner_decompose.go
+++ b/internal/executor/runner_decompose.go
@@ -436,6 +436,23 @@ func (r *Runner) finalizeDecomposedParentPR(ctx context.Context, task *Task, git
 		r.recordMemoryGuardRestoreEvents(task.LogExecutionID(), restored)
 	}
 
+	// GH-4496: hard veto — after strip+restore above, any memory doc still
+	// net-deleted vs baseBranch is a pre-existing, currently-unindexed doc a
+	// subtask session deleted outside its lane. Three strikes in 26 hours
+	// showed advisory-only handling here lets deletions ride into unrelated
+	// PRs unnoticed; block the push instead.
+	if vetoed, vetoErr := git.EnforceMemoryDocDeletionGuard(ctx, baseBranch, taskExplicitlyTargetsMemoryFiles(task)); vetoErr != nil {
+		result.Success = false
+		result.Error = fmt.Sprintf("blocked: %v", vetoErr)
+		log.Warn("Vetoed memory doc deletion(s) outside decomposed-parent branch's lane",
+			slog.String("task_id", task.ID),
+			slog.Any("files", vetoed),
+			slog.Any("error", vetoErr),
+		)
+		r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+		return
+	}
+
 	r.reportProgress(task.ID, "Creating PR", 96, "Pushing branch...")
 
 	var pushErr error

--- a/scripts/check_graph_test.py
+++ b/scripts/check_graph_test.py
@@ -215,6 +215,36 @@ class MainExitCodeTest(unittest.TestCase):
                 f.truncate()
             self.assertEqual(self._run_main(root, graph_path, memories_base), 0)
 
+    def test_deleted_indexed_and_added_unindexed_together_exits_one(self):
+        """GH-4496 regression: a single PR that both deletes an indexed
+        memory doc (broken link) AND adds a fresh unindexed one (present but
+        not referenced) must fail the gate on BOTH counts simultaneously —
+        neither direction may mask the other. This is the combined shape the
+        drift gate must catch even though strikes 1-2 of the TASK-410 series
+        additionally removed the dangling node itself (see
+        TestEnforceMemoryDocDeletionGuard in internal/executor/git_test.go
+        for that base-branch-aware case, which this single-tree-snapshot
+        gate cannot see)."""
+        with tempfile.TemporaryDirectory() as root:
+            graph_path, memories_base = self._build_repo(root)
+            # Delete the indexed file on disk but leave its graph node
+            # pointing at it — a broken link.
+            os.remove(os.path.join(memories_base, "patterns", "a.md"))
+            # Add a brand-new doc that no node references — an unindexed
+            # file.
+            _write(os.path.join(memories_base, "patterns", "orphan.md"), "x")
+
+            with open(graph_path, "r", encoding="utf-8") as f:
+                import json
+                graph = json.load(f)
+
+            broken_links = cg.find_broken_file_links(graph, root)
+            unindexed = cg.find_unindexed_memory_files(graph, memories_base, root)
+            self.assertEqual(broken_links, [("mem-001", ".agent/knowledge/memories/patterns/a.md")])
+            self.assertEqual(unindexed, [os.path.join(".agent", "knowledge", "memories", "patterns", "orphan.md")])
+
+            self.assertEqual(self._run_main(root, graph_path, memories_base), 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes GH-4496: the "strip unindexed memory doc" pass was deleting graph-INDEXED memory docs, and those deletions rode into unrelated PRs undetected — three strikes in 26 hours (GH-4484, GH-4489, PR #4495, all TASK-410 class).

- **Fixed indexed-detection bugs** in `indexedMemoryPaths`/`graphIndexedMemoryNodes`: previously stopped at the first present path field (`file`/`path`/`memory_file`) per node instead of checking all of them, and missed slug/concept_index-only references. `StripUnindexedMemoryDocs` now also matches by node-ID slug and concept_index membership, closing the false-negative that produced strike 3.
- **New hard-veto guard** `EnforceMemoryDocDeletionGuard`, wired into all 3 finalize/PR paths (`finalizeEpicBranchPR`, inline `executeWithOptions`, `finalizeDecomposedParentPR`): blocks push when a deleted `.agent/knowledge/memories/**.md` file was indexed in **baseBranch's** graph.json — not just HEAD's — unless the task explicitly targets memory files. Checking baseBranch is the key fix for strikes 1-2: those commits deleted the doc *and* its graph node together, so any check against the current tree sees nothing dangling and misses it entirely.
- **Drift-gate regression test** (`scripts/check_graph_test.py`): a repo state combining a deleted-indexed doc (broken link) and an added-unindexed doc (present but unreferenced) in the same tree, asserting the gate fails on both simultaneously.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full repo, all packages green)
- [x] `go vet ./...`
- [x] New/updated tests in `internal/executor/git_test.go`: `TestStripUnindexedMemoryDocs` (slug + concept_index fallback subtests), `TestEnforceMemoryDocDeletionGuard` (base-branch-indexed veto, allowed-when-task-targets-memory, allowed-when-never-indexed-on-base, no-op), `TestTaskExplicitlyTargetsMemoryFiles`
- [x] Existing `TestFinalizeDecomposedParentPR_RestoresDeletedIndexedMemoryDoc` / `_AllowsDeletingUnindexedMemoryDoc` still pass unchanged (guard doesn't regress the pre-existing "unindexed deletions stay allowed" contract)
- [x] `python3 -m unittest discover -s scripts -p "*_test.py"` (35 tests, including new combined regression test)
- [x] `python3 scripts/check-graph.py` on the repo's own tree — green