### PR TITLE
GH-4507: fix(executor): preflight judge truncates issue body at 4000 chars → false reject_vague on long specs (GH-4407 class)

### DIFF
--- a/internal/executor/intent_judge.go
+++ b/internal/executor/intent_judge.go
@@ -215,8 +215,45 @@ var (
 	preflightDecisionRegex   = regexp.MustCompile(`DECISION:\s*(\S+)`)
 	preflightReasonRegex     = regexp.MustCompile(`REASON:\s*(.+)`)
 	preflightConfidenceRegex = regexp.MustCompile(`CONFIDENCE:\s*([0-9]*\.?[0-9]+)`)
-	maxPreflightBodyChars    = 4000
+
+	// maxPreflightBodyChars caps the issue body sent to the preflight judge.
+	// GH-4507: raised from 4000 to 32000 — matching maxDiffCharsDefault, same
+	// token-budget reasoning as GH-4407. At 4000 chars, qf-studio/pilot-console#26
+	// (a complete, 22,926-char spec) was falsely rejected as reject_vague: the
+	// judge saw only ~17% of the issue and correctly noticed the acceptance
+	// criteria it referenced weren't visible. Bodies still over this larger
+	// cap are now middle-truncated (truncatePreflightBody) rather than
+	// tail-cut, since acceptance criteria, scope fences, and refs live at the
+	// end of our issue spec format.
+	maxPreflightBodyChars = 32000
 )
