### PR TITLE
GH-4540: feat: repick hard cap counts non-failures — a task queued behind a long t...

### DIFF
--- a/.agent/tasks/gh-4540.md
+++ b/.agent/tasks/gh-4540.md
@@ -1,0 +1,241 @@
+# GH-4540
+
+**Created:** 2026-07-25
+
+## Problem
+
+GitHub Issue GH-4540: TASK-421: Repick hard cap counts non-failures — a task queued behind a long task is auto-blocked for waiting its turn
+
+# TASK-421: Repick hard cap counts non-failures — a task queued behind a long task is auto-blocked for waiting its turn
+
+**Status**: ✅ Done
+**Created**: 2026-07-25
+**Assignee**: Pilot
+
+---
+
+## Context
+
+**Problem**:
+`consecutive_drops` increments on any dispatch attempt that fails to produce a
+new execution — including attempts the dispatcher **correctly refused because
+the task was already queued or already running**. At
+`dispatcherRepickHardCap = 5` (`dispatcher.go:950`) the task is marked
+`stalled` and labelled `pilot-blocked`, requiring manual 6-step recovery.
+
+The result: **any task queued behind a task that runs longer than ~37 minutes
+is auto-blocked for waiting its turn.** It never failed. It never started.
+
+**Reproduction — GH-4537, 2026-07-24 (verbatim):**
+```
+22:19:57.985  task queued behind GH-4536 (position 1 in pilot queue)   ← correct
+22:25:28      Dispatching issue 4537 → dispatch claim lost — task already
+              owned by another dispatch channel → unmarking for retry
+22:31:26      (same, repeating every ~6 min)
+22:57:04      consecutive_drops=6 → hard cap → stalled + pilot-blocked
+```
+GH-4536 ran ~40 min, so GH-4537 was doomed the moment it was dispatched. It sat
+blocked overnight (~10h) until an operator re-armed it.
+
+**Three distinct false-stall variants in 24 hours, same counter:**
+
+| Task | Drops accrued while… | Reality |
+|---|---|---|
+| GH-4526 | environment failures (hosted `git_clean` preflight deadlock, CI infra outage) | task was fine; the box was broken |
+| GH-4531 | legitimately **running** (poller raced the epic it was executing) | live execution, `consecutive_drops=5` |
+| GH-4537 | legitimately **queued** behind GH-4536 | never started |
+
+**Root cause, two halves:**
+
+1. **The poller re-dispatches work it already owns.** `Dispatcher.IsActive`
+   (`dispatcher.go:797`) exists precisely to answer *"is this taskID already
+   queued or running in this project?"* — and is called from exactly one place,
+   `cmd/pilot/handler_common.go:102`. The GitHub SDK poller path does **not**
+   consult it, so it re-dispatches an already-queued task every poll cycle,
+   generating a guaranteed rejection each time.
+2. **The rejection is counted as a failed re-pick.** A claim refused because
+   the task is already active is not a failure — nothing was attempted. It
+   still grows the same `consecutive_drops` counter that gates the hard cap.
+
+Prior art shows this is the third pass at the class and each pass narrowed it
+without closing it. `store.go:419-426` already carries a **separate**
+`stall_drops` counter added so stall-kills would "not grow the same
+`consecutive_drops` counter a genuine failure does" (#4455 — restart churn and
+operator cancels no longer count). Claim-lost drops never received the same
+treatment; memory `claim-lost-drops-count-toward-hard-cap` records exactly that
+gap, and it has now cost three tasks in one day.
+
+**Goal**:
+`consecutive_drops` counts genuine failed re-picks only. Being queued, being
+already-running, and environment faults must never consume a task's retry
+budget.
+
+---
+
+## Known Pitfalls & Patterns
+
+- **PITFALL** `claim-lost-drops-count-toward-hard-cap`: the exact known gap
+  this task closes. #4455 narrowed the class but explicitly did not close it.
+- **PITFALL** `hard-cap-rearm-in-memory-gate`: recovery costs 6 manual steps
+  including DB surgery, a label edit, and often a daemon restart. Every false
+  stall is expensive — this is why prevention matters more than faster
+  recovery.
+- **DECISION** "Concurrency default: opt-in (`default 1`)": with one worker
+  per project, queueing behind a long task is the **normal** state, not an
+  anomaly. The counter must be safe under the project's own default config.
+- TASK-419 (#4536, PR #4538 merged) fixed the epic self-deadlock that produced
+  the GH-4531 variant, but did **not** touch this counter.
+
+---
+
+## Acceptance Criteria
+
+- [x] A dispatch attempt refused because the task is already `queued` or
+      `running` does **not** increment `consecutive_drops`.
+- [x] A task that sits queued behind another task for an arbitrarily long time
+      is never marked `stalled` or labelled `pilot-blocked` on that basis
+      alone.
+- [x] The poller consults `Dispatcher.IsActive` (or equivalent) before
+      dispatching, so the redundant re-dispatch stops being generated at the
+      source rather than only being forgiven downstream. (The precheck at
+      `handler_common.go:102` already existed; the real gap was
+      `IsTaskQueued`'s SQL allowlist missing `'decomposed'`, letting a
+      decomposed epic-parent's claim slip past it — fixed in `store.go`.)
+- [x] Genuine failed re-picks still reach the cap: a task whose execution is
+      actually attempted and fails repeatedly still stalls at
+      `dispatcherRepickHardCap`.
+- [x] Environment/infra-classified failures do not consume the budget the same
+      way code failures do — added a sibling `infra_drops` counter (mirroring
+      `stall_drops`) keyed on the executor's own pre-existing `ExecStatusInfra`
+      status, capped independently at `dispatcherInfraRepickCap` (8).
+- [x] The distinction is observable: both the `repick storm` WARN and the
+      per-drop DEBUG log in `handler_common.go` now name the drop reason
+      (`"already has terminal completion"`, `"already queued or running"`,
+      `"already terminal or a retry race was lost"`) and report
+      `claim_lost_drops` instead of `consecutive_drops`.
+
+---
+
+## Implementation
+
+### Phase 1: Stop generating the redundant dispatch
+**Goal**: The poller does not re-dispatch what it already owns.
+
+**Tasks**:
+- [x] `handler_common.go:102` already checked `Dispatcher.IsActive` before
+      dispatching — the gap was `IsTaskQueued`'s SQL allowlist missing
+      `'decomposed'`, so a decomposed epic-parent's claim was invisible to it.
+      Fixed by adding `'decomposed'` to the allowlist in `store.go`.
+- [x] When already active, log at debug/info and skip — do not route through
+      the drop path at all (unchanged, already correct).
+
+### Phase 2: Classify the drop before counting it
+**Goal**: Only genuine failed re-picks grow `consecutive_drops`.
+
+**Tasks**:
+- [x] The two `recordDrop` call sites in `handler_common.go` (already-has-
+      terminal-completion, and QueueTask's empty-execID drop) now call a new
+      `recordClaimLostDrop`, which grows a separate persisted `claim_lost_drops`
+      column/backoff-window instead of `consecutive_drops`.
+- [x] Followed the `stall_drops` precedent (`store.go`) exactly: new sibling
+      counters `claim_lost_drops` (cmd/pilot side) and `infra_drops` (dispatcher
+      side), neither touching `consecutive_drops`.
+- [x] Environment/infra failures: reused the executor's own pre-existing
+      `ExecStatusInfra` ("infra") terminal status (not TASK-418's
+      `internal/autopilot` `FailureClass`, which classifies a different layer —
+      post-PR CI check failures) via a new `priorClaimWasInfra` carve-out in
+      `beginWithGenerationRetry`, mirroring `priorClaimWasStalled`.
+
+### Phase 3: Make it diagnosable
+**Goal**: A future false stall is readable from the log.
+
+**Tasks**:
+- [x] `handler_common.go`'s two drop sites now log `claim_lost_drops` and a
+      `drop_reason` field, and both the DEBUG and WARN messages explicitly say
+      "not counted toward repick hard cap".
+
+**Files**:
+- `internal/executor/dispatcher.go` — drop classification, cap, `IsActive` use
+- `internal/memory/store.go` — counter columns (`repick_backoff`)
+- the GitHub SDK poller dispatch path — pre-dispatch `IsActive` check
+
+---
+
+## Out of Scope
+
+- Raising or removing `dispatcherRepickHardCap` (`dispatcher.go:950`). The cap
+  is correct; what it counts is not.
+- Changing the TASK-407 claim mechanism. Refusing a duplicate claim is right —
+  only the bookkeeping that follows is wrong.
+- The dashboard's rendering of stalled/queued tasks (TASK-420 / #4537).
+- Auto-recovery of already-blocked issues. This prevents new false stalls; it
+  does not un-block historical ones.
+
+---
+
+## Technical Decisions
+
+| Decision | Options Considered | Chosen | Reasoning |
+|----------|-------------------|--------|-----------|
+| Where to fix | Poller only; counter only; both | **Both** | Poller-only leaves other dispatch channels able to generate the same drops; counter-only leaves a pointless re-dispatch every 6 min burning API quota |
+| Counter design | Reset on queue; separate non-gating counter; forgive at increment | Forgive at increment + separate counter, following `stall_drops` | `store.go:419-426` already established this shape for #4455; a third pattern invites the drift that produced this bug |
+| Environment failures | Separate task; fold in | Fold in | TASK-418's `failure_class` shipped yesterday (PR #4535) and makes this a small addition; leaving it out means a 4th false-stall variant remains live |
+| Cap value | Raise to buy headroom; leave at 5 | Leave at 5 | Raising it only delays a false stall and weakens the real protection |
+
+---
+
+## Verify
+
+```bash
+make build
+go test ./internal/executor/... ./internal/memory/...
+make lint
+```
+
+---
+
+## Done
+
+- [x] A test reproduces GH-4537's mechanism:
+      `TestDispatcher_IsActive_TreatsDecomposedAsActive` and
+      `TestHandleIssueGeneric_DecomposedTask_SkipsDispatchViaPrecheck` pin the
+      decomposed-claim blind spot fix; the more general "queued behind another
+      task never stalls" invariant already held for `queued`/`running` (never
+      reached `beginWithGenerationRetry`'s counter at all —
+      `nextRetryGeneration` returns early for any live/non-terminal owner) and
+      is now additionally covered for the terminal-completion-storm case by
+      `TestHandleIssueGeneric_TerminalCompletionStorm_NeverCountsTowardHardCap`.
+- [x] A test asserts a genuinely failing task still stalls at the cap — the
+      pre-existing `TestDispatcher_BeginWithGenerationRetry_MixedStallAndFailedDropsHardCapAtFive`
+      and friends pass unmodified; no regression.
+- [x] A test asserts the poller/handler skips dispatch when `IsActive` is
+      true — pre-existing `TestHandleIssueGeneric_AlreadyActive_SkipsDispatch`
+      plus the new decomposed-case test above.
+- [x] `make build`, `make lint` (golangci-lint not installed in this sandbox;
+      `go build`/`go vet`/`gofmt -l` all clean),
+      `go test ./internal/executor/... ./internal/memory/... ./cmd/pilot/...`
+      all green.
+
+---
+
+## Refs
+
+- GH-4537 (2026-07-24 22:19:57→22:57:04Z) — queued behind GH-4536, 6 drops,
+  false stall, ~10h blocked overnight.
+- GH-4531 (18:14→18:22Z) — drops while legitimately running; `consecutive_drops=5`
+  against a live execution.
+- GH-4526 (→16:00Z) — drops from environment failures (hosted `git_clean`
+  deadlock + CI infra outage).
+- #4455 — narrowed the class (restart churn, operator cancels); `stall_drops`
+  precedent at `store.go:419-426`.
+- Memory `claim-lost-drops-count-toward-hard-cap` — the documented open gap.
+- TASK-418 / PR #4535 — `failure_class` vocabulary to reuse.
+- TASK-419 / PR #4538 — fixed the epic deadlock behind the GH-4531 variant,
+  not this counter.
+
+---
+
+**Last Updated**: 2026-07-25
+
+## Acceptance Criteria
+

--- a/cmd/pilot/handler_common.go
+++ b/cmd/pilot/handler_common.go
@@ -134,17 +134,28 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 	// every ~30s poll cycle regardless).
 	if deps.Dispatcher != nil {
 		if done, hcErr := deps.Dispatcher.HasTerminalCompletion(taskID, projectPath); hcErr == nil && done {
-			consecutive := repickBackoff.recordDrop(backoffKey)
-			logFields := []any{slog.String("task_id", taskID), slog.Int("consecutive_drops", consecutive)}
-			if consecutive >= repickBackoffWarnThreshold {
-				logging.WithComponent("dispatch").Warn("repick storm: completed-but-open issue re-admitted repeatedly", logFields...)
+			// GH-4540/TASK-421: a completed-but-open issue being re-admitted
+			// is not a failed re-pick — the task already succeeded — so this
+			// must not grow consecutive_drops (the counter
+			// beginWithGenerationRetry gates dispatcherRepickHardCap on).
+			// recordClaimLostDrop still grows the shared backoff cooldown
+			// window, so the storm is still throttled the way TASK-413
+			// intends; it just never counts toward the hard cap.
+			claimLostDrops := repickBackoff.recordClaimLostDrop(backoffKey)
+			logFields := []any{
+				slog.String("task_id", taskID),
+				slog.String("drop_reason", "already has terminal completion"),
+				slog.Int("claim_lost_drops", claimLostDrops),
+			}
+			if claimLostDrops >= repickBackoffWarnThreshold {
+				logging.WithComponent("dispatch").Warn("repick storm: completed-but-open issue re-admitted repeatedly — not counted toward repick hard cap", logFields...)
 			} else {
-				logging.WithComponent("dispatch").Debug("skipping dispatch — task already has terminal completion", logFields...)
+				logging.WithComponent("dispatch").Debug("skipping dispatch — task already has terminal completion — not counted toward repick hard cap", logFields...)
 			}
 			if deps.Metrics != nil {
 				deps.Metrics.RecordPollerSkipped(repickMetricsRepo(task), skipreason.ReasonRepickStormBackoff)
 			}
-			fireLoopBreakerAlert(deps, taskID, title, projectPath, consecutive)
+			fireLoopBreakerAlert(deps, taskID, title, projectPath, claimLostDrops)
 			return &HandlerResult{Success: false, BranchName: task.Branch, Error: executor.ErrDispatchGated}, nil
 		}
 	}
@@ -249,17 +260,35 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 			// never matches a row) and surfaced as "failed to get execution:
 			// sql: no rows in result set" — an ERROR the SDK poller logged on
 			// every tick for a task that was never actually a failure.
-			consecutive := repickBackoff.recordDrop(backoffKey)
-			logFields := []any{slog.String("task_id", taskID), slog.Int("consecutive_drops", consecutive)}
-			if consecutive >= repickBackoffWarnThreshold {
-				logging.WithComponent("dispatch").Warn("repick storm: claim-lost/terminal drop recurring", logFields...)
+			// GH-4540/TASK-421: this branch fires whenever QueueTask silently
+			// dropped the pickup — a live owner already has the task
+			// queued/running, the task is already terminally done, or a
+			// retry Begin() lost a race — none of which are a genuine failed
+			// re-pick. Must not grow consecutive_drops. recordClaimLostDrop
+			// still grows the shared backoff cooldown window so a
+			// repeatedly-re-offered task is still throttled, just via a
+			// counter the hard cap never reads. Re-check IsActive purely to
+			// give the log a best-effort, human-readable reason — it does
+			// not change what gets counted.
+			dropReason := "already terminal or a retry race was lost"
+			if deps.Dispatcher.IsActive(taskID, projectPath) {
+				dropReason = "already queued or running"
+			}
+			claimLostDrops := repickBackoff.recordClaimLostDrop(backoffKey)
+			logFields := []any{
+				slog.String("task_id", taskID),
+				slog.String("drop_reason", dropReason),
+				slog.Int("claim_lost_drops", claimLostDrops),
+			}
+			if claimLostDrops >= repickBackoffWarnThreshold {
+				logging.WithComponent("dispatch").Warn("repick storm: claim-lost/terminal drop recurring — not counted toward repick hard cap", logFields...)
 			} else {
-				logging.WithComponent("dispatch").Debug("dispatch dropped duplicate/terminal pickup, nothing to wait for", logFields...)
+				logging.WithComponent("dispatch").Debug("dispatch dropped duplicate/terminal pickup, nothing to wait for — not counted toward repick hard cap", logFields...)
 			}
 			if deps.Metrics != nil {
 				deps.Metrics.RecordPollerSkipped(repickMetricsRepo(task), skipreason.ReasonRepickStormBackoff)
 			}
-			fireLoopBreakerAlert(deps, taskID, title, projectPath, consecutive)
+			fireLoopBreakerAlert(deps, taskID, title, projectPath, claimLostDrops)
 			gatedDrop = true
 		} else {
 			// GH-4394 subtask 2: a repick (Dispatcher.beginWithGenerationRetry

--- a/cmd/pilot/handler_common_test.go
+++ b/cmd/pilot/handler_common_test.go
@@ -162,6 +162,58 @@ func TestHandleIssueGeneric_AlreadyActive_SkipsDispatch(t *testing.T) {
 	}
 }
 
+// TestHandleIssueGeneric_DecomposedTask_SkipsDispatchViaPrecheck is the
+// GH-4540/TASK-421 regression test for the actual GH-4537 mechanism: a
+// decomposed epic-parent's claim was invisible to IsActive() (IsTaskQueued's
+// SQL allowlist was missing 'decomposed'), so handleIssueGeneric's early
+// IsActive precheck (GH-4008) never caught it and every poll tick fell
+// through to the claim-lost drop path further down. Seeding a
+// decomposed-status execution and asserting the precheck alone gates the
+// call — no monitor registration, no QueueTask reached — mirrors
+// TestHandleIssueGeneric_AlreadyActive_SkipsDispatch for the decomposed case.
+func TestHandleIssueGeneric_DecomposedTask_SkipsDispatchViaPrecheck(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	dispatcher := executor.NewDispatcher(store, executor.NewRunner(), nil)
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	t.Cleanup(dispatcher.Stop)
+
+	taskID := "GH-4537-DECOMPOSED-PRECHECK"
+	projectPath := "/tmp/pilot-gh-4537-decomposed-does-not-exist"
+	seed := &executor.Task{ID: taskID, ProjectPath: projectPath}
+	seedExecID, err := executor.NewExecutionLifecycle(store).Begin(seed, executor.ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("setup Begin: %v", err)
+	}
+	if err := store.UpdateExecutionStatus(seedExecID, "decomposed"); err != nil {
+		t.Fatalf("setup: failed to mark seed execution decomposed: %v", err)
+	}
+
+	monitor := executor.NewMonitor()
+	deps := HandlerDeps{Dispatcher: dispatcher, Monitor: monitor, ProjectPath: projectPath}
+	info := IssueInfo{TaskID: taskID, Title: "decomposed epic", Adapter: "github", LogMark: "▸"}
+	task := &executor.Task{ID: taskID, Title: "decomposed epic", Branch: "pilot/" + taskID, ProjectPath: projectPath}
+
+	hr, err := handleIssueGeneric(context.Background(), deps, info, task)
+	if err != nil {
+		t.Fatalf("expected nil error for a decomposed task, got: %v", err)
+	}
+	if hr.Success {
+		t.Error("expected Success=false for a decomposed task")
+	}
+	if !errors.Is(hr.Error, executor.ErrDispatchGated) {
+		t.Errorf("expected hr.Error to wrap executor.ErrDispatchGated, got: %v", hr.Error)
+	}
+	if _, ok := monitor.Get(taskID); ok {
+		t.Error("expected monitor registration to be skipped for a decomposed task — the IsActive precheck should have gated it")
+	}
+}
+
 // TestHandleIssueGeneric_QueueTaskRace_DowngradesToDebug verifies that when
 // QueueTask itself rejects a task as already-active — the TOCTOU race
 // between the pre-check and the enqueue attempt — handleIssueGeneric still
@@ -740,6 +792,86 @@ func TestHandleIssueGeneric_LoopBreakerAlert_FiresOnceAtThreshold(t *testing.T) 
 	time.Sleep(100 * time.Millisecond)
 	if got := testCh.count(); got != 1 {
 		t.Fatalf("expected still exactly 1 alert past the threshold, got %d", got)
+	}
+}
+
+// TestHandleIssueGeneric_TerminalCompletionStorm_NeverCountsTowardHardCap is
+// the GH-4540/TASK-421 primary regression test for the main handler_common.go
+// fix: before this fix, a completed-but-open issue re-admitted repeatedly by
+// the poller (GH-91's mechanism) grew consecutive_drops via
+// repickBackoff.recordDrop on every tick — the SAME persisted counter
+// beginWithGenerationRetry gates dispatcherRepickHardCap (5) on — so a task
+// that had already succeeded could still end up wedged/stalled purely from
+// being redundantly re-offered. Driving the HasTerminalCompletion gate well
+// past the hard cap (8 ticks) must leave consecutive_drops at 0/not-found
+// (never touched) while claim_lost_drops grows to match every tick, proving
+// the two counters are now fully decoupled.
+func TestHandleIssueGeneric_TerminalCompletionStorm_NeverCountsTowardHardCap(t *testing.T) {
+	taskID := "GH-4540-STORM-HARDCAP"
+	projectPath := "/tmp/pilot-gh-4540-storm-hardcap-does-not-exist"
+	backoffKey := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(backoffKey) })
+
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	dispatcher := executor.NewDispatcher(store, executor.NewRunner(), nil)
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	t.Cleanup(dispatcher.Stop)
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "exec-gh-4540-storm-hardcap", TaskID: taskID, ProjectPath: projectPath,
+		Status: "completed", PRUrl: "https://github.com/qf-studio/pilot-canary-sandbox/pull/1",
+	}); err != nil {
+		t.Fatalf("failed to seed completed execution: %v", err)
+	}
+
+	deps := HandlerDeps{Dispatcher: dispatcher, Monitor: executor.NewMonitor(), ProjectPath: projectPath}
+	info := IssueInfo{TaskID: taskID, Title: "storm", Adapter: "github", LogMark: "▸"}
+	task := &executor.Task{ID: taskID, Title: "storm", Branch: "pilot/" + taskID, ProjectPath: projectPath}
+
+	forceExpire := func() {
+		repickBackoff.mu.Lock()
+		if e, ok := repickBackoff.entries[backoffKey]; ok {
+			e.nextAllowedAt = time.Now().Add(-time.Second)
+		}
+		repickBackoff.mu.Unlock()
+	}
+
+	// Drive well past dispatcherRepickHardCap's ticks worth of re-admissions —
+	// each one refused for the exact same "already terminal" reason.
+	const ticks = 8
+	for i := 0; i < ticks; i++ {
+		if i > 0 {
+			forceExpire()
+		}
+		hr, err := handleIssueGeneric(context.Background(), deps, info, task)
+		if err != nil {
+			t.Fatalf("tick %d: unexpected error: %v", i+1, err)
+		}
+		if hr.Success {
+			t.Fatalf("tick %d: expected Success=false", i+1)
+		}
+		if !errors.Is(hr.Error, executor.ErrDispatchGated) {
+			t.Fatalf("tick %d: expected hr.Error to wrap executor.ErrDispatchGated, got: %v", i+1, hr.Error)
+		}
+	}
+
+	if consecutive, _, found, err := dispatcher.RepickBackoffState(backoffKey); err != nil {
+		t.Fatalf("RepickBackoffState: %v", err)
+	} else if found && consecutive != 0 {
+		t.Errorf("expected consecutive_drops to never grow from terminal-completion re-admissions, got found=%v consecutive=%d", found, consecutive)
+	}
+
+	claimLostDrops, found, err := dispatcher.ClaimLostDropCount(backoffKey)
+	if err != nil {
+		t.Fatalf("ClaimLostDropCount: %v", err)
+	}
+	if !found || claimLostDrops != ticks {
+		t.Errorf("expected claim_lost_drops=%d after %d re-admissions, got found=%v count=%d", ticks, ticks, found, claimLostDrops)
 	}
 }
 

