### PR TITLE
fix(executor): stream partial messages + effort-aware stall timeout

### DIFF
--- a/.agent/sops/executor-stall-watchdog-silent-turns.md
+++ b/.agent/sops/executor-stall-watchdog-silent-turns.md
@@ -1,0 +1,76 @@
+---
+title: Stall Watchdog — Silent Model Turn Class of Fixes
+created: 2026-07-22
+status: active
+related: GH-4501, GH-4357, GH-4364, pilot-console#24, TASK-416
+---
+
+# Stall Watchdog — Silent Model Turn Class of Fixes
+
+## Problem
+
+The stall watchdog (`internal/executor/watchdog.go`) kills a healthy session
+whenever no stdout line arrives for `stall_timeout` (default 3m). The reset
+logic itself has always been correct — `EventHandler` fires on every raw
+stdout line, unconditionally, and resets the idle clock regardless of parsed
+event type (`runner.go`, `EventHandler` closure at the backend.Execute call
+site). The recurring defect class is *upstream*: some legitimate activity
+produces zero stdout for longer than `stall_timeout`, so there's nothing to
+reset the clock on.
+
+Two instances so far:
+
+- **#4357** (background tasks): a backgrounded Bash command / sub-agent emits
+  no events until it completes. Fixed by tracking in-flight
+  `task_started`/`task_notification` pairs and suspending the idle clock
+  while any are outstanding.
+- **#4501** (silent model turns): a single high-effort/thinking turn produces
+  ONE complete `assistant` stream-json event at the very end, with zero bytes
+  written during the turn itself — because the CLI wasn't invoked with
+  `--include-partial-messages`. No CLI signal exists to suspend on, unlike
+  background tasks.
+
+## Root Cause (GH-4501 specifically)
+
+`claude` is spawned with `--verbose --output-format stream-json` but without
+`--include-partial-messages` (three call sites in
+`internal/executor/backend_claudecode.go`, `executeWithFromPR`). Without that
+flag, the CLI batches an entire turn into one `assistant` event emitted only
+at turn end.
+
+## Solution
+
+1. Add `--include-partial-messages` to all three spawn-arg sites. The CLI
+   then streams a `{"type":"stream_event","event":{"type":"..."}}` wrapper
+   (`message_start`, `content_block_start/delta/stop`, `message_delta`,
+   `message_stop`) throughout the turn. Any line — including these — already
+   resets the watchdog via the existing unconditional `EventHandler` call, so
+   no watchdog-side change was needed for this half of the fix.
+2. `parseStreamEvent` classifies these as `EventTypeStreamDelta`, a type with
+   deliberately **no case** in `processBackendEvent`'s switch — this is what
+   keeps them from being re-processed as complete `assistant`/`tool_use`
+   events (double counting) and from generating per-delta log lines (no log
+   call fires for an unhandled switch case).
+3. Defense-in-depth: `effortAwareStallTimeout` (`watchdog.go`) raises the
+   floor to 10m for `selectedEffort == "high"` or `complexity ==
+   ComplexityComplex`, in case a turn produces genuinely zero stdout of any
+   kind (not even a partial delta) for an extended stretch. An explicit
+   `stall_timeout_ms` config higher than the floor always wins; disabled
+   stall detection (negative `StallTimeoutMs`) is never re-enabled by this.
+
+## Prevention / Next Time
+
+If a new "healthy session killed as stalled" incident surfaces:
+
+1. Check whether the activity in question emits **any** stdout at all during
+   its silent stretch (`stdoutTail` capture in the execution's replay log or
+   `StdoutTail` on a failed result, GH-4395). If yes, the reset logic is
+   almost certainly fine — look upstream at what's suppressing output.
+2. If it's a backgrounded task class → mirror #4357 (track start/notification
+   pairs, suspend the idle clock).
+3. If it's a silent-CLI class (nothing to suspend on) → mirror #4501: find
+   the CLI/backend flag that turns silence into a heartbeat, and/or raise the
+   effort/complexity-aware floor in `effortAwareStallTimeout`.
+4. Verify against the *installed* CLI version — flag availability and event
+   shapes are not guaranteed stable across `claude` CLI releases; run
+   `claude --help` and a smoke invocation before assuming a flag exists.

