### PR TITLE
GH-4520: fix(autopilot): remove vestigial AutoReview self-approve — guaranteed 422 API call on every merge

### DIFF
--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -2914,7 +2914,6 @@ Note: Pilot must be running with --env flag for this to work.`,
 					"enabled":     true,
 					"environment": autopilotCfg.Environment,
 					"auto_merge":  autopilotCfg.AutoMerge,
-					"auto_review": autopilotCfg.AutoReview,
 					"release": map[string]interface{}{
 						"enabled": autopilotCfg.Release != nil && autopilotCfg.Release.Enabled,
 						"trigger": func() string {
@@ -2946,7 +2945,6 @@ Note: Pilot must be running with --env flag for this to work.`,
 
 			fmt.Println("Configuration:")
 			fmt.Printf("  Auto Merge:     %v\n", autopilotCfg.AutoMerge)
-			fmt.Printf("  Auto Review:    %v\n", autopilotCfg.AutoReview)
 			fmt.Printf("  Merge Method:   %s\n", autopilotCfg.MergeMethod)
 			fmt.Printf("  CI Timeout:     %s\n", autopilotCfg.CIWaitTimeout)
 			fmt.Printf("  Max Failures:   %d\n", autopilotCfg.MaxFailures)

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -2337,7 +2337,6 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		logging.WithComponent("start").Info("autopilot enabled",
 			slog.String("environment", string(cfg.Orchestrator.Autopilot.Environment)),
 			slog.Bool("auto_merge", cfg.Orchestrator.Autopilot.AutoMerge),
-			slog.Bool("auto_review", cfg.Orchestrator.Autopilot.AutoReview),
 		)
 	}
 

--- a/e2e/workflow_test.go
+++ b/e2e/workflow_test.go
@@ -52,7 +52,6 @@ func TestFullWorkflow_IssueToMerge(t *testing.T) {
 	cfg.CIPollInterval = 10 * time.Millisecond
 	cfg.DevCITimeout = 5 * time.Second
 	cfg.RequiredChecks = []string{"build", "test"}
-	cfg.AutoReview = false
 
 	controller := autopilot.NewController(cfg, ghClient, nil, "owner", "repo")
 

--- a/internal/autopilot/auto_merger.go
+++ b/internal/autopilot/auto_merger.go
@@ -54,17 +54,8 @@ func (m *AutoMerger) MergePR(ctx context.Context, prState *PRState) error {
 		"pr", prState.PRNumber,
 		"env", m.config.EnvironmentName(),
 		"method", m.config.MergeMethod,
-		"auto_review", m.config.AutoReview,
 		"sha", ShortSHA(prState.HeadSHA),
 	)
-
-	// Auto-review if enabled (creates approval review on the PR)
-	if m.config.AutoReview {
-		if err := m.approvePR(ctx, prState.PRNumber); err != nil {
-			m.log.Warn("auto-review failed", "pr", prState.PRNumber, "error", err)
-			// Continue anyway - might not need review or already reviewed
-		}
-	}
 
 	// Final CI verification immediately before merge to prevent race conditions.
 	// CI status can change between initial check and merge, so we verify again.
@@ -165,12 +156,6 @@ Tracked in #2598.`,
 		m.log.Warn("postMisconfigComment: failed to post PR comment",
 			"pr", prState.PRNumber, "error", postErr)
 	}
-}
-
-// approvePR creates an approval review on the PR.
-func (m *AutoMerger) approvePR(ctx context.Context, prNumber int) error {
-	body := "Auto-approved by Pilot autopilot"
-	return m.ghClient.ApprovePullRequest(ctx, m.owner, m.repo, prNumber, body)
 }
 
 // CanMerge checks if a PR is in a mergeable state.

