### PR TITLE
fix(release): add release-assets completeness gate (GH-4523)

### DIFF
--- a/.agent/sops/operations/release-asset-completeness-gate.md
+++ b/.agent/sops/operations/release-asset-completeness-gate.md
@@ -1,0 +1,50 @@
+# Release pipeline: asset completeness gate
+
+## Problem
+
+GH-4523: v2.245.1's GitHub release was reported missing both
+`pilot-linux-{amd64,arm64}.tar.gz` — the assets the S2 hosted-instance
+bootstrap (pilot-console S3 bridge) and the AWS box self-upgrade both
+depend on. Nothing in `.github/workflows/release.yml` verified the
+published release actually carried the full asset set, so an incomplete
+release could ship silently — the first signal would be a downstream
+consumer failing (as it did: today's S2 e2e had to fall back to v2.245.0).
+
+## Root Cause
+
+Investigated against ground truth (workflow run `30014298612`,
+`2026-07-23T14:06:55Z`, and `gh release view v2.245.1`): the goreleaser
+job for v2.245.1 actually built and uploaded both linux archives at
+`14:09:16Z`, and they are present in the release right now. The reported
+symptom did not reproduce from the pipeline's own logs or the current
+release state — most likely the observation was made during the ~90s
+asset-upload window, or hit a transient GitHub API/UI propagation delay.
+Regardless of the exact trigger, the pipeline had **no automated check**
+that would have caught a genuinely incomplete release, so the class of
+bug (partial goreleaser matrix, upload failure swallowed, API lag) was
+undetectable until a hosted-tenant deploy broke.
+
+## Solution
+
+- `scripts/verify-release-assets.sh <tag>` checks that every asset named
+  in `.goreleaser.yaml`'s build/archive matrix
+  (`pilot-{linux,darwin}-{amd64,arm64}.tar.gz`, `pilot-windows-amd64.zip`,
+  `checksums.txt`) exists on the tag's GitHub release, retrying up to 5
+  times with a 5s backoff to absorb listing propagation delay.
+- Wired into `.github/workflows/release.yml` as a "Verify release assets"
+  step immediately after the GoReleaser step — fails the job (and the
+  release train) loudly if anything is missing.
+- Desktop bundles (`Pilot-Desktop-*`, built by the separate
+  `release-desktop.yml` workflow) are intentionally NOT included in this
+  gate: that workflow can finish well after `release.yml` (three-runner
+  matrix + Wails build), so checking for them here would produce false
+  failures on every release.
+
+## Prevention
+
+If `.goreleaser.yaml`'s `builds`/`archives`/`ignore` blocks change (new
+GOOS/GOARCH, renamed archive template, etc.), update the
+`EXPECTED_ASSETS` list in `scripts/verify-release-assets.sh` in the same
+PR — the two are not otherwise linked and will silently drift apart
+(the gate would then either false-fail on a legitimately new matrix, or
+miss a genuinely dropped target).