--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -190,6 +190,19 @@ const (
 	// task finished (BackgroundTaskStatus carries "completed"/"failed"/
 	// "stopped"). GH-4357.
 	EventTypeTaskNotification BackendEventType = "task_notification"
+
+	// EventTypeStreamDelta indicates a partial/delta stream-json chunk
+	// (message_start, content_block_start/delta/stop, message_delta,
+	// message_stop) emitted only when --include-partial-messages is passed to
+	// the CLI. These exist purely to keep stdout non-silent — and thus the
+	// stall watchdog's idle clock fresh — during a long single-turn "thinking"
+	// stretch that produces no complete message for minutes (GH-4501). They
+	// must not be treated as complete assistant/tool events: the full
+	// "assistant" event for the same turn still arrives separately once the
+	// turn finishes, so processing deltas as text/tool_use would double-count
+	// output. Deliberately unhandled in processBackendEvent's switch (no
+	// case) so they generate no per-delta log lines.
+	EventTypeStreamDelta BackendEventType = "stream_delta"
 )
 
 // BackendResult contains the outcome of a backend execution.

--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -467,6 +467,10 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 			"-p", opts.Prompt,
 			"--verbose",
 			"--output-format", "stream-json",
+			// GH-4501: stream delta chunks during a turn (not just one complete
+			// message at the end) so a long silent "thinking" turn still emits
+			// stdout lines that reset the stall watchdog's idle clock.
+			"--include-partial-messages",
 			"--dangerously-skip-permissions",
 		}
 		b.log.Info("Resuming session from PR context",
@@ -479,6 +483,7 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 			"-p", opts.Prompt,
 			"--verbose",
 			"--output-format", "stream-json",
+			"--include-partial-messages", // GH-4501
 			"--dangerously-skip-permissions",
 		}
 		b.log.Info("Resuming session for context continuation",
@@ -489,6 +494,7 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 			"-p", opts.Prompt,
 			"--verbose",
 			"--output-format", "stream-json",
+			"--include-partial-messages", // GH-4501
 			"--dangerously-skip-permissions",
 		}
 	}