--- a/internal/autopilot/auto_merger_test.go
+++ b/internal/autopilot/auto_merger_test.go
@@ -201,7 +201,6 @@ func TestAutoMerger_MergePR_DevEnvironment(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = true
 	cfg.MergeMethod = github.MergeMethodSquash
 
 	merger := NewAutoMerger(ghClient, nil, nil, "owner", "repo", cfg)
@@ -248,7 +247,6 @@ func TestAutoMerger_MergePR_NonProdWithApprovalDisabled(t *testing.T) {
 
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = true
 
 	merger := NewAutoMerger(ghClient, approvalMgr, nil, "owner", "repo", cfg)
 
@@ -286,7 +284,6 @@ func TestAutoMerger_MergePR_DefaultMergeMethod(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 	cfg.MergeMethod = "" // Empty - should default to squash
 
 	merger := NewAutoMerger(ghClient, nil, nil, "owner", "repo", cfg)
@@ -320,7 +317,6 @@ func TestAutoMerger_MergePR_MergeFailure(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = true
 
 	merger := NewAutoMerger(ghClient, nil, nil, "owner", "repo", cfg)
 
@@ -329,43 +325,6 @@ func TestAutoMerger_MergePR_MergeFailure(t *testing.T) {
 	err := merger.MergePR(context.Background(), prState)
 	if err == nil {
 		t.Error("MergePR() should return error when merge fails")
-	}
-}
-
-func TestAutoMerger_MergePR_AutoReviewFailureContinues(t *testing.T) {
-	mergeWasCalled := false
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/repos/owner/repo/pulls/42/reviews":
-			// Auto-review fails (e.g., already reviewed)
-			w.WriteHeader(http.StatusUnprocessableEntity)
-		case "/repos/owner/repo/pulls/42/merge":
-			// Merge should still be attempted
-			mergeWasCalled = true
-			w.WriteHeader(http.StatusOK)
-		default:
-			w.WriteHeader(http.StatusOK)
-		}
-	}))
-	defer server.Close()
-
-	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
-	cfg := DefaultConfig()
-	cfg.Environment = EnvDev
-	cfg.AutoReview = true
-
-	merger := NewAutoMerger(ghClient, nil, nil, "owner", "repo", cfg)
-
-	prState := &PRState{PRNumber: 42}
-
-	err := merger.MergePR(context.Background(), prState)
-	if err != nil {
-		t.Errorf("MergePR() error = %v", err)
-	}
-
-	if !mergeWasCalled {
-		t.Error("merge should still be called when auto-review fails")
 	}
 }
 
@@ -388,7 +347,6 @@ func TestAutoMerger_MergePR_StageEnvironment(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvStage
-	cfg.AutoReview = true
 
 	merger := NewAutoMerger(ghClient, nil, nil, "owner", "repo", cfg)
 
@@ -401,40 +359,6 @@ func TestAutoMerger_MergePR_StageEnvironment(t *testing.T) {
 
 	if !mergeWasCalled {
 		t.Error("merge should be called for stage environment")
-	}
-}
-
-func TestAutoMerger_ApprovePR(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/repos/owner/repo/pulls/42/reviews" {
-			t.Errorf("unexpected path: %s", r.URL.Path)
-		}
-		if r.Method != http.MethodPost {
-			t.Errorf("expected POST, got %s", r.Method)
-		}
-
-		var body map[string]string
-		_ = json.NewDecoder(r.Body).Decode(&body)
-
-		if body["event"] != github.ReviewEventApprove {
-			t.Errorf("expected APPROVE event, got %s", body["event"])
-		}
-		if body["body"] != "Auto-approved by Pilot autopilot" {
-			t.Errorf("unexpected review body: %s", body["body"])
-		}
-
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
-	cfg := DefaultConfig()
-
-	merger := NewAutoMerger(ghClient, nil, nil, "owner", "repo", cfg)
-
-	err := merger.approvePR(context.Background(), 42)
-	if err != nil {
-		t.Errorf("approvePR() error = %v", err)
 	}
 }
 