+
+// truncatePreflightBody middle-truncates a body over maxPreflightBodyChars,
+// preserving a head slice (context) and a tail slice (acceptance criteria,
+// scope fences, refs) with an explicit omission marker in between. GH-4507:
+// replaces the previous tail-cut "...[truncated]", which discarded the exact
+// sections (ACs, scope, refs) that live at the end of long, fully-specified
+// issues, causing the preflight judge to see only a head fragment and
+// falsely reject_vague.
+func truncatePreflightBody(body string) string {
+	if len(body) <= maxPreflightBodyChars {
+		return body
+	}
+
+	// Head gets 1/4 of the budget (context, problem statement); the rest is
+	// kept from the tail, where acceptance criteria, scope fences, and refs
+	// live in our issue spec format.
+	headChars := maxPreflightBodyChars / 4
+	tailChars := maxPreflightBodyChars - headChars
+	if headChars+tailChars >= len(body) {
+		return body
+	}
+
+	omitted := len(body) - headChars - tailChars
+	head := body[:headChars]
+	tail := body[len(body)-tailChars:]
+	return fmt.Sprintf("%s\n...[truncated: %d chars omitted from middle of issue body]\n%s", head, omitted, tail)
+}
 
 const preflightJudgeSystemPrompt = `You are a pre-flight issue quality judge. Evaluate whether a GitHub issue is actionable for an autonomous AI developer.
 
@@ -227,6 +264,8 @@ Classify the issue as exactly one of:
 - reject_conflicting: contains contradictory requirements that cannot all be satisfied
 - reject_stale: describes something already done or clearly outdated
 - reject_out_of_scope: outside the repository's purpose or requires unavailable external resources
+
+IMPORTANT — truncation handling: A "...[truncated: N chars omitted from middle of issue body]" marker inside the issue description means content was cut from the middle for length only — it is NOT evidence the issue is vague or missing specification. Never cite the presence of this marker itself as a reason for reject_vague, and never base reject_vague on a section (e.g. specific acceptance criteria) simply because it falls inside the omitted range. Judge actionability from the head and tail content that IS shown.
 
 Output exactly:
 DECISION: <classification>
@@ -377,11 +416,10 @@ func buildJudgeDiffPayload(diff string, maxChars int) string {
 // JudgeIssue evaluates whether a GitHub issue is actionable before dispatching to a worker.
 // Returns a PreFlightVerdict with decision, reason, and confidence.
 // Empty body is treated as vague (returns reject_vague, not an error).
-// Body is truncated to maxPreflightBodyChars before sending.
+// Bodies over maxPreflightBodyChars are middle-truncated (see
+// truncatePreflightBody) before sending.
 func (j *IntentJudge) JudgeIssue(ctx context.Context, title, body, repoContext string) (*PreFlightVerdict, error) {
-	if len(body) > maxPreflightBodyChars {
-		body = body[:maxPreflightBodyChars] + "\n...[truncated]"
-	}
+	body = truncatePreflightBody(body)
 
 	userContent := fmt.Sprintf("## Issue Title\n%s\n\n## Issue Description\n%s", title, body)
 	if repoContext != "" {

--- a/internal/executor/intent_judge_test.go
+++ b/internal/executor/intent_judge_test.go
@@ -400,15 +400,74 @@ func TestJudgeIssue_BodyTruncation(t *testing.T) {
 		return []byte("DECISION: accept\nREASON: Looks good.\nCONFIDENCE: 0.9"), nil
 	}
 
-	largeBody := strings.Repeat("x", 5000) // > maxPreflightBodyChars (4000)
+	largeBody := strings.Repeat("x", maxPreflightBodyChars+5000) // > maxPreflightBodyChars (32000)
 
 	judge := newIntentJudgeWithRunner(runner)
 	_, err := judge.JudgeIssue(context.Background(), "title", largeBody, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(receivedPrompt, "...[truncated]") {
-		t.Error("expected body to be truncated in prompt")
+	if !strings.Contains(receivedPrompt, "...[truncated: 5000 chars omitted from middle of issue body]") {
+		t.Error("expected body to be middle-truncated with the omission marker in prompt")
+	}
+}
+
+// TestJudgeIssue_BodyMiddleTruncationPreservesTailACs is the direct
+// regression test for GH-4507: qf-studio/pilot-console#26 (a complete,
+// 22,926-char spec) was falsely rejected as reject_vague because the old
+// 4000-char tail-cut discarded the acceptance criteria, which live at the
+// end of our issue spec format. A body over the new 32000-char cap must
+// still deliver those trailing ACs verbatim to the judge, alongside an
+// explicit omission marker (never a bare "...[truncated]" that could be
+// mistaken for missing content).
+func TestJudgeIssue_BodyMiddleTruncationPreservesTailACs(t *testing.T) {
+	var receivedPrompt string
+	runner := func(ctx context.Context, args ...string) ([]byte, error) {
+		for i, arg := range args {
+			if arg == "-p" && i+1 < len(args) {
+				receivedPrompt = args[i+1]
+				break
+			}
+		}
+		return []byte("DECISION: accept\nREASON: Looks good.\nCONFIDENCE: 0.9"), nil
+	}
+
+	acSection := "## Acceptance Criteria\nAC1: does the thing\nAC2: handles the edge case\nAC3: has a test"
+	middle := strings.Repeat("filler spec content describing the implementation. ", 1000)
+	// Pad the tail so the AC section lands in the final 2000 chars of the body.
+	tailPadding := strings.Repeat("z", 2000-len(acSection))
+	body := "## Problem\n" + middle + tailPadding + acSection
+	if len(body) <= maxPreflightBodyChars {
+		t.Fatalf("test fixture body (%d chars) must exceed maxPreflightBodyChars (%d) to exercise truncation", len(body), maxPreflightBodyChars)
+	}
+	if !strings.HasSuffix(body[len(body)-2000:], acSection) {
+		t.Fatalf("test setup error: ACs are not within the final 2000 chars of the fixture body")
+	}
+
+	judge := newIntentJudgeWithRunner(runner)
+	_, err := judge.JudgeIssue(context.Background(), "title", body, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(receivedPrompt, acSection) {
+		t.Error("expected acceptance criteria from the tail of the body to survive truncation verbatim")
+	}
+	if !strings.Contains(receivedPrompt, "...[truncated: ") || !strings.Contains(receivedPrompt, "chars omitted from middle of issue body]") {
+		t.Error("expected a middle-omission marker in the prompt")
+	}
+}
+
+// TestPreflightPrompt_HasTruncationInstruction is the preflight-path
+// counterpart to TestIntentJudge_PerFileTruncationPreservesManifest's
+// GH-4407 prompt instruction: the preflight judge must be told that a
+// truncation marker is never evidence of vagueness. GH-4507.
+func TestPreflightPrompt_HasTruncationInstruction(t *testing.T) {
+	if !strings.Contains(preflightJudgeSystemPrompt, "truncated: N chars omitted from middle of issue body") {
+		t.Error("expected preflight prompt to reference the middle-truncation marker format")
+	}
+	if !strings.Contains(strings.ToLower(preflightJudgeSystemPrompt), "not evidence the issue is vague") {
+		t.Error("expected preflight prompt to instruct that a truncation marker is not evidence of vagueness")
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4507.

Closes #4507

## Changes

GitHub Issue GH-4507: fix(executor): preflight judge truncates issue body at 4000 chars → false reject_vague on long specs (GH-4407 class)

## Problem

The pre-flight intent judge truncates issue bodies to `maxPreflightBodyChars = 4000` (`internal/executor/intent_judge.go:218`, applied in the body-prep at ~`:380-384`) and appends a bare `...[truncated]` marker. Long, fully-specified issues are then rejected as `reject_vague` because the judge sees only the head of the spec and correctly observes that referenced sections are missing.

**Live incident 2026-07-23 11:21Z**: `qf-studio/pilot-console#26` (B8 config push, body = 22,926 chars, complete on GitHub) rejected with:

> decision=reject_vague reason="Issue description is truncated mid-specification, cutting off critical acceptance criteria and implementation requirements (AC5, AC6, etc. referenced but not shown)..."

The judge saw ~17% of the spec. `pilot-console#27` (5,527 chars) is queued next and is also over the cap. Every carefully-authored long spec (exactly the issues that pass adversarial review before dispatch) is at risk of a false preflight decline.

## Precedent — GH-4407 fixed the identical class for the diff payload

See the comment block at `intent_judge.go:197-203`: `maxDiffCharsDefault` was raised 8000→32000, truncation became structured (per-file with a never-truncated manifest), and the judge prompt gained an explicit rule that a truncation marker is NEVER evidence of missing work (`intent_judge.go:244`). The preflight body path got none of that treatment.

## Fix

1. Raise `maxPreflightBodyChars` to 32000 (match `maxDiffCharsDefault`; same token-budget reasoning as GH-4407).
2. When a body still exceeds the cap, truncate the MIDDLE, preserving head and tail — acceptance criteria, scope fences, and refs live at the end of our spec format. Marker format: `\n...[truncated: N chars omitted from middle of issue body]\n`.
3. Add the GH-4407-style instruction to the preflight judge prompt: a truncation marker in the issue body means content was cut for length only; it must never be cited as evidence of vagueness or missing specification, and `reject_vague` must not be based on sections that fall inside the omitted range.

## Acceptance criteria

- AC1: `maxPreflightBodyChars = 32000`, with a comment referencing this issue and GH-4407.
- AC2: bodies over the cap are middle-truncated head+tail; a table-driven test feeds a >cap body whose ACs are in the final 2000 chars and asserts the judge payload contains those ACs verbatim plus the omission marker.
- AC3: preflight prompt contains the truncation-handling instruction (assert substring in a test, mirroring the existing diff-payload coverage).
- AC4: existing preflight tests (`intent_judge_test.go`) stay green; empty-body → `reject_vague` behavior unchanged.

## Scope fence

Only the preflight body path. Do NOT touch the diff payload path (`buildJudgeDiffPayload`, `maxDiffCharsDefault`) — it already handles this class. No config knob needed; constant is fine.

## Refs

- `internal/executor/intent_judge.go:218` (cap), `:380-384` (truncation), `:197-203` + `:244` (GH-4407 precedent to mirror)
- Blocks: `qf-studio/pilot-console#26` (B8, S2), `qf-studio/pilot-console#27` (A3, S2) — both over the cap
- TASK-417 (B8 spec), saas-roadmap S2

## Planned Steps (execute all in sequence)

- Step 1: **fix(executor): middle-truncate preflight body and raise cap to 32000 (GH-4407 class)** — In internal/executor/intent_judge.go, raise maxPreflightBodyChars from 4000 to 32000 with a comment linking GH-4507 and the GH-4407 precedent. Change the body-prep block at ~:380-384 from tail-cut '...[truncated]' to a middle-truncation strategy that preserves head and tail with the marker '\n...[truncated: N chars omitted from middle of issue body]\n', since acceptance criteria, scope fences, and refs live at the end of the spec format. Add a GH-4407-style instruction to the preflight judge prompt (mirroring the diff-payload instruction at :244) stating that a truncation marker in the issue body means content was cut for length only and must never be cited as evidence of vagueness or missing specification, and that reject_vague must not be based on sections falling inside the omitted range. In internal/executor/intent_judge_test.go, add table-driven coverage: (a) a >32000-char body whose ACs sit in the final 2000 chars — assert the built judge payload contains those ACs verbatim plus the middle-omission marker; (b) a substring assertion on the preflight prompt for the new truncation-handling instruction; keep existing empty-body → reject_vague behavior unchanged and all current preflight tests green. Scope is strictly the preflight body path — do not touch buildJudgeDiffPayload or maxDiffCharsDefault. All work lives in internal/executor/ (intent_judge.go and its co-located test file); per the 'Avoid Single-Package Splits' rule this is kept as one subtask.