--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -335,6 +335,7 @@
 | Runner accessor methods | ✅ | executor | - | - | Has* introspection methods for test + wiring verification (v2.39.0, PR #1930) |
 | Docs version sync CI | ✅ | ci | - | - | Workflow closes previous version-sync PRs before creating new (v2.38.11) |
 | GoReleaser CI builds | ✅ | ci | - | - | Binary builds + uploads on release tag (v0.24.1) |
+| Release asset completeness gate | ✅ | ci | - | - | `scripts/verify-release-assets.sh` runs after the GoReleaser step in `release.yml` and asserts every expected asset (`pilot-{linux,darwin}-{amd64,arm64}.tar.gz`, `pilot-windows-amd64.zip`, `checksums.txt`) exists on the tag's release, retrying to absorb listing lag, failing the train loudly on a miss (GH-4523) |
 | install.sh | ✅ | install | - | - | curl-pipe installer for Linux/macOS (v0.3.x) |
 | Homebrew formula | ✅ | install | `brew install` | - | Homebrew tap formula for macOS (v0.3.x) |
 | Integration tests (patterns) | ✅ | testing | - | - | Integration tests for self-review pattern accumulation (v2.44.0, GH-1956) |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+      # GH-4523: v2.245.1's release was reported missing the linux
+      # tarballs, and nothing in this pipeline would have caught that
+      # class of failure. Assert the full asset set landed on the release
+      # before we call the train green (see
+      # .agent/sops/operations/release-asset-completeness-gate.md for the
+      # root-cause writeup).
+      - name: Verify release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: scripts/verify-release-assets.sh "${GITHUB_REF_NAME}"

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Verify a GitHub release carries the full expected asset set.
+#
+# Context (GH-4523): v2.245.1's release page was observed missing both
+# pilot-linux-{amd64,arm64}.tar.gz — the assets the S2 hosted-instance
+# bootstrap (pilot-console S3 bridge) and the AWS box self-upgrade both
+# depend on. Root-cause investigation against the actual workflow run
+# (goreleaser run 30014298612, 2026-07-23T14:06:55Z) showed the linux
+# archives WERE built and uploaded (14:09:16Z) and are present in the
+# release right now — the goreleaser job itself did not skip the linux
+# matrix. The pipeline had no automated check confirming asset
+# completeness though, so a transient upload failure or GitHub API
+# propagation delay could silently ship an incomplete release with no
+# signal until a downstream consumer (S2 e2e) broke. This script closes
+# that gap: it runs immediately after the goreleaser step and fails the
+# release train loudly if any expected asset is missing.
+#
+# Usage: scripts/verify-release-assets.sh <tag>
+#   GITHUB_TOKEN / GH_TOKEN must be set (gh CLI auth) when run in CI.
+
+set -euo pipefail
+
+TAG="${1:-}"
+if [ -z "$TAG" ]; then
+    echo "usage: $0 <tag>" >&2
+    exit 2
+fi
+
+# Expected assets for every release train run. Keep in sync with the
+# builds/archives/ignore blocks in .goreleaser.yaml — if that matrix
+# changes, update this list too.
+EXPECTED_ASSETS=(
+    "pilot-linux-amd64.tar.gz"
+    "pilot-linux-arm64.tar.gz"
+    "pilot-darwin-amd64.tar.gz"
+    "pilot-darwin-arm64.tar.gz"
+    "pilot-windows-amd64.zip"
+    "checksums.txt"
+)
+
+# GitHub's asset listing can lag a few seconds behind the final upload in
+# a goreleaser run, so retry with backoff before failing the train.
+MAX_ATTEMPTS=5
+SLEEP_SECONDS=5
+
+echo "Verifying release assets for tag ${TAG}..."
+
+ATTEMPT=1
+ACTUAL_ASSETS=""
+while [ "$ATTEMPT" -le "$MAX_ATTEMPTS" ]; do
+    ACTUAL_ASSETS=$(gh release view "$TAG" --json assets -q '.assets[].name' 2>/dev/null || true)
+    MISSING=()
+    for asset in "${EXPECTED_ASSETS[@]}"; do
+        if ! grep -qFx "$asset" <<<"$ACTUAL_ASSETS"; then
+            MISSING+=("$asset")
+        fi
+    done
+
+    if [ "${#MISSING[@]}" -eq 0 ]; then
+        echo "✓ All expected assets present for ${TAG}:"
+        printf '  - %s\n' "${EXPECTED_ASSETS[@]}"
+        exit 0
+    fi
+
+    if [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; then
+        echo "Attempt ${ATTEMPT}/${MAX_ATTEMPTS}: missing ${#MISSING[@]} asset(s), retrying in ${SLEEP_SECONDS}s..."
+        sleep "$SLEEP_SECONDS"
+    fi
+    ATTEMPT=$((ATTEMPT + 1))
+done
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "RELEASE ASSET COMPLETENESS CHECK FAILED for ${TAG}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "Missing asset(s):"
+printf '  - %s\n' "${MISSING[@]}"
+echo ""
+echo "Present asset(s):"
+if [ -n "$ACTUAL_ASSETS" ]; then
+    printf '  - %s\n' $ACTUAL_ASSETS
+else
+    echo "  (none — could not list release assets)"
+fi
+echo ""
+echo "This release is un-deployable to hosted tenants (GH-4523: the S2"
+echo "hosted-instance bootstrap and AWS box self-upgrade both require the"
+echo "linux tarballs). Investigate the goreleaser run for ${TAG} before"
+echo "shipping this tag anywhere."
+echo ""
+exit 1


### PR DESCRIPTION
## Summary

GH-4523 reported v2.245.1's GitHub release missing `pilot-linux-{amd64,arm64}.tar.gz`, which the S2 hosted-instance bootstrap (pilot-console S3 bridge) and the AWS box self-upgrade both depend on.

## Root cause

Investigated against ground truth:
- `gh release view v2.245.1` shows all 10 expected assets present today, including both linux tarballs.
- The goreleaser workflow run for that tag (`30014298612`, `2026-07-23T14:06:55Z`) shows in its own logs that `pilot-linux-amd64.tar.gz` and `pilot-linux-arm64.tar.gz` were built and uploaded successfully at `14:09:16Z`.
- There was only one workflow run for the `v2.245.1` tag (no retries/re-runs), and all release assets share the same upload timestamp window (14:09–14:10Z) from that single run.

So the reported symptom did not reproduce from the pipeline's own logs or the release's current state — most likely the observation happened during the ~90s upload window or hit a transient GitHub API/UI propagation delay. Regardless of the exact trigger, **the pipeline had no automated check** that would catch a genuinely incomplete release (partial goreleaser matrix, a swallowed upload failure, API listing lag), so that entire class of bug was invisible until a downstream consumer broke (today's S2 e2e had to fall back to v2.245.0).

## Fix

- Added `scripts/verify-release-assets.sh <tag>`: checks that every asset named in `.goreleaser.yaml`'s build/archive matrix (`pilot-{linux,darwin}-{amd64,arm64}.tar.gz`, `pilot-windows-amd64.zip`, `checksums.txt`) exists on the tag's GitHub release, retrying up to 5x with backoff to absorb any listing lag.
- Wired it into `.github/workflows/release.yml` as a "Verify release assets" step immediately after the GoReleaser step — fails the job (and the release train) loudly if anything is missing.
- Desktop bundles are intentionally excluded from this gate since `release-desktop.yml` is a separate, slower workflow that can finish after `release.yml`.
- Documented the investigation + design in `.agent/sops/operations/release-asset-completeness-gate.md` and added a `FEATURE-MATRIX.md` row.

## Test plan

- [x] `go build ./...` passes (no Go changes, sanity check only)
- [x] Ran `scripts/verify-release-assets.sh v2.245.1` locally against the real release — passes, confirms all 6 expected assets present
- [x] Ran a modified copy against a nonexistent tag — fails loudly with exit code 1 and a clear missing-assets report
- [x] `scripts/check-secret-patterns.sh` passes
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)