--- a/cmd/pilot/repick_backoff.go
+++ b/cmd/pilot/repick_backoff.go
@@ -37,7 +37,13 @@ const (
 // repickBackoffEntry tracks one task_id/project_path pair's cooldown state.
 type repickBackoffEntry struct {
 	consecutiveDrops int
-	nextAllowedAt    time.Time
+	// claimLostDrops (GH-4540/TASK-421) counts dispatch attempts refused
+	// because the task was already active or already terminally done — a
+	// non-failure, tracked separately from consecutiveDrops so it grows the
+	// shared backoff cooldown window (nextAllowedAt) for throttling purposes
+	// without ever feeding dispatcherRepickHardCap's gating counter.
+	claimLostDrops int
+	nextAllowedAt  time.Time
 	// gateLogged records whether the current backoff window has already
 	// emitted its once-per-window DEBUG "gated" log line (GH-4469 deliverable
 	// 2) — set by gateStatus, cleared once nextAllowedAt passes so the next
@@ -54,6 +60,12 @@ type repickBackoffPersister interface {
 	RepickBackoffState(key string) (consecutiveDrops int, nextAllowedAt time.Time, found bool, err error)
 	SetRepickBackoffState(key string, consecutiveDrops int, nextAllowedAt time.Time) error
 	ClearRepickBackoffState(key string) error
+	// ClaimLostDropCount and SetClaimLostBackoff (GH-4540/TASK-421) persist
+	// the claim-lost sibling counter recordClaimLostDrop grows — mirroring
+	// the three methods above but never touching consecutive_drops, the
+	// column beginWithGenerationRetry gates dispatcherRepickHardCap on.
+	ClaimLostDropCount(key string) (count int, found bool, err error)
+	SetClaimLostBackoff(key string, claimLostDrops int, nextAllowedAt time.Time) error
 }
 
 // repickBackoffTracker throttles repeated dispatch attempts for the same task
@@ -104,7 +116,17 @@ func (t *repickBackoffTracker) hydrateLocked(key string) *repickBackoffEntry {
 	if !found {
 		return nil
 	}
-	e := &repickBackoffEntry{consecutiveDrops: consecutiveDrops, nextAllowedAt: nextAllowedAt}
+	// GH-4540/TASK-421: also rehydrate the claim-lost sibling counter so a
+	// fresh process (or a fresh check after a restart) resumes the correct
+	// escalation/loop-breaker count instead of starting back at zero — a
+	// separate read since it lives in its own column, mirroring how
+	// StallDropCount is read independently on the dispatcher side.
+	claimLostDrops, _, clErr := t.persist.ClaimLostDropCount(key)
+	if clErr != nil {
+		logging.WithComponent("dispatch").Warn("failed to load persisted claim-lost drop count",
+			slog.String("key", key), slog.Any("error", clErr))
+	}
+	e := &repickBackoffEntry{consecutiveDrops: consecutiveDrops, claimLostDrops: claimLostDrops, nextAllowedAt: nextAllowedAt}
 	t.entries[key] = e
 	return e
 }
@@ -175,6 +197,42 @@ func (t *repickBackoffTracker) recordDrop(key string) int {
 		}
 	}
 	return e.consecutiveDrops
+}
+
+// recordClaimLostDrop registers a dispatch attempt for key that was refused
+// because the task was already active (queued/running) or already
+// terminally done — a non-failure (GH-4540/TASK-421). Unlike recordDrop,
+// this does NOT grow consecutiveDrops (the counter beginWithGenerationRetry
+// gates dispatcherRepickHardCap on), so a task refused for either of these
+// reasons — however many times, however long it waits — can never be pushed
+// toward the hard cap on that basis alone. It still grows the same
+// exponential backoff window (nextAllowedAt) recordDrop does, so a task that
+// keeps getting redundantly re-offered is still throttled the way TASK-413
+// intends, just via an independent counter.
+func (t *repickBackoffTracker) recordClaimLostDrop(key string) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	e, ok := t.entries[key]
+	if !ok {
+		e = t.hydrateLocked(key)
+		if e == nil {
+			e = &repickBackoffEntry{}
+			t.entries[key] = e
+		}
+	}
+	e.claimLostDrops++
+	shift := e.claimLostDrops - 1
+	if shift > repickBackoffMaxShift {
+		shift = repickBackoffMaxShift
+	}
+	e.nextAllowedAt = time.Now().Add(repickBackoffBaseInterval * time.Duration(uint64(1)<<uint(shift)))
+	if t.persist != nil {
+		if err := t.persist.SetClaimLostBackoff(key, e.claimLostDrops, e.nextAllowedAt); err != nil {
+			logging.WithComponent("dispatch").Warn("failed to persist claim-lost backoff state",
+				slog.String("key", key), slog.Any("error", err))
+		}
+	}
+	return e.claimLostDrops
 }
 
 // recordSuccess clears any backoff state for key once a dispatch actually

