### PR TITLE
GH-4526: fix(executor): hosted daemon scaffolds untracked .agent/ into fresh clones, then its own git_clean preflight blocks every dispatch

### DIFF
--- a/.agent/tasks/gh-4526.md
+++ b/.agent/tasks/gh-4526.md
@@ -1,0 +1,90 @@
+# GH-4526
+
+**Created:** 2026-07-25
+
+## Problem
+
+GitHub Issue GH-4526: fix(executor): hosted daemon scaffolds untracked .agent/ into fresh clones, then its own git_clean preflight blocks every dispatch
+
+## Defect (found on the first hosted tenant instance, S2 canary proof)
+
+Sequence on a freshly-cloned project repo (`PILOT_HOSTED=1`, fleet instance i-0decbc0dcf225cf18):
+
+1. Repo cloned clean at `/var/lib/pilot/repos/pilot-canary-sandbox` (console#51 apply-script clone).
+2. Daemon starts, scaffolds Navigator `.agent/` into the repo (~2 min after clone; untracked).
+3. First dispatch (GH-99/GH-100) → `preflight check "git_clean" failed: working directory has 1 uncommitted change(s)` → 5 re-picks → repick hard cap → `pilot-blocked`.
+
+The daemon deadlocks itself: its own scaffolding makes every fresh clone permanently dirty by its own preflight's definition. Box repos never hit this because `.agent/` is committed there. Every future hosted tenant repo hits it on first dispatch.
+
+Operator workaround applied on the canary instance: `.agent/` appended to `.git/info/exclude` + issues re-armed via `pilot-retry-ready`. That does not scale past the canary.
+
+## Fix options (pick one, first is recommended)
+
+1. **git_clean preflight ignores the daemon's own scaffold paths**: treat untracked `.agent/` (and any path the memory writer creates) as clean — e.g. `git status --porcelain -- ':!.agent'` or filter the untracked list against a known-scaffold allowlist. H3 precedent: the daemon already special-cases its own memory writes.
+2. Scaffold writes `.git/info/exclude` entries for whatever it creates untracked (self-cleaning, works per-clone).
+3. Don't scaffold `.agent/` in PILOT_HOSTED mode until the graph is actually used.
+
+## Secondary finding (same incident, fold in or split)
+
+Stalled-issue surfacing failed label updates on the fresh repo: `gh issue edit: 'pilot-failed' not found` — the daemon assumes its label set exists. Hosted repos are onboarded without labels; the daemon should create missing `pilot-*` labels on demand (idempotent `gh label create` before edit, or ensure-labels at repo-poller startup).
+
+## Acceptance criteria
+
+- Fresh clone + scaffold → git_clean preflight passes; regression test simulating an untracked .agent/ dir.
+- Label surfacing works on a repo with zero pre-existing pilot-* labels (creates them).
+- No weakening of git_clean for genuinely dirty user files.
+
+## Files
+
+- internal/executor preflight (git_clean check)
+- dispatcher stalled-issue surfacing (label ensure)
+
+---
+
+## Resolution
+
+**Status**: ✅ Done
+
+**Fix chosen**: option 1 — `checkGitClean` (`internal/executor/preflight.go`)
+now filters `git status --porcelain -z` output through `isExcluded` (`git.go`),
+the exact `defaultExcludeDirs`/`defaultExcludeGlobs` allowlist
+(`.agent/`, `.claude/`, `node_modules/`, `dist/`, `build/`, `coverage/`,
+`.cache/`, lock files, OS junk) `GitOperations.Commit` already uses to decide
+what it will never auto-stage. A path the executor already treats as "not a
+real project change" for commit purposes is, by the same reasoning, not
+evidence of a dirty tree for preflight purposes — this reuses existing logic
+rather than inventing a second exclude list. Genuinely dirty user files are
+unaffected: only paths matching the existing exclude set are ignored.
+
+**Secondary finding**: `ghEditLabels` (`internal/executor/title_rejection.go`)
+now calls a new `ghEnsureLabels` helper before every `gh issue edit` —
+idempotent `gh label create <name> --color ededed --force` for each
+referenced label (add + remove), best-effort. `gh issue edit` validates every
+`--add-label`/`--remove-label` against the repo's existing label set and
+fails atomically if any is missing; a hosted repo onboarded with zero
+pre-existing `pilot-*` labels made every surfacing call
+(`surfaceStalledIssue`, title-rejection escalation) fail outright. This
+covers both callers of `ghEditLabels`/`ghAddLabels` with one change.
+
+**Tests added**:
+- `TestCheckGitClean_IgnoresScaffoldedAgentDir` (preflight_test.go) — untracked
+  `.agent/` scaffold no longer blocks; a genuinely dirty user file alongside it
+  still does.
+- `TestGhEditLabels_CreatesMissingLabelsBeforeEditing` (title_rejection_test.go)
+  — fake `gh` reproduces real `gh issue edit`'s atomic label-validation
+  failure; asserts `ghEditLabels` succeeds on a repo with zero pre-existing
+  labels and that label creates precede the edit call.
+- `TestGhEditLabels_SkipsEmptyLabels` — defensive coverage for the dedup/empty
+  guard in `ghEnsureLabels`.
+
+**Verify**: `go build ./...`, `go vet ./...`, `gofmt -l` clean,
+`go test ./internal/executor/...` (full package, no regressions).
+
+## Acceptance Criteria
+
+- [x] Fresh clone + scaffold → git_clean preflight passes; regression test
+      simulating an untracked `.agent/` dir.
+- [x] Label surfacing works on a repo with zero pre-existing `pilot-*` labels
+      (creates them).
+- [x] No weakening of git_clean for genuinely dirty user files.
+

--- a/internal/executor/preflight.go
+++ b/internal/executor/preflight.go
@@ -182,20 +182,50 @@ func checkOpenAIAPIKey(backendType string) error {
 	return fmt.Errorf("%s backend requires an API key: set OPENAI_API_KEY (or configure executor.openai.api_key)", backendType)
 }
 
-// checkGitClean verifies the git working directory has no uncommitted changes.
-// This prevents execution from accidentally including unrelated changes.
+// checkGitClean verifies the git working directory has no uncommitted changes
+// outside of Pilot's own scaffold/excluded paths.
+//
+// GH-4526: on a hosted tenant repo, NavigatorInitializer.Initialize
+// (navigator.go) auto-scaffolds an untracked .agent/ structure into the
+// fresh clone before the first dispatch ever runs (box repos never hit this
+// because .agent/ is already committed there). This check's own definition
+// of "dirty" then blocks every dispatch attempt on that self-inflicted
+// scaffold — 5 re-picks, repick hard cap, pilot-blocked, on a repo whose only
+// "uncommitted change" is Pilot's own bootstrapping, not the user's code.
+// Reuse the exact defaultExcludeDirs/defaultExcludeGlobs list git.go's
+// Commit() step already uses to decide what it will never auto-stage
+// (.agent/, .claude/, node_modules/, build artifacts, lock files, ...): a
+// path the executor already treats as "not really a project change" for
+// commit purposes is, by the same reasoning, not evidence of a dirty working
+// tree for preflight purposes either. Genuinely dirty user files (anything
+// NOT matching that exclude list) still block exactly as before.
 func checkGitClean(ctx context.Context, projectPath string) error {
-	cmd := exec.CommandContext(ctx, "git", "status", "--porcelain")
+	cmd := exec.CommandContext(ctx, "git", "status", "--porcelain", "-z")
 	cmd.Dir = projectPath
 	output, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("git status failed: %w", err)
 	}
-	changes := strings.TrimSpace(string(output))
-	if len(changes) > 0 {
-		// Count number of changed files
-		lines := strings.Split(changes, "\n")
-		return fmt.Errorf("working directory has %d uncommitted change(s): run 'git stash' or 'git commit' first", len(lines))
+
+	trimmed := strings.TrimRight(string(output), "\x00")
+	if trimmed == "" {
+		return nil
+	}
+
+	var dirty []string
+	for _, entry := range strings.Split(trimmed, "\x00") {
+		if len(entry) < 4 {
+			continue
+		}
+		path := entry[3:]
+		if isExcluded(path) {
+			continue
+		}
+		dirty = append(dirty, path)
+	}
+
+	if len(dirty) > 0 {
+		return fmt.Errorf("working directory has %d uncommitted change(s): run 'git stash' or 'git commit' first", len(dirty))
 	}
 	return nil
 }

--- a/internal/executor/preflight_test.go
+++ b/internal/executor/preflight_test.go
@@ -101,6 +101,68 @@ func TestCheckGitClean(t *testing.T) {
 	})
 }
 
