### PR TITLE
GH-4526: fix(executor): hosted daemon scaffolds untracked .agent/ into fresh clones, then its own git_clean preflight blocks every dispatch

### DIFF
--- a/.agent/sops/onboarding/hosted-repo-scaffold-git-clean-deadlock.md
+++ b/.agent/sops/onboarding/hosted-repo-scaffold-git-clean-deadlock.md
@@ -1,0 +1,54 @@
+# Hosted repo scaffold vs. git_clean preflight deadlock (GH-4526)
+
+## Problem
+
+On a freshly onboarded hosted-tenant repo, the daemon's first dispatch
+repeatedly failed preflight: `preflight check "git_clean" failed: working
+directory has 1 uncommitted change(s)`, re-picked 5 times, hit the repick
+hard cap, and landed on `pilot-blocked`. Box repos (where `.agent/` is
+committed) never hit this — every new hosted tenant repo did, on its very
+first issue.
+
+Same incident also surfaced: `gh issue edit: 'pilot-failed' not found` when
+the dispatcher tried to label a stalled issue on a repo with no pilot-*
+labels pre-created.
+
+## Root Cause
+
+1. The daemon scaffolds Navigator's `.agent/` directory into a project
+   shortly after clone (`cmd/pilot/init_project.go`'s
+   `createNavigatorStructure`), and this write is untracked.
+2. The `git_clean` preflight check (`internal/executor/preflight.go`'s
+   `checkGitClean`) used to count *any* `git status --porcelain` output as
+   dirty — including the daemon's own untracked scaffold.
+3. Net effect: the daemon made every fresh clone "dirty" by its own
+   scaffolding, then its own preflight refused to dispatch against a dirty
+   tree. Self-inflicted, permanent deadlock on first dispatch.
+4. Separately, hosted repos are onboarded with zero pilot-* labels (labels
+   are a per-repo GitHub resource — cloning doesn't bring them along), so
+   any `gh issue edit --add-label pilot-*` call failed outright.
+
+## Solution
+
+- `checkGitClean` now filters `git status --porcelain -z` output through
+  `isExcluded` (`internal/executor/git.go`'s `defaultExcludeDirs` /
+  `defaultExcludeGlobs` — the same allowlist `GitOperations.Commit` already
+  uses to avoid auto-staging `.agent/`, `.claude/`, lockfiles, etc.) before
+  counting changes. A tree that's dirty *only* in excluded paths now passes;
+  a single real user file still fails the check.
+- `internal/executor/labels.go` adds `EnsureRepoLabels`, which runs
+  `gh label create <name> --color <c> --force` (idempotent — updates color
+  in place if the label exists) for every `pilot-*` label the daemon can
+  ever write. Wired into `cmd/pilot/poller_github.go`'s
+  `startGithubSDKPollerForRepo`, once per repo, before the poller starts.
+
+## Prevention
+
+- Any new "scaffold-on-first-touch" write the daemon makes to a tenant repo
+  must be added to `defaultExcludeDirs`/`defaultExcludeGlobs` in
+  `internal/executor/git.go` — that list is now load-bearing for both the
+  commit-staging filter *and* the git_clean preflight, not just the former.
+- Any new `pilot-*` label introduced anywhere in the codebase must be added
+  to `PilotLabels` in `internal/executor/labels.go`, or it will fail with
+  "not found" the first time it's written to a repo that has never had it
+  created before.

--- a/cmd/pilot/poller_github.go
+++ b/cmd/pilot/poller_github.go
@@ -285,6 +285,21 @@ func startGithubSDKPollerForRepo(ctx context.Context, deps *PollerDeps, log *slo
 	repoOwner, repoName := repoParts[0], repoParts[1]
 	repoLog := log.With(slog.String("repo", target.repoFullName))
 
+	// GH-4526: ensure every pilot-* label exists on this repo before the
+	// poller starts dispatching. Hosted tenant repos are onboarded with none
+	// of these labels pre-created; without this, the first label write
+	// (stalled-issue surfacing, title-rejection escalation, retry counters,
+	// ...) fails with "label ... not found" and that failure is silently
+	// swallowed by its best-effort caller. `gh label create --force` is
+	// idempotent, so re-running this on every restart is harmless.
+	func() {
+		labelCtx, labelCancel := context.WithTimeout(ctx, 30*time.Second)
+		defer labelCancel()
+		for _, labelErr := range executor.EnsureRepoLabels(labelCtx, target.projectPath) {
+			repoLog.Warn("failed to ensure pilot label exists", slog.Any("error", labelErr))
+		}
+	}()
+
 	// Determine interval (shared adapter polling config; projects have no per-repo interval).
 	interval := 30 * time.Second
 	if ghCfg.Polling != nil && ghCfg.Polling.Interval > 0 {

--- a/internal/executor/labels.go
+++ b/internal/executor/labels.go
@@ -1,0 +1,85 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// pilotLabelSpec describes one pilot-* label the daemon may apply to a
+// GitHub issue somewhere in its lifecycle, plus the color `gh label create`
+// uses the first time it creates the label.
+type pilotLabelSpec struct {
+	Name  string
+	Color string
+}
+
+// PilotLabels enumerates every label name the daemon writes anywhere in its
+// lifecycle: dispatcher.go's stalled-issue surfacing (pilot-blocked),
+// title_rejection.go's escalation (pilot-failed, pilot-title-rejected), the
+// GH-2432/GH-3715 retry-counter labels, and the base "pilot" trigger label
+// itself.
+//
+// GH-4526: hosted tenant repos are onboarded with none of these labels
+// pre-created (labels are a per-repo GitHub resource, not something `gh repo
+// clone` brings along). The first label write on such a repo — e.g. stalled-
+// issue surfacing's `gh issue edit --add-label pilot-blocked` — failed with
+// `'pilot-blocked' not found`, and that failure is logged but swallowed by
+// the caller (best-effort by design, since the store-side status is the
+// durable source of truth). EnsureRepoLabels creates every label below
+// up front so no future write can hit that error.
+var PilotLabels = []pilotLabelSpec{
+	{"pilot", "1d76db"},
+	{"pilot-in-progress", "fbca04"},
+	{"pilot-done", "0e8a16"},
+	{"pilot-failed", "d73a4a"},
+	{"pilot-retry-ready", "c5def5"},
+	{"pilot-title-rejected", "c5def5"},
+	{"pilot-superseded", "c5def5"},
+	{"pilot-blocked", "d73a4a"},
+	{"pilot-needs-clarification", "e99695"},
+	{"pilot-spec-incomplete", "e99695"},
+	{"pilot-skip-spec-check", "c5def5"},
+	{"pilot-retry-1", "fbca04"},
+	{"pilot-retry-2", "fbca04"},
+	{"pilot-retry-exhausted", "d73a4a"},
+	{"pilot-failed-retry-1", "fbca04"},
+	{"pilot-failed-retry-2", "fbca04"},
+	{"pilot-failed-retry-exhausted", "d73a4a"},
+	{"pilot-needs-human", "5319e7"},
+}
+
+// EnsureRepoLabels creates every label in PilotLabels against dir's repo via
+// `gh label create --force`, which is idempotent: it creates the label if
+// absent and just updates its color in place if already present, so this is
+// safe to call on every poller startup rather than only once per repo.
+//
+// Each label is attempted independently and a failure on one does not stop
+// the rest — callers should log the returned errors (if any) as warnings,
+// not treat them as fatal, mirroring the rest of this file's gh-CLI helpers.
+func EnsureRepoLabels(ctx context.Context, dir string) []error {
+	var errs []error
+	for _, spec := range PilotLabels {
+		if err := ghLabelCreate(ctx, dir, spec.Name, spec.Color); err != nil {
+			errs = append(errs, fmt.Errorf("label %q: %w", spec.Name, err))
+		}
+	}
+	return errs
+}
+
+// ghLabelCreate creates a single GitHub label via `gh label create --force`.
+// --force makes this idempotent: an existing label has its color updated
+// in place instead of the command failing with "already exists".
+func ghLabelCreate(ctx context.Context, dir, name, color string) error {
+	cmd := exec.CommandContext(ctx, "gh", "label", "create", name, "--color", color, "--force")
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("gh label create: %w (stderr: %s)", err, stderr.String())
+	}
+	return nil
+}

--- a/internal/executor/labels_test.go
+++ b/internal/executor/labels_test.go
@@ -1,0 +1,101 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
+
+// writeFakeGhLabelCreate installs a fake "gh" on PATH that logs every
+// invocation's args to logFile (one line per call, space-joined) and exits
+// with failExitCode for any label name in failFor (simulating a transient
+// per-label failure), 0 otherwise. Used by the GH-4526 EnsureRepoLabels
+// tests below.
+func writeFakeGhLabelCreate(t *testing.T, logFile string, failFor map[string]bool) string {
+	t.Helper()
+	fakeBin := t.TempDir()
+	script := `#!/bin/sh
+echo "$@" >> ` + logFile + `
+`
+	for name := range failFor {
+		script += `if [ "$3" = "` + name + `" ]; then echo "fail" 1>&2; exit 1; fi
+`
+	}
+	script += `exit 0
+`
+	if err := os.WriteFile(fakeBin+"/gh", []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	return fakeBin
+}
+
+// TestEnsureRepoLabels_CreatesEveryPilotLabel is the GH-4526 regression
+// guard for the secondary finding: a hosted tenant repo onboarded with zero
+// pre-existing pilot-* labels must have all of them created (idempotently,
+// via `gh label create --force`) so stalled-issue surfacing's
+// `gh issue edit --add-label pilot-blocked` (and every sibling label write)
+// never again fails with "label ... not found".
+func TestEnsureRepoLabels_CreatesEveryPilotLabel(t *testing.T) {
+	logFile := t.TempDir() + "/gh-calls.log"
+	if err := os.WriteFile(logFile, nil, 0o644); err != nil {
+		t.Fatalf("failed to seed log file: %v", err)
+	}
+	fakeBin := writeFakeGhLabelCreate(t, logFile, nil)
+	t.Setenv("PATH", fakeBin+":"+os.Getenv("PATH"))
+
+	errs := EnsureRepoLabels(context.Background(), "")
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got: %v", errs)
+	}
+
+	logged, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("failed to read call log: %v", err)
+	}
+	calls := string(logged)
+	for _, spec := range PilotLabels {
+		want := "label create " + spec.Name
+		if !strings.Contains(calls, want) {
+			t.Errorf("expected a call creating label %q, log:\n%s", spec.Name, calls)
+		}
+		if !strings.Contains(calls, "--force") {
+			t.Errorf("expected --force for idempotent creation, log:\n%s", calls)
+		}
+	}
+}
+
+// TestEnsureRepoLabels_OneFailureDoesNotBlockOthers guards the best-effort
+// contract: a single label failing to create (transient error) must not
+// stop the rest from being attempted, and must be reported back to the
+// caller rather than silently swallowed.
+func TestEnsureRepoLabels_OneFailureDoesNotBlockOthers(t *testing.T) {
+	logFile := t.TempDir() + "/gh-calls.log"
+	if err := os.WriteFile(logFile, nil, 0o644); err != nil {
+		t.Fatalf("failed to seed log file: %v", err)
+	}
+	fakeBin := writeFakeGhLabelCreate(t, logFile, map[string]bool{"pilot-blocked": true})
+	t.Setenv("PATH", fakeBin+":"+os.Getenv("PATH"))
+
+	errs := EnsureRepoLabels(context.Background(), "")
+	if len(errs) != 1 {
+		t.Fatalf("expected exactly 1 error, got %d: %v", len(errs), errs)
+	}
+	if !strings.Contains(errs[0].Error(), "pilot-blocked") {
+		t.Errorf("expected error to name the failing label, got: %v", errs[0])
+	}
+
+	logged, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("failed to read call log: %v", err)
+	}
+	calls := string(logged)
+	// Every label, including ones after the failing one, must still have
+	// been attempted.
+	for _, spec := range PilotLabels {
+		want := "label create " + spec.Name
+		if !strings.Contains(calls, want) {
+			t.Errorf("expected label %q to still be attempted despite an earlier failure, log:\n%s", spec.Name, calls)
+		}
+	}
+}