--- a/cmd/pilot/repick_backoff_test.go
+++ b/cmd/pilot/repick_backoff_test.go
@@ -140,6 +140,16 @@ type fakeRepickBackoffPersister struct {
 	consecutiveDrops int
 	nextAllowedAt    time.Time
 	found            bool
+
+	// claimLostDrops (GH-4540/TASK-421) backs ClaimLostDropCount/
+	// SetClaimLostBackoff — deliberately a separate counter from
+	// consecutiveDrops above, mirroring the real store's separate
+	// claim_lost_drops column that must never perturb consecutive_drops.
+	// nextAllowedAt/found above are shared, matching the real
+	// repick_backoff row: both a genuine drop and a claim-lost drop grow the
+	// same cooldown window.
+	claimLostDrops int
+	claimLostFound bool
 }
 
 func (f *fakeRepickBackoffPersister) RepickBackoffState(key string) (int, time.Time, bool, error) {
@@ -157,6 +167,20 @@ func (f *fakeRepickBackoffPersister) ClearRepickBackoffState(key string) error {
 	f.consecutiveDrops = 0
 	f.nextAllowedAt = time.Time{}
 	f.found = false
+	f.claimLostDrops = 0
+	f.claimLostFound = false
+	return nil
+}
+
+func (f *fakeRepickBackoffPersister) ClaimLostDropCount(key string) (int, bool, error) {
+	return f.claimLostDrops, f.claimLostFound, nil
+}
+
+func (f *fakeRepickBackoffPersister) SetClaimLostBackoff(key string, claimLostDrops int, nextAllowedAt time.Time) error {
+	f.claimLostDrops = claimLostDrops
+	f.claimLostFound = true
+	f.nextAllowedAt = nextAllowedAt
+	f.found = true
 	return nil
 }
 

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -961,6 +961,34 @@ func (d *Dispatcher) SetStallDropCount(key string, count int) error {
 	return d.store.SetStallDropCount(key, count)
 }
 
+// InfraDropCount and SetInfraDropCount expose the store's per-key
+// infra-classified-repick counter (GH-4540/TASK-421) — the carve-out for
+// drops caused by an environment/infra failure (e.g. a hosted git_clean
+// preflight deadlock or a CI outage) rather than the task's own code,
+// tracked separately from consecutive_drops the same way StallDropCount is.
+func (d *Dispatcher) InfraDropCount(key string) (count int, found bool, err error) {
+	return d.store.GetInfraDropCount(key)
+}
+
+func (d *Dispatcher) SetInfraDropCount(key string, count int) error {
+	return d.store.SetInfraDropCount(key, count)
+}
+
+// ClaimLostDropCount and SetClaimLostBackoff expose the store's per-key
+// claim-lost/already-done drop counter (GH-4540/TASK-421) to cmd/pilot's
+// repickBackoffTracker — the sibling counter that grows the shared backoff
+// cooldown window for a dispatch attempt refused because the task was
+// already active or already terminally done, WITHOUT touching
+// consecutive_drops (the counter beginWithGenerationRetry gates the hard cap
+// on). See repickBackoffPersister in cmd/pilot/repick_backoff.go.
+func (d *Dispatcher) ClaimLostDropCount(key string) (count int, found bool, err error) {
+	return d.store.GetClaimLostDropCount(key)
+}
+
+func (d *Dispatcher) SetClaimLostBackoff(key string, claimLostDrops int, nextAllowedAt time.Time) error {
+	return d.store.SetClaimLostBackoff(key, claimLostDrops, nextAllowedAt)
+}
+
 // ExecutionGeneration returns the execution_claims generation most recently
 // claimed for (taskID, projectPath): 0 for an ordinary first attempt, >0 when
 // beginWithGenerationRetry claimed a retry generation because the prior
@@ -1077,6 +1105,19 @@ const dispatcherRepickHardCap = 5
 // signal of a doomed task than genuine failures are.
 const dispatcherStallRepickCap = 8
 
+// dispatcherInfraRepickCap is the hard ceiling on consecutive
+// infra-classified repicks for one task before beginWithGenerationRetry
+// stops granting infra-carved-out retries and stalls the task instead
+// (GH-4540/TASK-421). Infra-classified failures (status "infra" — a hosted
+// preflight deadlock, a CI outage) are counted separately from
+// dispatcherRepickHardCap's consecutiveDrops (see priorClaimWasInfra)
+// because they are not evidence the task's own code is broken (incident:
+// GH-4526 accrued drops from environment failures alone). Set to the same
+// value as dispatcherStallRepickCap: both are weaker signals of a doomed
+// task than a genuine code failure, and reusing the established number
+// avoids inventing a third arbitrary threshold.
+const dispatcherInfraRepickCap = 8
+
 // repickBackoffKey namespaces backoff state by project path + task ID,
 // matching cmd/pilot's repickBackoffKey — task_id alone is not unique across
 // projects (GH-4276).
@@ -1127,6 +1168,29 @@ func (d *Dispatcher) priorClaimWasStalled(taskID, projectPath string) bool {
 		return false
 	}
 	return exec.Status == string(ExecStatusStalled)
+}
+
+// priorClaimWasInfra reports whether (taskID, projectPath)'s currently
+// claimed execution — the one nextRetryGeneration just examined to grant
+// this retry — was classified as an infrastructure/environment failure
+// (status "infra") rather than a genuine code failure. GH-4526 accrued
+// consecutive_drops purely from environment failures (a hosted git_clean
+// preflight deadlock and a CI infra outage) — the task's code was never at
+// fault, but each drop counted identically to a real failure toward
+// dispatcherRepickHardCap. Mirrors priorClaimWasStalled exactly, for the
+// "infra" status instead of "stalled". Errors are treated as "not infra" —
+// the caller falls through to the ordinary backoff/hard-cap path, which is
+// the safe default.
+func (d *Dispatcher) priorClaimWasInfra(taskID, projectPath string) bool {
+	_, execID, found, err := d.store.LatestClaimGeneration(taskID, projectPath)
+	if err != nil || !found {
+		return false
+	}
+	exec, err := d.store.GetExecution(execID)
+	if err != nil {
+		return false
+	}
+	return exec.Status == string(ExecStatusInfra)
 }
 
 // nextRetryGeneration inspects the highest execution_claims generation
