### PR TITLE
fix(executor): survive oversized stream-json lines in stdout reader (GH-4519)

### DIFF
--- a/.agent/sops/executor-stdout-oversized-line-silent-death.md
+++ b/.agent/sops/executor-stdout-oversized-line-silent-death.md
@@ -1,0 +1,74 @@
+---
+title: Stdout Reader Silent Death on Oversized stream-json Line
+created: 2026-07-23
+status: active
+related: GH-4519, pilot-console#26 (B8 gen-2)
+---
+
+# Stdout Reader Silent Death on Oversized stream-json Line
+
+## Problem
+
+B8 gen-2 (pilot-console#26) died after 10m17s with exit 137
+`shutdown_terminated`, `stdout_tail` pure base64, all completed work lost —
+even though the process was still alive and producing output at the time it
+was killed.
+
+## Root Cause
+
+`internal/executor/backend_claudecode.go`'s stdout reader used
+`bufio.Scanner` capped at 1MB (`scanner.Buffer(buf, 1024*1024)`). A single
+stream-json line over 1MB (e.g. a tool result embedding a base64 blob) makes
+`scanner.Scan()` return `false` with `bufio.ErrTooLong` — and the loop had no
+`scanner.Err()` check afterward, so this was completely silent.
+
+Once `Scan()` returns false, the goroutine stops calling `Read` on the pipe.
+The child process, still mid-write on that oversized line, fills the OS pipe
+buffer and blocks in the `write()` syscall — for real, not a bug in the
+child. `lastEventAt` (only updated inside the scan loop) freezes at that
+moment. 5 minutes later (`DefaultHeartbeatTimeout`), the heartbeat monitor
+sees no update and SIGKILLs a process group that was never actually hung —
+it was just waiting on a full pipe with nobody reading it. The finished work
+already sitting in the model's context is lost along with it.
+
+## Solution
+
+1. Replaced the stdout `bufio.Scanner` with `bufio.NewReaderSize` +
+   `readBoundedLine` — a helper built on `(*bufio.Reader).ReadLine()` that
+   keeps at most `maxStdoutLineBytes` (1MB) of a line but **keeps draining**
+   past that cap instead of aborting, so the pipe never backs up regardless
+   of how large a single line gets. Truncated lines get a bounded marker
+   (`[line truncated: N bytes] <snippet>`) written to `stdoutTail` instead of
+   the raw payload, and are only fed to `parseStreamEvent` if the kept prefix
+   happens to still be complete, valid JSON (`json.Valid`) — an oversized
+   line's prefix almost never is, since the closing braces got truncated
+   away.
+2. The heartbeat (`lastEventAt`) now updates on every underlying chunk read
+   (`onBytes` callback into `readBoundedLine`), not just on completed lines —
+   so heartbeat freeze can no longer happen mid-line even for very large single
+   lines.
+3. Both the stdout and stderr reader goroutines now log a WARN with the
+   terminal read error (skipping plain `io.EOF`) after their loop exits — a
+   reader exiting must never be silent again.
+
+## Prevention / Next Time
+
+If a run dies with `shutdown_terminated` and `stdout_tail` looking like raw
+base64 or otherwise truncated/binary-ish content with no trailing
+stream-json `result` event:
+
+1. Check whether the tail cuts off mid-line with no evidence of a
+   `[line truncated:` marker for it — if there's a marker, the new reader
+   already recovered gracefully and the failure is something else (the
+   marker's reported byte size tells you exactly how big the offending line
+   was).
+2. If a *new* silent-reader-exit shows up (no WARN log at all despite a dead
+   reader), that means some other code path bypassed `readBoundedLine` /
+   the `scanner.Err()` check added here — grep
+   `internal/executor/backend_claudecode.go` for any additional
+   `bufio.Scanner` on the stdout/stderr pipes and apply the same pattern.
+3. `maxStdoutLineBytes` (1MB) and `stdoutTruncationSnippetBytes` (256B) are
+   deliberately conservative — raising the line cap defeats the point
+   (unbounded pipe backpressure risk returns as the cap approaches the OS
+   pipe buffer size); raising the snippet size risks the marker itself being
+   evicted by `stdoutTail`'s own 64KB tail-truncation policy.

--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -37,6 +38,20 @@ const MaxStderrBufferBytes = 1 << 20 // 1 MiB
 // to look at when a nonzero exit produced no stderr and no parsed assistant
 // text, not to reconstruct the full session transcript.
 const MaxStdoutTailBufferBytes = 64 * 1024 // 64 KiB
+
+// maxStdoutLineBytes caps how much of a single stdout stream-json line the
+// reader keeps before treating it as oversized (GH-4519). A line over this
+// cap (e.g. a tool result embedding a base64 blob) is truncated rather than
+// aborting the read — bufio.Scanner previously errored out with
+// bufio.ErrTooLong on exactly this case and silently stopped draining the
+// pipe, wedging the child process and freezing the heartbeat.
+const maxStdoutLineBytes = 1024 * 1024 // 1 MiB
+
+// stdoutTruncationSnippetBytes bounds how much of an oversized line's kept
+// prefix is copied into stdoutTail alongside the truncation marker. Keeping
+// this small ensures the marker survives stdoutTail's own tail-truncation
+// policy instead of being pushed out by megabytes of low-value snippet data.
+const stdoutTruncationSnippetBytes = 256
 
 // DefaultHeartbeatTimeout is the default time to wait for any stream-json event before considering the process hung.
 const DefaultHeartbeatTimeout = 5 * time.Minute
@@ -753,67 +768,109 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 	wg.Add(1)
 	logging.SafeGo("executor-backend-claudecode", func() {
 		defer wg.Done()
-		scanner := bufio.NewScanner(stdout)
-		// Increase buffer size for large JSON events
-		buf := make([]byte, 0, 64*1024)
-		scanner.Buffer(buf, 1024*1024)
+		reader := bufio.NewReaderSize(stdout, 64*1024)
 
-		for scanner.Scan() {
-			line := scanner.Text()
+		for {
+			lineBytes, truncated, totalBytes, rerr := readBoundedLine(reader, maxStdoutLineBytes, func(n int) {
+				// GH-4519: heartbeat must track raw byte flow, not just
+				// completed lines — an oversized line spanning many reads
+				// must not let the heartbeat monitor think the process is
+				// hung while it's still actively streaming data.
+				lastEventAt.Store(time.Now().UnixNano())
+			})
 
-			// GH-4395: capture the raw line regardless of whether it parses as
-			// a stream-json event — a crash mid-line or non-JSON diagnostic
-			// output would otherwise vanish entirely.
-			stdoutTail.WriteLine(line)
+			if len(lineBytes) > 0 || truncated {
+				line := string(lineBytes)
 
-			// Update heartbeat timestamp on each stream event
-			lastEventAt.Store(time.Now().UnixNano())
-
-			if opts.Verbose {
-				fmt.Printf("   %s\n", line)
-			}
-
-			// Parse and convert to BackendEvent
-			event := b.parseStreamEvent(line)
-			if opts.EventHandler != nil {
-				opts.EventHandler(event)
-			}
-
-			// GH-2328: track the last assistant text block so refusals (Claude
-			// exits 0 after politely declining) can be surfaced to the user.
-			if event.Type == EventTypeText && event.Message != "" {
-				result.LastAssistantText = event.Message
-			}
-
-			// Track final result
-			if event.Type == EventTypeResult {
-				// GH-2103: Cancel heartbeat on result event.
-				// On slow I/O flush, the heartbeat timer could fire and kill
-				// the process after it had already produced output.
-				cancelHeartbeat()
-
-				if event.IsError {
-					result.Error = event.Message
+				if truncated {
+					// GH-4519: a stream-json line over the 1MB cap (e.g. a
+					// tool result carrying a base64 blob) previously made
+					// bufio.Scanner abort with ErrTooLong and silently stop
+					// draining the pipe — the child then blocked writing to
+					// a full pipe, the heartbeat froze, and the heartbeat
+					// monitor SIGKILLed a process that was still alive and
+					// producing output. Record a bounded marker instead and
+					// keep reading subsequent lines.
+					snippet := line
+					if len(snippet) > stdoutTruncationSnippetBytes {
+						snippet = snippet[:stdoutTruncationSnippetBytes]
+					}
+					stdoutTail.WriteLine(fmt.Sprintf("[line truncated: %d bytes] %s", totalBytes, snippet))
 				} else {
-					result.Output = event.Message
-					result.SawSuccessResult = true // GH-2107: track successful result for timeout recovery
+					// GH-4395: capture the raw line regardless of whether it parses as
+					// a stream-json event — a crash mid-line or non-JSON diagnostic
+					// output would otherwise vanish entirely.
+					stdoutTail.WriteLine(line)
 				}
-				// Cancel heartbeat — process is finishing, don't kill it
-				cancelHeartbeat()
+
+				if opts.Verbose {
+					fmt.Printf("   %s\n", line)
+				}
+
+				// GH-4519: an oversized line's kept prefix dropped its
+				// closing braces/brackets along with the rest of the line,
+				// so it is essentially never complete JSON — only attempt
+				// to parse it if it actually validates; otherwise skip
+				// parsing this line rather than feeding a corrupt event
+				// through.
+				if !truncated || json.Valid(lineBytes) {
+					// Parse and convert to BackendEvent
+					event := b.parseStreamEvent(line)
+					if opts.EventHandler != nil {
+						opts.EventHandler(event)
+					}
+
+					// GH-2328: track the last assistant text block so refusals (Claude
+					// exits 0 after politely declining) can be surfaced to the user.
+					if event.Type == EventTypeText && event.Message != "" {
+						result.LastAssistantText = event.Message
+					}
+
+					// Track final result
+					if event.Type == EventTypeResult {
+						// GH-2103: Cancel heartbeat on result event.
+						// On slow I/O flush, the heartbeat timer could fire and kill
+						// the process after it had already produced output.
+						cancelHeartbeat()
+
+						if event.IsError {
+							result.Error = event.Message
+						} else {
+							result.Output = event.Message
+							result.SawSuccessResult = true // GH-2107: track successful result for timeout recovery
+						}
+						// Cancel heartbeat — process is finishing, don't kill it
+						cancelHeartbeat()
+					}
+
+					// Capture session ID from init event (GH-1265)
+					if event.Type == EventTypeInit && event.SessionID != "" {
+						result.SessionID = event.SessionID
+					}
+
+					// Accumulate token usage
+					result.TokensInput += event.TokensInput
+					result.TokensOutput += event.TokensOutput
+					result.CacheCreationInputTokens += event.CacheCreationInputTokens
+					result.CacheReadInputTokens += event.CacheReadInputTokens
+					if event.Model != "" {
+						result.Model = event.Model
+					}
+				}
 			}
 
-			// Capture session ID from init event (GH-1265)
-			if event.Type == EventTypeInit && event.SessionID != "" {
-				result.SessionID = event.SessionID
-			}
-
-			// Accumulate token usage
-			result.TokensInput += event.TokensInput
-			result.TokensOutput += event.TokensOutput
-			result.CacheCreationInputTokens += event.CacheCreationInputTokens
-			result.CacheReadInputTokens += event.CacheReadInputTokens
-			if event.Model != "" {
-				result.Model = event.Model
+			if rerr != nil {
+				// GH-4519: a reader exiting must never be silent — the
+				// previous scanner-based loop had no Err() check at all, so
+				// an ErrTooLong (or any other read error) stopped draining
+				// stdout with zero diagnostic trace.
+				if !errors.Is(rerr, io.EOF) {
+					b.log.Warn("stdout reader exited with error",
+						slog.String("task_id", opts.TaskID),
+						slog.Any("error", rerr),
+					)
+				}
+				return
 			}
 		}
 	})
@@ -829,6 +886,13 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 			if opts.Verbose {
 				fmt.Printf("   [err] %s\n", line)
 			}
+		}
+		if err := scanner.Err(); err != nil {
+			// GH-4519: a reader exiting must never be silent.
+			b.log.Warn("stderr reader exited with error",
+				slog.String("task_id", opts.TaskID),
+				slog.Any("error", err),
+			)
 		}
 	})
 
@@ -999,6 +1063,54 @@ func truncate(s string, n int) string {
 		return s
 	}
 	return s[:n] + "..."
+}
+
+// readBoundedLine reads a single newline-terminated line from r, keeping at
+// most maxBytes of it. Unlike bufio.Scanner (which aborts the entire read
+// with bufio.ErrTooLong the moment a line exceeds its fixed buffer), this
+// keeps draining an oversized line to its end so the caller can continue
+// reading subsequent lines — GH-4519: a silently-abandoned oversized line
+// left the child process blocked writing to a full pipe, which froze the
+// heartbeat and got the whole (otherwise-healthy) process SIGKILLed.
+//
+// onBytes, if non-nil, is invoked with the length of each underlying chunk
+// read — including chunks belonging to a line that ends up truncated — so
+// callers can drive a heartbeat off raw byte flow rather than only
+// completed lines.
+//
+// It returns the (possibly truncated) line content without the trailing
+// newline, whether truncation occurred, the original untruncated line
+// length in bytes, and any terminal read error (e.g. io.EOF).
+func readBoundedLine(r *bufio.Reader, maxBytes int, onBytes func(n int)) (line []byte, truncated bool, totalBytes int, err error) {
+	var buf []byte
+	for {
+		chunk, isPrefix, rerr := r.ReadLine()
+		if len(chunk) > 0 {
+			if onBytes != nil {
+				onBytes(len(chunk))
+			}
+			totalBytes += len(chunk)
+			if len(buf) < maxBytes {
+				remaining := maxBytes - len(buf)
+				take := chunk
+				if len(take) > remaining {
+					take = take[:remaining]
+				}
+				buf = append(buf, take...)
+				if len(take) < len(chunk) {
+					truncated = true
+				}
+			} else {
+				truncated = true
+			}
+		}
+		if rerr != nil {
+			return buf, truncated, totalBytes, rerr
+		}
+		if !isPrefix {
+			return buf, truncated, totalBytes, nil
+		}
+	}
 }
 
 // parseStreamEvent converts Claude Code stream-json to BackendEvent.

--- a/internal/executor/backend_claudecode_test.go
+++ b/internal/executor/backend_claudecode_test.go
@@ -1,9 +1,12 @@
 package executor
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -1731,5 +1734,217 @@ exit 0
 	}
 	if result.StdoutTail != "" {
 		t.Errorf("expected empty StdoutTail on success, got: %q", result.StdoutTail)
+	}
+}
+
+// TestReadBoundedLine_OversizedLineDoesNotExitSilently covers GH-4519: unlike
+// bufio.Scanner, which aborts the entire read with bufio.ErrTooLong the
+// moment a line exceeds its fixed buffer (and never surfaces that error to
+// the caller unless Err() is checked), readBoundedLine must keep draining an
+// oversized line to its end and let the caller continue reading subsequent
+// lines — this is the exact silent-exit bug that let a hung child process
+// wedge on a full stdout pipe and get SIGKILLed by the heartbeat monitor.
+func TestReadBoundedLine_OversizedLineDoesNotExitSilently(t *testing.T) {
+	const maxBytes = 1024 * 1024 // 1 MiB, matches maxStdoutLineBytes
+
+	oversized := strings.Repeat("a", 5*1024*1024) // 5 MiB, no newline yet
+	input := oversized + "\n" + `{"type":"result","result":"done"}` + "\n"
+
+	// Sanity check that a bufio.Scanner with the same 1MB buffer really does
+	// abort silently on this input, i.e. this test reproduces the original bug.
+	t.Run("reproduces bufio.Scanner ErrTooLong", func(t *testing.T) {
+		scanner := bufio.NewScanner(strings.NewReader(input))
+		buf := make([]byte, 0, 64*1024)
+		scanner.Buffer(buf, maxBytes)
+		lineCount := 0
+		for scanner.Scan() {
+			lineCount++
+		}
+		if lineCount != 0 {
+			t.Fatalf("expected scanner to abort before returning any line, got %d lines", lineCount)
+		}
+		if !errors.Is(scanner.Err(), bufio.ErrTooLong) {
+			t.Fatalf("expected bufio.ErrTooLong, got %v", scanner.Err())
+		}
+	})
+
+	reader := bufio.NewReaderSize(strings.NewReader(input), 64*1024)
+
+	var totalBytesSeenByHeartbeat int
+	onBytes := func(n int) { totalBytesSeenByHeartbeat += n }
+
+	// First line: oversized, must be truncated but must NOT return an error —
+	// the loop must be able to continue to the next line.
+	line, truncated, totalBytes, err := readBoundedLine(reader, maxBytes, onBytes)
+	if err != nil {
+		t.Fatalf("readBoundedLine returned error on oversized line, want nil (silent exit not allowed): %v", err)
+	}
+	if !truncated {
+		t.Fatal("expected truncated=true for a line exceeding maxBytes")
+	}
+	if len(line) != maxBytes {
+		t.Fatalf("expected kept line length %d, got %d", maxBytes, len(line))
+	}
+	if totalBytes != len(oversized) {
+		t.Fatalf("expected totalBytes=%d, got %d", len(oversized), totalBytes)
+	}
+	if totalBytesSeenByHeartbeat == 0 {
+		t.Fatal("expected onBytes callback to fire while draining the oversized line (heartbeat must track raw byte flow)")
+	}
+
+	// Second line: normal, must parse cleanly — proving the reader survived
+	// the oversized line and continues with subsequent lines.
+	line2, truncated2, _, err2 := readBoundedLine(reader, maxBytes, onBytes)
+	if err2 != nil {
+		t.Fatalf("readBoundedLine returned error on subsequent normal line: %v", err2)
+	}
+	if truncated2 {
+		t.Fatal("normal line should not be marked truncated")
+	}
+	want := `{"type":"result","result":"done"}`
+	if string(line2) != want {
+		t.Fatalf("line2 = %q, want %q", string(line2), want)
+	}
+
+	// Third read: EOF, terminal error must be surfaced (not swallowed).
+	_, _, _, err3 := readBoundedLine(reader, maxBytes, onBytes)
+	if !errors.Is(err3, io.EOF) {
+		t.Fatalf("expected io.EOF at end of stream, got %v", err3)
+	}
+}
+
+// TestClaudeCodeBackendSurvivesOversizedStdoutLine covers GH-4519 end to end:
+// a single stream-json line over 1MB (e.g. a tool result carrying a base64
+// blob) must not kill the stdout reader. Before the fix, bufio.Scanner
+// aborted on this input and stopped draining stdout entirely; since the fake
+// CLI keeps writing past the OS pipe buffer capacity afterward, the child
+// blocks and the run would eventually be killed rather than complete.
+func TestClaudeCodeBackendSurvivesOversizedStdoutLine(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-CLI test relies on shell scripts; skipping on windows")
+	}
+
+	tmpDir := t.TempDir()
+	script := tmpDir + "/fake-claude"
+
+	// Emit one line well over the 1MB cap (5MB of 'a's) with no embedded
+	// newlines, then a normal stream-json result event.
+	body := `#!/bin/sh
+head -c 5000000 /dev/zero | tr '\0' 'a'
+echo ""
+echo '{"type":"result","subtype":"success","result":"done","is_error":false}'
+exit 0
+`
+	if err := os.WriteFile(script, []byte(body), 0755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	backend := NewClaudeCodeBackend(&ClaudeCodeConfig{Command: script})
+	var events []BackendEvent
+	opts := ExecuteOptions{
+		Prompt:      "hello",
+		ProjectPath: tmpDir,
+		EventHandler: func(e BackendEvent) {
+			events = append(events, e)
+		},
+	}
+
+	// Generous timeout: with the fix this completes in well under a second.
+	// A regression that reintroduces the silent-scanner-exit bug would hang
+	// here until context cancellation, blowing well past this bound.
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	result, err := backend.Execute(ctx, opts)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("Execute() took %v, want well under 5s — suggests the oversized line wedged the reader", elapsed)
+	}
+	if !result.SawSuccessResult {
+		t.Error("expected SawSuccessResult=true — the result event after the oversized line must still parse")
+	}
+	if result.Output != "done" {
+		t.Errorf("result.Output = %q, want %q", result.Output, "done")
+	}
+	// Note: result.StdoutTail is only attached to the result on failure
+	// (GH-4395 — success runs don't need the diagnostic transcript); the
+	// truncation-marker content itself is covered on the failure path by
+	// TestClaudeCodeBackendStdoutTailShowsTruncationMarkerOnFailure below.
+
+	sawResultEvent := false
+	for _, e := range events {
+		if e.Type == EventTypeResult {
+			sawResultEvent = true
+		}
+	}
+	if !sawResultEvent {
+		t.Error("expected the result event to reach EventHandler after the oversized line")
+	}
+}
+
+// TestClaudeCodeBackendStdoutTailShowsTruncationMarkerOnFailure covers AC2:
+// when a run fails, the bounded diagnostic stdoutTail must contain a
+// truncation marker (not the raw multi-megabyte line) for any oversized
+// line encountered — proving the reader captured evidence instead of
+// silently dropping it (GH-4519), while keeping memory bounded.
+func TestClaudeCodeBackendStdoutTailShowsTruncationMarkerOnFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-CLI test relies on shell scripts; skipping on windows")
+	}
+
+	tmpDir := t.TempDir()
+	script := tmpDir + "/fake-claude"
+
+	// Oversized line with no subsequent successful result event, then a
+	// nonzero exit — reproduces the failure-diagnostics path (GH-4395)
+	// combined with an oversized line (GH-4519), without GH-2107's
+	// SawSuccessResult recovery masking the failure.
+	body := `#!/bin/sh
+head -c 5000000 /dev/zero | tr '\0' 'a'
+echo ""
+exit 1
+`
+	if err := os.WriteFile(script, []byte(body), 0755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	backend := NewClaudeCodeBackend(&ClaudeCodeConfig{Command: script})
+	opts := ExecuteOptions{
+		Prompt:       "hello",
+		ProjectPath:  tmpDir,
+		EventHandler: func(BackendEvent) {},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	result, err := backend.Execute(ctx, opts)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error from fake CLI exiting 1, got nil")
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("Execute() took %v, want well under 5s — suggests the oversized line wedged the reader", elapsed)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result even on failure")
+	}
+	if !strings.Contains(result.StdoutTail, "[line truncated:") {
+		t.Errorf("expected StdoutTail to contain a truncation marker, got: %q", truncate(result.StdoutTail, 300))
+	}
+	if !strings.Contains(result.StdoutTail, "5000000 bytes") {
+		t.Errorf("expected truncation marker to report the original line size, got: %q", truncate(result.StdoutTail, 300))
+	}
+	// AC2: bounded memory — the raw 5MB payload must never appear in the
+	// (64KB-capped) tail, only the small marker + snippet.
+	if len(result.StdoutTail) > MaxStdoutTailBufferBytes+1024 {
+		t.Errorf("StdoutTail is %d bytes, expected it to stay close to the %d-byte cap", len(result.StdoutTail), MaxStdoutTailBufferBytes)
 	}
 }