@@ -987,6 +993,21 @@ func (b *ClaudeCodeBackend) parseStreamEvent(line string) BackendEvent {
 
 	// Map stream event type to backend event type
 	switch streamEvent.Type {
+	case "stream_event":
+		// GH-4501: partial-message chunk from --include-partial-messages
+		// (message_start, content_block_start/delta/stop, message_delta,
+		// message_stop). The complete "assistant" event for this turn still
+		// arrives separately once the turn finishes, so classify these as a
+		// distinct no-op event type rather than re-deriving text/tool_use from
+		// them — that would double-process the same content. Every stdout
+		// line already resets the stall watchdog's idle clock unconditionally
+		// (see the EventHandler call site in Execute), so simply existing is
+		// enough for these to do their job.
+		event.Type = EventTypeStreamDelta
+		if streamEvent.Event != nil {
+			event.Message = streamEvent.Event.Type
+		}
+
 	case "system":
 		switch streamEvent.Subtype {
 		case "init":

--- a/internal/executor/backend_claudecode_test.go
+++ b/internal/executor/backend_claudecode_test.go
@@ -202,6 +202,195 @@ func TestClaudeCodeBackendParseToolInput(t *testing.T) {
 	}
 }
 
+// TestClaudeCodeBackendParsePartialMessageStreamEvent covers GH-4501: with
+// --include-partial-messages, the CLI wraps mid-turn delta chunks in a
+// top-level {"type":"stream_event","event":{"type":"..."}} envelope. These
+// must classify as EventTypeStreamDelta — a distinct, unhandled-in-processing
+// type — rather than being misparsed as a complete assistant/tool event.
+func TestClaudeCodeBackendParsePartialMessageStreamEvent(t *testing.T) {
+	backend := NewClaudeCodeBackend(nil)
+
+	tests := []struct {
+		name string
+		line string
+	}{
+		{
+			name: "message_start",
+			line: `{"type":"stream_event","event":{"type":"message_start","message":{"model":"claude-sonnet-5","id":"msg_1","type":"message","role":"assistant","content":[],"usage":{"input_tokens":2,"output_tokens":5}}},"session_id":"s1","uuid":"u1"}`,
+		},
+		{
+			name: "content_block_start",
+			line: `{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}},"session_id":"s1","uuid":"u2"}`,
+		},
+		{
+			name: "content_block_delta text",
+			line: `{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial chunk"}},"session_id":"s1","uuid":"u3"}`,
+		},
+		{
+			name: "content_block_delta thinking",
+			line: `{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"reasoning..."}},"session_id":"s1","uuid":"u4"}`,
+		},
+		{
+			name: "content_block_stop",
+			line: `{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"s1","uuid":"u5"}`,
+		},
+		{
+			name: "message_delta",
+			line: `{"type":"stream_event","event":{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":14}},"session_id":"s1","uuid":"u6"}`,
+		},
+		{
+			name: "message_stop",
+			line: `{"type":"stream_event","event":{"type":"message_stop"},"session_id":"s1","uuid":"u7"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := backend.parseStreamEvent(tt.line)
+
+			if event.Type != EventTypeStreamDelta {
+				t.Errorf("Type = %q, want %q", event.Type, EventTypeStreamDelta)
+			}
+			if event.ToolName != "" {
+				t.Errorf("ToolName should be empty for a partial delta, got %q", event.ToolName)
+			}
+			// A partial text_delta/thinking_delta must never surface as
+			// TokensInput/TokensOutput on its own — usage in these envelopes
+			// lives under "event", which the top-level StreamEvent.Usage field
+			// (tagged "usage" at the top level) does not reach, so accounting
+			// stays sourced from the complete assistant/result events only.
+			if event.TokensInput != 0 || event.TokensOutput != 0 {
+				t.Errorf("partial delta should not carry token usage, got in=%d out=%d", event.TokensInput, event.TokensOutput)
+			}
+			if event.Raw != tt.line {
+				t.Errorf("Raw = %q, want %q", event.Raw, tt.line)
+			}
+		})
+	}
+}
+
+// TestClaudeCodeBackendPartialDeltasDoNotDuplicateCompleteMessage covers
+// GH-4501's double-processing requirement: a realistic interleaved sequence
+// (partial deltas for a turn, followed by the complete "assistant" event for
+// the same turn, followed by "result") must produce exactly one
+// EventTypeText event with the full text and exactly one token-usage
+// accounting event — not one per delta.
+func TestClaudeCodeBackendPartialDeltasDoNotDuplicateCompleteMessage(t *testing.T) {
+	backend := NewClaudeCodeBackend(nil)
+
+	lines := []string{
+		`{"type":"stream_event","event":{"type":"message_start"}}`,
+		`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi! What"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" can I help?"}}}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"Hi! What can I help?"}]}}`,
+		`{"type":"stream_event","event":{"type":"content_block_stop","index":0}}`,
+		`{"type":"stream_event","event":{"type":"message_delta","delta":{"stop_reason":"end_turn"}}}`,
+		`{"type":"stream_event","event":{"type":"message_stop"}}`,
+		`{"type":"result","result":"Hi! What can I help?","is_error":false,"usage":{"input_tokens":2,"output_tokens":14}}`,
+	}
+
+	var (
+		textEvents   int
+		deltaEvents  int
+		fullText     string
+		tokensInput  int64
+		tokensOutput int64
+	)
+	for _, line := range lines {
+		event := backend.parseStreamEvent(line)
+		switch event.Type {
+		case EventTypeText:
+			textEvents++
+			fullText = event.Message
+		case EventTypeStreamDelta:
+			deltaEvents++
+		}
+		tokensInput += event.TokensInput
+		tokensOutput += event.TokensOutput
+	}
+
+	if textEvents != 1 {
+		t.Errorf("expected exactly 1 EventTypeText, got %d", textEvents)
+	}
+	if fullText != "Hi! What can I help?" {
+		t.Errorf("assembled text = %q, want full complete-message text", fullText)
+	}
+	if deltaEvents != 7 {
+		t.Errorf("expected 7 EventTypeStreamDelta events, got %d", deltaEvents)
+	}
+	if tokensInput != 2 || tokensOutput != 14 {
+		t.Errorf("token accounting = in=%d out=%d, want in=2 out=14 (sourced only from the result event)", tokensInput, tokensOutput)
+	}
+}
+
+// TestClaudeCodeBackendIncludesPartialMessagesFlag covers GH-4501: the CLI
+// must be invoked with --include-partial-messages so long silent "thinking"
+// turns still emit stdout that resets the stall watchdog's idle clock. Uses
+// a fake CLI script (same technique as TestClaudeCodeBackendResumeSessionFallback)
+// to capture the real argv rather than asserting against unexported
+// arg-building internals.
+func TestClaudeCodeBackendIncludesPartialMessagesFlag(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-CLI test relies on shell scripts; skipping on windows")
+	}
+
+	tmpDir := t.TempDir()
+	logFile := tmpDir + "/calls.log"
+	script := tmpDir + "/fake-claude"
+
+	body := `#!/bin/sh
+printf '%s\n' "$*" >> ` + logFile + `
+exit 0
+`
+	if err := os.WriteFile(script, []byte(body), 0755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	backend := NewClaudeCodeBackend(&ClaudeCodeConfig{Command: script})
+
+	t.Run("default invocation", func(t *testing.T) {
+		opts := ExecuteOptions{
+			Prompt:       "hello",
+			ProjectPath:  tmpDir,
+			EventHandler: func(BackendEvent) {},
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if _, err := backend.Execute(ctx, opts); err != nil {
+			t.Fatalf("Execute() error: %v", err)
+		}
+	})
+
+	t.Run("resume invocation", func(t *testing.T) {
+		opts := ExecuteOptions{
+			Prompt:          "hello",
+			ProjectPath:     tmpDir,
+			ResumeSessionID: "abc-123",
+			EventHandler:    func(BackendEvent) {},
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if _, err := backend.Execute(ctx, opts); err != nil {
+			t.Fatalf("Execute() error: %v", err)
+		}
+	})
+
+	data, readErr := os.ReadFile(logFile)
+	if readErr != nil {
+		t.Fatalf("read log: %v", readErr)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 CLI invocations, got %d: %q", len(lines), lines)
+	}
+	for i, line := range lines {
+		if !strings.Contains(line, "--include-partial-messages") {
+			t.Errorf("invocation %d missing --include-partial-messages: %q", i, line)
+		}
+	}
+}
+
 func TestClaudeCodeBackendIsAvailable(t *testing.T) {
 	// Test with non-existent command
 	backend := NewClaudeCodeBackend(&ClaudeCodeConfig{

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -282,6 +282,22 @@ type StreamEvent struct {
 	// Status carries the terminal status ("completed"/"failed"/"stopped") on
 	// task_notification system events (GH-4357).
 	Status string `json:"status,omitempty"`
+	// Event carries the inner partial-message chunk when Type == "stream_event"
+	// (emitted only with --include-partial-messages, GH-4501). These arrive
+	// mid-turn — message_start, content_block_start/delta/stop, message_delta,
+	// message_stop — solely to keep stdout non-silent during long "thinking"
+	// turns; the complete "assistant" event still arrives separately afterward,
+	// so only Type is captured here for classification, not full delta content.
+	Event *StreamEventInner `json:"event,omitempty"`
+}
+
+// StreamEventInner captures just the inner event type for a "stream_event"
+// wrapper line (GH-4501). The delta/content_block payload shape varies by
+// inner type (message_start, content_block_delta, message_delta, ...) and is
+// intentionally not modeled here — these chunks exist to reset the stall
+// watchdog's idle clock, not to be re-parsed as complete assistant output.
+type StreamEventInner struct {
+	Type string `json:"type"`
 }
 
 // UsageInfo represents token usage in stream events
@@ -2733,7 +2749,13 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		stallDone               = make(chan struct{})
 	)
 	lastEventAt.Store(time.Now().UnixNano())
-	stallTimeout := r.effectiveStallTimeout()
+	// GH-4501: high-effort/complex-lane turns can still produce several
+	// minutes of silent stdout even with --include-partial-messages (e.g. an
+	// extended non-tool reasoning stretch with no content_block_delta at all),
+	// so raise the floor for those lanes as defense-in-depth alongside the
+	// partial-message streaming fix. An explicit stall_timeout_ms config value
+	// higher than the floor still wins.
+	stallTimeout := effortAwareStallTimeout(r.effectiveStallTimeout(), selectedEffort, complexity)
 	var stallExecutionCtx context.Context
 	var stallCancel context.CancelFunc
 	if stallTimeout > 0 {

--- a/internal/executor/watchdog.go
+++ b/internal/executor/watchdog.go
@@ -13,6 +13,31 @@ const defaultStallWatchdogInterval = 30 * time.Second
 // stall timeout can't spin the watchdog hot.
 const minStallWatchdogInterval = time.Second
 
+// highEffortStallFloor is the minimum stall timeout applied to high-effort or
+// complex-lane executions (GH-4501). A single high-effort thinking turn can
+// legitimately produce no complete message — and, rarely, no partial-message
+// delta either — for several minutes, so the default 3m stall timeout is too
+// aggressive for these lanes.
+const highEffortStallFloor = 10 * time.Minute
+
+// effortAwareStallTimeout raises configured to highEffortStallFloor for
+// high-effort or complex-lane executions, unless configured (an explicit
+// stall_timeout_ms) is already higher — an explicit config value always wins
+// when it's the larger of the two. When configured <= 0 (stall detection
+// disabled via a negative StallTimeoutMs), it is returned unchanged so the
+// watchdog stays off for every lane. GH-4501.
+func effortAwareStallTimeout(configured time.Duration, effort string, complexity Complexity) time.Duration {
+	if configured <= 0 {
+		return configured
+	}
+	if effort == "high" || complexity == ComplexityComplex {
+		if configured < highEffortStallFloor {
+			return highEffortStallFloor
+		}
+	}
+	return configured
+}
+
 // watchdogTickInterval derives the watchdog poll interval from stallTimeout so a
 // small configured timeout is actually honored (detection latency ≈ one tick).
 // It is min(defaultStallWatchdogInterval, stallTimeout/3), floored at

--- a/internal/executor/watchdog_test.go
+++ b/internal/executor/watchdog_test.go
@@ -242,3 +242,158 @@ func TestEffectiveStallTimeout(t *testing.T) {
 		})
 	}
 }
+
+// TestEffortAwareStallTimeout covers GH-4501: high-effort or complex-lane
+// executions get a raised stall-timeout floor (defense-in-depth alongside the
+// --include-partial-messages streaming fix), but an explicit configured
+// timeout that's already higher always wins, and disabled stall detection
+// (configured <= 0) is never re-enabled by this logic.
+func TestEffortAwareStallTimeout(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured time.Duration
+		effort     string
+		complexity Complexity
+		want       time.Duration
+	}{
+		{
+			name:       "default effort, default complexity: unchanged at 3m",
+			configured: 3 * time.Minute,
+			effort:     "medium",
+			complexity: ComplexityMedium,
+			want:       3 * time.Minute,
+		},
+		{
+			name:       "high effort raises 3m default to the 10m floor",
+			configured: 3 * time.Minute,
+			effort:     "high",
+			complexity: ComplexityMedium,
+			want:       highEffortStallFloor,
+		},
+		{
+			name:       "complex-lane raises 3m default to the 10m floor",
+			configured: 3 * time.Minute,
+			effort:     "medium",
+			complexity: ComplexityComplex,
+			want:       highEffortStallFloor,
+		},
+		{
+			name:       "explicit config already above the floor wins",
+			configured: 15 * time.Minute,
+			effort:     "high",
+			complexity: ComplexityComplex,
+			want:       15 * time.Minute,
+		},
+		{
+			name:       "explicit config exactly at the floor is left unchanged",
+			configured: highEffortStallFloor,
+			effort:     "high",
+			complexity: ComplexityMedium,
+			want:       highEffortStallFloor,
+		},
+		{
+			name:       "disabled stall detection stays disabled regardless of effort",
+			configured: 0,
+			effort:     "high",
+			complexity: ComplexityComplex,
+			want:       0,
+		},
+		{
+			name:       "negative (explicitly disabled) stays disabled",
+			configured: -1,
+			effort:     "high",
+			complexity: ComplexityComplex,
+			want:       -1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := effortAwareStallTimeout(tt.configured, tt.effort, tt.complexity)
+			if got != tt.want {
+				t.Errorf("effortAwareStallTimeout(%v, %q, %q) = %v, want %v",
+					tt.configured, tt.effort, tt.complexity, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestStallWatchdog_PartialDeltasSurviveGapBetweenCompleteEvents covers
+// GH-4501's core regression: a long silent single model turn now emits
+// partial-message stdout lines (thanks to --include-partial-messages) even
+// though the two surrounding *complete* stream-json events (e.g. two
+// "assistant" messages) are far more than stallTimeout apart. Every stdout
+// line resets the watchdog's idle clock unconditionally (mirroring the real
+// EventHandler wiring in runner.go), so the session must survive.
+func TestStallWatchdog_PartialDeltasSurviveGapBetweenCompleteEvents(t *testing.T) {
+	r := &Runner{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	var (
+		lastEventAt   atomic.Int64
+		stallDetected atomic.Bool
+		inFlight      atomic.Int64
+		done          = make(chan struct{})
+	)
+
+	stallTimeout := 300 * time.Millisecond
+	// watchdogTickInterval floors at 1s, so the watchdog's first real check
+	// lands ~1s in — comfortably after the simulated gap below.
+	start := time.Now()
+	lastEventAt.Store(start.UnixNano())
+
+	go r.runStallWatchdog("test-task", &lastEventAt, &stallDetected, &inFlight, stallTimeout, done, func() {})
+
+	// Simulate partial-delta lines arriving every 150ms (well under
+	// stallTimeout) for 900ms — spanning a gap between "complete" events far
+	// larger than stallTimeout, but with no single idle gap exceeding it.
+	deltaInterval := 150 * time.Millisecond
+	deadline := start.Add(900 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		time.Sleep(deltaInterval)
+		lastEventAt.Store(time.Now().UnixNano()) // simulates EventHandler firing on a delta line
+	}
+
+	// Give the watchdog's ~1s tick a chance to fire before we conclude.
+	time.Sleep(300 * time.Millisecond)
+	close(done)
+
+	if stallDetected.Load() {
+		t.Fatal("stall watchdog fired despite partial-delta lines keeping the idle clock fresh")
+	}
+}
+
+// TestStallWatchdog_NoPartialDeltasFiresOnGenuineSilence is the negative
+// control for the test above: with no lines at all resetting lastEventAt
+// (the pre-GH-4501 failure mode — a CLI without --include-partial-messages
+// during a long silent turn), the watchdog must still fire once idle exceeds
+// stallTimeout.
+func TestStallWatchdog_NoPartialDeltasFiresOnGenuineSilence(t *testing.T) {
+	r := &Runner{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	var (
+		lastEventAt   atomic.Int64
+		stallDetected atomic.Bool
+		inFlight      atomic.Int64
+		done          = make(chan struct{})
+	)
+
+	// Simulate a stale last-event timestamp from well before the watchdog's
+	// first tick, with nothing refreshing it in between.
+	lastEventAt.Store(time.Now().Add(-1 * time.Second).UnixNano())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stallTimeout := 50 * time.Millisecond
+	go r.runStallWatchdog("test-task", &lastEventAt, &stallDetected, &inFlight, stallTimeout, done, cancel)
+
+	select {
+	case <-ctx.Done():
+		// expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("stall watchdog did not fire on genuine silence past stallTimeout")
+	}
+	if !stallDetected.Load() {
+		t.Fatal("stallDetected should be true after genuine silence")
+	}
+	close(done)
+}


### PR DESCRIPTION
## Summary

Fixes GH-4501: the stall watchdog killed healthy executor sessions during long silent high-effort model turns (incident: pilot-console GH-24, generations 1-4 each killed after ~30-60s of real work followed by one long silent claude-sonnet-5 effort=high thinking turn).

Root cause: `claude` was spawned with `--verbose --output-format stream-json` but without `--include-partial-messages`, so an entire silent turn batches into a single complete `assistant` event emitted only at the end — nothing exists on stdout to reset the (already-correct) unconditional per-line idle-clock reset in the meantime.

- Verified the installed CLI (`claude 2.1.104`) supports `--include-partial-messages` via `claude --help` and a live smoke invocation (captured the actual `stream_event` wrapper shapes: `message_start`, `content_block_start/delta/stop`, `message_delta`, `message_stop`).
- Added `--include-partial-messages` to all three spawn-arg sites in `internal/executor/backend_claudecode.go`.
- Added a new `EventTypeStreamDelta` classification in `parseStreamEvent` for the `stream_event` wrapper — deliberately unhandled in `processBackendEvent`'s switch so partial deltas can't double-process as complete assistant/tool_use events and never produce per-delta log lines.
- Added `effortAwareStallTimeout` (defense-in-depth): raises the stall floor to 10m when `selectedEffort == "high"` or `complexity == ComplexityComplex`, unless an explicit `stall_timeout_ms` config is already higher.
- Added a brief SOP (`.agent/sops/executor-stall-watchdog-silent-turns.md`) documenting this as a recurring "silent activity" class alongside GH-4357 (background tasks).

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/executor/...` (full suite green, ~38s)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] New unit tests:
  - `TestClaudeCodeBackendParsePartialMessageStreamEvent` — all partial-delta shapes classify as `EventTypeStreamDelta`, carry no stray token usage
  - `TestClaudeCodeBackendPartialDeltasDoNotDuplicateCompleteMessage` — interleaved deltas + complete message produce exactly one `EventTypeText` and correct (non-duplicated) token accounting
  - `TestClaudeCodeBackendIncludesPartialMessagesFlag` — fake-CLI argv capture confirms the flag is present on default and `--resume` invocations
  - `TestEffortAwareStallTimeout` — table test covering high-effort/complex-lane floor raise, explicit-config-wins, and disabled-stays-disabled
  - `TestStallWatchdog_PartialDeltasSurviveGapBetweenCompleteEvents` — simulated partial-delta cadence across a gap between complete events larger than stallTimeout → not killed
  - `TestStallWatchdog_NoPartialDeltasFiresOnGenuineSilence` — negative control: genuine silence still fires the watchdog