--- a/internal/executor/preflight.go
+++ b/internal/executor/preflight.go
@@ -182,20 +182,40 @@ func checkOpenAIAPIKey(backendType string) error {
 	return fmt.Errorf("%s backend requires an API key: set OPENAI_API_KEY (or configure executor.openai.api_key)", backendType)
 }
 
-// checkGitClean verifies the git working directory has no uncommitted changes.
-// This prevents execution from accidentally including unrelated changes.
+// checkGitClean verifies the git working directory has no uncommitted changes,
+// ignoring paths the daemon's own scaffolding/excludes never auto-stage (see
+// isExcluded / defaultExcludeDirs in git.go).
+//
+// GH-4526: on a freshly cloned hosted-tenant repo, the daemon scaffolds
+// Navigator's ".agent/" directory in place (untracked) shortly after clone.
+// Before this fix, that untracked directory made this check see the working
+// directory as dirty on every fresh clone — the daemon's own scaffolding
+// permanently blocked its own first dispatch via this exact preflight check
+// (5 re-picks, then the repick hard cap, then pilot-blocked). Filtering
+// scaffold/exclude paths out of the dirty count — the same allowlist
+// GitOperations.Commit already uses so it never auto-stages ".agent/" et al
+// — makes "clean" mean "clean modulo the daemon's own known writes" without
+// weakening the check for genuinely dirty user files.
 func checkGitClean(ctx context.Context, projectPath string) error {
-	cmd := exec.CommandContext(ctx, "git", "status", "--porcelain")
+	cmd := exec.CommandContext(ctx, "git", "status", "--porcelain", "-z")
 	cmd.Dir = projectPath
 	output, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("git status failed: %w", err)
 	}
