### PR TITLE
fix(executor): auto-preserve dirty worktree instead of no_op discard

### DIFF
--- a/internal/executor/gh4517_test.go
+++ b/internal/executor/gh4517_test.go
@@ -1,0 +1,291 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// TestApplyGhostSHAGuard_DirtyWorktreeAutoPreserved is the AC1/AC2
+// table-driven test for the GH-4517 harvester backstop: a worktree the
+// ghost-SHA guard is about to classify no_op — and which the runner's
+// deferred worktree cleanup would then delete — must not be silently
+// discarded when it still has uncommitted work.
+//
+// Incident: pilot-console#26 (B8), 2026-07-23 — a 44-minute session did
+// real, test-passing work and never ran `git commit`; the harvested SHA
+// turned out to be a ghost (already on origin/main), so the run was
+// classified no_op and the worktree deleted, destroying the work.
+func TestApplyGhostSHAGuard_DirtyWorktreeAutoPreserved(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		dirty         bool
+		wantPreserved bool
+	}{
+		{
+			name:          "dirty worktree (new + modified files) is auto-committed and pushed, not classified no_op",
+			dirty:         true,
+			wantPreserved: true,
+		},
+		{
+			name:          "clean worktree still classifies no_op exactly as today",
+			dirty:         false,
+			wantPreserved: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			repoDir, bareDir := setupFreshnessRepo(t)
+
+			// Seed a tracked file on main so the dirty case has something to
+			// modify (setupFreshnessRepo's initial commit is --allow-empty).
+			seedPath := filepath.Join(repoDir, "existing.txt")
+			if err := os.WriteFile(seedPath, []byte("v1\n"), 0o644); err != nil {
+				t.Fatalf("write seed file: %v", err)
+			}
+			runGit(t, repoDir, "add", "existing.txt")
+			runGit(t, repoDir, "commit", "-m", "feat: seed file")
+			runGit(t, repoDir, "push", "origin", "main")
+			seedSHA := strings.TrimSpace(gitOutput(t, repoDir, "rev-parse", "HEAD"))
+
+			branch := fmt.Sprintf("pilot/GH-4517-%v", tc.dirty)
+			runGit(t, repoDir, "checkout", "-b", branch)
+
+			if tc.dirty {
+				// Modified tracked file + new untracked file — matches AC1's
+				// "new and modified files".
+				if err := os.WriteFile(seedPath, []byte("v2\n"), 0o644); err != nil {
+					t.Fatalf("modify seed file: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(repoDir, "new_work.go"), []byte("package x\n"), 0o644); err != nil {
+					t.Fatalf("write new file: %v", err)
+				}
+			}
+
+			var logBuf bytes.Buffer
+			log := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+			task := &Task{ID: "GH-4517T", Branch: branch, BaseBranch: "main"}
+			// seedSHA is already on origin/main — the ghost-SHA scenario: the
+			// harvester "recovered" a SHA that turns out to be stale.
+			result := &ExecutionResult{TaskID: task.ID, CommitSHA: seedSHA, Success: true}
+
+			preserved := applyGhostSHAGuard(ctx, task, result, repoDir, log)
+
+			if preserved != tc.wantPreserved {
+				t.Fatalf("applyGhostSHAGuard preserved = %v, want %v (result: %+v)", preserved, tc.wantPreserved, result)
+			}
+
+			// Regardless of outcome, a no-op-classified run must never be
+			// reported as completed.
+			if result.Success {
+				t.Error("result.Success must be false — not a completed classification")
+			}
+
+			if tc.wantPreserved {
+				if result.CommitSHA == "" || result.CommitSHA == seedSHA {
+					t.Errorf("expected a new commit SHA distinct from the ghost SHA, got %q", result.CommitSHA)
+				}
+				if strings.Contains(result.Error, "no new commit produced") {
+					t.Errorf("preserved result must not carry the no_op error text, got %q", result.Error)
+				}
+				status := TerminalStatus(result)
+				if status == "no_op" || status == "completed" {
+					t.Errorf("TerminalStatus = %q, want neither no_op nor completed (failed-with-artifact)", status)
+				}
+
+				// AC1: worktree cleanup only after the push succeeds — verify
+				// the commit actually landed on origin's branch, not just
+				// locally.
+				out := gitOutput(t, bareDir, "log", "-1", "--format=%s", "refs/heads/"+branch)
+				if !strings.Contains(out, "auto-preserved") {
+					t.Errorf("expected pushed commit message to mention auto-preserved, got %q", out)
+				}
+
+				// AC3: a WARN log is emitted.
+				if !strings.Contains(logBuf.String(), "auto-preserved") {
+					t.Error("expected a WARN log mentioning auto-preserved")
+				}
+			} else {
+				// AC2: clean-tree no-commit case is byte-identical to the
+				// pre-GH-4517 behavior.
+				if result.CommitSHA != "" {
+					t.Errorf("clean-tree case: CommitSHA should be cleared, got %q", result.CommitSHA)
+				}
+				if result.Error != "no new commit produced — worktree HEAD matches base branch parent" {
+					t.Errorf("clean-tree case: unexpected error %q", result.Error)
+				}
+				if TerminalStatus(result) != "no_op" {
+					t.Errorf("clean-tree case: TerminalStatus = %q, want no_op", TerminalStatus(result))
+				}
+			}
+		})
+	}
+}
+
+// TestApplyGhostSHAGuardWithPreserve_RecordsExecutionEvent covers AC3: the
+// auto-preserve path must emit an execution_events row (StageWorkPreserved)
+// so it's visible in `pilot trace` / the dashboard, not just a log line.
+func TestApplyGhostSHAGuardWithPreserve_RecordsExecutionEvent(t *testing.T) {
+	ctx := context.Background()
+	repoDir, _ := setupFreshnessRepo(t)
+
+	seedPath := filepath.Join(repoDir, "existing.txt")
+	if err := os.WriteFile(seedPath, []byte("v1\n"), 0o644); err != nil {
+		t.Fatalf("write seed file: %v", err)
+	}
+	runGit(t, repoDir, "add", "existing.txt")
+	runGit(t, repoDir, "commit", "-m", "feat: seed file")
+	runGit(t, repoDir, "push", "origin", "main")
+	seedSHA := strings.TrimSpace(gitOutput(t, repoDir, "rev-parse", "HEAD"))
+
+	branch := "pilot/GH-4517WORK"
+	runGit(t, repoDir, "checkout", "-b", branch)
+	if err := os.WriteFile(seedPath, []byte("v2\n"), 0o644); err != nil {
+		t.Fatalf("modify seed file: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	execID := "exec-gh4517"
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          execID,
+		TaskID:      "GH-4517WORK",
+		ProjectPath: repoDir,
+		Status:      "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution failed: %v", err)
+	}
+
+	runner := NewRunner()
+	runner.SetLogStore(store)
+
+	task := &Task{ID: "GH-4517WORK", ExecutionID: execID, Branch: branch, BaseBranch: "main"}
+	result := &ExecutionResult{TaskID: task.ID, CommitSHA: seedSHA, Success: true}
+
+	runner.applyGhostSHAGuardWithPreserve(ctx, task, result, repoDir, slog.Default())
+
+	if result.Success {
+		t.Fatal("expected Success=false after auto-preserve")
+	}
+	if result.CommitSHA == "" || result.CommitSHA == seedSHA {
+		t.Fatalf("expected a new preserved commit SHA, got %q", result.CommitSHA)
+	}
+
+	events, err := store.ListExecutionEvents(execID)
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+	found := false
+	for _, e := range events {
+		if e.Stage == memory.StageWorkPreserved {
+			found = true
+			if !strings.Contains(e.Detail, "auto-preserved") {
+				t.Errorf("event detail = %q, want mention of auto-preserved", e.Detail)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected a %q execution event, got stages: %+v", memory.StageWorkPreserved, events)
+	}
+}
+
+// mockDirtyBackend simulates the exact incident behavior (pilot-console#26 /
+// B8): the model edits files on disk and reports success, but never runs
+// `git commit`. Used to exercise the runner's other no-op classification
+// site — the GH-916 "no commits after retry" path in Execute — end to end.
+type mockDirtyBackend struct {
+	mu        sync.Mutex
+	dir       string
+	execCount int
+}
+
+func (m *mockDirtyBackend) Name() string      { return "mock-dirty" }
+func (m *mockDirtyBackend) IsAvailable() bool { return true }
+func (m *mockDirtyBackend) Execute(_ context.Context, _ ExecuteOptions) (*BackendResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.execCount++
+	content := fmt.Sprintf("package x // attempt %d\n", m.execCount)
+	if err := os.WriteFile(filepath.Join(m.dir, "implementation.go"), []byte(content), 0o644); err != nil {
+		return nil, err
+	}
+	return &BackendResult{Success: true, Output: "implementation complete"}, nil
+}
+
+// TestRunner_DirtyWorktreeAfterNoCommitRetry_AutoPreserved covers the GH-916
+// no-commit-after-retry path (runner.go, "No-commit detection and retry"):
+// when the backend leaves real, uncommitted files on disk across both the
+// initial attempt and the retry, the run must not be silently classified
+// no_op — the dirty state must be auto-committed and pushed instead.
+func TestRunner_DirtyWorktreeAfterNoCommitRetry_AutoPreserved(t *testing.T) {
+	const branch = "pilot/GH-4517RETRY"
+	dir, bareDir := setupFreshnessRepo(t)
+	runGit(t, dir, "checkout", "-b", branch)
+
+	backend := &mockDirtyBackend{dir: dir}
+	runner := NewRunnerWithBackend(backend)
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+
+	task := &Task{
+		ID:          "GH-4517RETRY",
+		Title:       "fix(executor): dirty worktree after no-commit retry",
+		Description: "model edits files but never commits",
+		ProjectPath: dir,
+		Branch:      branch,
+		BaseBranch:  "main",
+		CreatePR:    true,
+	}
+
+	result, err := runner.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+	if result.Success {
+		t.Error("expected Success=false — not a completed classification")
+	}
+	if strings.HasPrefix(result.Error, "no_changes:") {
+		t.Errorf("expected auto-preserve, not the no_changes/no_op classification, got: %q", result.Error)
+	}
+	if !strings.Contains(result.Error, "auto-preserved") {
+		t.Errorf("expected result.Error to mention auto-preserved, got: %q", result.Error)
+	}
+	if result.CommitSHA == "" {
+		t.Error("expected a preserved commit SHA")
+	}
+	if status := TerminalStatus(result); status == "no_op" || status == "completed" {
+		t.Errorf("TerminalStatus = %q, want neither no_op nor completed", status)
+	}
+
+	// Verify the commit actually landed on origin's branch (AC1: cleanup only
+	// after push succeeds).
+	out := gitOutput(t, bareDir, "log", "-1", "--format=%s", "refs/heads/"+branch)
+	if !strings.Contains(out, "auto-preserved") {
+		t.Errorf("expected pushed commit on origin, got log: %q", out)
+	}
+
+	backend.mu.Lock()
+	count := backend.execCount
+	backend.mu.Unlock()
+	if count != 2 {
+		t.Errorf("expected backend called 2 times (initial + retry), got %d", count)
+	}
+}

--- a/internal/executor/git_freshness.go
+++ b/internal/executor/git_freshness.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os/exec"
@@ -14,13 +15,19 @@ import (
 // Skipped for LocalMode tasks (read-only intents have no commit expectation — GH-3642).
 // Fails open on check errors (e.g. no origin configured in test repos): only rejects
 // when the check conclusively shows the SHA is already on origin/<base>.
-func applyGhostSHAGuard(ctx context.Context, task *Task, result *ExecutionResult, executionPath string, log *slog.Logger) {
+// Returns true when the GH-4517 dirty-worktree backstop fired: the ghost SHA
+// was rejected, but the worktree still had uncommitted changes, so they were
+// auto-committed and pushed to the task branch instead of being silently
+// discarded. Callers should record this as a visible execution event — see
+// Runner.applyGhostSHAGuardWithPreserve, the sole call site.
+func applyGhostSHAGuard(ctx context.Context, task *Task, result *ExecutionResult, executionPath string, log *slog.Logger) bool {
 	if task.LocalMode || result.CommitSHA == "" || !result.Success {
-		return
+		return false
 	}
+	git := NewGitOperations(executionPath)
 	ghostBase := task.BaseBranch
 	if ghostBase == "" {
-		ghostBase, _ = NewGitOperations(executionPath).GetDefaultBranch(ctx)
+		ghostBase, _ = git.GetDefaultBranch(ctx)
 		if ghostBase == "" {
 			ghostBase = "main"
 		}
@@ -37,10 +44,81 @@ func applyGhostSHAGuard(ctx context.Context, task *Task, result *ExecutionResult
 			slog.String("sha", result.CommitSHA[:min(7, len(result.CommitSHA))]),
 			slog.String("base", ghostBase),
 		)
+		// GH-4517: the ghost-SHA guard only proves the *harvested* SHA is
+		// stale — it says nothing about the worktree's working tree. Incident
+		// pilot-console#26/B8 (2026-07-23): a 44-minute session did real,
+		// test-passing work and never ran `git commit`; the worktree was then
+		// silently deleted as a no-op by the runner's deferred cleanup,
+		// destroying it. Before discarding, check for uncommitted changes and
+		// preserve them onto the task branch rather than losing them.
+		if sha, preserved := preserveDirtyWorktreeAsWIP(ctx, git, task, log); preserved {
+			result.CommitSHA = sha
+			result.Success = false
+			result.Error = fmt.Sprintf(
+				"worktree had uncommitted work at no-op classification — auto-preserved as %s on branch %s; needs manual review, not a genuine no-op",
+				sha[:min(7, len(sha))], task.Branch,
+			)
+			return true
+		}
 		result.CommitSHA = ""
 		result.Success = false
 		result.Error = "no new commit produced — worktree HEAD matches base branch parent"
 	}
+	return false
+}
+
+// preserveDirtyWorktreeAsWIP is the GH-4517 harvester backstop for a
+// worktree that is about to be classified no_op — and thus deleted by the
+// runner's deferred worktree cleanup — despite still holding uncommitted
+// changes. It auto-commits any stageable dirty paths (GitOperations.Commit
+// already excludes noise: .agent/, .claude/, node_modules/, lockfiles, etc.)
+// to the task branch as a wip(<task-id>) commit and pushes it, so a human or
+// a retry can pick the work up instead of it silently vanishing.
+//
+// Returns preserved=false with no side effects when the tree is genuinely
+// clean, or when only excluded noise paths are dirty (GitOperations.Commit
+// returns ErrNoStageableChanges) — the classic no_op case is left untouched,
+// so genuine no-ops still classify exactly as before.
+func preserveDirtyWorktreeAsWIP(ctx context.Context, git *GitOperations, task *Task, log *slog.Logger) (sha string, preserved bool) {
+	if task.Branch == "" {
+		return "", false
+	}
+	message := fmt.Sprintf("wip(%s): uncommitted session work (auto-preserved)", task.ID)
+	newSHA, commitErr := git.Commit(ctx, message)
+	if commitErr != nil {
+		if !errors.Is(commitErr, ErrNoStageableChanges) {
+			log.Warn("executor: dirty-worktree auto-preserve commit attempt failed",
+				slog.String("task_id", task.ID),
+				slog.Any("error", commitErr),
+			)
+		}
+		return "", false
+	}
+	if pushErr := git.Push(ctx, task.Branch); pushErr != nil {
+		// Pin the commit under a recovery ref (GH-3785 pattern) so it
+		// survives worktree cleanup even though the push itself failed —
+		// never leave a preserved commit reachable only via a worktree that
+		// is about to be removed.
+		recoveryRef, refErr := git.CreateRecoveryRef(ctx, task.ID, "HEAD")
+		fields := []any{
+			slog.String("task_id", task.ID),
+			slog.String("sha", newSHA[:min(7, len(newSHA))]),
+			slog.Any("push_error", pushErr),
+		}
+		if refErr == nil {
+			fields = append(fields, slog.String("recovery_ref", recoveryRef))
+		} else {
+			fields = append(fields, slog.Any("recovery_ref_error", refErr))
+		}
+		log.Warn("executor: dirty-worktree auto-preserve push failed — commit pinned via recovery ref", fields...)
+		return newSHA, true
+	}
+	log.Warn("executor: auto-preserved uncommitted session work — worktree was dirty at no-op classification",
+		slog.String("task_id", task.ID),
+		slog.String("branch", task.Branch),
+		slog.String("sha", newSHA[:min(7, len(newSHA))]),
+	)
+	return newSHA, true
 }
 
 // commitSHAIsNew returns true iff sha exists in the repo AND is NOT an ancestor of

--- a/internal/executor/prompt_builder.go
+++ b/internal/executor/prompt_builder.go
@@ -273,6 +273,7 @@ func (r *Runner) BuildPrompt(task *Task, executionPath string) (prompt string) {
 		sb.WriteString("\nIf any verification fails, fix it before committing.\n\n")
 
 		sb.WriteString("CRITICAL: You MUST commit all changes before completing. A task is NOT complete until changes are committed. Use format: `type(scope): description (TASK-XX)`\n")
+		sb.WriteString("If your context was compacted mid-session, run `git log`/`git status` before concluding anything is done — verify the commit actually exists rather than assuming earlier work already landed.\n")
 	} else if hasNavigator && complexity.ShouldSkipNavigator() {
 		// Trivial task in Navigator project - minimal prompt without Navigator overhead (GH-216)
 		// Still need Pilot execution mode notice since CLAUDE.md may have "don't write code" rules

--- a/internal/executor/prompt_builder_test.go
+++ b/internal/executor/prompt_builder_test.go
@@ -487,6 +487,49 @@ func TestBuildPromptContainsErrcheckGuidance(t *testing.T) {
 	}
 }
 
+// TestBuildPromptContainsCompletionContract covers GH-4517 AC4: the prompt
+// must explicitly state that work is only complete after `git commit`, and
+// that after a context compaction the model must verify git log/git status
+// before concluding anything is done — "tests pass" in a dirty tree is not
+// done. Incident: pilot-console#26 (B8), 2026-07-23 — a session attributed
+// its own uncommitted work to "an earlier session" post-compaction and
+// skipped straight to reporting completion.
+func TestBuildPromptContainsCompletionContract(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "pilot-test-completion-contract")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	agentDir := filepath.Join(tempDir, ".agent")
+	if err := os.MkdirAll(agentDir, 0755); err != nil {
+		t.Fatalf("Failed to create .agent dir: %v", err)
+	}
+
+	runner := NewRunner()
+	task := &Task{
+		ID:          "GH-4517",
+		Title:       "harvester backstop for dirty worktrees",
+		Description: "auto-preserve uncommitted work instead of classifying no_op",
+		ProjectPath: tempDir,
+		Branch:      "pilot/GH-4517",
+	}
+
+	prompt := runner.BuildPrompt(task, tempDir)
+
+	for _, want := range []string{
+		"Completion Contract",
+		"git commit",
+		"context was compacted",
+		"git status --porcelain",
+		"git log",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("BuildPrompt should contain %q (completion contract / post-compaction verify), got:\n%s", want, prompt)
+		}
+	}
+}
+
 // GH-3224: every executor prompt must carry the evidence-backed-spec directive
 // so the model does not silently no-op on explicit changes that "look correct."
 func TestBuildPromptContainsEvidenceBackedSpecDirective(t *testing.T) {

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1361,6 +1361,17 @@ func (r *Runner) recordExecutionEvent(executionID string, stage memory.Stage, de
 	}
 }
 
+// applyGhostSHAGuardWithPreserve wraps the free applyGhostSHAGuard so a
+// GH-4517 dirty-worktree auto-preserve is also recorded to the
+// execution_events audit trail — without this, the only trace of a
+// ~44-minute rescue is a WARN log line, invisible in `pilot trace` and the
+// dashboard (AC3).
+func (r *Runner) applyGhostSHAGuardWithPreserve(ctx context.Context, task *Task, result *ExecutionResult, executionPath string, log *slog.Logger) {
+	if applyGhostSHAGuard(ctx, task, result, executionPath, log) {
+		r.recordExecutionEvent(task.LogExecutionID(), memory.StageWorkPreserved, result.Error)
+	}
+}
+
 // recordResearchPhaseEvent persists the parallel-research phase's cost to the
 // execution_events ledger — previously only slog.Info, so per-execution
 // research spend wasn't queryable (GH-4129).
@@ -3322,7 +3333,9 @@ retrySucceeded:
 
 	// GH-3126: Ghost-SHA guard — reject SHAs that are already on the base branch.
 	// Skipped for LocalMode tasks (read-only intents have no commit expectation — GH-3642).
-	applyGhostSHAGuard(ctx, task, result, executionPath, log)
+	// GH-4517: also auto-preserves any uncommitted worktree changes it finds
+	// before the caller's deferred worktree cleanup can delete them.
+	r.applyGhostSHAGuardWithPreserve(ctx, task, result, executionPath, log)
 
 	// Fill in additional metrics from state
 	result.FilesChanged = state.filesWrite
@@ -3557,6 +3570,37 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 							recorder.SetModel(result.ModelName)
 							recorder.SetNavigator(state.hasNavigator)
 							if finErr := recorder.Finish("declined"); finErr != nil {
+								log.Warn("Failed to finish recording", slog.Any("error", finErr))
+							}
+						}
+						return result, nil
+					}
+
+					// GH-4517: before declaring a genuine no_changes no-op, check
+					// whether the worktree still has uncommitted changes despite
+					// zero counted commits — the model may have done real work and
+					// simply never run `git commit` (pilot-console#26/B8, where the
+					// same failure mode showed up via the ghost-SHA guard instead
+					// of this no-commit-after-retry path). If so, auto-preserve
+					// instead of letting the deferred worktree cleanup delete it.
+					if sha, preserved := preserveDirtyWorktreeAsWIP(ctx, git, task, log); preserved {
+						result.CommitSHA = sha
+						result.Success = false
+						result.Error = fmt.Sprintf(
+							"worktree had uncommitted work after no-commit retry — auto-preserved as %s on branch %s; needs manual review, not a genuine no-op",
+							sha[:min(7, len(sha))], task.Branch,
+						)
+						r.recordExecutionEvent(task.LogExecutionID(), memory.StageWorkPreserved, result.Error)
+						log.Warn("executor: auto-preserved dirty worktree after no-commit retry",
+							slog.String("task_id", task.ID),
+							slog.String("sha", sha[:min(7, len(sha))]),
+						)
+						r.reportProgress(task.ID, "Auto-Preserved", 100, result.Error)
+						r.persistBackendDiagnostics(task.LogExecutionID(), backendResult)
+						if recorder != nil {
+							recorder.SetModel(result.ModelName)
+							recorder.SetNavigator(state.hasNavigator)
+							if finErr := recorder.Finish("failed"); finErr != nil {
 								log.Warn("Failed to finish recording", slog.Any("error", finErr))
 							}
 						}

--- a/internal/executor/workflow.go
+++ b/internal/executor/workflow.go
@@ -173,6 +173,26 @@ to the actual change you made):
 
 ---
 