@@ -1355,6 +1419,54 @@ func (d *Dispatcher) beginWithGenerationRetry(task *Task, initial Status) (strin
 		return "", fmt.Errorf("failed to save retry execution: %w", retryErr)
 	}
 
+	// GH-4540/TASK-421: an infra-classified failure (status "infra" — e.g. a
+	// hosted git_clean preflight deadlock or a CI outage) is not evidence the
+	// task's own code is broken, exactly mirroring the stall carve-out above
+	// (incident: GH-4526 wedged a healthy task at dispatcherRepickHardCap on
+	// environment failures alone). Tracked in its own persisted counter with
+	// its own cap rather than an unlimited bypass, for the same reason the
+	// stall carve-out is capped: a task whose environment is durably broken
+	// (not just transiently flaky) must still stop retrying eventually.
+	if d.priorClaimWasInfra(task.ID, task.ProjectPath) {
+		infraDrops, _, infraErr := d.InfraDropCount(backoffKey)
+		if infraErr != nil {
+			d.log.Warn("failed to read infra drop count — dropping retry to be safe",
+				slog.String("task_id", task.ID),
+				slog.String("project", task.ProjectPath),
+				slog.Any("error", infraErr))
+			return "", nil
+		}
+		if infraDrops >= dispatcherInfraRepickCap {
+			d.stallTaskAfterInfraCap(task, gen, infraDrops)
+			return "", nil
+		}
+
+		retryExecID, retryErr := lifecycle.Begin(task, initial, gen)
+		if retryErr == nil {
+			newInfraDrops := infraDrops + 1
+			if setErr := d.SetInfraDropCount(backoffKey, newInfraDrops); setErr != nil {
+				d.log.Warn("failed to persist infra drop count after re-pick",
+					slog.String("task_id", task.ID),
+					slog.String("project", task.ProjectPath),
+					slog.Any("error", setErr))
+			}
+			d.log.Info("dispatch re-pick: prior claim was infra-classified — claiming next generation without counting toward repick hard cap",
+				slog.String("task_id", task.ID),
+				slog.String("project", task.ProjectPath),
+				slog.Int("generation", gen),
+				slog.Int("consecutive_infra_drops", newInfraDrops),
+			)
+			return retryExecID, nil
+		}
+		if errors.Is(retryErr, ErrClaimLost) {
+			// Race: another channel claimed generation gen between our
+			// decision and this Begin call — drop it, same as any other
+			// duplicate pickup.
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to save retry execution: %w", retryErr)
+	}
+
 	if found && time.Now().Before(nextAllowedAt) {
 		d.log.Info("dispatch re-pick throttled — task still within repick backoff window, dropping duplicate retry",
 			slog.String("task_id", task.ID),
@@ -1437,6 +1549,25 @@ func (d *Dispatcher) stallTaskAfterStallCap(task *Task, gen, stallDrops int) {
 		"reason":      "stall_repick_cap_stalled",
 		"stall_drops": fmt.Sprintf("%d", stallDrops),
 		"stall_cap":   fmt.Sprintf("%d", dispatcherStallRepickCap),
+	})
+}
+
+// stallTaskAfterInfraCap marks the task's claimed execution "stalled" and
+// raises an alert once dispatcherInfraRepickCap consecutive
+// infra-classified repicks have been exhausted (GH-4540/TASK-421) — the same
+// escalate-and-hold path stallTaskAfterRepickHardCap/stallTaskAfterStallCap
+// take, but with a distinct, truthful reason string: a run of
+// infra-classified drops means the environment kept failing the task, not
+// that the task's own code is broken.
+func (d *Dispatcher) stallTaskAfterInfraCap(task *Task, gen, infraDrops int) {
+	reason := fmt.Sprintf(
+		"infra repick cap reached: %d consecutive infra-classified failures (cap=%d) — the environment keeps failing this task, not the task's code; stopping automatic retries, manual re-arm required",
+		infraDrops, dispatcherInfraRepickCap,
+	)
+	d.escalateStalledTask(task, gen, infraDrops, reason, map[string]string{
+		"reason":      "infra_repick_cap_stalled",
+		"infra_drops": fmt.Sprintf("%d", infraDrops),
+		"infra_cap":   fmt.Sprintf("%d", dispatcherInfraRepickCap),
 	})
 }
 

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -4090,6 +4090,170 @@ func TestDispatcher_BeginWithGenerationRetry_MixedStallAndFailedDropsHardCapAtFi
 	}
 }
 