-	changes := strings.TrimSpace(string(output))
+	var changes []string
+	for _, entry := range strings.Split(strings.TrimRight(string(output), "\x00"), "\x00") {
+		if len(entry) < 4 {
+			continue
+		}
+		path := entry[3:]
+		if isExcluded(path) {
+			continue
+		}
+		changes = append(changes, path)
+	}
 	if len(changes) > 0 {
-		// Count number of changed files
-		lines := strings.Split(changes, "\n")
-		return fmt.Errorf("working directory has %d uncommitted change(s): run 'git stash' or 'git commit' first", len(lines))
+		return fmt.Errorf("working directory has %d uncommitted change(s): run 'git stash' or 'git commit' first", len(changes))
 	}
 	return nil
 }

--- a/internal/executor/preflight_test.go
+++ b/internal/executor/preflight_test.go
@@ -101,6 +101,61 @@ func TestCheckGitClean(t *testing.T) {
 	})
 }
 
+// TestCheckGitClean_IgnoresScaffoldedAgentDir is the GH-4526 regression
+// guard: the daemon scaffolds an untracked ".agent/" directory into fresh
+// clones shortly after they land, and before this fix that untracked
+// directory alone made checkGitClean report the working directory as dirty
+// — permanently blocking every dispatch on a freshly onboarded hosted tenant
+// repo via its own preflight check. ".agent/" is one of git.go's
+// defaultExcludeDirs (the same list GitOperations.Commit already refuses to
+// auto-stage), so simulating exactly that scaffold write here proves the
+// check now treats it as clean.
+func TestCheckGitClean_IgnoresScaffoldedAgentDir(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	if err := exec.Command("git", "init", tmpDir).Run(); err != nil {
+		t.Fatalf("failed to init git repo: %v", err)
+	}
+	_ = exec.Command("git", "-C", tmpDir, "config", "user.email", "test@test.com").Run()
+	_ = exec.Command("git", "-C", tmpDir, "config", "user.name", "Test").Run()
+
+	// Simulate the daemon's Navigator scaffold: an untracked .agent/ tree,
+	// exactly as init_project.go's createNavigatorStructure leaves behind.
+	agentDir := filepath.Join(tmpDir, ".agent", "tasks")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("failed to scaffold .agent dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, ".agent", "DEVELOPMENT-README.md"), []byte("# Navigator Index\n"), 0o644); err != nil {
+		t.Fatalf("failed to write scaffold file: %v", err)
+	}
+
+	t.Run("untracked_agent_dir_alone_is_clean", func(t *testing.T) {
+		if err := checkGitClean(ctx, tmpDir); err != nil {
+			t.Errorf("expected untracked .agent/ scaffold to be ignored, got: %v", err)
+		}
+	})
+
+	// A genuinely dirty user file alongside the scaffold must still fail —
+	// the fix must not weaken the check for real uncommitted changes.
+	t.Run("real_user_file_alongside_scaffold_still_dirty", func(t *testing.T) {
+		if err := os.WriteFile(filepath.Join(tmpDir, "real_change.go"), []byte("package x"), 0o644); err != nil {
+			t.Fatalf("failed to create real change file: %v", err)
+		}
+		err := checkGitClean(ctx, tmpDir)
+		if err == nil {
+			t.Fatal("expected error: a genuinely dirty user file must still fail git_clean")
+		}
+		if !strings.Contains(err.Error(), "uncommitted change") {
+			t.Errorf("expected error to mention uncommitted changes, got: %v", err)
+		}
+		// Only the real file should count, not the excluded scaffold.
+		if !strings.Contains(err.Error(), "1 uncommitted change(s)") {
+			t.Errorf("expected exactly 1 counted change (scaffold excluded), got: %v", err)
+		}
+	})
+}
+
 func TestRunPreflightChecks(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4526.

Closes #4526

## Changes

GitHub Issue GH-4526: fix(executor): hosted daemon scaffolds untracked .agent/ into fresh clones, then its own git_clean preflight blocks every dispatch

## Defect (found on the first hosted tenant instance, S2 canary proof)

Sequence on a freshly-cloned project repo (`PILOT_HOSTED=1`, fleet instance i-0decbc0dcf225cf18):

1. Repo cloned clean at `/var/lib/pilot/repos/pilot-canary-sandbox` (console#51 apply-script clone).
2. Daemon starts, scaffolds Navigator `.agent/` into the repo (~2 min after clone; untracked).
3. First dispatch (GH-99/GH-100) → `preflight check "git_clean" failed: working directory has 1 uncommitted change(s)` → 5 re-picks → repick hard cap → `pilot-blocked`.

The daemon deadlocks itself: its own scaffolding makes every fresh clone permanently dirty by its own preflight's definition. Box repos never hit this because `.agent/` is committed there. Every future hosted tenant repo hits it on first dispatch.

Operator workaround applied on the canary instance: `.agent/` appended to `.git/info/exclude` + issues re-armed via `pilot-retry-ready`. That does not scale past the canary.

## Fix options (pick one, first is recommended)

1. **git_clean preflight ignores the daemon's own scaffold paths**: treat untracked `.agent/` (and any path the memory writer creates) as clean — e.g. `git status --porcelain -- ':!.agent'` or filter the untracked list against a known-scaffold allowlist. H3 precedent: the daemon already special-cases its own memory writes.
2. Scaffold writes `.git/info/exclude` entries for whatever it creates untracked (self-cleaning, works per-clone).
3. Don't scaffold `.agent/` in PILOT_HOSTED mode until the graph is actually used.

## Secondary finding (same incident, fold in or split)

Stalled-issue surfacing failed label updates on the fresh repo: `gh issue edit: 'pilot-failed' not found` — the daemon assumes its label set exists. Hosted repos are onboarded without labels; the daemon should create missing `pilot-*` labels on demand (idempotent `gh label create` before edit, or ensure-labels at repo-poller startup).

## Acceptance criteria

- Fresh clone + scaffold → git_clean preflight passes; regression test simulating an untracked .agent/ dir.
- Label surfacing works on a repo with zero pre-existing pilot-* labels (creates them).
- No weakening of git_clean for genuinely dirty user files.

## Files

- internal/executor preflight (git_clean check)
- dispatcher stalled-issue surfacing (label ensure)