+### Completion Contract (Non-negotiable)
+
+Work is only complete once you have run ` + "`git commit`" + ` on the task
+branch — never before. Passing tests, a working build, or a final message
+claiming all acceptance criteria are met do NOT count as done while the
+working tree is still dirty. "Tests pass" in a dirty tree is not done — if
+` + "`git status --porcelain`" + ` shows anything unexpected, commit it before
+you conclude.
+
+**After any context compaction** (if your context was summarized or you
+notice earlier turns are no longer directly visible): before reporting
+anything as complete, run ` + "`git log --oneline -5`" + ` and
+` + "`git status --porcelain`" + ` in the task branch and verify they
+actually reflect the work you believe you did. Do not attribute your own
+prior uncommitted edits to "an earlier session" and skip straight to
+verification — if ` + "`git log`" + ` does not show your commit, the work is
+not saved yet. Commit it now, before doing anything else.
+
+---
+
 ### Error Recovery
 
 **Stuck after 3 attempts?**

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -980,6 +980,19 @@ const (
 	// {"path","node_id"}. Without this, a guard that silently rewrites the
 	// branch would be invisible to anyone reviewing the PR or `pilot trace`.
 	StageMemoryGuardRestore Stage = "memory_guard_restore"
+	// StageWorkPreserved records the GH-4517 harvester backstop firing: the
+	// worktree was about to be classified no_op (and deleted by the runner's
+	// deferred worktree cleanup) but still had uncommitted changes, so the
+	// executor auto-committed them to the task branch as a wip(<task-id>)
+	// commit and pushed instead of silently discarding the work. Detail
+	// carries the same human-readable message as result.Error (short SHA,
+	// branch, "needs manual review" note). Distinct from StageCommit (a
+	// normal, agent-authored commit) and StageNoOp (a genuine no-op with
+	// nothing to preserve) — this is a rescue path for a session that did
+	// real work but never ran `git commit` itself. Incident: pilot-console#26
+	// (B8), 2026-07-23 — 44 minutes of completed, test-passing work destroyed
+	// before this backstop existed.
+	StageWorkPreserved Stage = "work_preserved"
 )
 
 // Event represents a single stage-transition record for an execution.


