### PR TITLE
fix(executor): sweep orphaned epic children to stalled on parent abort

### DIFF
--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -2481,6 +2481,128 @@ func (r *Runner) finalizeSubIssueExecution(execID, status string, result *Execut
 	}
 }
 
+// createdIssueTaskID converts a CreatedIssue into its dispatch task-ID form —
+// "GH-N" for GitHub issues (Number > 0) or the raw Identifier for non-GitHub
+// adapters (Number == 0, GH-1471) — mirroring the exact issueRef/taskID
+// derivation executeSubIssuesTracked uses a few lines into its loop below.
+// GH-4561: the decompose-abort sweep (runner.go) must resolve child task IDs
+// straight from CreateSubIssues' returned []CreatedIssue — that abort can
+// fire before executeSubIssuesTracked ever runs, so no StageDecomposed
+// execution_events entry exists yet for GetDecomposedChildTaskIDs to parse.
+// Returns "" for a malformed CreatedIssue (neither a positive Number nor a
+// non-empty Identifier); callers must skip empty results.
+func createdIssueTaskID(issue CreatedIssue) string {
+	if issue.Number > 0 {
+		return fmt.Sprintf("GH-%d", issue.Number)
+	}
+	return issue.Identifier
+}
+
+// createdIssueTaskIDs maps createdIssueTaskID over issues, dropping any entry
+// that resolves to "" (a malformed CreatedIssue with neither a Number nor an
+// Identifier). GH-4561: used by the decompose-abort sweep to turn a partial
+// CreateSubIssues batch straight into the child task IDs sweepStalledEpicChildren
+// expects.
+func createdIssueTaskIDs(issues []CreatedIssue) []string {
+	ids := make([]string, 0, len(issues))
+	for _, iss := range issues {
+		if id := createdIssueTaskID(iss); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// sweepStalledEpicChildren marks every non-terminal execution among
+// childTaskIDs "stalled" via the ExecutionLifecycle chokepoint, carrying the
+// parent epic's failure text as the child's error (GH-4561). Each child
+// sub-issue is dispatched as its own independently-claimed GitHub issue
+// (GH-1471) and may already be running/queued on another dispatch channel —
+// the poller, a different ProjectWorker — at the moment the parent epic
+// aborts terminally: epic PR creation failing, the epic's title being
+// rejected, or CreateSubIssues itself aborting mid-decomposition with a
+// partial batch already created (see createdIssueTaskID's doc comment).
+//
+// Left unswept, that child's execution row sits "running"/"queued" forever —
+// the parent that would have reconciled or retried it is already done, so
+// nothing else ever transitions the row, and (per
+// Dispatcher.nextRetryGeneration) a live-looking claim blocks any fresh
+// re-pick of the child task indefinitely.
+//
+// Reuses ExecutionLifecycle.Classify/Persist (TASK-404/FK-787: no raw status
+// UPDATEs) with result=nil so Persist's metrics write is skipped entirely — a
+// child that already burned real tokens/cost before going silent must keep
+// that data, not have it zeroed by a synthetic all-empty ExecutionResult. The
+// reason is threaded through as execErr (rather than result.Error) so
+// Classify's nil-result path still lands override=ExecStatusStalled with
+// outcome.Error set to the parent-failure text. Classify/Persist are called
+// directly instead of the Finish shortcut so the execution_events row can be
+// recorded between them, per Persist's own doc comment (GH-4259): recording
+// the event AFTER Persist would let a poller observe the terminal status via
+// GetExecution and read the (still-missing) event ledger before this write
+// lands.
+//
+// "stalled" is itself a terminal status (dispatcher.go's
+// terminalExecutionStatuses), so this transition IS the claim release: the
+// next scheduling pass sees a terminal-but-not-done claimed execution and
+// (per nextRetryGeneration) grants a fresh generation — no separate
+// claim-release call is needed.
+func (r *Runner) sweepStalledEpicChildren(parentID, projectPath string, childTaskIDs []string, parentFailureReason string) {
+	if r.logStore == nil || len(childTaskIDs) == 0 {
+		return
+	}
+	lifecycle := NewExecutionLifecycle(r.logStore)
+	reason := fmt.Sprintf("parent epic %s aborted: %s", parentID, parentFailureReason)
+	for _, childID := range childTaskIDs {
+		if childID == "" {
+			continue
+		}
+		exec, err := r.logStore.GetLatestExecutionByTaskID(childID, projectPath)
+		if err != nil || exec == nil {
+			continue
+		}
+		if isTerminalExecutionStatus(exec.Status) {
+			continue
+		}
+		outcome := lifecycle.Classify(nil, errors.New(reason), ExecStatusStalled)
+		r.recordExecutionEvent(exec.ID, memory.StageStalled, reason)
+		if persistErr := lifecycle.Persist(exec.ID, outcome, nil, 0); persistErr != nil {
+			r.log.Warn("sweepStalledEpicChildren: failed to stall orphaned child execution",
+				slog.String("parent_id", parentID),
+				slog.String("child_id", childID),
+				slog.String("execution_id", exec.ID),
+				slog.Any("error", persistErr),
+			)
+			continue
+		}
+		r.log.Warn("sweepStalledEpicChildren: stalled orphaned child execution after parent epic abort",
+			slog.String("parent_id", parentID),
+			slog.String("child_id", childID),
+			slog.String("execution_id", exec.ID),
+			slog.String("prior_status", exec.Status),
+		)
+	}
+}
+
+// sweepEpicChildrenOnAbort is sweepStalledEpicChildren for callers that only
+// hold the parent Task, not its already-resolved child task IDs (GH-4561):
+// finalizeEpicBranchPR's push/title-rejection/PR-creation failure paths run
+// AFTER executeSubIssuesTracked has already recorded the StageDecomposed
+// execution_events entry (executeSubIssuesTracked, ~L2600), so the children
+// can be recovered from the store via GetDecomposedChildTaskIDs instead of
+// threading them through every intermediate call site. A lookup miss (no
+// decomposed event, or a store error) is silent — there is nothing to sweep.
+func (r *Runner) sweepEpicChildrenOnAbort(task *Task, failureReason string) {
+	if r.logStore == nil || task == nil {
+		return
+	}
+	childIDs, found, err := r.logStore.GetDecomposedChildTaskIDs(task.ID, task.ProjectPath)
+	if err != nil || !found || len(childIDs) == 0 {
+		return
+	}
+	r.sweepStalledEpicChildren(task.ID, task.ProjectPath, childIDs, failureReason)
+}
+
 // executeSubIssuesTracked is ExecuteSubIssues plus each child's terminal state
 // (TerminalStatus of its ExecutionResult, e.g. "completed" / "no_op") and the
 // aggregated token/cost/file metrics rolled up from every child that actually

--- a/internal/executor/epic_abort_sweep_test.go
+++ b/internal/executor/epic_abort_sweep_test.go
@@ -1,0 +1,252 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// writeFakeGhPRCreateFailing writes a fake "gh" binary that answers `gh pr
+// list ...` with an empty array (no merged/open PR short-circuit) and fails
+// `gh pr create ...` outright (exit 1, no "already exists" in the output) —
+// simulating a genuine PR-creation failure (rate limit, transient GitHub API
+// error, ...) distinct from a push failure or a title-normalization failure.
+func writeFakeGhPRCreateFailing(t *testing.T, fakeBin string) {
+	t.Helper()
+	script := `#!/bin/sh
+case "$*" in
+  *"pr list"*) echo "[]" ;;
+  *"pr create"*) echo "gh: unexpected server error" >&2; exit 1 ;;
+  *) echo "[]" ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(fakeBin, "gh"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+}
+
+// setUpFakeGhPRCreateFailingPATH prepends writeFakeGhPRCreateFailing's fake
+// "gh" binary to PATH for the duration of the test.
+func setUpFakeGhPRCreateFailingPATH(t *testing.T) {
+	t.Helper()
+	fakeBin := t.TempDir()
+	writeFakeGhPRCreateFailing(t, fakeBin)
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+os.Getenv("PATH"))
+}
+
+// TestFinalizeEpicBranchPR_AbortSweepsRunningChildren is the GH-4561
+// acceptance test: whichever way finalizeEpicBranchPR terminally aborts the
+// epic parent (push failure, title rejection, or PR-creation failure), any
+// child sub-issue execution still non-terminal ("running" here, simulating a
+// child independently picked up by the poller while the parent's own
+// sequential loop was finalizing) must be swept to "stalled" carrying the
+// parent's failure text — instead of being left claimed forever with no
+// owner left to reconcile it.
+//
+// Each case verifies three things the task spec calls out explicitly:
+//  1. the child's execution transitions to "stalled" with an error string
+//     naming the parent epic and its failure reason (reusing
+//     ExecutionLifecycle.Finish — no raw status UPDATEs, TASK-404/FK-787);
+//  2. the child's execution_events ladder is preserved (the earlier
+//     queued/running events are still there, appended-to, not replaced); and
+//  3. re-dispatch is admitted — Dispatcher.nextRetryGeneration grants a
+//     fresh generation for the child once its stalled claim is examined,
+//     because "stalled" is itself a terminal status (dispatcher.go's
+//     terminalExecutionStatuses) — the sweep's transition IS the claim
+//     release, no separate release call is needed.
+func TestFinalizeEpicBranchPR_AbortSweepsRunningChildren(t *testing.T) {
+	tests := []struct {
+		name          string
+		setUp         func(t *testing.T) (dir string, task *Task)
+		wantErrSubstr string // substring finalizeEpicBranchPR's result.Error must contain
+	}{
+		{
+			name: "push failure",
+			setUp: func(t *testing.T) (string, *Task) {
+				dir := initRepoWithCommitTask359(t)
+				runGit(t, dir, "checkout", "-b", "feature")
+				if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("work\n"), 0644); err != nil {
+					t.Fatalf("write: %v", err)
+				}
+				runGit(t, dir, "add", "f.txt")
+				runGit(t, dir, "commit", "-m", "feature work")
+				task := &Task{ID: "GH-431", Title: "feat: epic work", Description: "d", Branch: "feature", BaseBranch: "main", CreatePR: true}
+				return dir, task
+			},
+			wantErrSubstr: "epic branch push failed",
+		},
+		{
+			name: "title rejection",
+			setUp: func(t *testing.T) (string, *Task) {
+				dir := initRepoWithRemoteAndFeatureBranch(t, "pilot/GH-431-epic")
+				task := &Task{ID: "GH-431", Title: "   ", Description: "d", Branch: "pilot/GH-431-epic", BaseBranch: "main", CreatePR: true}
+				return dir, task
+			},
+			wantErrSubstr: "epic PR creation failed",
+		},
+		{
+			name: "PR creation failure",
+			setUp: func(t *testing.T) (string, *Task) {
+				setUpFakeGhPRCreateFailingPATH(t)
+				dir := initRepoWithRemoteAndFeatureBranch(t, "pilot/GH-431-epic2")
+				task := &Task{ID: "GH-431", Title: "feat: epic work", Description: "d", Branch: "pilot/GH-431-epic2", BaseBranch: "main", CreatePR: true}
+				return dir, task
+			},
+			wantErrSubstr: "epic PR creation failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, task := tt.setUp(t)
+
+			store, err := memory.NewStore(t.TempDir())
+			if err != nil {
+				t.Fatalf("memory.NewStore: %v", err)
+			}
+			defer func() { _ = store.Close() }()
+
+			task.ProjectPath = dir
+			lifecycle := NewExecutionLifecycle(store)
+
+			// Seed the parent's own execution row with a StageDecomposed event
+			// naming the child — this is the record executeSubIssuesTracked
+			// leaves behind, and what sweepEpicChildrenOnAbort's
+			// GetDecomposedChildTaskIDs lookup parses to find the child.
+			parentExecID, err := lifecycle.Begin(task, ExecStatusRunning)
+			if err != nil {
+				t.Fatalf("Begin(parent): %v", err)
+			}
+			if err := store.RecordExecutionEvent(parentExecID, memory.StageDecomposed, "decomposed into 1 children: #101"); err != nil {
+				t.Fatalf("RecordExecutionEvent(StageDecomposed): %v", err)
+			}
+
+			// Seed the child's execution row as "running" — simulating the
+			// poller having independently picked up and started GH-101 while
+			// the parent's own finalize step is running concurrently.
+			childTask := &Task{ID: "GH-101", ProjectPath: dir}
+			childExecID, err := lifecycle.Begin(childTask, ExecStatusQueued)
+			if err != nil {
+				t.Fatalf("Begin(child): %v", err)
+			}
+			if err := store.RecordExecutionEvent(childExecID, memory.StageQueued, "queued"); err != nil {
+				t.Fatalf("RecordExecutionEvent(StageQueued): %v", err)
+			}
+			if err := lifecycle.Transition(childExecID, ExecStatusRunning); err != nil {
+				t.Fatalf("Transition(child running): %v", err)
+			}
+			if err := store.RecordExecutionEvent(childExecID, memory.StageRunning, "running"); err != nil {
+				t.Fatalf("RecordExecutionEvent(StageRunning): %v", err)
+			}
+
+			r := newSilentRunnerTask359()
+			r.logStore = store
+
+			result := &ExecutionResult{TaskID: task.ID, Success: true, IsEpic: true}
+			r.finalizeEpicBranchPR(context.Background(), task, NewGitOperations(dir), result, nil)
+
+			if result.Success {
+				t.Fatalf("expected epic parent finalize to fail, got Success=true")
+			}
+			if !strings.Contains(result.Error, tt.wantErrSubstr) {
+				t.Fatalf("result.Error = %q, want substring %q", result.Error, tt.wantErrSubstr)
+			}
+
+			// (1) Child transitioned to "stalled" with the parent-failure text.
+			childExec, err := store.GetExecution(childExecID)
+			if err != nil {
+				t.Fatalf("GetExecution(child): %v", err)
+			}
+			if childExec.Status != string(ExecStatusStalled) {
+				t.Fatalf("child status = %q, want %q", childExec.Status, ExecStatusStalled)
+			}
+			wantPrefix := fmt.Sprintf("parent epic %s aborted:", task.ID)
+			if !strings.HasPrefix(childExec.Error, wantPrefix) {
+				t.Errorf("child error = %q, want prefix %q", childExec.Error, wantPrefix)
+			}
+			if !strings.Contains(childExec.Error, tt.wantErrSubstr) {
+				t.Errorf("child error = %q, want it to carry the parent's failure text %q", childExec.Error, tt.wantErrSubstr)
+			}
+
+			// (2) Ladder events preserved: the earlier queued/running events
+			// are still there, with a stalled event appended — not replaced.
+			events, err := store.ListExecutionEvents(childExecID)
+			if err != nil {
+				t.Fatalf("ListExecutionEvents: %v", err)
+			}
+			var stages []string
+			for _, e := range events {
+				stages = append(stages, string(e.Stage))
+			}
+			wantStages := []string{string(memory.StageQueued), string(memory.StageRunning), string(memory.StageStalled)}
+			if len(stages) != len(wantStages) {
+				t.Fatalf("child event ladder = %v, want %v", stages, wantStages)
+			}
+			for i, want := range wantStages {
+				if stages[i] != want {
+					t.Errorf("child event ladder[%d] = %q, want %q (full ladder: %v)", i, stages[i], want, stages)
+				}
+			}
+
+			// (3) Re-dispatch admitted: nextRetryGeneration must grant a fresh
+			// generation for the child now that its claimed execution is
+			// terminal (stalled) and the task was never marked done.
+			dispatcher := NewDispatcher(store, NewRunner(), nil)
+			gen, retry, err := dispatcher.nextRetryGeneration(childTask.ID, childTask.ProjectPath)
+			if err != nil {
+				t.Fatalf("nextRetryGeneration: %v", err)
+			}
+			if !retry {
+				t.Fatalf("expected retry=true (child re-dispatchable) after stalling, got retry=false")
+			}
+			if gen != 1 {
+				t.Errorf("expected next generation 1, got %d", gen)
+			}
+		})
+	}
+}
+
+// TestSweepStalledEpicChildren_SkipsAlreadyTerminalChildren verifies that a
+// child execution which already reached a terminal status (e.g. "completed")
+// before the parent's abort is left untouched — the sweep must not clobber a
+// child that already shipped its own outcome.
+func TestSweepStalledEpicChildren_SkipsAlreadyTerminalChildren(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const projectPath = "/proj"
+	lifecycle := NewExecutionLifecycle(store)
+
+	childTask := &Task{ID: "GH-102", ProjectPath: projectPath}
+	childExecID, err := lifecycle.Begin(childTask, ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("Begin(child): %v", err)
+	}
+	if err := store.MarkExecutionCompleted(childExecID, "https://github.com/o/r/pull/1", "sha123", 500); err != nil {
+		t.Fatalf("MarkExecutionCompleted: %v", err)
+	}
+
+	r := newSilentRunnerTask359()
+	r.logStore = store
+
+	r.sweepStalledEpicChildren("GH-431", projectPath, []string{childTask.ID}, "epic PR creation failed: boom")
+
+	childExec, err := store.GetExecution(childExecID)
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if childExec.Status != string(ExecStatusCompleted) {
+		t.Errorf("child status = %q, want unchanged %q", childExec.Status, ExecStatusCompleted)
+	}
+	if childExec.PRUrl != "https://github.com/o/r/pull/1" {
+		t.Errorf("child PRUrl clobbered: got %q", childExec.PRUrl)
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1750,6 +1750,11 @@ func (r *Runner) finalizeEpicBranchPR(ctx context.Context, task *Task, git *GitO
 				slog.Any("error", err),
 			)
 			r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+			// GH-4561: a child sub-issue may already be running/queued on
+			// another dispatch channel while this parent-terminal failure
+			// leaves it permanently unreconciled — sweep it stalled so it
+			// becomes re-dispatchable instead of stuck forever.
+			r.sweepEpicChildrenOnAbort(task, result.Error)
 			return
 		}
 	}
@@ -1798,6 +1803,8 @@ func (r *Runner) finalizeEpicBranchPR(ctx context.Context, task *Task, git *GitO
 		// forever instead of tripping the stop-retry guidance comment.
 		r.recordTitleRejection(ctx, task, result)
 		r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+		// GH-4561: see the push-failure sweep above — same abandoned-child risk.
+		r.sweepEpicChildrenOnAbort(task, result.Error)
 		return
 	}
 	r.clearTitleRejectionState(task)
@@ -1811,6 +1818,8 @@ func (r *Runner) finalizeEpicBranchPR(ctx context.Context, task *Task, git *GitO
 			slog.Any("error", prErr),
 		)
 		r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+		// GH-4561: see the push-failure sweep above — same abandoned-child risk.
+		r.sweepEpicChildrenOnAbort(task, result.Error)
 		return
 	}
 	result.PRUrl = prURL
@@ -1823,6 +1832,8 @@ func (r *Runner) finalizeEpicBranchPR(ctx context.Context, task *Task, git *GitO
 		result.Success = false
 		result.Error = "epic finalize produced no PR URL"
 		r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+		// GH-4561: see the push-failure sweep above — same abandoned-child risk.
+		r.sweepEpicChildrenOnAbort(task, result.Error)
 		return
 	}
 
@@ -2319,6 +2330,12 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 								gapPlan := &EpicPlan{ParentTask: plan.ParentTask, Subtasks: plannedNow, TotalEffort: plan.TotalEffort, PlanOutput: plan.PlanOutput}
 								gapErr := r.handleSubIssueCoverageGap(epicCtx, gapPlan, reconciled, executionPath, cause)
 								r.reportProgress(task.ID, "Needs Clarification", 100, gapErr.Error())
+								// GH-4561: decompose-abort sweep — reconciled already holds
+								// the partial batch of real sub-issues created before this
+								// coverage gap aborted the rest of decomposition; any of
+								// those already picked up and running elsewhere would
+								// otherwise be orphaned by this parent's terminal "declined".
+								r.sweepStalledEpicChildren(task.ID, task.ProjectPath, createdIssueTaskIDs(reconciled), gapErr.Error())
 								return &ExecutionResult{
 									TaskID:         task.ID,
 									Success:        false,
@@ -2375,6 +2392,10 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 						var gapErr *SubIssueCoverageGapError
 						if errors.As(err, &gapErr) {
 							r.reportProgress(task.ID, "Needs Clarification", 100, gapErr.Error())
+							// GH-4561: decompose-abort sweep — issues already holds the
+							// partial batch of real sub-issues CreateSubIssues created
+							// before this coverage gap aborted the rest of decomposition.
+							r.sweepStalledEpicChildren(task.ID, task.ProjectPath, createdIssueTaskIDs(issues), gapErr.Error())
 							return &ExecutionResult{
 								TaskID:         task.ID,
 								Success:        false,


### PR DESCRIPTION
## Summary

- Epic parent finalization can abort terminally in several ways: branch push failure, title-normalization rejection, PR-creation failure (`finalizeEpicBranchPR`, runner.go), or a decompose-time sub-issue coverage gap (`executeWithOptions`). Any child sub-issue execution still non-terminal at that moment (e.g. already picked up and running on another dispatch channel/poller) was left claimed forever, since the parent that would have reconciled or retried it is already done.
- Adds `sweepStalledEpicChildren`/`sweepEpicChildrenOnAbort` (internal/executor/epic.go) and wires them into every `finalizeEpicBranchPR` failure branch and both decompose-abort branches.
- Each orphaned child is transitioned to `stalled` via `ExecutionLifecycle.Classify`+`Persist` (TASK-404/FK-787: no raw status `UPDATE`s), carrying the parent's failure text as the child's error, with the `execution_events` row recorded between `Classify` and `Persist` per the GH-4259 ordering contract (event must exist before the terminal status becomes visible to a poller).
- `stalled` is itself a terminal status, so the transition doubles as the admission-claim release — `Dispatcher.nextRetryGeneration` grants a fresh generation on the next dispatch pass with no separate release call needed.

Closes #4561

## Test plan

- [x] New table-driven test `TestFinalizeEpicBranchPR_AbortSweepsRunningChildren` (internal/executor/epic_abort_sweep_test.go) covers push-failure, title-rejection, and PR-creation-failure abort paths, each verifying: child transitions to `stalled` with parent-failure text, the execution_events ladder is preserved (queued → running → stalled), and re-dispatch is admitted (`Dispatcher.nextRetryGeneration` returns `retry=true`).
- [x] New test `TestSweepStalledEpicChildren_SkipsAlreadyTerminalChildren` confirms an already-terminal child (e.g. `completed`) is left untouched.
- [x] `go build ./...`
- [x] `go test ./internal/executor/...` passes (including the full existing suite)
- [x] `gofmt -l` / `go vet ./internal/executor/...` clean