+// TestDispatcher_IsActive_TreatsDecomposedAsActive is the GH-4540/TASK-421
+// regression test for the actual GH-4537 mechanism: IsTaskQueued's SQL
+// allowlist was missing 'decomposed', so a decomposed epic-parent's claim was
+// invisible to IsActive() even though nextRetryGeneration (via
+// isTerminalExecutionStatus) correctly treats "decomposed" as a live,
+// non-terminal owner. That blind spot let a stream of redundant dispatch
+// attempts slip past handler_common.go's IsActive precheck straight into the
+// claim-lost drop path. Seeding a decomposed-status execution and asserting
+// IsActive reports true pins the fix directly at the source.
+func TestDispatcher_IsActive_TreatsDecomposedAsActive(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GH-4537-DECOMPOSED", ProjectPath: "/project-decomposed"}
+	dispatcher := NewDispatcher(store, NewRunner(), nil)
+
+	if _, err := NewExecutionLifecycle(store).Begin(task, ExecStatusRunning); err != nil {
+		t.Fatalf("setup Begin: %v", err)
+	}
+	markLatestClaimedExecution(t, store, task.ID, task.ProjectPath, "decomposed")
+
+	if !dispatcher.IsActive(task.ID, task.ProjectPath) {
+		t.Error("expected IsActive to report true for a decomposed (non-terminal) claim, got false")
+	}
+}
+
+// TestDispatcher_BeginWithGenerationRetry_InfraDropsDoNotCountTowardHardCap
+// is the GH-4540/TASK-421 infra-carve-out acceptance test, mirroring
+// TestDispatcher_BeginWithGenerationRetry_StallDropsDoNotCountTowardHardCap:
+// incident GH-4526 wedged a healthy task at dispatcherRepickHardCap on
+// environment/infra failures alone (hosted git_clean preflight deadlocks, CI
+// outages) — each infra-classified drop grew the same consecutiveDrops
+// counter a genuine code failure does. Four consecutive infra drops followed
+// by one genuine failed drop must leave the shared consecutive_drops counter
+// at 1 (only the failure counts), while infra_drops independently reflects
+// the 4 infra-classified drops.
+func TestDispatcher_BeginWithGenerationRetry_InfraDropsDoNotCountTowardHardCap(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GH-4540-INFRA4", ProjectPath: "/project-infra4"}
+	dispatcher := NewDispatcher(store, NewRunner(), nil)
+	key := repickBackoffKey(task.ProjectPath, task.ID)
+	freshTask := &Task{ID: task.ID, ProjectPath: task.ProjectPath}
+
+	if _, err := NewExecutionLifecycle(store).Begin(task, ExecStatusRunning); err != nil {
+		t.Fatalf("setup Begin: %v", err)
+	}
+
+	// Four consecutive infra-classified drops: each repick must be granted
+	// (not wedged) and must NOT grow consecutive_drops.
+	for i := 0; i < 4; i++ {
+		markLatestClaimedExecution(t, store, task.ID, task.ProjectPath, "infra")
+		execID, err := dispatcher.beginWithGenerationRetry(freshTask, ExecStatusQueued)
+		if err != nil {
+			t.Fatalf("beginWithGenerationRetry (infra %d): %v", i+1, err)
+		}
+		if execID == "" {
+			t.Fatalf("expected infra drop %d to be granted a retry, got dropped", i+1)
+		}
+	}
+
+	infraDrops, found, err := dispatcher.InfraDropCount(key)
+	if err != nil {
+		t.Fatalf("InfraDropCount: %v", err)
+	}
+	if !found || infraDrops != 4 {
+		t.Errorf("expected infra_drops=4 after 4 infra-classified drops, got found=%v count=%d", found, infraDrops)
+	}
+	if consecutive, _, found, err := dispatcher.RepickBackoffState(key); err != nil {
+		t.Fatalf("RepickBackoffState: %v", err)
+	} else if found && consecutive != 0 {
+		t.Errorf("expected consecutive_drops=0 after only infra drops, got found=%v consecutive=%d", found, consecutive)
+	}
+
+	// A fifth, genuine failure must grow consecutive_drops — and must still
+	// be granted, since only 1 genuine failure has happened so far, nowhere
+	// near dispatcherRepickHardCap.
+	markLatestClaimedExecution(t, store, task.ID, task.ProjectPath, "failed")
+	execID, err := dispatcher.beginWithGenerationRetry(freshTask, ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("beginWithGenerationRetry (failed): %v", err)
+	}
+	if execID == "" {
+		t.Fatal("expected the task to NOT be wedged after 4 infra drops + 1 failure — hard cap must not have tripped")
+	}
+
+	consecutive, _, found, err := dispatcher.RepickBackoffState(key)
+	if err != nil {
+		t.Fatalf("RepickBackoffState after failure: %v", err)
+	}
+	if !found || consecutive != 1 {
+		t.Errorf("expected consecutive_drops=1 reflecting only the genuine failure, got found=%v consecutive=%d", found, consecutive)
+	}
+
+	if infraDrops, _, err := dispatcher.InfraDropCount(key); err != nil {
+		t.Fatalf("InfraDropCount after failure: %v", err)
+	} else if infraDrops != 4 {
+		t.Errorf("expected infra_drops to remain 4 (untouched by the genuine failure), got %d", infraDrops)
+	}
+}
+
+// TestDispatcher_BeginWithGenerationRetry_InfraCapEscalatesWithDistinctReason
+// is the GH-4540/TASK-421 infra-cap acceptance test, mirroring
+// TestDispatcher_BeginWithGenerationRetry_StallCapEscalatesWithDistinctReason:
+// once dispatcherInfraRepickCap consecutive infra-classified drops have
+// accumulated, the next infra-classified repick must escalate/hold the task
+// with a distinct, truthful reason string identifying the infra class — not
+// the generic hard-cap message a genuine code failure would produce.
+func TestDispatcher_BeginWithGenerationRetry_InfraCapEscalatesWithDistinctReason(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GH-4540-INFRACAP", ProjectPath: "/project-infracap", Title: "Infra-capped task"}
+	runner := NewRunner()
+	processor := &fakeAlertProcessor{}
+	runner.SetAlertProcessor(processor)
+	dispatcher := NewDispatcher(store, runner, nil)
+	key := repickBackoffKey(task.ProjectPath, task.ID)
+
+	// Already at the infra cap.
+	if err := dispatcher.SetInfraDropCount(key, dispatcherInfraRepickCap); err != nil {
+		t.Fatalf("SetInfraDropCount: %v", err)
+	}
+
+	execID, err := NewExecutionLifecycle(store).Begin(task, ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("setup Begin: %v", err)
+	}
+	if err := store.UpdateExecutionStatus(execID, "infra"); err != nil {
+		t.Fatalf("setup: failed to mark generation 0 as infra: %v", err)
+	}
+
+	freshTask := &Task{ID: task.ID, ProjectPath: task.ProjectPath, Title: task.Title}
+	retryExecID, err := dispatcher.beginWithGenerationRetry(freshTask, ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("beginWithGenerationRetry: %v", err)
+	}
+	if retryExecID != "" {
+		t.Fatal("expected the re-pick to be dropped once the infra cap is reached, got a fresh execID")
+	}
+
+	infraExec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if infraExec.Status != "stalled" {
+		t.Errorf("expected the claimed execution to be marked stalled, got status=%q", infraExec.Status)
+	}
+	if !strings.Contains(infraExec.Error, "infra") {
+		t.Errorf("expected an infra-class reason string, got %q", infraExec.Error)
+	}
+	if strings.Contains(infraExec.Error, "consecutive failed re-picks") {
+		t.Errorf("expected the infra-class reason to be distinct from the generic hard-cap message, got %q", infraExec.Error)
+	}
+
+	if len(processor.events) != 1 {
+		t.Fatalf("expected exactly 1 alert event, got %d: %+v", len(processor.events), processor.events)
+	}
+	if processor.events[0].Metadata["reason"] != "infra_repick_cap_stalled" {
+		t.Errorf("expected alert metadata reason=infra_repick_cap_stalled, got %q", processor.events[0].Metadata["reason"])
+	}
+}
+
 // TestRepickBackoffKey_FormatMatchesCmdPilotPackage is the GH-4394 subtask 4
 // counterpart to cmd/pilot's TestRepickBackoffKey_FormatMatchesDispatcherPackage.
 // cmd/pilot cannot import internal/executor's unexported repickBackoffKey (and

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -430,6 +430,21 @@ func (s *Store) migrate() error {
 		// rides along with the existing repick_backoff persistence/migration
 		// path instead of duplicating it.
 		`ALTER TABLE repick_backoff ADD COLUMN stall_drops INTEGER NOT NULL DEFAULT 0`,
+		// GH-4540/TASK-421: a dispatch attempt refused because the task is
+		// already queued/running, or already terminally done, is not
+		// evidence of a genuine failure any more than a stall-kill is (same
+		// reasoning as stall_drops above) — but unlike a stall-kill, this
+		// class of drop is detected at the cmd/pilot chokepoint
+		// (handleIssueGeneric), not inside beginWithGenerationRetry, so it
+		// needs its own column reachable from that package too. See
+		// cmd/pilot/repick_backoff.go's recordClaimLostDrop.
+		`ALTER TABLE repick_backoff ADD COLUMN claim_lost_drops INTEGER NOT NULL DEFAULT 0`,
+		// GH-4540/TASK-421: an infra-classified failure (status "infra" —
+		// e.g. a hosted git_clean preflight deadlock or a CI outage) is not
+		// evidence the task's own code is broken, mirroring stall_drops'
+		// reasoning exactly but for a different prior-claim status. See
+		// Dispatcher.priorClaimWasInfra.
+		`ALTER TABLE repick_backoff ADD COLUMN infra_drops INTEGER NOT NULL DEFAULT 0`,
 	}
 
 	for _, migration := range migrations {
@@ -2822,9 +2837,16 @@ func (s *Store) DeleteExecution(id string) error {
 // duplicate.
 func (s *Store) IsTaskQueued(taskID, projectPath string) (bool, error) {
 	var count int
+	// GH-4540/TASK-421: 'decomposed' was missing from this allowlist even
+	// though it is a non-terminal status (see executor.terminalExecutionStatuses)
+	// — an epic parent sitting "decomposed" was invisible to this check (and
+	// thus to Dispatcher.IsActive's pre-dispatch admission gate) while still
+	// being a live, non-terminal claim owner from nextRetryGeneration's point
+	// of view, letting the poller re-offer it on every tick and generate an
+	// unbounded run of claim-lost drops.
 	err := s.db.QueryRow(`
 		SELECT COUNT(*) FROM executions
-		WHERE task_id = ? AND project_path = ? AND status IN ('queued', 'pending', 'running')
+		WHERE task_id = ? AND project_path = ? AND status IN ('queued', 'pending', 'running', 'decomposed')
 	`, taskID, canonicalizeProjectPath(projectPath)).Scan(&count)
 	if err != nil {
 		return false, err
@@ -2979,6 +3001,83 @@ func (s *Store) SetStallDropCount(key string, count int) error {
 			stall_drops = excluded.stall_drops,
 			updated_at = CURRENT_TIMESTAMP
 	`, key, count)
+	return err
+}
+
+// GetInfraDropCount returns the persisted count of consecutive
+// infra-classified repick drops for key (GH-4540/TASK-421) — the same
+// "project_path|task_id" string repickBackoffKey mints. found is false when
+// no infra drop has ever been recorded for key. Distinct from
+// consecutive_drops on the same row: that counter tracks genuine (non-infra,
+// non-stall) drops toward dispatcherRepickHardCap; this one tracks
+// infra-classified repicks toward the separate dispatcherInfraRepickCap.
+func (s *Store) GetInfraDropCount(key string) (count int, found bool, err error) {
+	err = s.db.QueryRow(`
+		SELECT infra_drops FROM repick_backoff WHERE key = ?
+	`, key).Scan(&count)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	return count, true, nil
+}
+
+// SetInfraDropCount persists count as the infra-classified drop count for
+// key (GH-4540/TASK-421), creating the repick_backoff row if key has no
+// prior state. consecutive_drops/next_allowed_at are only supplied for a
+// brand-new row — an existing row's genuine-failure counter and backoff
+// window are left untouched by the ON CONFLICT clause, since an
+// infra-classified repick must not perturb genuine-failure accounting.
+func (s *Store) SetInfraDropCount(key string, count int) error {
+	_, err := s.db.Exec(`
+		INSERT INTO repick_backoff (key, consecutive_drops, next_allowed_at, infra_drops, updated_at)
+		VALUES (?, 0, CURRENT_TIMESTAMP, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT (key) DO UPDATE SET
+			infra_drops = excluded.infra_drops,
+			updated_at = CURRENT_TIMESTAMP
+	`, key, count)
+	return err
+}
+
+// GetClaimLostDropCount returns the persisted count of consecutive
+// claim-lost/already-done drops for key (GH-4540/TASK-421) — dropped pickups
+// that cmd/pilot's handleIssueGeneric chokepoint refused because the task
+// was already active or already terminally done, not because anything
+// failed. Distinct from consecutive_drops: that counter only grows for a
+// genuine failed re-pick (see Dispatcher.beginWithGenerationRetry); this one
+// exists purely for backoff-window growth and observability (WARN
+// escalation, loop-breaker alert) so a task queued behind another task
+// indefinitely is never pushed toward dispatcherRepickHardCap.
+func (s *Store) GetClaimLostDropCount(key string) (count int, found bool, err error) {
+	err = s.db.QueryRow(`
+		SELECT claim_lost_drops FROM repick_backoff WHERE key = ?
+	`, key).Scan(&count)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	return count, true, nil
+}
+
+// SetClaimLostBackoff persists claimLostDrops and the backoff cooldown
+// deadline for key (GH-4540/TASK-421), creating the repick_backoff row if
+// key has no prior state. Unlike SetRepickBackoff, this intentionally never
+// touches consecutive_drops — growing the shared cooldown window (so a
+// repeatedly-re-offered task still gets throttled the way TASK-413 intends)
+// must not also push the task toward the genuine-failure hard cap.
+func (s *Store) SetClaimLostBackoff(key string, claimLostDrops int, nextAllowedAt time.Time) error {
+	_, err := s.db.Exec(`
+		INSERT INTO repick_backoff (key, consecutive_drops, next_allowed_at, claim_lost_drops, updated_at)
+		VALUES (?, 0, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT (key) DO UPDATE SET
+			next_allowed_at = excluded.next_allowed_at,
+			claim_lost_drops = excluded.claim_lost_drops,
+			updated_at = CURRENT_TIMESTAMP
+	`, key, nextAllowedAt, claimLostDrops)
 	return err
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4540.

Closes #4540

## Changes

GitHub Issue GH-4540: TASK-421: Repick hard cap counts non-failures — a task queued behind a long task is auto-blocked for waiting its turn

# TASK-421: Repick hard cap counts non-failures — a task queued behind a long task is auto-blocked for waiting its turn

**Status**: 🚧 In Progress
**Created**: 2026-07-25
**Assignee**: Pilot

---

## Context

**Problem**:
`consecutive_drops` increments on any dispatch attempt that fails to produce a
new execution — including attempts the dispatcher **correctly refused because
the task was already queued or already running**. At
`dispatcherRepickHardCap = 5` (`dispatcher.go:950`) the task is marked
`stalled` and labelled `pilot-blocked`, requiring manual 6-step recovery.

The result: **any task queued behind a task that runs longer than ~37 minutes
is auto-blocked for waiting its turn.** It never failed. It never started.

**Reproduction — GH-4537, 2026-07-24 (verbatim):**
```
22:19:57.985  task queued behind GH-4536 (position 1 in pilot queue)   ← correct
22:25:28      Dispatching issue 4537 → dispatch claim lost — task already
              owned by another dispatch channel → unmarking for retry
22:31:26      (same, repeating every ~6 min)
22:57:04      consecutive_drops=6 → hard cap → stalled + pilot-blocked
```
GH-4536 ran ~40 min, so GH-4537 was doomed the moment it was dispatched. It sat
blocked overnight (~10h) until an operator re-armed it.

**Three distinct false-stall variants in 24 hours, same counter:**

| Task | Drops accrued while… | Reality |
|---|---|---|
| GH-4526 | environment failures (hosted `git_clean` preflight deadlock, CI infra outage) | task was fine; the box was broken |
| GH-4531 | legitimately **running** (poller raced the epic it was executing) | live execution, `consecutive_drops=5` |
| GH-4537 | legitimately **queued** behind GH-4536 | never started |

**Root cause, two halves:**

1. **The poller re-dispatches work it already owns.** `Dispatcher.IsActive`
   (`dispatcher.go:797`) exists precisely to answer *"is this taskID already
   queued or running in this project?"* — and is called from exactly one place,
   `cmd/pilot/handler_common.go:102`. The GitHub SDK poller path does **not**
   consult it, so it re-dispatches an already-queued task every poll cycle,
   generating a guaranteed rejection each time.
2. **The rejection is counted as a failed re-pick.** A claim refused because
   the task is already active is not a failure — nothing was attempted. It
   still grows the same `consecutive_drops` counter that gates the hard cap.

Prior art shows this is the third pass at the class and each pass narrowed it
without closing it. `store.go:419-426` already carries a **separate**
`stall_drops` counter added so stall-kills would "not grow the same
`consecutive_drops` counter a genuine failure does" (#4455 — restart churn and
operator cancels no longer count). Claim-lost drops never received the same
treatment; memory `claim-lost-drops-count-toward-hard-cap` records exactly that
gap, and it has now cost three tasks in one day.

**Goal**:
`consecutive_drops` counts genuine failed re-picks only. Being queued, being
already-running, and environment faults must never consume a task's retry
budget.

---

## Known Pitfalls & Patterns

- **PITFALL** `claim-lost-drops-count-toward-hard-cap`: the exact known gap
  this task closes. #4455 narrowed the class but explicitly did not close it.
- **PITFALL** `hard-cap-rearm-in-memory-gate`: recovery costs 6 manual steps
  including DB surgery, a label edit, and often a daemon restart. Every false
  stall is expensive — this is why prevention matters more than faster
  recovery.
- **DECISION** "Concurrency default: opt-in (`default 1`)": with one worker
  per project, queueing behind a long task is the **normal** state, not an
  anomaly. The counter must be safe under the project's own default config.
- TASK-419 (#4536, PR #4538 merged) fixed the epic self-deadlock that produced
  the GH-4531 variant, but did **not** touch this counter.

---

## Acceptance Criteria

- [ ] A dispatch attempt refused because the task is already `queued` or
      `running` does **not** increment `consecutive_drops`.
- [ ] A task that sits queued behind another task for an arbitrarily long time
      is never marked `stalled` or labelled `pilot-blocked` on that basis
      alone.
- [ ] The poller consults `Dispatcher.IsActive` (or equivalent) before
      dispatching, so the redundant re-dispatch stops being generated at the
      source rather than only being forgiven downstream.
- [ ] Genuine failed re-picks still reach the cap: a task whose execution is
      actually attempted and fails repeatedly still stalls at
      `dispatcherRepickHardCap`.
- [ ] Environment/infra-classified failures do not consume the budget the same
      way code failures do — reuse the `failure_class` vocabulary shipped in
      TASK-418 (PR #4535) rather than inventing a parallel taxonomy.
- [ ] The distinction is observable: the `repick storm` WARN
      (`dispatcher.go:1250`) names *why* a drop was counted or forgiven, so the
      next false stall is diagnosable from the log alone.

---

## Implementation

### Phase 1: Stop generating the redundant dispatch
**Goal**: The poller does not re-dispatch what it already owns.

**Tasks**:
- [ ] Have the GitHub SDK poller path check `Dispatcher.IsActive(taskID,
      projectPath)` (`dispatcher.go:797`) before dispatching, matching the
      existing `cmd/pilot/handler_common.go:102` usage.
- [ ] When already active, log at debug/info and skip — do not route through
      the drop path at all.

### Phase 2: Classify the drop before counting it
**Goal**: Only genuine failed re-picks grow `consecutive_drops`.

**Tasks**:
- [ ] At the drop site feeding `dispatcher.go:1250`/`1305`, distinguish
      "refused because already active" from "re-picked and failed". Do not
      increment `consecutive_drops` for the former.
- [ ] Follow the established precedent: `store.go:419-426`'s `stall_drops`
      column shows the accepted shape for a non-gating counter. Either reuse
      that mechanism or add a sibling — do not overload `consecutive_drops`.
- [ ] Apply the same forgiveness to environment/infra-classified failures via
      TASK-418's `failure_class` (PR #4535, `internal/autopilot`), so the
      GH-4526 variant is covered too.

### Phase 3: Make it diagnosable
**Goal**: A future false stall is readable from the log.

**Tasks**:
- [ ] Extend the `repick storm` WARN (`dispatcher.go:1250`) and the stall
      reason (`dispatcher.go:1305`) to carry the drop classification and the
      counted-vs-forgiven decision.

**Files**:
- `internal/executor/dispatcher.go` — drop classification, cap, `IsActive` use
- `internal/memory/store.go` — counter columns (`repick_backoff`)
- the GitHub SDK poller dispatch path — pre-dispatch `IsActive` check

---

## Out of Scope

- Raising or removing `dispatcherRepickHardCap` (`dispatcher.go:950`). The cap
  is correct; what it counts is not.
- Changing the TASK-407 claim mechanism. Refusing a duplicate claim is right —
  only the bookkeeping that follows is wrong.
- The dashboard's rendering of stalled/queued tasks (TASK-420 / #4537).
- Auto-recovery of already-blocked issues. This prevents new false stalls; it
  does not un-block historical ones.

---

## Technical Decisions

| Decision | Options Considered | Chosen | Reasoning |
|----------|-------------------|--------|-----------|
| Where to fix | Poller only; counter only; both | **Both** | Poller-only leaves other dispatch channels able to generate the same drops; counter-only leaves a pointless re-dispatch every 6 min burning API quota |
| Counter design | Reset on queue; separate non-gating counter; forgive at increment | Forgive at increment + separate counter, following `stall_drops` | `store.go:419-426` already established this shape for #4455; a third pattern invites the drift that produced this bug |
| Environment failures | Separate task; fold in | Fold in | TASK-418's `failure_class` shipped yesterday (PR #4535) and makes this a small addition; leaving it out means a 4th false-stall variant remains live |
| Cap value | Raise to buy headroom; leave at 5 | Leave at 5 | Raising it only delays a false stall and weakens the real protection |

---

## Verify

```bash
make build
go test ./internal/executor/... ./internal/memory/...
make lint
```

---

## Done

- [ ] A test reproduces GH-4537: task B queued behind long-running task A,
      poller attempts dispatch N > cap times, and B is still queued —
      not `stalled`, not `pilot-blocked`.
- [ ] A test asserts a genuinely failing task still stalls at the cap
      (no regression in the real protection).
- [ ] A test asserts the poller skips dispatch when `IsActive` is true.
- [ ] `make build`, `make lint`, `go test ./internal/executor/... ./internal/memory/...`
      green.

---

## Refs

- GH-4537 (2026-07-24 22:19:57→22:57:04Z) — queued behind GH-4536, 6 drops,
  false stall, ~10h blocked overnight.
- GH-4531 (18:14→18:22Z) — drops while legitimately running; `consecutive_drops=5`
  against a live execution.
- GH-4526 (→16:00Z) — drops from environment failures (hosted `git_clean`
  deadlock + CI infra outage).
- #4455 — narrowed the class (restart churn, operator cancels); `stall_drops`
  precedent at `store.go:419-426`.
- Memory `claim-lost-drops-count-toward-hard-cap` — the documented open gap.
- TASK-418 / PR #4535 — `failure_class` vocabulary to reuse.
- TASK-419 / PR #4538 — fixed the epic deadlock behind the GH-4531 variant,
  not this counter.

---

**Last Updated**: 2026-07-25