@@ -494,7 +418,6 @@ func TestAutoMerger_MergePR_AllMergeMethods(t *testing.T) {
 			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			cfg := DefaultConfig()
 			cfg.Environment = EnvDev
-			cfg.AutoReview = false
 			cfg.MergeMethod = method
 
 			merger := NewAutoMerger(ghClient, nil, nil, "owner", "repo", cfg)
@@ -567,7 +490,6 @@ func TestAutoMerger_MergePR_SquashUsePRTitle(t *testing.T) {
 			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			cfg := DefaultConfig()
 			cfg.Environment = EnvDev
-			cfg.AutoReview = false
 			cfg.MergeMethod = tt.method
 
 			merger := NewAutoMerger(ghClient, nil, nil, "owner", "repo", cfg)
@@ -637,7 +559,6 @@ func TestAutoMerger_MergePR_SquashStripsIssuePrefix(t *testing.T) {
 			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			cfg := DefaultConfig()
 			cfg.Environment = EnvDev
-			cfg.AutoReview = false
 			cfg.MergeMethod = github.MergeMethodSquash
 
 			merger := NewAutoMerger(ghClient, nil, nil, "owner", "repo", cfg)
@@ -867,7 +788,6 @@ func TestAutoMerger_MergePR_StageWithCIVerification(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvStage
-	cfg.AutoReview = true
 	cfg.RequiredChecks = []string{}
 
 	ciMonitor := NewCIMonitor(ghClient, "owner", "repo", cfg)
@@ -924,7 +844,6 @@ func TestAutoMerger_MergePR_StageWithCIFailure(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvStage
-	cfg.AutoReview = true
 	cfg.RequiredChecks = []string{}
 
 	ciMonitor := NewCIMonitor(ghClient, "owner", "repo", cfg)
@@ -974,7 +893,6 @@ func TestAutoMerger_MergePR_DevWithCIVerification(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 	cfg.RequiredChecks = []string{"build"}
 
 	ciMonitor := NewCIMonitor(ghClient, "owner", "repo", cfg)

--- a/internal/autopilot/controller_duplicate_registration_test.go
+++ b/internal/autopilot/controller_duplicate_registration_test.go
@@ -135,7 +135,6 @@ func TestController_OnPRCreated_DuplicateDoesNotDuplicateMergedComment(t *testin
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 	cfg.RequiredChecks = []string{"build"}
 
 	c := NewController(cfg, ghClient, nil, "owner", "repo")

--- a/internal/autopilot/controller_execution_events_test.go
+++ b/internal/autopilot/controller_execution_events_test.go
@@ -58,7 +58,6 @@ func TestController_ExecutionEvents_PRLifecycle(t *testing.T) {
 			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			cfg := DefaultConfig()
 			cfg.Environment = EnvStage
-			cfg.AutoReview = false
 			cfg.RequiredChecks = []string{"build"}
 			if configure != nil {
 				configure(cfg)

--- a/internal/autopilot/controller_merge_test.go
+++ b/internal/autopilot/controller_merge_test.go
@@ -196,7 +196,6 @@ func TestController_HandleMerging_ClosesIssueWithPilotDone(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
 	cfg.AutoMerge = true
-	cfg.AutoReview = false
 	cfg.RequiredChecks = []string{"build"}
 
 	c := NewController(cfg, ghClient, nil, "owner", "repo")
@@ -270,7 +269,6 @@ func TestController_HandleMerging_CallsOnIssueDone(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
 	cfg.AutoMerge = true
-	cfg.AutoReview = false
 	cfg.RequiredChecks = []string{"ci"}
 
 	c := NewController(cfg, ghClient, nil, "owner", "repo")

--- a/internal/autopilot/controller_prstate_race_test.go
+++ b/internal/autopilot/controller_prstate_race_test.go
@@ -88,7 +88,6 @@ func TestController_PRStateRace_Concurrent(t *testing.T) {
 
 	cfg := DefaultConfig()
 	cfg.Environment = EnvProd // prod → approval path is reachable
-	cfg.AutoReview = false
 	cfg.CIPollInterval = time.Millisecond
 	cfg.CIWaitTimeout = time.Hour // don't time out CI mid-test
 	cfg.MaxFailures = 1 << 30     // keep the per-PR circuit breaker from tripping

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -445,7 +445,6 @@ func TestController_ProcessPR_DevEnvironment(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 	cfg.CIPollInterval = 10 * time.Millisecond
 	cfg.DevCITimeout = 1 * time.Second
 	cfg.RequiredChecks = []string{"build", "test", "lint"}
@@ -547,7 +546,6 @@ func TestController_ProcessPR_StageEnvironment_CIPass(t *testing.T) {
 	cfg.Environment = EnvStage
 	cfg.CIPollInterval = 10 * time.Millisecond
 	cfg.CIWaitTimeout = 1 * time.Second
-	cfg.AutoReview = false
 	cfg.RequiredChecks = []string{"build", "test", "lint"}
 
 	c := NewController(cfg, ghClient, nil, "owner", "repo")
@@ -725,7 +723,6 @@ func TestController_HandleMerging_SelfHealsExecution(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 	cfg.RequiredChecks = []string{"build"}
 
 	// TASK-352: scope self-heal to the project's filesystem path (the value the
@@ -1272,7 +1269,6 @@ func TestController_MergeAttemptIncrement(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 	cfg.RequiredChecks = []string{"build"}
 
 	c := NewController(cfg, ghClient, nil, "owner", "repo")
@@ -1352,7 +1348,6 @@ func TestController_FirstMergeAttemptSucceedsOnNoCIRepo(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 	cfg.RequiredChecks = nil
 	cfg.CIChecks = &CIChecksConfig{
 		Mode:                 "auto",
@@ -3025,7 +3020,6 @@ func TestController_handleMerging_ConflictClearsLabel(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 	cfg.RequiredChecks = []string{"build"}
 
 	c := NewController(cfg, ghClient, nil, "owner", "repo")
@@ -3130,7 +3124,6 @@ func TestController_handleMerging_Success_RemovesFailedLabel(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 	cfg.RequiredChecks = []string{"build"}
 
 	c := NewController(cfg, ghClient, nil, "owner", "repo")
@@ -3231,7 +3224,6 @@ func TestController_handleMerging_Success_ClearsRetryLabels(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 	cfg.RequiredChecks = []string{"build"}
 
 	c := NewController(cfg, ghClient, nil, "owner", "repo")
@@ -3490,7 +3482,6 @@ func TestController_MonitorCompletedOnMerge(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 	cfg.CIPollInterval = 10 * time.Millisecond
 	cfg.DevCITimeout = 1 * time.Second
 	cfg.RequiredChecks = []string{"build"}
@@ -3551,7 +3542,6 @@ func TestController_MonitorNilSafe(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 	cfg.CIPollInterval = 10 * time.Millisecond
 	cfg.DevCITimeout = 1 * time.Second
 	cfg.RequiredChecks = []string{"build"}
@@ -4146,7 +4136,6 @@ func TestController_handleMergeConflict_AutoRebaseSuccess(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 	cfg.RequiredChecks = []string{"build"}
 
 	c := NewController(cfg, ghClient, nil, "owner", "repo")
@@ -4248,7 +4237,6 @@ func TestController_handleMergeConflict_AutoRebaseFails(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 	cfg.RequiredChecks = []string{"build"}
 
 	c := NewController(cfg, ghClient, nil, "owner", "repo")
@@ -4331,7 +4319,6 @@ func TestHandleMerged_LearnsFromReviews(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 
 	c := NewController(cfg, ghClient, nil, "owner", "repo")
 	loop, cleanup := newTestLearningLoop(t)
@@ -4376,7 +4363,6 @@ func TestHandleMerged_NoReviews(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 
 	c := NewController(cfg, ghClient, nil, "owner", "repo")
 	loop, cleanup := newTestLearningLoop(t)
@@ -4411,7 +4397,6 @@ func TestHandleMerged_NilLearningLoop(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 
 	c := NewController(cfg, ghClient, nil, "owner", "repo")
 	// learningLoop intentionally not set
@@ -5244,7 +5229,6 @@ func TestHandleMerged_ExtractsEvalTask(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 
 	c := NewController(cfg, ghClient, nil, "owner", "repo")
 	evalMock := &mockEvalStore{}
@@ -7309,7 +7293,6 @@ func TestController_handleMerging_IdempotentCompletionComment(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 	cfg.RequiredChecks = []string{"build"}
 
 	c := NewController(cfg, ghClient, nil, "owner", "repo")
@@ -7386,7 +7369,6 @@ func TestController_handleMerging_CommentFlagPersists(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 	cfg.RequiredChecks = []string{"build"}
 
 	c := NewController(cfg, ghClient, nil, "owner", "repo")
@@ -7445,7 +7427,6 @@ func TestController_handleMerging_NotifiesApprovalGatedMerge(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 	cfg.RequiredChecks = []string{"build"}
 
 	notifier := &mockApprovalMergeNotifier{}
@@ -7487,7 +7468,6 @@ func TestController_handleMerging_NoApprovalGate_SkipsMergeFollowup(t *testing.T
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 	cfg.RequiredChecks = []string{"build"}
 
 	notifier := &mockApprovalMergeNotifier{}
@@ -7524,7 +7504,6 @@ func TestController_handleMerging_MergeFollowupNotDoubleFired(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 	cfg.RequiredChecks = []string{"build"}
 
 	notifier := &mockApprovalMergeNotifier{}
@@ -8728,7 +8707,6 @@ func TestController_IssuesProcessed_Success(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 	cfg.RequiredChecks = []string{"build"}
 	c := NewController(cfg, ghClient, nil, "owner", "repo")
 	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "mergesha1", "pilot/GH-10", "")

--- a/internal/autopilot/gh3715_test.go
+++ b/internal/autopilot/gh3715_test.go
@@ -222,7 +222,6 @@ func TestController_HandleMerging_ResetsRebaseAttemptsOnSuccess(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 	cfg.RequiredChecks = []string{"build"}
 
 	c := NewController(cfg, ghClient, nil, "owner", "repo")

--- a/internal/autopilot/gh4415_restore_ci_poll_test.go
+++ b/internal/autopilot/gh4415_restore_ci_poll_test.go
@@ -82,7 +82,6 @@ func TestController_RestoreState_WaitingCIPolling_GH4415(t *testing.T) {
 		ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 		cfg := &Config{
 			Environment:    EnvDev,
-			AutoReview:     false,
 			AutoMerge:      true,
 			MergeMethod:    github.MergeMethodSquash,
 			CIWaitTimeout:  30 * time.Minute,
@@ -192,7 +191,6 @@ func TestController_RestoreState_WaitingCIPolling_GH4415(t *testing.T) {
 		ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 		cfg := &Config{
 			Environment:    EnvDev,
-			AutoReview:     false,
 			AutoMerge:      true,
 			MergeMethod:    github.MergeMethodSquash,
 			CIWaitTimeout:  30 * time.Minute,

--- a/internal/autopilot/scope_schedule_test.go
+++ b/internal/autopilot/scope_schedule_test.go
@@ -400,7 +400,6 @@ func TestAutoMerger_SquashTitleSuffix_ResolvesAsTrainMember(t *testing.T) {
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, mergeServer.URL)
 	cfg := DefaultConfig()
 	cfg.Environment = EnvDev
-	cfg.AutoReview = false
 	cfg.MergeMethod = github.MergeMethodSquash
 
 	merger := NewAutoMerger(ghClient, nil, nil, "owner", "repo", cfg)

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -100,8 +100,6 @@ type Config struct {
 	GitHubReview *GitHubReviewConfig `yaml:"github_review"`
 
 	// PR Handling
-	// AutoReview enables automatic PR review comments.
-	AutoReview bool `yaml:"auto_review"`
 	// AutoMerge enables automatic PR merging when conditions are met.
 	AutoMerge bool `yaml:"auto_merge"`
 	// MergeMethod specifies how to merge PRs: merge, squash, or rebase.
@@ -421,7 +419,6 @@ func DefaultConfig() *Config {
 		GitHubReview: &GitHubReviewConfig{
 			PollInterval: 30 * time.Second,
 		},
-		AutoReview:     true,
 		AutoMerge:      true,
 		MergeMethod:    "squash",
 		CIWaitTimeout:  30 * time.Minute,

--- a/internal/wiring/testconfig.go
+++ b/internal/wiring/testconfig.go
@@ -22,7 +22,6 @@ func MinimalConfig() *config.Config {
 func WithAutopilot(cfg *config.Config) *config.Config {
 	cfg.Orchestrator.Autopilot.Enabled = true
 	cfg.Orchestrator.Autopilot.AutoMerge = true
-	cfg.Orchestrator.Autopilot.AutoReview = true
 	return cfg
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4520.

Closes #4520

## Changes

GitHub Issue GH-4520: fix(autopilot): remove vestigial AutoReview self-approve — guaranteed 422 API call on every merge

## Context

Every auto-merge logs `auto-review failed … 422 "Review Can not approve your own pull request"` (seen on pilot PRs 4514/4515/4516/4518 and console PR 30 on 2026-07-23 alone). The daemon tries to submit an APPROVE review on a PR authored by its own token — GitHub always rejects this with 422.

## Root cause (ground truth @ main)

- `internal/autopilot/types.go:103-104` — `AutoReview bool` config field; `:424` defaults it to `true`.
- `internal/autopilot/auto_merger.go:62-67` — `MergePR` calls `approvePR` when `AutoReview` is set; the error is swallowed as a WARN and merge proceeds.
- The comment at `auto_merger.go:51` states approval is obtained upstream by the controller's `handleAwaitApproval` before `MergePR` is called — the auto-review is vestigial. Net effect: one guaranteed-fail GitHub API call per merged PR on the shared 5000/hr user pool.

## Required changes

1. Delete the `AutoReview` config field, its default, and the `approvePR` call path in `MergePR` (including `approvePR` itself if nothing else references it).
2. Keep loading configs that still contain `auto_review:` without erroring (lax YAML decode already handles unknown keys — verify).

## Acceptance criteria

- AC1: `MergePR` performs no review-submission API call.
- AC2: A config file containing `auto_review: true` still loads (ignored, no error).
- AC3: Existing merge-path tests pass; remove/adjust any test asserting the auto-review call.

## Scope

`internal/autopilot/types.go`, `internal/autopilot/auto_merger.go` + tests. No behavior change to the approval-gate flow (`handleAwaitApproval`).