### PR TITLE
GH-4537: feat: dashboard panels disagree about the same task — queue marks live wo...

### DIFF
--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -2644,6 +2644,14 @@ func collectDashboardTasks(p *pilot.Pilot, gwMonitor *executor.Monitor, gwStore 
 // convertTaskStatesToDisplay converts executor TaskStates to dashboard TaskDisplay format.
 // Maps all 5 states: done, running, queued, pending, failed for state-aware dashboard rendering.
 // GH-1220: Added deduplication safety net to prevent duplicate tasks in rendering.
+//
+// TASK-420/GH-4537: this is the ONE place a executor.TaskStatus becomes a
+// dashboard.QueueStatus — every one of the five UpdateTasks call sites
+// (cmd/pilot/main.go, cmd/pilot/commands.go) funnels through here, so there
+// is a single closed mapping, not five independently-typed strings. Callers
+// are responsible for reconciling the TaskState against the executions table
+// (Monitor.ReconcileWithStore) before calling this — the ledger, not the
+// in-memory TaskStatus, is what's authoritative for done-vs-running.
 func convertTaskStatesToDisplay(states []*executor.TaskState) []dashboard.TaskDisplay {
 	seen := make(map[string]bool)
 	var displays []dashboard.TaskDisplay
@@ -2654,23 +2662,23 @@ func convertTaskStatesToDisplay(states []*executor.TaskState) []dashboard.TaskDi
 		}
 		seen[state.ID] = true
 
-		var status string
+		var status dashboard.QueueStatus
 		switch state.Status {
 		case executor.StatusRunning:
-			status = "running"
+			status = dashboard.QueueStatusRunning
 		case executor.StatusQueued:
-			status = "queued"
+			status = dashboard.QueueStatusQueued
 		case executor.StatusCompleted:
-			status = "done"
-		case executor.StatusFailed:
-			status = "failed"
+			status = dashboard.QueueStatusDone
+		case executor.StatusFailed, executor.StatusCancelled, executor.StatusStalled:
+			status = dashboard.QueueStatusFailed
 		case executor.StatusNoOp:
 			// GH-4490 subtask 2: a no-commit run is a non-failure terminal
 			// outcome — must not fall to "pending" (looks unstarted) or
 			// "failed" (looks like a genuine failure).
-			status = "no_op"
+			status = dashboard.QueueStatusNoOp
 		default:
-			status = "pending"
+			status = dashboard.QueueStatusPending
 		}
 
 		var duration string

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -2167,6 +2167,19 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			lastDashboardUpdate = time.Now()
 			dashboardMu.Unlock()
 
+			// TASK-420/GH-4537: this was the one UpdateTasks producer of the
+			// five that skipped the GH-4490 reconcile step before rendering —
+			// the periodic ticker below (~2s cadence) self-heals eventually,
+			// but this path could still push a queue snapshot with a stale
+			// Monitor status (e.g. a false-complete card) straight to the
+			// dashboard on every progress tick in between. Reconcile against
+			// the executions table (ledger authoritative) the same way the
+			// ticker does before converting.
+			if store != nil {
+				if reconcileErr := monitor.ReconcileWithStore(store); reconcileErr != nil {
+					logging.WithComponent("dashboard").Warn("failed to reconcile monitor with store", slog.Any("error", reconcileErr))
+				}
+			}
 			tasks := convertTaskStatesToDisplay(monitor.GetAll())
 			program.Send(dashboard.UpdateTasks(tasks)())
 

--- a/cmd/pilot/wiring_utils_test.go
+++ b/cmd/pilot/wiring_utils_test.go
@@ -269,7 +269,7 @@ func TestConvertTaskStatesToDisplay(t *testing.T) {
 		if displays[i].ID != exp.id {
 			t.Errorf("display[%d].ID = %q, want %q", i, displays[i].ID, exp.id)
 		}
-		if displays[i].Status != exp.status {
+		if string(displays[i].Status) != exp.status {
 			t.Errorf("display[%d].Status = %q, want %q", i, displays[i].Status, exp.status)
 		}
 	}
@@ -324,6 +324,33 @@ func TestConvertTaskStatesToDisplay_DefaultStatus(t *testing.T) {
 	}
 	if displays[0].Status != "pending" {
 		t.Errorf("expected 'pending' for unknown status, got %q", displays[0].Status)
+	}
+}
+
+// TestConvertTaskStatesToDisplay_TerminalStatusesNeverLookPending is a
+// TASK-420/GH-4537 regression test: executor.StatusCancelled and
+// executor.StatusStalled used to fall through convertTaskStatesToDisplay's
+// switch into the default "pending" bucket, which misleadingly implies the
+// task hasn't started yet rather than that it's a dead, terminal outcome.
+// They must map alongside StatusFailed to dashboard.QueueStatusFailed.
+func TestConvertTaskStatesToDisplay_TerminalStatusesNeverLookPending(t *testing.T) {
+	states := []*executor.TaskState{
+		{ID: "GH-1", Title: "Cancelled", Status: executor.StatusCancelled},
+		{ID: "GH-2", Title: "Stalled", Status: executor.StatusStalled},
+	}
+
+	displays := convertTaskStatesToDisplay(states)
+
+	if len(displays) != 2 {
+		t.Fatalf("expected 2 displays, got %d", len(displays))
+	}
+	for _, d := range displays {
+		if d.Status == dashboard.QueueStatusPending {
+			t.Errorf("display[%s].Status = %q, a terminal outcome must never render as pending", d.ID, d.Status)
+		}
+		if d.Status != dashboard.QueueStatusFailed {
+			t.Errorf("display[%s].Status = %q, want %q", d.ID, d.Status, dashboard.QueueStatusFailed)
+		}
 	}
 }
 

--- a/internal/dashboard/queue_width_test.go
+++ b/internal/dashboard/queue_width_test.go
@@ -15,7 +15,7 @@ func TestRenderTask_WidthAware(t *testing.T) {
 	longTitle := "a very long queued task title that definitely exceeds twenty visible characters by a lot"
 
 	widths := []int{65, 90, 120}
-	statuses := []string{"done", "running", "queued", "failed", "pending"}
+	statuses := []QueueStatus{QueueStatusDone, QueueStatusRunning, QueueStatusQueued, QueueStatusFailed, QueueStatusPending}
 
 	for _, iw := range widths {
 		for _, status := range statuses {
@@ -76,7 +76,7 @@ func TestRenderTask_NarrowRegressionPin(t *testing.T) {
 	task := TaskDisplay{
 		ID:       "GH-1234",
 		Title:    "a very long title that exceeds twenty chars for sure",
-		Status:   "done",
+		Status:   QueueStatusDone,
 		Progress: 42,
 		PRURL:    "https://github.com/o/r/pull/42",
 	}
@@ -95,7 +95,7 @@ func TestRenderTask_NarrowRegressionPin(t *testing.T) {
 // glyph, not color — see grom_chrome_test.go for the width-invariant pattern.
 func TestRenderTask_BarColumnsAligned(t *testing.T) {
 	m := NewModel("test")
-	statuses := []string{"done", "running", "queued", "failed", "pending"}
+	statuses := []QueueStatus{QueueStatusDone, QueueStatusRunning, QueueStatusQueued, QueueStatusFailed, QueueStatusPending}
 
 	for _, iw := range []int{65, 90, 120} {
 		for _, status := range statuses {

--- a/internal/dashboard/stage_strip.go
+++ b/internal/dashboard/stage_strip.go
@@ -88,6 +88,15 @@ func displayStatus(execStatus string) string {
 // work starts, so the row has zero execution_events — with no override it
 // rendered an unknown-glyph meter and a blank "–" label (indistinguishable
 // from a truly unaccounted-for row) instead of a muted, labeled one.
+//
+// cancelled (TASK-420/GH-4537): unlike failed/stalled, a cancellation is a
+// pure executions.status write with no execution_events row of its own (see
+// memory.terminalExecutionStatuses' dead-API note — it's written by operator
+// surgery / claim-loss cleanup, not the normal event-emitting path). Without
+// this entry buildStageInfo has no terminal signal to reduce over, so the
+// label freezes at whatever rung the row last reached (typically "running")
+// and HISTORY renders a task cancelled hours ago as still running — the
+// GH-4531 ghost row captured 2026-07-24 22:17:07Z that motivated this task.
 var mutedOutcomes = map[string]bool{
 	"skipped":            true,
 	"no_op":              true,
@@ -95,6 +104,7 @@ var mutedOutcomes = map[string]bool{
 	"rate_limited":       true,
 	"infra":              true,
 	"declined-preflight": true,
+	"cancelled":          true,
 }
 
 // stageStripCleanTerminalEvents are execution_events that close out a run
@@ -127,6 +137,28 @@ func stageInfoForExecution(events []*memory.Event, status string) StageInfo {
 		info.Known = true
 	}
 	return info
+}
+
+// HistoryStatus is the icon-status + stage-meter pair every HISTORY call site
+// renders together for one execution row.
+type HistoryStatus struct {
+	Status string    // icon/vocabulary value — see statusIconStyle
+	Stage  StageInfo // stage-meter fraction + label for the same row
+}
+
+// resolveHistoryStatus is the single resolver every HISTORY-populating call
+// site (tui.go's hydrateFromStore/storeRefreshCmd, zoom.go's historyZoomCmd)
+// must go through for a memory.Execution row (TASK-420/GH-4537). Before this,
+// each of the three call sites hand-chained `status := displayStatus(...)`
+// into `stageInfoForExecution(events, status)` itself — correct by
+// coincidence (the two happened to agree at every call site) but not
+// enforced, which is exactly the "two independent strings" shape GH-4368's
+// icon/text split came from. Routing every call site through one function
+// makes that divergence structurally impossible instead of merely absent
+// today.
+func resolveHistoryStatus(execStatus string, events []*memory.Event) HistoryStatus {
+	status := displayStatus(execStatus)
+	return HistoryStatus{Status: status, Stage: stageInfoForExecution(events, status)}
 }
 
 // buildStageInfo reduces an execution's execution_events timeline to a

--- a/internal/dashboard/stage_strip_test.go
+++ b/internal/dashboard/stage_strip_test.go
@@ -395,6 +395,27 @@ func TestStageInfoForExecution_MutedOutcomesTable(t *testing.T) {
 			events: nil,
 			want:   StageInfo{Reached: 0, Label: "infra", Failed: false, Known: true, Muted: true},
 		},
+		{
+			// TASK-420/GH-4537: cancellation is written directly to the
+			// executions row (claim-loss cleanup / operator surgery) without
+			// ever emitting an execution_events row of its own — before this
+			// status was added to mutedOutcomes, the running-max reducer
+			// froze on the last real event ("running") and HISTORY kept
+			// showing a ghost "running Nh ago" row for a task that was
+			// actually dead (GH-4531 capture). Zero-events case.
+			status: "cancelled",
+			events: nil,
+			want:   StageInfo{Reached: 0, Label: "cancelled", Failed: false, Known: true, Muted: true},
+		},
+		{
+			// Same ghost-row scenario but with a prior "running" event on
+			// record (the realistic case — the task really was running
+			// before it got cancelled) — the muted-outcome override must
+			// still win over the running-max reducer's frozen label.
+			status: "cancelled",
+			events: []*memory.Event{evt(memory.StageRunning)},
+			want:   StageInfo{Reached: 2, Label: "cancelled", Failed: false, Known: true, Muted: true},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.status, func(t *testing.T) {
@@ -420,4 +441,42 @@ func TestDisplayStatus(t *testing.T) {
 			t.Errorf("displayStatus(%q) = %q, want %q", in, got, want)
 		}
 	}
+}
+
+// TestResolveHistoryStatus_SharedByAllCallSites is the TASK-420/GH-4537
+// regression test: resolveHistoryStatus is now the one place hydrateFromStore
+// (tui.go), storeRefreshCmd (tui.go), and historyZoomCmd (zoom.go) go through
+// to turn an executions.status + its event ladder into a rendered HISTORY
+// row. A genuinely-running execution must never resolve to a done/success
+// status, and a cancelled (terminal) execution must never resolve to
+// "running" even though its last real event was a running rung — reproducing
+// the exact divergence captured on the dashboard: GH-A stuck "running" for
+// hours while other panels called it done, GH-B cancelled but HISTORY still
+// showed "running Nh ago".
+func TestResolveHistoryStatus_SharedByAllCallSites(t *testing.T) {
+	t.Run("running task never resolves to a done status", func(t *testing.T) {
+		hs := resolveHistoryStatus("running", []*memory.Event{evt(memory.StageQueued), evt(memory.StageRunning)})
+		if hs.Status != "running" {
+			t.Errorf("Status = %q, want %q (a running execution must never render as done/success)", hs.Status, "running")
+		}
+		if hs.Stage.Label == "success" || hs.Stage.Label == "completed" {
+			t.Errorf("Stage.Label = %q, must not read as a completed outcome for a running task", hs.Stage.Label)
+		}
+	})
+
+	t.Run("cancelled task never resolves to running, even with a running event on record", func(t *testing.T) {
+		hs := resolveHistoryStatus("cancelled", []*memory.Event{evt(memory.StageQueued), evt(memory.StageRunning)})
+		if hs.Status == "running" {
+			t.Errorf("Status = %q, want non-running (a cancelled/terminal execution must never render as running)", hs.Status)
+		}
+		if hs.Stage.Label == "running" {
+			t.Errorf("Stage.Label = %q, want %q (muted-outcome override must beat the running-max reducer's frozen label)", hs.Stage.Label, "cancelled")
+		}
+		if hs.Stage.Label != "cancelled" {
+			t.Errorf("Stage.Label = %q, want %q", hs.Stage.Label, "cancelled")
+		}
+		if !hs.Stage.Muted {
+			t.Error("expected cancelled outcome to be muted, matching other terminal-without-ladder-rung statuses")
+		}
+	})
 }

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -120,6 +120,17 @@ func NewAutopilotPanel(controller *autopilot.Controller) *AutopilotPanel {
 // "+ N more" summary line.
 const maxAutopilotRows = 4
 
+// autopilotNoActivePRLabel is shown when GetActivePRs() is empty. TASK-420/
+// GH-4537: previously read "idle · no active PR" — "idle" reads as "nothing
+// is happening", but this panel only tracks PR-side lifecycle (CI/approval/
+// merge/release); it says nothing about executions in flight pre-PR. The
+// 2026-07-24 22:17:07Z capture had this panel showing exactly that text while
+// a Claude Code process was actively running toward GH-4536's first commit —
+// correct for what the panel tracks, but routinely misread as "nothing is
+// running" (see queue/history for that). Drop "idle" and point at the queue
+// instead of implying total inactivity.
+const autopilotNoActivePRLabel = "no active PR · check queue for running work"
+
 // View renders the autopilot panel in the history-row grammar: one line per
 // active PR — status glyph, #id, title, 5-cell lifecycle meter
 // (ci→rebase→merge→tag→release), stage label, age — plus a ↳ detail line
@@ -141,7 +152,7 @@ func (p *AutopilotPanel) View() string {
 
 	prs := p.controller.GetActivePRs()
 	if len(prs) == 0 {
-		return renderPanelStyled("autopilot", "", "  "+dimStyle.Render("idle · no active PR"), tw, chrome)
+		return renderPanelStyled("autopilot", "", "  "+dimStyle.Render(autopilotNoActivePRLabel), tw, chrome)
 	}
 
 	cfg := p.controller.Config()
@@ -350,11 +361,30 @@ func truncateString(s string, maxLen int) string {
 	return s[:maxLen-3] + "..."
 }
 
+// QueueStatus is the closed vocabulary for TaskDisplay.Status (TASK-420/
+// GH-4537). It is a presentational rename of the executor package's
+// TaskStatus/ExecStatus* vocabulary (internal/executor/monitor.go,
+// internal/executor/lifecycle.go) — StatusCompleted -> "done", etc. — chosen
+// once, in convertTaskStatesToDisplay (cmd/pilot/commands.go), the single
+// function every UpdateTasks producer funnels through. Before this type
+// existed the value was a bare string with no named source of truth; nothing
+// stopped a sixth call site from inventing its own spelling of "done".
+type QueueStatus string
+
+const (
+	QueueStatusDone    QueueStatus = "done"    // executor.StatusCompleted
+	QueueStatusRunning QueueStatus = "running" // executor.StatusRunning
+	QueueStatusQueued  QueueStatus = "queued"  // executor.StatusQueued
+	QueueStatusFailed  QueueStatus = "failed"  // executor.StatusFailed (and cancelled/stalled — see terminalMonitorStatus)
+	QueueStatusNoOp    QueueStatus = "no_op"   // executor.StatusNoOp
+	QueueStatusPending QueueStatus = "pending" // executor.StatusPending / zero value
+)
+
 // TaskDisplay represents a task for display
 type TaskDisplay struct {
 	ID          string
 	Title       string
-	Status      string
+	Status      QueueStatus
 	Phase       string
 	Progress    int
 	Duration    string
@@ -697,7 +727,6 @@ func (m *Model) hydrateFromStore() {
 	// groupedHistory dedups by task ID a 4×-retried task collapses the panel to a
 	// couple of entries. Cap on task_id instead so 5 real tasks always show.
 	for _, exec := range firstNDistinctByTask(executions, 5) {
-		status := displayStatus(exec.Status)
 		completedAt := exec.CreatedAt
 		if exec.CompletedAt != nil {
 			completedAt = *exec.CompletedAt
@@ -709,14 +738,17 @@ func (m *Model) hydrateFromStore() {
 		if err != nil {
 			slog.Warn("failed to load execution events", slog.Any("error", err), slog.String("execution_id", exec.ID))
 		}
+		// TASK-420/GH-4537: resolveHistoryStatus is the single resolver for
+		// icon-status + stage label — see stage_strip.go.
+		hs := resolveHistoryStatus(exec.Status, events)
 		m.completedTasks = append(m.completedTasks, CompletedTask{
 			ID:          exec.TaskID,
 			Title:       exec.TaskTitle,
-			Status:      status,
+			Status:      hs.Status,
 			Duration:    fmt.Sprintf("%dms", exec.DurationMs),
 			CompletedAt: completedAt,
 			PeakRSSMB:   exec.PeakRSSMB,
-			Stage:       stageInfoForExecution(events, status),
+			Stage:       hs.Stage,
 			PRUrl:       exec.PRUrl,
 		})
 	}
@@ -1031,7 +1063,6 @@ func storeRefreshCmd(store *memory.Store, projectPath string) tea.Cmd {
 			return msg
 		}
 		for _, exec := range firstNDistinctByTask(executions, 5) {
-			status := displayStatus(exec.Status)
 			completedAt := exec.CreatedAt
 			if exec.CompletedAt != nil {
 				completedAt = *exec.CompletedAt
@@ -1042,14 +1073,17 @@ func storeRefreshCmd(store *memory.Store, projectPath string) tea.Cmd {
 			if err != nil {
 				slog.Warn("store refresh: failed to load execution events", slog.Any("error", err), slog.String("execution_id", exec.ID))
 			}
+			// TASK-420/GH-4537: resolveHistoryStatus is the single resolver for
+			// icon-status + stage label — see stage_strip.go.
+			hs := resolveHistoryStatus(exec.Status, events)
 			msg.completedTasks = append(msg.completedTasks, CompletedTask{
 				ID:          exec.TaskID,
 				Title:       exec.TaskTitle,
-				Status:      status,
+				Status:      hs.Status,
 				Duration:    fmt.Sprintf("%dms", exec.DurationMs),
 				CompletedAt: completedAt,
 				PeakRSSMB:   exec.PeakRSSMB,
-				Stage:       stageInfoForExecution(events, status),
+				Stage:       hs.Stage,
 				PRUrl:       exec.PRUrl,
 			})
 		}
@@ -1938,17 +1972,17 @@ func (m Model) renderMetricsCards() string {
 }
 
 // taskStatePriority returns sort priority for task states (lower = higher in list).
-func taskStatePriority(status string) int {
+func taskStatePriority(status QueueStatus) int {
 	switch status {
-	case "done":
+	case QueueStatusDone:
 		return 0
-	case "running":
+	case QueueStatusRunning:
 		return 1
-	case "queued":
+	case QueueStatusQueued:
 		return 2
-	case "pending":
+	case QueueStatusPending:
 		return 3
-	case "failed":
+	case QueueStatusFailed:
 		return 4
 	default:
 		return 5
@@ -1973,7 +2007,7 @@ func (m Model) renderTasks() string {
 				content.WriteString("\n")
 			}
 			offset := 0
-			if task.Status == "queued" {
+			if task.Status == QueueStatusQueued {
 				offset = queueIdx
 				queueIdx++
 			}
@@ -1985,7 +2019,7 @@ func (m Model) renderTasks() string {
 	// — running count first, then intake adapter status (buildAdapterLegend).
 	running := 0
 	for _, t := range m.tasks {
-		if t.Status == "running" {
+		if t.Status == QueueStatusRunning {
 			running++
 		}
 	}
@@ -2117,27 +2151,27 @@ func (m Model) renderTask(task TaskDisplay, selected bool, queueOffset int, iw i
 	var iconStyle lipgloss.Style
 
 	switch task.Status {
-	case "done":
+	case QueueStatusDone:
 		icon = "✓"
 		stateLabel = "done"
 		meta = extractPRNumber(task.PRURL)
 		iconStyle = statusDoneStyle
-	case "running":
+	case QueueStatusRunning:
 		icon = "●"
 		stateLabel = "running"
 		meta = fmt.Sprintf("%4d%%", task.Progress)
 		iconStyle = statusRunningStyle
-	case "queued":
+	case QueueStatusQueued:
 		icon = "◌"
 		stateLabel = "queued"
 		meta = fmt.Sprintf("  #%d", queueOffset+1)
 		iconStyle = statusQueuedStyle
-	case "failed":
+	case QueueStatusFailed:
 		icon = "✗"
 		stateLabel = "failed"
 		meta = truncateVisual(task.Phase, 5)
 		iconStyle = statusFailedStyle
-	case "no_op":
+	case QueueStatusNoOp:
 		// GH-4490 subtask 2: mirrors statusIconStyle's existing "no_op" glyph
 		// (TASK-358) — a no-commit run is a terminal, non-failure outcome, so
 		// it gets the same subdued pending style rather than the red failed
@@ -2155,7 +2189,7 @@ func (m Model) renderTask(task TaskDisplay, selected bool, queueOffset int, iw i
 
 	// Pulse the running icon on animation tick
 	renderedIcon := iconStyle.Render(icon)
-	if task.Status == "running" && !m.sparklineTick {
+	if task.Status == QueueStatusRunning && !m.sparklineTick {
 		renderedIcon = dimStyle.Render(icon)
 	}
 
@@ -2174,11 +2208,11 @@ func (m Model) renderTask(task TaskDisplay, selected bool, queueOffset int, iw i
 	const barWidth = 16
 	var progressBar string
 	switch task.Status {
-	case "done":
+	case QueueStatusDone:
 		progressBar = segmentMeter(1, 1, barWidth, gromTheme.Success)
-	case "running":
+	case QueueStatusRunning:
 		progressBar = segmentMeter(task.Progress, 100, barWidth, gromTheme.Accent)
-	case "failed":
+	case QueueStatusFailed:
 		progressBar = segmentMeter(task.Progress, 100, barWidth, gromTheme.Error)
 	default: // queued, pending — no known progress yet
 		progressBar = meterTrack.Render(strings.Repeat("■", barWidth))
@@ -2588,6 +2622,11 @@ func statusIconStyle(status string) (string, lipgloss.Style) {
 		return "!", statusPendingStyle // TASK-358: plumbing/resource failure, not the work
 	case "skipped":
 		return "·", statusPendingStyle // TASK-358: never ran / cancelled
+	case "cancelled":
+		// TASK-420/GH-4537: explicit case rather than falling through to the
+		// default glyph — cancelled is a real, muted terminal outcome (see
+		// mutedOutcomes in stage_strip.go), not an unaccounted-for row.
+		return "○", statusPendingStyle
 	case "running":
 		return "●", statusRunningStyle
 	case "pending":

--- a/internal/dashboard/tui_test.go
+++ b/internal/dashboard/tui_test.go
@@ -2001,7 +2001,7 @@ func TestAutopilotPanelView_AllStates(t *testing.T) {
 			name:        "idle",
 			ctl:         newFakeCtl(nil, 3, nil),
 			wantLines:   5, // top border + empty + content + empty + bottom border
-			wantContain: "idle · no active PR",
+			wantContain: "no active PR · check queue for running work",
 			wantAbsent:  "STATE",
 		},
 		{

--- a/internal/dashboard/zoom.go
+++ b/internal/dashboard/zoom.go
@@ -412,7 +412,7 @@ func (m Model) renderZoomedQueue(w, h int) string {
 	offsets := make([]int, len(sorted))
 	qi := 0
 	for i, t := range sorted {
-		if t.Status == "queued" {
+		if t.Status == QueueStatusQueued {
 			offsets[i] = qi
 			qi++
 		}
@@ -447,7 +447,7 @@ func (m Model) renderZoomedAutopilot(w, h int) string {
 	}
 	prs := m.autopilotPanel.sortedActivePRs()
 	if len(prs) == 0 {
-		return renderPanelStyled("autopilot", "", "  "+dimStyle.Render("idle · no active PR"), w, focusChrome)
+		return renderPanelStyled("autopilot", "", "  "+dimStyle.Render(autopilotNoActivePRLabel), w, focusChrome)
 	}
 
 	cfg := m.autopilotPanel.controller.Config()
@@ -545,7 +545,6 @@ func historyZoomCmd(store *memory.Store, projectPath string) tea.Cmd {
 
 		var tasks []CompletedTask
 		for _, exec := range firstNDistinctByTask(executions, 100) {
-			status := displayStatus(exec.Status)
 			completedAt := exec.CreatedAt
 			if exec.CompletedAt != nil {
 				completedAt = *exec.CompletedAt
@@ -555,14 +554,17 @@ func historyZoomCmd(store *memory.Store, projectPath string) tea.Cmd {
 				slog.Warn("history zoom: failed to load execution events",
 					slog.Any("error", err), slog.String("execution_id", exec.ID))
 			}
+			// TASK-420/GH-4537: resolveHistoryStatus is the single resolver for
+			// icon-status + stage label — see stage_strip.go.
+			hs := resolveHistoryStatus(exec.Status, events)
 			tasks = append(tasks, CompletedTask{
 				ID:          exec.TaskID,
 				Title:       exec.TaskTitle,
-				Status:      status,
+				Status:      hs.Status,
 				Duration:    fmt.Sprintf("%dms", exec.DurationMs),
 				CompletedAt: completedAt,
 				PeakRSSMB:   exec.PeakRSSMB,
-				Stage:       stageInfoForExecution(events, status),
+				Stage:       hs.Stage,
 				PRUrl:       exec.PRUrl,
 			})
 		}

--- a/internal/executor/monitor.go
+++ b/internal/executor/monitor.go
@@ -127,16 +127,28 @@ func (m *Monitor) HydrateFromStore(store *memory.Store) error {
 	return nil
 }
 
-// ReconcileWithStore corrects any in-memory task whose executions row has
-// already reached a terminal status while the Monitor still shows it as
-// running/queued/pending. Event-driven transitions (Start/Complete/Fail/...)
-// are skipped or raced in some failure paths — e.g. a no-commit failure or
-// an externally closed PR that updates the executions row without ever
-// calling back into this Monitor — which otherwise leaves a card stuck at
-// "running"/100% forever (GH-4490). The executions table is the source of
-// truth, so call this periodically (e.g. alongside the dashboard's refresh
-// tick, before GetAll()) as a self-correcting backstop on top of the normal
-// event path, not a replacement for it.
+// ReconcileWithStore corrects any in-memory task whose Status disagrees with
+// its executions row in either direction (GH-4490; extended bidirectionally
+// by TASK-420/GH-4537):
+//
+//  1. non-terminal Monitor state, terminal store row — the original GH-4490
+//     case. Event-driven transitions (Start/Complete/Fail/...) are skipped or
+//     raced in some failure paths — e.g. a no-commit failure or an externally
+//     closed PR that updates the executions row without ever calling back
+//     into this Monitor — which otherwise leaves a card stuck at
+//     "running"/100% forever.
+//  2. terminal Monitor state, store row still "running" — the false-complete
+//     case captured 2026-07-24 22:17:07Z (queue showed "✓ done GH-4536" while
+//     its executions row was running with 3 live processes). Whatever raced
+//     Monitor into a terminal state early (duplicate dispatch, a stale
+//     completion callback, ...), the executions row is still the ground
+//     truth for "is this task's work actually finished" — a terminal Monitor
+//     card must not survive a store row that says otherwise.
+//
+// The executions table is the source of truth, so call this periodically
+// (e.g. alongside the dashboard's refresh tick, before GetAll()) as a
+// self-correcting backstop on top of the normal event path, not a
+// replacement for it.
 func (m *Monitor) ReconcileWithStore(store *memory.Store) error {
 	if store == nil {
 		return nil
@@ -146,13 +158,11 @@ func (m *Monitor) ReconcileWithStore(store *memory.Store) error {
 	type candidate struct {
 		id          string
 		projectPath string
+		status      TaskStatus
 	}
 	candidates := make([]candidate, 0, len(m.tasks))
 	for id, state := range m.tasks {
-		switch state.Status {
-		case StatusRunning, StatusQueued, StatusPending:
-			candidates = append(candidates, candidate{id: id, projectPath: state.ProjectPath})
-		}
+		candidates = append(candidates, candidate{id: id, projectPath: state.ProjectPath, status: state.Status})
 	}
 	m.mu.RUnlock()
 
@@ -163,6 +173,29 @@ func (m *Monitor) ReconcileWithStore(store *memory.Store) error {
 				continue // no execution row yet (e.g. registered but not dispatched) — nothing to reconcile
 			}
 			return fmt.Errorf("reconcile monitor with store: %w", err)
+		}
+
+		if dbStatus == "running" {
+			// Case 2: ledger says running but Monitor already shows a
+			// terminal outcome — revert the false-complete/false-terminal
+			// card back to running so a live task never renders done.
+			if c.status == StatusRunning || c.status == StatusQueued || c.status == StatusPending {
+				continue
+			}
+			m.mu.Lock()
+			if state, ok := m.tasks[c.id]; ok && state.Status != StatusRunning {
+				state.Status = StatusRunning
+				state.CompletedAt = nil
+				state.Error = ""
+				state.Phase = "Running (reconciled)"
+			}
+			m.mu.Unlock()
+			continue
+		}
+
+		// Case 1: existing non-terminal -> terminal correction.
+		if c.status != StatusRunning && c.status != StatusQueued && c.status != StatusPending {
+			continue
 		}
 
 		newStatus, terminal := terminalMonitorStatus(dbStatus)

--- a/internal/executor/monitor_test.go
+++ b/internal/executor/monitor_test.go
@@ -775,6 +775,90 @@ func TestMonitorReconcileWithStore_AlreadyTerminalUntouched(t *testing.T) {
 	}
 }
 
+// TASK-420/GH-4537: a Monitor entry that reached a terminal state prematurely
+// (e.g. via a claim-loss race or duplicate-dispatch bug elsewhere in the
+// pipeline) must self-heal back to running once the ledger — the
+// authoritative source — still says the execution is running. Before this
+// fix, ReconcileWithStore only ever corrected non-terminal -> terminal
+// (GH-4490's Case 1); a Monitor card stuck at "done" while the ledger still
+// says "running" would never recover, even across the periodic 2s reconcile
+// ticker, producing the exact QUEUE false-complete captured in GH-4536
+// (2026-07-24 22:17:07Z, "3 live claude/node procs" while the card read
+// "done").
+func TestMonitorReconcileWithStore_TerminalRevertsToRunning(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "e1", TaskID: "GH-30", ProjectPath: "/p", Status: "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	m := NewMonitor()
+	m.Register("GH-30", "Task 30", "")
+	m.SetProjectInfo("GH-30", "/p", "proj")
+	m.Start("GH-30")
+	// Simulate the premature-terminal race: the in-memory card already
+	// believes the task is done, even though the ledger still says running.
+	m.Complete("GH-30", "https://example.com/pr/3")
+
+	state, ok := m.Get("GH-30")
+	if !ok {
+		t.Fatal("GH-30 not found before reconcile")
+	}
+	if state.Status != StatusCompleted {
+		t.Fatalf("precondition failed: Status = %s, want %s", state.Status, StatusCompleted)
+	}
+
+	if err := m.ReconcileWithStore(store); err != nil {
+		t.Fatalf("ReconcileWithStore: %v", err)
+	}
+
+	state, ok = m.Get("GH-30")
+	if !ok {
+		t.Fatal("GH-30 not found after reconcile")
+	}
+	if state.Status != StatusRunning {
+		t.Errorf("Status = %s, want %s (a running ledger row must always win over a stale terminal Monitor entry)", state.Status, StatusRunning)
+	}
+	if state.CompletedAt != nil {
+		t.Error("expected CompletedAt to be cleared when reverting to running")
+	}
+}
+
+// A Monitor entry that is genuinely queued/pending (never terminal) must be
+// left alone by the new running-reversion branch — it should keep whatever
+// non-terminal status it already has rather than being forced to
+// StatusRunning.
+func TestMonitorReconcileWithStore_QueuedStaysQueuedWhenStoreRunning(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "e1", TaskID: "GH-31", ProjectPath: "/p", Status: "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	m := NewMonitor()
+	m.Register("GH-31", "Task 31", "")
+	m.SetProjectInfo("GH-31", "/p", "proj")
+	m.Queue("GH-31")
+
+	if err := m.ReconcileWithStore(store); err != nil {
+		t.Fatalf("ReconcileWithStore: %v", err)
+	}
+
+	state, ok := m.Get("GH-31")
+	if !ok {
+		t.Fatal("GH-31 not found after reconcile")
+	}
+	if state.Status != StatusQueued {
+		t.Errorf("Status = %s, want %s (non-terminal statuses other than running must not be forced to running)", state.Status, StatusQueued)
+	}
+}
+
 func TestMonitorReconcileWithStoreNilStore(t *testing.T) {
 	m := NewMonitor()
 	m.Register("GH-25", "Task 25", "")


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4537.

Closes #4537

## Changes

GitHub Issue GH-4537: TASK-420: Dashboard panels disagree about the same task — queue marks live work "done", history keeps dead work "running"

# TASK-420: Dashboard panels disagree about the same task — queue marks live work "done", history keeps dead work "running"

**Status**: 🚧 In Progress
**Created**: 2026-07-24
**Assignee**: Pilot

---

## Context

**Problem**:
The TUI's three panels read three different sources and are reconciled by
nothing. At a single observed moment they were wrong about two different
tasks **in opposite directions**, which makes cross-checking them useless —
the operator cannot tell which panel is lying without dropping to sqlite.

**Captured reproduction (2026-07-24 22:17:07Z, daemon v2.245.2):**

| Panel | Displayed | Ground truth (`executions` table) | |
|---|---|---|---|
| queue | `✓ done  GH-4536` | `running`, started 21:49:31, `completed_at` NULL, **3 live claude/node procs** | ❌ false-complete |
| history | `GH-4536 … running 26m ago` | same — running | ✅ correct |
| history | `GH-4531 … running 3h ago` | **6 rows, all `cancelled`** (set 19:09Z); issue closed | ❌ ghost row |
| autopilot | `idle · no active PR` | no PR existed for GH-4536 yet | ✅ correct, but PR-only — it says nothing about executions and is routinely misread as "nothing is happening" |

So on one screen: a running task shown as done, a cancelled task shown as
running, and a panel whose "idle" means something narrower than it looks.

**Why this matters**: the operational workaround is already codified as a hard
rule in the `pilot-aws` skill — *"Trust the ledger over dashboard panels"* —
and in the memory `tui-subtask-ghost-rows` ("restart clears; trust ledger").
A dashboard that must be distrusted is worse than no dashboard: it costs a
sqlite round-trip on every question and has repeatedly sent debugging down the
wrong path (this session: ~15 min lost, and an incorrect "it's done" call).

**Known sources**:
- **queue** renders `[]TaskDisplay` (`internal/dashboard/tui.go:354-365`),
  pushed in wholesale via `dashboard.UpdateTasks` (`tui.go:2677`) →
  `m.tasks = msg` (`tui.go:1132`). Producers are outside the dashboard
  package: `cmd/pilot/main.go:2171`, `cmd/pilot/main.go:3137`,
  `cmd/pilot/commands.go:2528,2552,2574`. `TaskDisplay.Status` is a plain
  string with no defined vocabulary and no tie to `executions.status`.
- **history** renders `[]CompletedTask`; the zoomed view reads the store
  directly (`internal/dashboard/zoom.go:535` `historyZoomCmd(store, projectPath)`),
  while the inline view is served from in-memory `completedTasks`
  (`tui.go:561,579,599,616`) that nothing reconciles against the ledger.
- **status vocabulary** is split by design: `displayStatus`
  (`internal/dashboard/stage_strip.go:69-75`) maps `executions.status` →
  icon, while the status *text* comes from a running-max reducer over
  `execution_events` (`StageInfo`, `stage_strip.go:61-68`). GH-3927/GH-4064
  already fixed one half of this (a skipped/running run rendering ✓).

**Goal**:
One source of truth for "what is this task doing right now", so no two panels
can disagree about the same task, and no panel can show a terminal task as
running or a running task as terminal.

---

## Known Pitfalls & Patterns

- **PITFALL** `tui-subtask-ghost-rows`: completion never closes the in-memory
  dashboard row and no ledger row reconciles it — restart clears. This task
  must fix the reconciliation, not add another restart-to-clear path.
- **GH-4368** (open): the ✓/✗ icon (`executions.status`) and the status text
  (`execution_events` ladder running-max) disagree **permanently** for rows
  whose event ladder never got a terminal rung. That issue covers only this
  icon-vs-text split *within* history — not the queue false-complete, and not
  the ghost rows. Land them consistently; do not duplicate or contradict it.
- **GH-3927 / GH-4064**: prior fixes in exactly this area collapsed every
  non-failed status to success. Any new mapping must keep a *still-running*
  status distinguishable from a *successful* one.

---

## Acceptance Criteria

- [ ] A task that is `running` in `executions` (no `completed_at`) is never
      rendered as done/complete in **any** panel.
- [ ] A task that is terminal in `executions` (`completed`/`failed`/
      `cancelled`/`stalled`/`no_op`/…) is never rendered as running in **any**
      panel, without requiring a daemon restart to clear.
- [ ] queue and history cannot disagree about the same task ID at the same
      render: they derive status from one shared resolver, not two independent
      strings.
- [ ] `TaskDisplay.Status` uses a defined, closed vocabulary tied to
      `executions.status` (reuse the `ExecStatus*` vocabulary from
      `internal/executor/lifecycle.go`, TASK-404) rather than a free-form
      string set by five separate call sites in `cmd/pilot`.
- [ ] Ghost rows are reconciled: an in-memory dashboard row whose ledger row
      has gone terminal is updated or dropped on the next refresh.
- [ ] The autopilot panel's `idle` state is unambiguous about scope — it must
      not read as "nothing is running" when executions are in flight.
      Wording/labelling change is acceptable; no new data source needed.
- [ ] Regression test reproducing the captured divergence: given a ledger with
      GH-A `running` and GH-B `cancelled`, no panel renders GH-A complete and
      none renders GH-B running.

---

## Implementation

### Phase 1: One status resolver
**Goal**: Kill the two-independent-strings design.

**Tasks**:
- [ ] Introduce a single resolver that maps a ledger row (+ its
      `execution_events` ladder) to the display status used by every panel.
      Fold `displayStatus` (`stage_strip.go:69`) and the `StageInfo`
      running-max reducer into it so icon and text can never diverge — this is
      GH-4368's fix; reference that issue and close it with this work.
- [ ] Define the closed vocabulary against `ExecStatus*`
      (`internal/executor/lifecycle.go`). Preserve the GH-3927/GH-4064
      invariant: running ≠ success.

### Phase 2: Queue panel reads the same truth
**Goal**: No more false-complete.

**Tasks**:
- [ ] Have the queue panel derive its status through the Phase 1 resolver.
- [ ] Audit the five `UpdateTasks` producers (`cmd/pilot/main.go:2171,3137`;
      `cmd/pilot/commands.go:2528,2552,2574`) — find which one publishes a
      completed-looking `TaskDisplay` for a task whose ledger row is still
      `running`, and fix at the source rather than papering over it in the
      renderer.

### Phase 3: Reconcile ghost rows
**Goal**: Terminal tasks stop rendering as running without a restart.

**Tasks**:
- [ ] On each refresh, reconcile in-memory `completedTasks`/`tasks` against the
      ledger for the visible set; update or drop rows whose ledger row is
      terminal.
- [ ] Keep it bounded — reconcile only the rows on screen (plus the zoom
      dataset), not the whole table, so the TUI refresh stays cheap.

**Files**:
- `internal/dashboard/stage_strip.go` — the shared resolver
- `internal/dashboard/tui.go` — `TaskDisplay`, queue render, in-memory reconcile
- `internal/dashboard/zoom.go` — zoomed history path
- `cmd/pilot/main.go`, `cmd/pilot/commands.go` — `UpdateTasks` producers

---

## Out of Scope

- Visual redesign of the panels. This is a correctness fix; layout, colours,
  and the stage strip's appearance stay as they are.
- The underlying reason GH-4531's rows went `cancelled` by operator surgery
  (that is TASK-419 / #4536).
- Adding new telemetry or a new store. The `executions` table is already the
  source of truth; this task makes the UI use it.

---

## Technical Decisions

| Decision | Options Considered | Chosen | Reasoning |
|----------|-------------------|--------|-----------|
| Source of truth | Reconcile panels against each other; make ledger authoritative for all | Ledger authoritative | It has been right every time; the operational runbook already says to trust it |
| Fix location for the queue false-complete | Renderer-side clamp; fix the producer | Fix the producer, resolver as backstop | A renderer clamp hides a producer publishing wrong state, which will resurface elsewhere (e.g. Slack/web views) |
| Status vocabulary | New dashboard enum; reuse `ExecStatus*` | Reuse `ExecStatus*` | TASK-404 already made this the one lifecycle vocabulary; a second enum re-creates the drift this task exists to fix |
| Relationship to GH-4368 | Land separately; fold in | Fold in and close GH-4368 | Same root cause (icon and text from independent sources); fixing one without the other leaves the panel half-reconciled |

---

## Verify

```bash
make build
go test ./internal/dashboard/... ./cmd/pilot/...
make lint
```

---

## Done

- [ ] A test builds a ledger fixture with one `running` and one `cancelled`
      task and asserts every panel's rendered status matches the ledger —
      reproducing the 22:17:07Z divergence and failing before the fix.
- [ ] `displayStatus` and the `StageInfo` reducer no longer produce
      independently-derived statuses; GH-4368 is closed by this work.
- [ ] No panel renders a `running` task as done or a terminal task as running,
      verified without a daemon restart.
- [ ] `make build`, `make lint`, `go test ./internal/dashboard/... ./cmd/pilot/...`
      green.

---

## Refs

- Captured divergence 2026-07-24 22:17:07Z: queue `✓ done GH-4536` while the
  ledger had it `running` with 3 live claude/node processes; history
  `GH-4531 running 3h ago` while all 6 of its rows were `cancelled` since
  19:09Z and the issue was closed.
- GH-4368 — icon-vs-text split within history (to be closed by this task).
- GH-3927 / GH-4064 — prior fixes; the running ≠ success invariant.
- TASK-404 — `ExecutionLifecycle` / `ExecStatus*` vocabulary.
- Memory `tui-subtask-ghost-rows`; `pilot-aws` skill hard rule 5 ("trust the
  ledger over dashboard panels") — both are workarounds this task retires.

---

**Last Updated**: 2026-07-24