+// TestCheckGitClean_IgnoresScaffoldedAgentDir is the GH-4526 regression
+// test: NavigatorInitializer.Initialize scaffolds an untracked .agent/
+// structure into every fresh hosted clone before the first dispatch runs.
+// checkGitClean must not treat that self-inflicted scaffold as a dirty
+// working directory — otherwise every first dispatch on a hosted tenant
+// repo deadlocks itself on its own preflight (5 re-picks, repick hard cap,
+// pilot-blocked, per the incident on i-0decbc0dcf225cf18).
+func TestCheckGitClean_IgnoresScaffoldedAgentDir(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	if err := exec.Command("git", "init", tmpDir).Run(); err != nil {
+		t.Fatalf("failed to init git repo: %v", err)
+	}
+	_ = exec.Command("git", "-C", tmpDir, "config", "user.email", "test@test.com").Run()
+	_ = exec.Command("git", "-C", tmpDir, "config", "user.name", "Test").Run()
+
+	// Simulate a real project file already committed (the "fresh clone" state).
+	readme := filepath.Join(tmpDir, "README.md")
+	if err := os.WriteFile(readme, []byte("hello"), 0644); err != nil {
+		t.Fatalf("failed to write README: %v", err)
+	}
+	if err := exec.Command("git", "-C", tmpDir, "add", "README.md").Run(); err != nil {
+		t.Fatalf("failed to stage README: %v", err)
+	}
+	if err := exec.Command("git", "-C", tmpDir, "commit", "-m", "initial").Run(); err != nil {
+		t.Fatalf("failed to commit README: %v", err)
+	}
+
+	t.Run("untracked_agent_scaffold_is_ignored", func(t *testing.T) {
+		agentDir := filepath.Join(tmpDir, ".agent", "system")
+		if err := os.MkdirAll(agentDir, 0755); err != nil {
+			t.Fatalf("failed to create scaffold dir: %v", err)
+		}
+		scaffoldFile := filepath.Join(agentDir, "DEVELOPMENT-README.md")
+		if err := os.WriteFile(scaffoldFile, []byte("scaffolded"), 0644); err != nil {
+			t.Fatalf("failed to write scaffold file: %v", err)
+		}
+
+		if err := checkGitClean(ctx, tmpDir); err != nil {
+			t.Errorf("expected no error for untracked .agent/ scaffold, got: %v", err)
+		}
+	})
+
+	t.Run("genuinely_dirty_user_file_still_blocks", func(t *testing.T) {
+		// The scaffold from the previous subtest is still present — a
+		// genuinely dirty user file alongside it must still be caught.
+		dirtyFile := filepath.Join(tmpDir, "main.go")
+		if err := os.WriteFile(dirtyFile, []byte("package main"), 0644); err != nil {
+			t.Fatalf("failed to write dirty user file: %v", err)
+		}
+
+		err := checkGitClean(ctx, tmpDir)
+		if err == nil {
+			t.Fatal("expected error for genuinely dirty user file, got nil")
+		}
+		if !strings.Contains(err.Error(), "uncommitted change") {
+			t.Errorf("expected error to mention uncommitted changes, got: %v", err)
+		}
+	})
+}
+
 func TestRunPreflightChecks(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/executor/title_rejection.go
+++ b/internal/executor/title_rejection.go
@@ -245,7 +245,18 @@ func ghAddLabels(ctx context.Context, dir, issueID string, labels []string) erro
 // edit` call. Used by stallTaskAfterRepickHardCap (dispatcher.go, GH-4454
 // subtask 3) to swap pilot-failed/pilot-in-progress for pilot-blocked in one
 // shot, alongside ghAddLabels' add-only callers.
+//
+// GH-4526: `gh issue edit` validates every label it references — both
+// --add-label and --remove-label — against the repo's label set before
+// applying anything, and fails the whole call atomically if any one of them
+// is missing (`gh issue edit: 'pilot-failed' not found`). Hosted tenant
+// repos are onboarded with zero pre-existing pilot-* labels, so the very
+// first surfacing call (e.g. stallTaskAfterRepickHardCap) failed outright on
+// every fresh repo. Pre-creating whatever labels this call is about to
+// reference sidesteps that without a separate onboarding step.
 func ghEditLabels(ctx context.Context, dir, issueID string, addLabels, removeLabels []string) error {
+	ghEnsureLabels(ctx, dir, append(append([]string{}, addLabels...), removeLabels...))
+
 	args := []string{"issue", "edit", issueID}
 	for _, l := range addLabels {
 		args = append(args, "--add-label", l)
@@ -263,4 +274,30 @@ func ghEditLabels(ctx context.Context, dir, issueID string, addLabels, removeLab
 		return fmt.Errorf("gh issue edit: %w (stderr: %s)", err, stderr.String())
 	}
 	return nil
+}
+
+// pilotLabelColor is applied to any pilot-* label ghEnsureLabels has to
+// create on demand — a plain, unobtrusive gray. The color is cosmetic only;
+// nothing in the dispatch pipeline reads it back.
+const pilotLabelColor = "ededed"
+
+// ghEnsureLabels idempotently creates any of the given labels that don't yet
+// exist on the repo. `gh label create --force` updates-in-place rather than
+// erroring when the label is already present, so repeat calls are no-ops.
+// Best-effort: a creation failure (e.g. missing repo permissions) is not
+// fatal here — the caller's own `gh issue edit` is the source of truth for
+// whether the edit itself ultimately succeeded.
+func ghEnsureLabels(ctx context.Context, dir string, labels []string) {
+	seen := make(map[string]bool, len(labels))
+	for _, l := range labels {
+		if l == "" || seen[l] {
+			continue
+		}
+		seen[l] = true
+		cmd := exec.CommandContext(ctx, "gh", "label", "create", l, "--color", pilotLabelColor, "--force")
+		if dir != "" {
+			cmd.Dir = dir
+		}
+		_ = cmd.Run()
+	}
 }

--- a/internal/executor/title_rejection_test.go
+++ b/internal/executor/title_rejection_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -166,13 +167,110 @@ func TestRecordTitleRejection_NilTrackerIsNoOp(t *testing.T) {
 // TestClearTitleRejectionState_NilTrackerIsNoOp mirrors the nil-tracker guard
 // for the success-path clear helper.
 func TestClearTitleRejectionState_NilTrackerIsNoOp(t *testing.T) {
-	r := newSilentRunnerTask359() // titleRejections left nil
+	r := newSilentRunnerTask359()                 // titleRejections left nil
 	r.clearTitleRejectionState(&Task{ID: "GH-1"}) // must not panic
 }
 
 // TestClearTitleRejectionState_DropsTrackedCount verifies the success-path
 // helper actually resets the counter (mirrors TestTitleRejectionTracker_Clear
 // but through the Runner-level wrapper finalize paths call).
+// TestGhEditLabels_CreatesMissingLabelsBeforeEditing is the GH-4526
+// regression test for the secondary finding on the same incident: a repo
+// onboarded with zero pre-existing pilot-* labels made every `gh issue edit`
+// call fail atomically with `gh issue edit: 'pilot-failed' not found`
+// (real `gh` validates every --add-label/--remove-label against the repo's
+// label set before applying anything). The fake `gh` below reproduces that
+// atomic-validation behavior: `gh issue edit` fails if any referenced label
+// isn't already recorded via a prior `gh label create`. ghEditLabels must
+// ensure-create every label it references first so the edit succeeds even
+// when none of them exist yet.
+func TestGhEditLabels_CreatesMissingLabelsBeforeEditing(t *testing.T) {
+	fakeBin := t.TempDir()
+	logFile := filepath.Join(t.TempDir(), "gh-calls.log")
+	labelsFile := filepath.Join(t.TempDir(), "labels.txt")
+	script := filepath.Join(fakeBin, "gh")
+
+	content := "#!/bin/sh\n" +
+		`echo "$@" >> "` + logFile + `"` + "\n" +
+		`if [ "$1" = "label" ] && [ "$2" = "create" ]; then` + "\n" +
+		`  echo "$3" >> "` + labelsFile + `"` + "\n" +
+		`  exit 0` + "\n" +
+		`fi` + "\n" +
+		`if [ "$1" = "issue" ] && [ "$2" = "edit" ]; then` + "\n" +
+		`  shift 3` + "\n" +
+		`  while [ $# -gt 0 ]; do` + "\n" +
+		`    case "$1" in` + "\n" +
+		`      --add-label|--remove-label)` + "\n" +
+		`        if ! grep -qxF "$2" "` + labelsFile + `" 2>/dev/null; then` + "\n" +
+		`          echo "gh issue edit: '$2' not found" >&2` + "\n" +
+		`          exit 1` + "\n" +
+		`        fi` + "\n" +
+		`        shift 2 ;;` + "\n" +
+		`      *) shift ;;` + "\n" +
+		`    esac` + "\n" +
+		`  done` + "\n" +
+		`  exit 0` + "\n" +
+		`fi` + "\n" +
+		`exit 0` + "\n"
+
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+os.Getenv("PATH"))
+
+	err := ghEditLabels(context.Background(), "", "42", []string{"pilot-blocked"}, []string{"pilot-failed", "pilot-in-progress"})
+	if err != nil {
+		t.Fatalf("expected ghEditLabels to succeed on a repo with zero pre-existing labels, got: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("expected gh CLI to be invoked, but log file missing: %v", err)
+	}
+	calls := string(logBytes)
+
+	for _, label := range []string{"pilot-blocked", "pilot-failed", "pilot-in-progress"} {
+		if !strings.Contains(calls, "label create "+label) {
+			t.Errorf("expected gh label create for %q, got calls:\n%s", label, calls)
+		}
+	}
+	if !strings.Contains(calls, "issue edit 42") {
+		t.Errorf("expected gh issue edit 42, got calls:\n%s", calls)
+	}
+
+	// The label creates must precede the issue edit — otherwise the fake gh's
+	// atomic-validation check above would have failed the edit.
+	createIdx := strings.Index(calls, "label create pilot-blocked")
+	editIdx := strings.Index(calls, "issue edit 42")
+	if createIdx == -1 || editIdx == -1 || createIdx > editIdx {
+		t.Errorf("expected label create calls before issue edit, got calls:\n%s", calls)
+	}
+}
+
+// TestGhEditLabels_SkipsEmptyLabels guards ghEnsureLabels against shelling
+// out for empty label strings (defensive: no known caller passes one today).
+func TestGhEditLabels_SkipsEmptyLabels(t *testing.T) {
+	fakeBin := t.TempDir()
+	logFile := filepath.Join(t.TempDir(), "gh-calls.log")
+	script := filepath.Join(fakeBin, "gh")
+	content := "#!/bin/sh\n" + `echo "$@" >> "` + logFile + `"` + "\nexit 0\n"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+os.Getenv("PATH"))
+
+	ghEnsureLabels(context.Background(), "", []string{"", "pilot-blocked", ""})
+
+	logBytes, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("expected gh CLI to be invoked: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(logBytes)), "\n")
+	if len(lines) != 1 {
+		t.Errorf("expected exactly 1 gh label create call (empty labels skipped), got %d:\n%s", len(lines), string(logBytes))
+	}
+}
+
 func TestClearTitleRejectionState_DropsTrackedCount(t *testing.T) {
 	r := newSilentRunnerTask359()
 	r.titleRejections = newTitleRejectionTracker()


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4526.

Closes #4526

## Changes

GitHub Issue GH-4526: fix(executor): hosted daemon scaffolds untracked .agent/ into fresh clones, then its own git_clean preflight blocks every dispatch

## Defect (found on the first hosted tenant instance, S2 canary proof)

Sequence on a freshly-cloned project repo (`PILOT_HOSTED=1`, fleet instance i-0decbc0dcf225cf18):

1. Repo cloned clean at `/var/lib/pilot/repos/pilot-canary-sandbox` (console#51 apply-script clone).
2. Daemon starts, scaffolds Navigator `.agent/` into the repo (~2 min after clone; untracked).
3. First dispatch (GH-99/GH-100) → `preflight check "git_clean" failed: working directory has 1 uncommitted change(s)` → 5 re-picks → repick hard cap → `pilot-blocked`.

The daemon deadlocks itself: its own scaffolding makes every fresh clone permanently dirty by its own preflight's definition. Box repos never hit this because `.agent/` is committed there. Every future hosted tenant repo hits it on first dispatch.

Operator workaround applied on the canary instance: `.agent/` appended to `.git/info/exclude` + issues re-armed via `pilot-retry-ready`. That does not scale past the canary.

## Fix options (pick one, first is recommended)

1. **git_clean preflight ignores the daemon's own scaffold paths**: treat untracked `.agent/` (and any path the memory writer creates) as clean — e.g. `git status --porcelain -- ':!.agent'` or filter the untracked list against a known-scaffold allowlist. H3 precedent: the daemon already special-cases its own memory writes.
2. Scaffold writes `.git/info/exclude` entries for whatever it creates untracked (self-cleaning, works per-clone).
3. Don't scaffold `.agent/` in PILOT_HOSTED mode until the graph is actually used.

## Secondary finding (same incident, fold in or split)

Stalled-issue surfacing failed label updates on the fresh repo: `gh issue edit: 'pilot-failed' not found` — the daemon assumes its label set exists. Hosted repos are onboarded without labels; the daemon should create missing `pilot-*` labels on demand (idempotent `gh label create` before edit, or ensure-labels at repo-poller startup).

## Acceptance criteria

- Fresh clone + scaffold → git_clean preflight passes; regression test simulating an untracked .agent/ dir.
- Label surfacing works on a repo with zero pre-existing pilot-* labels (creates them).
- No weakening of git_clean for genuinely dirty user files.

## Files

- internal/executor preflight (git_clean check)
- dispatcher stalled-issue surfacing (label ensure)