### PR DESCRIPTION
## Summary

- B8 gen-2 (pilot-console#26, 2026-07-23 15:50Z) died after 10m17s with exit 137 (self-inflicted heartbeat kill), `stdout_tail` pure base64, all completed work lost — while the process was actually still alive and producing output.
- Root cause: `bufio.Scanner` capped at 1MB aborted silently (unchecked `bufio.ErrTooLong`) on any stream-json line over 1MB (e.g. a tool result carrying a base64 blob), stopped draining stdout, and let the child block writing to a full pipe. The heartbeat (only updated inside the scan loop) froze, and the heartbeat monitor SIGKILLed a process that was never actually hung.
- Replaced the stdout scanner with a `bufio.Reader`-based `readBoundedLine` helper that keeps at most 1MB of an oversized line but **keeps draining** past that cap instead of aborting — so the pipe never backs up. Oversized lines get a bounded `[line truncated: N bytes] <snippet>` marker in `stdoutTail` instead of the raw payload, and are only parsed if the kept prefix happens to still be complete, valid JSON.
- Heartbeat (`lastEventAt`) now updates on every underlying chunk read, not just completed lines, so it can no longer freeze mid-line.
- Both stdout and stderr reader goroutines now log a WARN with the terminal read error (skipping plain `io.EOF`) after their loop exits — a reader exiting must never be silent again.
- Added a short SOP at `.agent/sops/executor-stdout-oversized-line-silent-death.md` documenting the failure signature for future triage.

Scope: `internal/executor/backend_claudecode.go` + tests only. Heartbeat timeout constants and the watchdog are untouched.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/executor/...` (full package, existing tests unchanged/passing)
- [x] `go test -race ./internal/executor/...` on the touched tests
- [x] New unit test `TestReadBoundedLine_OversizedLineDoesNotExitSilently` — reproduces the original `bufio.Scanner`/`ErrTooLong` silent-abort bug, then proves `readBoundedLine` survives the same input without a silent exit and continues to subsequent lines (AC3)
- [x] New integration test `TestClaudeCodeBackendSurvivesOversizedStdoutLine` — 5MB line followed by a normal result event completes the run quickly, no heartbeat kill, subsequent event parses normally (AC1)
- [x] New integration test `TestClaudeCodeBackendStdoutTailShowsTruncationMarkerOnFailure` — confirms `stdoutTail` carries a bounded truncation marker (not the raw 5MB payload) on failure (AC2)
