### PR TITLE
GH-4536: feat: epic sub-issue claim-loss self-deadlock — ProjectWorker waits forev...

### DIFF
--- a/.agent/knowledge/memories/pitfalls/shared-oauth-session-strands-second-machine.md
+++ b/.agent/knowledge/memories/pitfalls/shared-oauth-session-strands-second-machine.md
@@ -1,0 +1,60 @@
+---
+name: shared-oauth-session-strands-second-machine
+description: Copying ~/.claude/.credentials.json to a second machine makes both share one OAuth session — whichever refreshes first strands the other; the stranded side shows the TUI working while headless `claude --print` hangs forever and every daemon subprocess dies with EMPTY stderr and zero tokens
+type: pitfall
+---
+
+# One OAuth session, two machines — the second one strands the first
+
+**What happened (2026-07-24, box outage 16:2x–18:17Z):** to unblock the
+hosted canary tenant, the box's live `~/.claude/.credentials.json` was copied
+to the canary instance via S3 SSE-KMS. Both machines then ran on the same
+OAuth session. The canary refreshed the token; the **box** was left holding an
+invalidated one. Every Pilot execution on the box died for ~2 hours.
+
+Cost: 5 consecutive failed executions of GH-4531 (45 min of compute), the
+repick hard cap tripping, and a `pilot-blocked` label — all attributed to the
+task, none to the environment.
+
+## Diagnostic signature (this is the valuable part)
+
+The failure is **silent in every channel that normally reports errors**:
+
+| Probe | Result on a stranded box |
+|---|---|
+| `claude` (interactive TUI) | **works** — renders "Welcome back", answers prompts |
+| `claude --print "say OK"` | **hangs forever**, killed by timeout, exit 124, no output |
+| executor subprocess | `unknown: exit status 1`, **stderr EMPTY**, stdout = only the `{"type":"system","subtype":"init"}` line, ~4m30s |
+| intent judge / classifiers | `signal: killed (cause=context_deadline)`, hang exactly to their 30s deadline |
+| `curl https://api.anthropic.com/v1/models` | **fast 401** — dns 2ms, tls 20ms, total 147ms |
+| `stat -c %y ~/.claude/.credentials.json` | mtime **hours stale** (08:54Z after 9h) |
+
+**The TUI working is not evidence the daemon can work** — the banner renders
+from the local credentials file without an API round-trip, and launching the
+TUI can itself perform the refresh that fixes the problem. Test the headless
+path (`--print`), because that is what the daemon spawns.
+
+Perfect network + fast unauthenticated 401 **rules out** the GH-4401
+`fetch failed` class. Network-fine + headless-hang = credential.
+
+## How to avoid
+
+1. **Never run one OAuth session on two machines.** Give each consumer its own
+   credential: fund a separate `ANTHROPIC_API_KEY` per tenant, or authenticate
+   each host independently. A copied credentials file is a time bomb whose
+   fuse is the other machine's next refresh.
+2. Fix on the stranded host = re-authenticate locally: `claude` → `/login`
+   (or `claude setup-token`). Verify with `claude --print` **and** a fresh
+   mtime on `.credentials.json` — not with the TUI banner.
+3. **No daemon restart is needed for credentials alone** — the daemon spawns a
+   fresh `claude` per execution and reads the file from disk each time. Restart
+   only to clear in-memory dispatch gates.
+4. When every task fails with empty stderr and zero tokens, probe the
+   environment **before** re-reading the task spec. Five executions were burned
+   here re-attempting a task that was never the problem.
+
+Related: [[oauth-ssm-params-rot-live-credentials-source-of-truth]] (the same
+credential rotting in SSM — this is the reverse direction, where the *live*
+host is the one left stale), [[ci-infra-failure-misclassified-as-code]] (same
+family: environment failure billed to the task),
+[[hard-cap-rearm-in-memory-gate]] (cleaning up after the cap trips).

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -133,7 +133,7 @@ func NewDispatcher(store *memory.Store, runner *Runner, config *DispatcherConfig
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	return &Dispatcher{
+	d := &Dispatcher{
 		config:  config,
 		store:   store,
 		runner:  runner,
@@ -142,6 +142,16 @@ func NewDispatcher(store *memory.Store, runner *Runner, config *DispatcherConfig
 		ctx:     ctx,
 		cancel:  cancel,
 	}
+
+	// GH-4536 (TASK-419): wire the self-owned-queued-child takeover mechanism
+	// into the Runner so reconcileChildOutcome (epic.go) can break the
+	// structural self-deadlock instead of polling forever. nil runner is only
+	// used by tests exercising Dispatcher in isolation.
+	if runner != nil {
+		runner.setReclaimSelfOwnedQueuedChildFn(d.reclaimSelfOwnedQueuedChild)
+	}
+
+	return d
 }
 
 // SetDecomposer sets the task decomposer for auto-splitting complex tasks.
@@ -779,6 +789,108 @@ func (d *Dispatcher) hasLiveWorker(projectPath string) bool {
 	defer d.mu.RUnlock()
 	_, ok := d.workers[projectPath]
 	return ok
+}
+
+// projectWorkerIdentityKey is the context.Value key used to mark a context as
+// being executed synchronously by a ProjectWorker (TASK-393's sole
+// per-project serialization point). GH-4536 (TASK-419).
+type projectWorkerIdentityKey struct{}
+
+// withProjectWorkerIdentity marks ctx as executing synchronously on
+// projectPath's ProjectWorker. Set once, at processQueue's call into
+// Runner.Execute — the only place that call happens — so anything deep in
+// the call stack (epic.go's reconcileChildOutcome) can explicitly detect
+// "I am the project's own worker" instead of inferring it from timing or a
+// package-level global. GH-4536 (TASK-419): this is what lets a queued child
+// of an epic be recognized as unrunnable-by-anyone-else, rather than waited
+// on forever as if it were just queued behind other work (GH-2331/GH-4413's
+// legitimate case, which by construction never carries this identity for a
+// DIFFERENT project).
+func withProjectWorkerIdentity(ctx context.Context, projectPath string) context.Context {
+	return context.WithValue(ctx, projectWorkerIdentityKey{}, projectPath)
+}
+
+// projectWorkerIdentity returns the project path of the ProjectWorker
+// executing ctx synchronously, and whether that identity was set at all.
+// false for contexts built outside the real Dispatcher->ProjectWorker path
+// (e.g. tests calling epic/runner code directly with a bare context) —
+// callers must treat "unknown" as "not self-owned", preserving existing
+// behavior for those paths.
+func projectWorkerIdentity(ctx context.Context) (string, bool) {
+	v, ok := ctx.Value(projectWorkerIdentityKey{}).(string)
+	return v, ok
+}
+
+// reclaimSelfOwnedQueuedChild takes over a queued sub-issue execution that
+// only the caller's own ProjectWorker could ever run (GH-4536/TASK-419): the
+// blocked worker IS the sole goroutine serializing subTask.ProjectPath
+// (TASK-393), so waiting for some other channel to progress a queued row it
+// owns is a guaranteed, structural deadlock, not a legitimate queue-wait.
+//
+// Mechanics mirror reconcileOrphanedExecutions' boot-time precedent (dead
+// claim -> "stalled" -> clear repick backoff -> eligible for a fresh
+// generation) but scoped to one row and triggered in-flight rather than only
+// at boot, with a CAS guard since other writers may be live:
+//  1. Force the existing non-terminal claim to "stalled" via
+//     UpdateExecutionStatusIfNotTerminal, freeing nextRetryGeneration to grant
+//     a new generation for it (a plain "queued"/"running" claim reads as a
+//     live owner forever, GH-4372).
+//  2. Clear its repick_backoff state — this deadlock is not a genuine
+//     execution failure and must not inherit or grow the orphan channel's
+//     drop count toward dispatcherRepickHardCap (mirrors GH-4454).
+//  3. Route the actual re-claim through beginWithGenerationRetry — the one
+//     production caller of nextRetryGeneration+the shared repick_backoff
+//     store — instead of re-implementing a second, driftable claim-retry path
+//     (the exact warning at epic.go's sub-issue Begin() call site).
+//
+// Returns ok=false (no error) when beginWithGenerationRetry itself declines
+// the retry (hard cap already tripped, still inside the backoff window, or a
+// genuine race lost to another channel) — the caller must fail the sub-issue
+// rather than hang, per GH-4536's acceptance criteria, not treat this as
+// grounds to keep polling.
+func (d *Dispatcher) reclaimSelfOwnedQueuedChild(subTask *Task) (execID string, ok bool, err error) {
+	taskID, projectPath := subTask.ID, subTask.ProjectPath
+
+	existing, lookupErr := d.store.GetLatestExecutionByTaskID(taskID, projectPath)
+	if lookupErr != nil && !errors.Is(lookupErr, sql.ErrNoRows) {
+		return "", false, fmt.Errorf("reclaimSelfOwnedQueuedChild: execution lookup failed: %w", lookupErr)
+	}
+	if existing != nil && !isTerminalExecutionStatus(existing.Status) {
+		reason := "GH-4536 (TASK-419): force-stalled for takeover — this Runner's own ProjectWorker is the only goroutine that could ever run this queued child"
+		applied, casErr := d.store.UpdateExecutionStatusIfNotTerminal(existing.ID, string(ExecStatusStalled), reason)
+		if casErr != nil {
+			return "", false, fmt.Errorf("reclaimSelfOwnedQueuedChild: force-stall failed: %w", casErr)
+		}
+		if applied {
+			d.log.Warn("reclaimSelfOwnedQueuedChild: force-stalled self-owned queued child for takeover",
+				slog.String("task_id", taskID),
+				slog.String("project", projectPath),
+				slog.String("execution_id", existing.ID),
+			)
+			d.recordExecutionEvent(existing.ID, memory.StageStalled, reason)
+		} else {
+			// Lost a race with another writer (e.g. the sweep reaping the same
+			// row concurrently) — it already reached a terminal status, which
+			// is exactly what we needed; fall through to the claim attempt.
+			d.log.Info("reclaimSelfOwnedQueuedChild: existing claim already reached a terminal status before force-stall landed",
+				slog.String("task_id", taskID), slog.String("project", projectPath))
+		}
+
+		backoffKey := repickBackoffKey(projectPath, taskID)
+		if clearErr := d.ClearRepickBackoffState(backoffKey); clearErr != nil {
+			d.log.Warn("reclaimSelfOwnedQueuedChild: failed to clear repick backoff state",
+				slog.String("task_id", taskID), slog.String("project", projectPath), slog.Any("error", clearErr))
+		}
+	}
+
+	newExecID, beginErr := d.beginWithGenerationRetry(subTask, ExecStatusRunning)
+	if beginErr != nil {
+		return "", false, fmt.Errorf("reclaimSelfOwnedQueuedChild: beginWithGenerationRetry failed: %w", beginErr)
+	}
+	if newExecID == "" {
+		return "", false, nil
+	}
+	return newExecID, true, nil
 }
 
 // IsActive reports whether taskID is already queued or running in
@@ -1617,6 +1729,18 @@ func (d *Dispatcher) ensureWorker(projectPath string) {
 	d.wg.Add(1)
 	logging.SafeGo("executor-dispatcher", func() {
 		defer d.wg.Done()
+		// GH-4536 (TASK-419): remove this worker from d.workers once its
+		// goroutine actually exits. This defer runs during panic unwind
+		// before SafeGo's own recover (defers inside the wrapped fn fire
+		// first), so it covers normal return (ctx cancellation, Stop()) AND
+		// the SafeGo panic-recover path (dispatcher.go's own comment on that
+		// mechanism) alike. Before this, hasLiveWorker was pure map presence
+		// and never reflected reality: a worker that panicked mid-task left
+		// its project permanently "live"-but-dead until a daemon restart, and
+		// recoverStaleQueuedTasks/recoverStaleRunningTasks — which both skip
+		// any project where hasLiveWorker is true — could never reap behind
+		// it.
+		defer d.removeWorker(projectPath, worker)
 		worker.Run(d.ctx)
 	})
 
@@ -1624,6 +1748,22 @@ func (d *Dispatcher) ensureWorker(projectPath string) {
 
 	// Signal to process any queued tasks
 	worker.Signal()
+}
+
+// removeWorker deletes worker from d.workers, but only if it is still the
+// CURRENT entry registered for projectPath (GH-4536/TASK-419). The identity
+// check guards a narrow race: if a brand-new worker was already registered
+// for the same project (e.g. ensureWorker ran again right as this one's
+// Run() was returning) before this cleanup runs, a bare
+// delete(d.workers, projectPath) would remove the NEW live worker's entry
+// instead of this exiting one's — comparing pointer identity first ensures
+// only the actual exiting worker's own map entry is ever removed.
+func (d *Dispatcher) removeWorker(projectPath string, worker *ProjectWorker) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.workers[projectPath] == worker {
+		delete(d.workers, projectPath)
+	}
 }
 
 // GetWorkerStatus returns the status of all active workers.
@@ -2034,7 +2174,12 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 
 		// Execute (blocking)
 		start := time.Now()
-		result, execErr := w.runner.Execute(ctx, task)
+		// GH-4536 (TASK-419): mark ctx as executing on THIS project's
+		// ProjectWorker — the only place Runner.Execute is invoked
+		// synchronously by the dispatcher — so a queued epic sub-issue owned
+		// by this same project (reconcileChildOutcome, epic.go) can be
+		// recognized as self-owned rather than waited on forever.
+		result, execErr := w.runner.Execute(withProjectWorkerIdentity(ctx, w.projectPath), task)
 		duration := time.Since(start)
 
 		// GH-4243: single chokepoint classifies the outcome (TerminalStatus).

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -2023,6 +2023,18 @@ func evaluateEmptyBranchPRGuard(decomposed bool, childTerminalStates []string, r
 const (
 	defaultChildOutcomeReconcilePollInterval = 3 * time.Second
 	defaultChildOutcomeReconcileTimeout      = 5 * time.Minute
+	// defaultChildOutcomeQueuedAbsoluteCeiling is a GH-4536 (TASK-419)
+	// backstop on the queued-phase poll, which by design otherwise has "no
+	// ceiling at all" while the child is queued (GH-4413, see the big
+	// comment on reconcileChildOutcome below). The self-ownership takeover
+	// added alongside this constant is the real fix for the self-deadlock
+	// this guards against; this ceiling exists only so an unforeseen variant
+	// of the same failure class degrades to a bounded failure instead of
+	// reproducing the hang. Sized generously above any legitimate queue-wait
+	// this codebase is known to produce (GH-2331's queued-behind-other-work
+	// case; the GH-4531 incident's own child sat queued ~7 minutes before
+	// the deadlock) so it should never fire for a real wait.
+	defaultChildOutcomeQueuedAbsoluteCeiling = 2 * time.Hour
 )
 
 // reconcileChildOutcome re-checks a sub-issue's own execution row before
@@ -2080,8 +2092,18 @@ const (
 // no live worker (a dead claim) to a terminal status, which surfaces here on
 // the next tick via the terminal-row check; a queued row with a live worker
 // is, by that same GH-2331 reasoning, just waiting its turn and must not be
-// timed out. ctx cancellation remains the only bound while queued.
-func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath, selfExecID string, result *ExecutionResult, execErr error, externallyOwned bool) (*ExecutionResult, error) {
+// timed out. ctx cancellation remains the only bound while queued — except
+// for the self-ownership case immediately below and the absolute backstop
+// ceiling further down (both GH-4536/TASK-419).
+//
+// GH-4536 (TASK-419): a queued child whose project_path matches the project
+// this call is ITSELF executing on (per ctx's projectWorkerIdentity, set at
+// dispatcher.go's processQueue) is not "just waiting its turn" — under
+// TASK-393's one-worker-per-project invariant, this goroutine IS the only
+// one that could ever pick it up, so waiting on it is a guaranteed deadlock.
+// subTask carries that child's full Task (including ProjectPath) so a
+// detected self-deadlock can be taken over inline rather than merely failed.
+func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath, selfExecID string, result *ExecutionResult, execErr error, externallyOwned bool, subTask *Task) (*ExecutionResult, error) {
 	hasFailureSignal := execErr != nil || (result != nil && !result.Success)
 	if !hasFailureSignal && !externallyOwned {
 		return result, execErr
@@ -2125,6 +2147,15 @@ func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath,
 	if timeout <= 0 {
 		timeout = defaultChildOutcomeReconcileTimeout
 	}
+	// GH-4536 (TASK-419): absolute backstop for the queued phase, which is
+	// otherwise unbounded by design (see the GH-4413 comment above). Anchored
+	// to when this poll loop started, not to any per-tick state, so it can't
+	// be reset by a state regression the way runningDeadline deliberately is.
+	queuedCeiling := r.childOutcomeQueuedAbsoluteCeiling
+	if queuedCeiling <= 0 {
+		queuedCeiling = defaultChildOutcomeQueuedAbsoluteCeiling
+	}
+	pollStart := time.Now()
 
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
@@ -2162,13 +2193,36 @@ func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath,
 		}
 
 		if !running {
-			// Still queued (or no row visible yet): no ceiling applies. A
-			// queued row behind a live worker is legitimately waiting its
-			// turn (GH-2331); a queued row with a dead claim gets reaped to
-			// a terminal status by recoverStaleQueuedTasks and will be
-			// caught by the terminal check above on a later tick. Reset any
-			// previously-observed running deadline in case the child
-			// regressed to queued (a fresh re-pick row sorting first).
+			// GH-4536 (TASK-419): a queued (or not-yet-visible) child that
+			// this call is externally owned for, and whose project this call
+			// is ITSELF executing on, is not "just waiting its turn" — it is
+			// unrunnable by anyone else (TASK-393's one-worker-per-project
+			// invariant), so this is a guaranteed structural deadlock, not a
+			// legitimate queue-wait. Detected explicitly via ctx identity,
+			// never inferred from how long we've been polling. Take over
+			// (preferred) or fail distinctly — never keep polling.
+			if externallyOwned {
+				if workerProject, hasIdentity := projectWorkerIdentity(ctx); hasIdentity && workerProject == projectPath {
+					return r.reconcileSelfOwnedTakeover(ctx, taskID, projectPath, subTask)
+				}
+			}
+			// Still queued (or no row visible yet), and not self-owned: no
+			// per-tick ceiling applies. A queued row behind a live worker on
+			// a DIFFERENT project is legitimately waiting its turn (GH-2331);
+			// a queued row with a dead claim gets reaped to a terminal status
+			// by recoverStaleQueuedTasks and will be caught by the terminal
+			// check above on a later tick. Reset any previously-observed
+			// running deadline in case the child regressed to queued (a
+			// fresh re-pick row sorting first). The absolute backstop below
+			// still bounds the total wait regardless.
+			if time.Since(pollStart) > queuedCeiling {
+				r.log.Warn("reconcileChildOutcome: gave up waiting for a queued child past the absolute backstop ceiling",
+					"task_id", taskID, "project_path", projectPath, "queued_ceiling", queuedCeiling)
+				if externallyOwned {
+					return &ExecutionResult{TaskID: taskID}, fmt.Errorf("reconcileChildOutcome: queued child %s exceeded absolute backstop ceiling (%s) without reaching a terminal state (GH-4536/TASK-419)", taskID, queuedCeiling)
+				}
+				return result, execErr
+			}
 			runningDeadline = time.Time{}
 			continue
 		}
@@ -2188,6 +2242,53 @@ func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath,
 			return result, execErr
 		}
 	}
+}
+
+// reconcileSelfOwnedTakeover breaks the GH-4536 (TASK-419) self-deadlock:
+// ctx carries proof that this call is running on subTask.ProjectPath's own
+// ProjectWorker (TASK-393's sole per-project serialization point), and the
+// child is still queued — under the one-worker-per-project model that queued
+// child can never be picked up by any other goroutine. Waiting on it, as the
+// externally-owned poll loop otherwise would, is a guaranteed hang, not a
+// legitimate queue-wait (the GH-2331 assumption reconcileChildOutcome
+// otherwise relies on).
+//
+// Prefers takeover: force-stall the dead-end claim and re-claim it through
+// the shared beginWithGenerationRetry/repick_backoff path
+// (reclaimSelfOwnedQueuedChildFn, wired by NewDispatcher — see the warning at
+// this file's sub-issue Begin() call site about not re-implementing a second,
+// driftable claim-retry path), then execute the child inline: this IS the
+// worker that would have run it anyway. Falls back to a distinct, greppable
+// failure — never a hang, never a silent success — when no reclaim mechanism
+// is wired (e.g. a test exercising this path directly, without a real
+// Dispatcher) or the reclaim itself is rejected (hard cap already tripped,
+// still inside the backoff window, or a genuine race lost to another
+// channel).
+func (r *Runner) reconcileSelfOwnedTakeover(ctx context.Context, taskID, projectPath string, subTask *Task) (*ExecutionResult, error) {
+	if r.reclaimSelfOwnedQueuedChildFn == nil {
+		return &ExecutionResult{TaskID: taskID}, fmt.Errorf("reconcileChildOutcome: self-owned-queued-child deadlock detected for task=%s project=%s (GH-4536/TASK-419) and no reclaim mechanism is wired — refusing to wait forever", taskID, projectPath)
+	}
+
+	newExecID, ok, err := r.reclaimSelfOwnedQueuedChildFn(subTask)
+	if err != nil {
+		return &ExecutionResult{TaskID: taskID}, fmt.Errorf("reconcileChildOutcome: self-owned-queued-child takeover failed for task=%s project=%s (GH-4536/TASK-419): %w", taskID, projectPath, err)
+	}
+	if !ok {
+		return &ExecutionResult{TaskID: taskID}, fmt.Errorf("reconcileChildOutcome: self-owned-queued-child takeover rejected for task=%s project=%s (GH-4536/TASK-419): reclaim declined (hard cap, backoff window, or lost a race) — failing instead of hanging", taskID, projectPath)
+	}
+
+	r.log.Info("reconcileChildOutcome: took over self-owned queued child after claim-loss deadlock detection",
+		"task_id", taskID, "project_path", projectPath, "execution_id", newExecID)
+
+	var execResult *ExecutionResult
+	var execErr error
+	if r.executeFunc != nil {
+		execResult, execErr = r.executeFunc(ctx, subTask)
+	} else {
+		execResult, execErr = r.executeWithOptions(ctx, subTask, true)
+	}
+
+	return r.reconcileChildOutcome(ctx, taskID, projectPath, newExecID, execResult, execErr, false, subTask)
 }
 
 // findTerminalChildExecution scans every execution row tracked for taskID
@@ -2576,7 +2677,7 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 			r.recordExecutionEvent(parent.LogExecutionID(), memory.StageDispatchClaimLost,
 				fmt.Sprintf("sub-issue %s claim lost to another dispatch channel", issueRef))
 
-			result, err = r.reconcileChildOutcome(ctx, taskID, subTaskRepoPath, "", nil, nil, true)
+			result, err = r.reconcileChildOutcome(ctx, taskID, subTaskRepoPath, "", nil, nil, true, subTask)
 		} else {
 			if err != nil {
 				r.log.Warn("Failed to insert sub-issue execution row",
@@ -2610,7 +2711,7 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 			// is actually done — it can race a separately-tracked run of the same
 			// sub-issue. Re-check the child's own execution row before trusting
 			// this signal as terminal.
-			result, err = r.reconcileChildOutcome(ctx, taskID, subTaskRepoPath, subExecID, result, err, false)
+			result, err = r.reconcileChildOutcome(ctx, taskID, subTaskRepoPath, subExecID, result, err, false, subTask)
 		}
 
 		if err != nil {

--- a/internal/executor/gh4536_test.go
+++ b/internal/executor/gh4536_test.go
@@ -1,0 +1,307 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// gh4536TwoPackageSubtasks returns two subtasks in distinct directories (so
+// isSinglePackageScope doesn't consolidate them into a single in-process
+// task) — mirrors GH-4531's real shape: sub-issue 1 (GH-4532) and sub-issue 2
+// (GH-4533).
+func gh4536TwoPackageSubtasks() []PlannedSubtask {
+	return []PlannedSubtask{
+		{Order: 1, Title: "feat(gateway): add websocket handler", Description: "Implement upgrade handler in internal/gateway/server.go"},
+		{Order: 2, Title: "feat(adapters): add telegram bot", Description: "Wire bot client in internal/adapters/telegram/bot.go"},
+	}
+}
+
+// TestDispatcher_EpicSelfOwnedQueuedChild_TakesOverAndTerminates is the
+// GH-4536 (TASK-419) end-to-end regression test: it drives an epic through
+// the REAL Dispatcher -> ProjectWorker -> Runner.Execute path (not
+// ExecuteSubIssues directly, which would bypass the very code — the epic
+// branch's lack of a bounded context, and Runner.Execute's lack of any
+// project-worker identity on ctx — that let the GH-4531 incident happen).
+//
+// Sub-issue 2's execution claim is pre-seeded as already held by an orphaned
+// dispatch channel BEFORE the epic even starts, exactly mirroring GH-4531's
+// shape: sub-issue 1 (GH-4532) ships normally, then sub-issue 2 (GH-4533)'s
+// Begin() loses its claim to a channel that will never progress. Under the
+// old code this polled forever with no ceiling on the queued phase, and
+// since the ONLY goroutine that could ever run GH-4533 for this project is
+// this very ProjectWorker (TASK-393's one-worker-per-project invariant), the
+// parent execution row stayed "running" forever. This test asserts the
+// parent instead reaches a terminal status within a bounded wait, and that
+// both children actually executed — the second one via takeover.
+func TestDispatcher_EpicSelfOwnedQueuedChild_TakesOverAndTerminates(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	projectPath := filepath.Join(os.TempDir(), "gh4536-deadlock-project")
+
+	runner := NewRunner()
+	runner.skipPreflightChecks = true
+	runner.childOutcomeReconcilePollInterval = 20 * time.Millisecond
+	runner.childOutcomeReconcileTimeout = 200 * time.Millisecond
+	runner.childOutcomeQueuedAbsoluteCeiling = 2 * time.Second
+
+	subtasks := gh4536TwoPackageSubtasks()
+	runner.planEpicFn = func(_ context.Context, task *Task, _ string) (*EpicPlan, error) {
+		return &EpicPlan{ParentTask: task, Subtasks: subtasks}, nil
+	}
+	// Force the recovery path instead of a real `gh issue create` — the
+	// sub-issues are treated as already existing, matching GH-4531's shape
+	// where the issues themselves were already open.
+	runner.openSubIssueCheck = func(_ context.Context, _, _ string) (bool, error) {
+		return true, nil
+	}
+	runner.recoverSubIssuesFn = func(_ context.Context, _, _ string) ([]CreatedIssue, error) {
+		return []CreatedIssue{
+			{Number: 4532, State: "open", Subtask: subtasks[0]},
+			{Number: 4533, State: "open", Subtask: subtasks[1]},
+		}, nil
+	}
+
+	var executedIDs []string
+	runner.executeFunc = func(_ context.Context, task *Task) (*ExecutionResult, error) {
+		executedIDs = append(executedIDs, task.ID)
+		// Non-zero tokens/files so the zero-delivery no_op guard doesn't
+		// reclassify this otherwise-successful epic.
+		return &ExecutionResult{TaskID: task.ID, Success: true, TokensOutput: 100, FilesChanged: 1}, nil
+	}
+
+	dispatcher := NewDispatcher(store, runner, nil)
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	// GH-4531 incident setup: sub-issue 2 (GH-4533)'s claim is already held
+	// by an orphaned dispatch channel (e.g. a duplicate poller pickup that
+	// crashed) before the epic ever reaches it. ClaimExecution only touches
+	// execution_claims, matching the real incident: the winning claim holder
+	// never got as far as writing its own executions row.
+	claimed, err := store.ClaimExecution("GH-4533", projectPath, 0, "exec-orphan-4533")
+	if err != nil {
+		t.Fatalf("failed to pre-seed orphan claim: %v", err)
+	}
+	if !claimed {
+		t.Fatal("test setup: expected the seeded orphan claim to win")
+	}
+
+	epicTask := &Task{
+		ID:          "GH-4536E",
+		Title:       "[epic] GH-4536 self-owned queued child deadlock regression",
+		Description: "epic",
+		ProjectPath: projectPath,
+		CreatePR:    true,
+	}
+
+	execID, err := dispatcher.QueueTask(context.Background(), epicTask)
+	if err != nil {
+		t.Fatalf("failed to queue epic task: %v", err)
+	}
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	exec, err := dispatcher.WaitForExecution(waitCtx, execID, 20*time.Millisecond)
+	if err != nil {
+		t.Fatalf("epic parent did not reach a terminal state within the bounded wait — this is the GH-4531/GH-4536 deadlock regressing: %v", err)
+	}
+	if !isTerminalExecutionStatus(exec.Status) {
+		t.Fatalf("expected epic parent execution to reach a terminal status, got %q", exec.Status)
+	}
+	if exec.Status != "completed" {
+		t.Errorf("expected epic parent to complete successfully after takeover, got status %q (error: %s)", exec.Status, exec.Error)
+	}
+
+	if len(executedIDs) != 2 {
+		t.Fatalf("expected 2 child executions (sub-issue 1 normally + sub-issue 2 via takeover), got %d: %v", len(executedIDs), executedIDs)
+	}
+	if executedIDs[0] != "GH-4532" || executedIDs[1] != "GH-4533" {
+		t.Errorf("expected children executed in order [GH-4532 GH-4533], got %v", executedIDs)
+	}
+}
+
+// TestDispatcher_WorkerPanic_HasLiveWorkerReflectsExitAndStaleSweepReaps is
+// the GH-4536 (TASK-419) regression test for hasLiveWorker's delete-on-exit
+// fix. Before this fix, d.workers only ever gained entries — a worker whose
+// goroutine panicked mid-task stayed "live" in the map forever (until a
+// daemon restart), permanently disabling the stale-sweep's live-worker skip
+// guard for that project (recoverStaleQueuedTasks/recoverStaleRunningTasks
+// both treat hasLiveWorker==true as "leave it alone, something is still
+// making progress"). This drives a real panic through the real
+// Dispatcher -> ProjectWorker -> Runner.Execute stack (via the planEpicFn
+// test seam, the same injection point production wires through
+// NewDispatcher) and asserts: (1) hasLiveWorker eventually reports false
+// once the SafeGo-wrapped goroutine's cleanup defer runs during panic
+// unwind, and (2) the stale sweep — which used to skip any project with a
+// "live" worker regardless of reality — now reaps the row the panicked
+// worker left behind.
+func TestDispatcher_WorkerPanic_HasLiveWorkerReflectsExitAndStaleSweepReaps(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	projectPath := filepath.Join(os.TempDir(), "gh4536-panic-project")
+
+	runner := NewRunner()
+	runner.skipPreflightChecks = true
+	runner.planEpicFn = func(context.Context, *Task, string) (*EpicPlan, error) {
+		panic("GH-4536 (TASK-419) test: simulated worker panic")
+	}
+
+	config := &DispatcherConfig{
+		StaleRunningThreshold: 0, // everything is stale immediately once no live worker guards it
+		StaleQueuedThreshold:  0,
+		StaleRecoveryInterval: time.Hour, // won't tick during this test
+	}
+	dispatcher := NewDispatcher(store, runner, config)
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	task := &Task{
+		ID:          "GH-4536PANIC",
+		Title:       "[epic] GH-4536 worker panic regression",
+		Description: "epic",
+		ProjectPath: projectPath,
+	}
+
+	execID, err := dispatcher.QueueTask(context.Background(), task)
+	if err != nil {
+		t.Fatalf("failed to queue task: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for dispatcher.hasLiveWorker(projectPath) {
+		if time.Now().After(deadline) {
+			t.Fatal("worker still considered live 5s after its goroutine panicked — hasLiveWorker is not reflecting real liveness (GH-4536/TASK-419)")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// The panicked worker never returned to let processQueue finish the row,
+	// so it should still be sitting "running".
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("failed to get execution: %v", err)
+	}
+	if exec.Status != "running" {
+		t.Fatalf("expected the panicked task's row to still be 'running' before the sweep, got %q", exec.Status)
+	}
+
+	dispatcher.recoverStaleTasks()
+
+	reaped, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("failed to get execution after sweep: %v", err)
+	}
+	if reaped.Status == "running" {
+		t.Errorf("expected the stale sweep to reap the row left behind by the panicked worker now that hasLiveWorker correctly reports it dead, got %q", reaped.Status)
+	}
+}
+
+// TestExecuteSubIssues_ClaimLost_QueuedBehindDifferentProjectWorkerNotFalselyTakenOver
+// is the GH-4536 (TASK-419) non-regression test for GH-4413: a child queued
+// behind OTHER work on a busy project whose live worker is a DIFFERENT
+// project than the one recorded on ctx must NOT be mistaken for a
+// self-owned deadlock. It mirrors
+// TestExecuteSubIssues_ClaimLost_QueuedBeyondTimeoutStillSucceeds (the
+// existing GH-4413 regression test) but additionally stamps ctx with a
+// projectWorkerIdentity for a project that is NOT the child's own — proving
+// the self-ownership check (workerProject == projectPath) correctly stays
+// silent for the "different project, still legitimately busy" case, not
+// just the "no identity at all" case the pre-existing test covers (that
+// test calls context.Background() directly, which the real
+// Runner.Execute/Dispatcher path never does after this fix).
+func TestExecuteSubIssues_ClaimLost_QueuedBehindDifferentProjectWorkerNotFalselyTakenOver(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const taskID = "GH-4413" // must match makeSubIssues(1, 4413) below: taskID = fmt.Sprintf("GH-%d", issue.Number)
+	const projectPath = "/busy/project"
+
+	claimed, err := store.ClaimExecution(taskID, projectPath, 0, "exec-owner-4413")
+	if err != nil {
+		t.Fatalf("ClaimExecution: %v", err)
+	}
+	if !claimed {
+		t.Fatal("test setup: expected the seeded claim to win")
+	}
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-owner-4413",
+		TaskID:      taskID,
+		ProjectPath: projectPath,
+		Status:      "queued",
+	}); err != nil {
+		t.Fatalf("SaveExecution (queued row): %v", err)
+	}
+
+	issues := makeSubIssues(1, 4413)
+	parent := &Task{ID: "GH-94", Title: "[epic] queued behind a different project's busy worker", ProjectPath: projectPath}
+
+	execCalled := false
+	execFn := func(ctx context.Context, task *Task) (*ExecutionResult, error) {
+		execCalled = true
+		return &ExecutionResult{TaskID: task.ID, Success: true}, nil
+	}
+
+	runner := newTestRunnerWithExecFunc(execFn)
+	runner.logStore = store
+	runner.childOutcomeReconcilePollInterval = 20 * time.Millisecond
+	const timeout = 1500 * time.Millisecond
+	const queuedPhase = 2000 * time.Millisecond // > timeout: proves queue-wait isn't charged against it
+	runner.childOutcomeReconcileTimeout = timeout
+
+	takeoverCalled := false
+	runner.setReclaimSelfOwnedQueuedChildFn(func(subTask *Task) (string, bool, error) {
+		takeoverCalled = true
+		return "", false, fmt.Errorf("takeover must never be attempted for a child queued on a different project than ctx's identity")
+	})
+
+	go func() {
+		time.Sleep(queuedPhase)
+		if uErr := store.UpdateExecutionStatus("exec-owner-4413", "running"); uErr != nil {
+			t.Errorf("UpdateExecutionStatus(running): %v", uErr)
+		}
+		time.Sleep(100 * time.Millisecond) // well under timeout, running phase
+		if mcErr := store.MarkExecutionCompleted("exec-owner-4413", "https://github.com/owner/repo/pull/9413", "sha-4413", 500); mcErr != nil {
+			t.Errorf("MarkExecutionCompleted: %v", mcErr)
+		}
+	}()
+
+	// ctx carries a DIFFERENT project's identity than the child's own — the
+	// legitimate GH-2331/GH-4413 case: this Runner happens to be executing
+	// on some OTHER project's ProjectWorker while this child sits queued
+	// behind unrelated work on its own, still-live, still-progressing
+	// project worker.
+	ctx := withProjectWorkerIdentity(context.Background(), "/some/other/project")
+
+	start := time.Now()
+	err = runner.ExecuteSubIssues(ctx, parent, issues, parent.ProjectPath, "")
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("ExecuteSubIssues returned error, want nil (a different project's identity must not trigger takeover or a false timeout): %v", err)
+	}
+	if takeoverCalled {
+		t.Error("self-owned takeover fired for a child queued on a DIFFERENT project than ctx's identity — false positive (GH-4536/TASK-419 regression)")
+	}
+	if execCalled {
+		t.Error("expected the backend NOT to be invoked when the execution claim was already lost")
+	}
+	if elapsed < queuedPhase {
+		t.Errorf("elapsed = %s, want >= %s (queue-wait must still not be charged against the running timeout for a legitimately busy different-project worker)", elapsed, queuedPhase)
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -743,11 +743,26 @@ type Runner struct {
 	// defaultChildOutcomeReconcileTimeout); tests shrink these for fast runs.
 	childOutcomeReconcilePollInterval time.Duration
 	childOutcomeReconcileTimeout      time.Duration
+	// GH-4536 (TASK-419): absolute backstop on reconcileChildOutcome's
+	// queued-phase poll, which is otherwise unbounded by design (GH-4413).
+	// Zero uses defaultChildOutcomeQueuedAbsoluteCeiling; tests shrink this
+	// for fast runs.
+	childOutcomeQueuedAbsoluteCeiling time.Duration
 	// GH-4300: bounds the retry loop around each per-subtask `gh issue create`
 	// call. Zero uses the package defaults (defaultSubIssueCreateRetryAttempts /
 	// defaultSubIssueCreateRetryDelay); tests shrink the delay for fast runs.
 	subIssueCreateRetryAttempts int
 	subIssueCreateRetryDelay    time.Duration
+	// reclaimSelfOwnedQueuedChildFn lets reconcileChildOutcome (epic.go,
+	// GH-4536/TASK-419) take over a queued child that only this Runner's own
+	// ProjectWorker could ever run — force-stalling the dead-end claim and
+	// re-claiming it via the shared beginWithGenerationRetry/repick_backoff
+	// path instead of polling forever. Wired by NewDispatcher to
+	// Dispatcher.reclaimSelfOwnedQueuedChild; nil in tests/call paths that
+	// bypass the real Dispatcher (e.g. direct ExecuteSubIssues calls), in
+	// which case a detected self-owned deadlock fails the sub-issue instead
+	// of hanging.
+	reclaimSelfOwnedQueuedChildFn func(subTask *Task) (execID string, ok bool, err error)
 }
 
 // SetRepoAllowlist injects the allowlist used by the sub-issue creation
@@ -757,6 +772,16 @@ type Runner struct {
 // PILOT_ALLOW_UNMANAGED_REPO=1 is set, which logs a WARN).
 func (r *Runner) SetRepoAllowlist(allow RepoAllowlist) {
 	r.repoAllowlist = allow
+}
+
+// setReclaimSelfOwnedQueuedChildFn wires the takeover mechanism used when
+// reconcileChildOutcome (epic.go, GH-4536/TASK-419) detects a queued child
+// only this Runner's own ProjectWorker could ever run. Called by
+// NewDispatcher; unexported since only the Dispatcher constructor should set
+// it — everything else should treat the Runner/Dispatcher wiring as an
+// implementation detail.
+func (r *Runner) setReclaimSelfOwnedQueuedChildFn(fn func(subTask *Task) (execID string, ok bool, err error)) {
+	r.reclaimSelfOwnedQueuedChildFn = fn
 }
 
 // NewRunner creates a new Runner instance with Claude Code backend by default.
@@ -2129,6 +2154,27 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		)
 		r.reportProgress(task.ID, "Planning", 10, "Running epic planning...")
 
+		// GH-4536 (TASK-419): the epic block previously ran with no deadline
+		// at all — Runner.Execute built its per-task watchdog context (below,
+		// ~runner.go:2461) only AFTER this entire block, so an epic that
+		// planned successfully and entered sub-issue execution never got a
+		// bound and Execute() could block forever, leaving the parent
+		// execution row stuck non-terminal (dispatcher.go:2122's
+		// lifecycle.Persist is only reached once Execute returns). Bound the
+		// epic block from its very first Claude call.
+		//
+		// Budget choice: a single shared deadline across N sequential
+		// sub-issues would starve later sub-issues (planning eats into the
+		// same budget the last sub-issue needs). So planning gets its own
+		// bounded context here, and once the plan is known the multi-package
+		// branch below derives a second, independent context sized off the
+		// actual sub-issue count (see epicCtx below) — deriving it fresh from
+		// the top-level ctx, not nested under planCtx, so planning's
+		// cancellation can't shrink the execution phase's budget.
+		planTimeout := r.modelRouter.GetTimeoutForComplexity(ComplexityComplex)
+		planCtx, planCancel := context.WithTimeout(ctx, planTimeout)
+		defer planCancel()
+
 		planFn := r.planEpicFn
 		if planFn == nil {
 			planFn = r.PlanEpic
@@ -2138,7 +2184,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		// previously emitted nothing past spec_validated, leaving `pilot trace`
 		// silent for the entire epic lifecycle.
 		r.recordExecutionEvent(task.LogExecutionID(), memory.StageClaudeStarted, "epic planning invoked claude")
-		plan, err := planFn(ctx, task, executionPath)
+		plan, err := planFn(planCtx, task, executionPath)
 		if err != nil {
 			// GH-1687: Planning failure is non-fatal — fall through to direct execution
 			r.log.Warn("Epic planning failed, falling back to direct execution",
@@ -2184,6 +2230,24 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 			} else {
 				// Multi-package epic: safe to create separate GitHub issues
 
+				// GH-4536 (TASK-419): size the execution-phase ceiling from the
+				// actual planned sub-issue count now that it's known, rather
+				// than reusing planCtx's single-task budget (which would
+				// starve later sub-issues) or leaving this phase unbounded
+				// (the original incident — see epic.go's reconcileChildOutcome
+				// for the self-ownership half of this fix). Each planned
+				// sub-issue gets a full complex-task budget. Derived fresh
+				// from the top-level ctx (not nested under planCtx), so
+				// planning's own — already-expired-by-now — deadline can't
+				// shrink this one.
+				perSubIssueTimeout := r.modelRouter.GetTimeoutForComplexity(ComplexityComplex)
+				epicTimeout := perSubIssueTimeout * time.Duration(len(plan.Subtasks))
+				if epicTimeout < perSubIssueTimeout {
+					epicTimeout = perSubIssueTimeout // overflow/empty-plan guard
+				}
+				epicCtx, epicCancel := context.WithTimeout(ctx, epicTimeout)
+				defer epicCancel()
+
 				// GH-3513 wave 2 (#3538/#3553): refuse to create sub-issues from a
 				// plan whose ParentTask diverges from the dispatched task — children
 				// were observed claiming "parent: GH-201" while unrelated epics ran.
@@ -2213,7 +2277,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 				// GH-412: Create sub-issues from the plan
 				r.reportProgress(task.ID, "Creating Issues", 40, "Creating GitHub sub-issues...")
 
-				issues, err := r.CreateSubIssues(ctx, plan, executionPath)
+				issues, err := r.CreateSubIssues(epicCtx, plan, executionPath)
 				if err != nil {
 					// GH-2883: Recover existing sub-issues instead of failing hard when they
 					// were already created by a prior run (e.g., Pilot restarted mid-epic).
@@ -2226,7 +2290,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 						if recover == nil {
 							recover = recoverExistingSubIssues
 						}
-						recovered, _ := recover(ctx, executionPath, plan.ParentTask.ID)
+						recovered, _ := recover(epicCtx, executionPath, plan.ParentTask.ID)
 
 						// GH-4300: a recovered set smaller than this run's plan means at
 						// least one planned subtask never got an issue created at all (the
@@ -2246,14 +2310,14 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 							// issues only for the ones genuinely missing; only a real
 							// conflict (nothing recovered matches the plan) or a failed
 							// creation attempt falls through to the decline below.
-							reconciled, reconcileErr := r.reconcilePartialSubIssueRecovery(ctx, plan, plannedNow, recovered, executionPath)
+							reconciled, reconcileErr := r.reconcilePartialSubIssueRecovery(epicCtx, plan, plannedNow, recovered, executionPath)
 							cause := err
 							if reconcileErr != nil {
 								cause = reconcileErr
 							}
 							if len(reconciled) < len(plannedNow) {
 								gapPlan := &EpicPlan{ParentTask: plan.ParentTask, Subtasks: plannedNow, TotalEffort: plan.TotalEffort, PlanOutput: plan.PlanOutput}
-								gapErr := r.handleSubIssueCoverageGap(ctx, gapPlan, reconciled, executionPath, cause)
+								gapErr := r.handleSubIssueCoverageGap(epicCtx, gapPlan, reconciled, executionPath, cause)
 								r.reportProgress(task.ID, "Needs Clarification", 100, gapErr.Error())
 								return &ExecutionResult{
 									TaskID:         task.ID,
@@ -2346,7 +2410,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 				// one whose deliverables shipped entirely via child sub-issue PRs.
 				// GH-3938: childMetrics carries the real tokens/files/cost every child
 				// actually burned, rolled up onto the epic-parent's own result below.
-				childStates, childMetrics, err := r.executeSubIssuesTracked(ctx, task, issues, executionPath, task.ProjectPath)
+				childStates, childMetrics, err := r.executeSubIssuesTracked(epicCtx, task, issues, executionPath, task.ProjectPath)
 				if err != nil {
 					execErr := fmt.Sprintf("sub-issue execution failed: %v", err)
 					r.recordExecutionEvent(task.LogExecutionID(), memory.StageFailed, truncateForLog(execErr, 200))
@@ -2399,7 +2463,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 					// instead of warn-and-continue, so a stranded epic is never recorded
 					// as a "completed" row with an empty PR (Shape A). A pre-create
 					// merged-work check avoids opening a duplicate PR (Shape C).
-					r.finalizeEpicBranchPR(ctx, task, NewGitOperations(executionPath), epicResult, childStates)
+					r.finalizeEpicBranchPR(epicCtx, task, NewGitOperations(executionPath), epicResult, childStates)
 				} else {
 					r.reportProgress(task.ID, "Complete", 100, "Epic completed successfully")
 				}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4536.

Closes #4536

## Changes

GitHub Issue GH-4536: TASK-419: Epic sub-issue claim-loss self-deadlock — ProjectWorker waits forever for a child only it can run

# TASK-419: Epic sub-issue claim-loss self-deadlock — the ProjectWorker waits forever for a child only it can run

**Status**: 🚧 In Progress
**Created**: 2026-07-24
**Assignee**: Pilot

---

## Context

**Problem**:
On 2026-07-24 epic GH-4531 shipped sub-issue 1 (GH-4532 → PR #4534, merged)
and then hung forever without ever starting sub-issue 2 (GH-4533). The parent
`executions` row sat `running` for 35+ minutes with **zero claude/node
processes alive**, holding the project's only worker slot and its claim, until
an operator killed it by hand. Nothing reaped it.

This is not a timeout-tuning bug. It is a **structural self-deadlock**: the
goroutine blocked waiting for a queued child is the only goroutine that could
ever run that child.

**Observed sequence** (daemon v2.245.2):
```
18:42:59  executions row for GH-4533 created, status=queued   (claimed by the
          GitHub poller, which then dropped its own dispatch — orphan owner)
18:50:05  merge-wait decision: not waiting   dependency_reason=none
18:50:08  Sub-issue completed  sub_issue=4532  pr=4534
18:50:09  sub-issue dispatch claim lost — another channel already owns this
          execution; polling for its outcome   sub_issue=4533
   (…nothing, forever. "Executing sub-issue order=2" never appears.
    Meanwhile every poll tick: poller dispatches 4533 → "dispatch claim lost
    — task already owned by another dispatch channel" → drops.
    "stale recovery complete, reset N tasks count=0" repeats throughout.)
```

**Root cause** — three individually-reasonable decisions compose into a
guaranteed hang:

1. `epic.go:2566-2579` — on `ErrClaimLost`, the epic does not fail; it calls
   `reconcileChildOutcome(ctx, taskID, path, "", nil, nil, /*externallyOwned=*/true)`
   to wait for the "winning" channel's outcome (GH-4359).
2. `epic.go:2063-2083` + `epic.go:2129-2134` — **GH-4413** deliberately made
   the reconcile timeout bound only time the child spends **running**. While
   the child is `queued` (or no row is visible) it "keeps polling with **no
   ceiling at all**". Its stated safety net is that
   `recoverStaleQueuedTasks` reaps a queued row "whose owning project has no
   live worker", and that "a queued row with a live worker is … just waiting
   its turn and must not be timed out."
3. That safety net cannot fire here. `recoverStaleQueuedTasks`/
   `recoverStaleRunningTasks` skip any row whose project passes
   `hasLiveWorker` (`dispatcher.go:499`, `dispatcher.go:715`), and
   `hasLiveWorker` (`dispatcher.go:777-782`) is **pure map presence** —
   `grep -c 'delete(d\.workers' internal/executor/dispatcher.go` returns
   **0**, so a worker is never removed from the map, alive, wedged, or dead.

The project **does** have a live worker — it is the one blocked in step 2,
inside `Runner.Execute` called synchronously at `dispatcher.go:2037`. Under
the one-worker-per-project model (TASK-393 ProjectWorker), a queued child of
the epic that worker is running can **never** start. The waiter is the runner.

`ctx` cancellation is documented as "the only bound while queued" — and the
epic branch never gets a deadline: `Runner.Execute` builds its watchdog
context at `runner.go:2454-2462`, which is **after** the epic block
(`runner.go:2125-2416`, returning at `2413`). Epics therefore run under the
dispatcher's daemon-lifetime context. There is no bound at all.

Because the parent's terminal status is written only by the shared chokepoint
`w.lifecycle.Persist` at `dispatcher.go:2122` — reached only after
`Execute()` returns — the parent row can never go terminal either.

**Goal**:
Make this class of hang impossible: a queued child that the blocked worker
itself owns must be detected and resolved, not waited on; and no epic may
occupy a worker without a deadline.

---

## Known Pitfalls & Patterns

- **PITFALL** `claim-lost-drops-count-toward-hard-cap`: while the epic hung,
  the poller's rejected re-dispatches incremented the repick counter to 5/5,
  which would have force-stalled a task that was (nominally) running. Do not
  "fix" this by making claim-loss louder in the poller — fix the deadlock.
- **PITFALL** `hard-cap-rearm-in-memory-gate`: recovery from this state
  required 6 manual steps including a DB surgery and a daemon restart. A fix
  that only shortens the hang without producing a terminal status still leaves
  operators doing surgery.
- **DECISION** "Where parallelism lives: ProjectWorker pool — it is the sole
  serialization point": that decision is what makes self-ownership fatal here.
  The fix must respect it, not add a second execution path around it.

---

## Acceptance Criteria

- [ ] An epic whose sub-issue `Begin()` returns `ErrClaimLost`, where the
      child's execution row is `queued` and owned by a channel that is not
      making progress, terminates in **bounded** time rather than polling
      forever.
- [ ] Self-ownership is detected explicitly: when the goroutine executing the
      epic is the project's own worker, a `queued` child of that epic is
      recognized as unrunnable-by-anyone-else and is **not** treated as
      "waiting its turn".
- [ ] On that detection the epic either takes over the child's execution
      (preferred — the work still gets done) or fails the sub-issue with a
      distinct, greppable reason. It must not hang, and must not silently
      succeed.
- [ ] The epic branch of `Runner.Execute` runs under a bounded context, so
      `Execute()` always returns and `dispatcher.go:2122`'s
      `lifecycle.Persist` always writes a terminal parent status.
- [ ] `hasLiveWorker` reflects liveness, not map presence: a worker goroutine
      that exits (normally, by ctx cancellation, or via the `SafeGo` panic
      recover at `dispatcher.go:1618-1620`) no longer counts as live, so the
      stale-recovery sweeps can actually reap rows behind it.
- [ ] No regression to GH-4413's real goal: a child legitimately queued behind
      *other* work on a busy project, with a *different* live worker making
      progress, must still not be timed out.

---

## Implementation

### Phase 1: Detect self-ownership in the claim-lost wait (root cause)
**Goal**: The blocked worker must never wait on a child only it can run.

**Tasks**:
- [ ] In `reconcileChildOutcome` (`epic.go:2084`), the `externallyOwned=true`
      queued-phase poll gains a self-ownership check: if the child's
      `project_path` is the same project whose worker is executing this epic,
      the "just waiting its turn" assumption is false by construction.
- [ ] Plumb whatever identity is needed (project path is already on the
      subtask; if worker identity is required, pass it down from
      `dispatcher.go:2037` / `executeSubIssuesTracked`) — do not infer it from
      globals.
- [ ] On detection: prefer **takeover** — steal/re-claim the orphan claim and
      execute the child inline (it is the same worker that would have run it
      anyway), routing the re-claim through the existing
      `beginWithGenerationRetry` + shared `repick_backoff` store, per the
      warning at `epic.go:2556-2562` about not re-implementing a second
      driftable copy. If takeover is rejected, fail the sub-issue with a
      distinct error naming the deadlock.
- [ ] Add an absolute ceiling on the queued phase as a backstop, so an
      unforeseen variant degrades to a bounded failure instead of a hang.

### Phase 2: Bound the epic branch
**Goal**: `Execute()` always returns, so the parent always goes terminal.

**Tasks**:
- [ ] Hoist the watchdog-context construction (`runner.go:2454-2462`) to
      **before** the epic-detection branch at `runner.go:2125` so the epic
      block runs under it.
- [ ] Budget deliberately: one shared deadline across N sub-issues can starve
      the last sub-issue. Either derive a per-sub-issue timeout inside the
      loop, or size the epic ceiling from the sub-issue count. State the
      choice in a comment.
- [ ] Verify `recordEpicTerminalEvent` (`runner.go:1898-1907`, audit-only) is
      not mistaken for the status write — the status write stays at
      `dispatcher.go:2122`.

### Phase 3: Make `hasLiveWorker` mean live
**Goal**: The stale-recovery sweeps stop being unreachable.

**Tasks**:
- [ ] Remove the worker from `d.workers` when its goroutine exits — a
      `defer` inside `ProjectWorker.Run` guarded by `d.mu`, so it also covers
      the `SafeGo` panic-recover path (`dispatcher.go:1618-1620`), which today
      leaves a project permanently dead-but-"live" until a daemon restart.
- [ ] Alternatively/additionally, a heartbeat timestamp the sweeps can test.
      Whichever is chosen, `dispatcher.go:499` and `dispatcher.go:715` must be
      able to reap behind a wedged worker.
- [ ] Preserve the `dispatcher.go:167` startup case ("nothing alive yet").

**Files**:
- `internal/executor/epic.go` — claim-lost path + reconcile self-ownership
- `internal/executor/runner.go` — epic-branch context bounding
- `internal/executor/dispatcher.go` — worker liveness + sweeps

---

## Out of Scope

- Re-architecting `subIssueMergeWait` into an event-driven "resume epic on
  child-PR-merge" design. It was **not** implicated here
  (`dependency_reason=none`, it explicitly did not wait), and it is a separate
  throughput initiative.
- Changing the TASK-407 claim mechanism. It behaved **correctly** — it
  prevented a double execution. Only the loser's fallback is defective.
- The poller-side defect where a channel claims a sub-issue, creates a
  `queued` row, then abandons it without cleanup (the orphan owner at
  18:42:59). Real, but a separate issue — Phase 1 must survive orphan owners
  regardless of who creates them.
- Alert-engine tuning (`engine.go:657-691` stuck-task watchdog freezing at
  child-start because the parent heartbeat only refreshes per child,
  `epic.go:2496-2507`). File separately.

---

## Technical Decisions

| Decision | Options Considered | Chosen | Reasoning |
|----------|-------------------|--------|-----------|
| Where to break the deadlock | Global timeout only; self-ownership detection; abolish the claim-lost wait | Self-ownership detection **+** timeout backstop | A pure timeout re-breaks GH-4413 (queue-wait erosion) and still wastes the full ceiling on every occurrence; detection fixes the actual invariant and the timeout catches unforeseen variants |
| Response on detection | Fail the sub-issue; take over and run it | Take over, fail only if re-claim is refused | The blocked worker is exactly the worker that should run the child; failing wastes a correct, already-planned sub-issue and leaves the epic half-shipped (which is what happened) |
| Re-claim path | New generation-retry logic; reuse `beginWithGenerationRetry` | Reuse | `epic.go:2556-2562` explicitly warns a second copy will drift from the shared `repick_backoff` store |
| Worker liveness | Heartbeat timestamp; delete-on-exit | Delete-on-exit (heartbeat optional) | Smallest correct change; also fixes the panic-kills-project-forever case in the same stroke |

---

## Verify

```bash
make build
go test ./internal/executor/...
make lint
```

---

## Done

- [ ] A test drives an epic through the **real** `Dispatcher` →
      `ProjectWorker` → `Runner.Execute` path (not `ExecuteSubIssues`
      directly) with a sub-issue whose claim is pre-held by an orphan owner,
      and asserts the run terminates bounded with a terminal parent status.
      Existing coverage cannot catch this: every test in
      `epic_sequential_test.go:667-813` injects an instantly-returning mock,
      and `TestSequentialEpicFlow_ContextDeadline`
      (`epic_sequential_test.go:611-659`) hand-builds a bounded context and
      passes it straight to `ExecuteSubIssues`, bypassing the very code path
      (`Runner.Execute`) that fails to build one.
- [ ] A test asserts a worker that exits or panics is no longer `hasLiveWorker`,
      and that the stale sweeps then reap rows behind it.
- [ ] A test asserts the GH-4413 behaviour is preserved: a child queued behind
      other work on a project with a different, progressing worker is not
      timed out.
- [ ] `make build`, `make lint`, and `go test ./internal/executor/...` green.

---

## Refs

- Incident: epic GH-4531 (2026-07-24). Sub-issue 1 GH-4532 → PR #4534 merged
  18:57:45Z; sub-issue 2 GH-4533 never started; parent zombie `running` for
  35+ min; operator surgery + daemon restart to recover. GH-4533 later shipped
  fine standalone (PR #4535, merged 20:18:59Z) — proving the sub-issue was
  always runnable and only the epic path was broken.
- `epic.go:2063-2083` — GH-4413's own comment stating the no-ceiling queued
  phase and naming the safety net that cannot fire.
- GH-4359 — why claim-loss polls instead of failing.
- GH-2331 — `recoverStaleQueuedTasks` / `StaleQueuedThreshold`.
- TASK-407 — atomic dispatch-admission claim (correct; not the defect).
- TASK-393 — ProjectWorker as the sole serialization point.
- TASK-359 — daemon finalization hardening (the stall-before-push family).

---

**Last Updated**: 2026-07-24