### PR DESCRIPTION
## Summary
- Adds a harvester backstop (GH-4517): before a no-op classification deletes an isolated worktree, check for uncommitted changes and auto-commit + push them to the task branch (`wip(<task-id>): uncommitted session work (auto-preserved)`) instead of silently discarding them
- Wired into both no-op classification sites: the ghost-SHA guard (harvested-but-stale SHA) and the GH-916 no-commit-after-retry path — both now classify as failed-with-artifact, never `no_op`/`completed`, when a rescue fires
- Falls back to a recovery ref (GH-3785 pattern) if the push itself fails, and records a `StageWorkPreserved` execution event so the rescue is visible in `pilot trace`/the dashboard, not just a log line
- Hardens the executor prompt/workflow completion contract: work is only complete after `git commit`, and after any context compaction the model must verify `git log`/`git status` before concluding rather than attributing its own uncommitted work to "an earlier session"

Incident: pilot-console#26 (B8), 2026-07-23 — a 43m54s session did real, test-passing work but never ran `git commit`; the harvester recovered a ghost SHA already on `main`, the run was classified `no_op`, and the worktree was deleted, destroying the work.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] New table-driven test `TestApplyGhostSHAGuard_DirtyWorktreeAutoPreserved` covers dirty (auto-preserved) vs. clean (unchanged `no_op`) cases
- [x] `TestApplyGhostSHAGuardWithPreserve_RecordsExecutionEvent` covers the `StageWorkPreserved` execution-event audit trail
- [x] `TestRunner_DirtyWorktreeAfterNoCommitRetry_AutoPreserved` exercises the GH-916 no-commit-retry path end to end via `runner.Execute()`
- [x] `TestBuildPromptContainsCompletionContract` asserts the prompt carries the new completion-contract language
- [x] `go test ./internal/executor/...` — full package passes, no regressions