### PR TITLE
GH-4562: fix(alerts): orphan evictor heals ledger row via ExecutionLifecycle

### DIFF
--- a/.agent/knowledge/memories/pitfalls/top-level-autopilot-yaml-binds-to-nothing.md
+++ b/.agent/knowledge/memories/pitfalls/top-level-autopilot-yaml-binds-to-nothing.md
@@ -1,0 +1,62 @@
+---
+name: top-level-autopilot-yaml-binds-to-nothing
+description: A top-level `autopilot:` block in config.yaml decodes into nothing — the only binding is `orchestrator.autopilot` — and `Enabled` is otherwise set only by the `--env` flag, so a daemon can execute issues and open PRs while no CI monitor or merger exists at all
+type: pitfall
+---
+
+# Top-level `autopilot:` binds to nothing; without `--env` autopilot never starts
+
+**What happened (2026-07-24 → 07-26):** the hosted canary tenant
+(`i-0decbc0dcf225cf18`) executed issues with real tool-use and opened green PRs
+#103/#105 on `pilot-canary-sandbox` — which then sat OPEN and unmerged for two
+days. S2 exit evidence went unmet. The roadmap's leading hypothesis was
+`stage.require_approval: true` with no approval channel wired. Wrong: the
+instance config reads `require_approval: false`. **Autopilot was never running
+in the process at all.**
+
+## Mechanism (three layers, each sufficient on its own)
+
+1. **The YAML key binds to nothing.** `internal/config/config.go:41` `Config`
+   has no top-level `Autopilot` field. The only binding is
+   `OrchestratorConfig.Autopilot` (`config.go:153`, `yaml:"autopilot"`), i.e.
+   the block must be nested under `orchestrator:`. No normalization lifts a
+   top-level key. yaml decode is non-strict, so an entire misplaced
+   `autopilot:` block is discarded **silently** — no warning, no error.
+2. **`enabled` was never emitted.** `pilot-console/internal/fleet/configrender.go:109`
+   `writeAutopilotBlock` renders `default_environment` + `environments.hosted.*`
+   but no `enabled: true`.
+3. **No `--env` flag.** `cmd/pilot/main.go:422-426` is the *only* place that
+   forces `Autopilot.Enabled = true`, and it runs only when `envFlag != ""`.
+   The tenant systemd unit is
+   `ExecStart=/opt/pilot/bin/pilot start --config /var/lib/pilot/config.yaml`.
+
+Every controller construction site (`main.go:1687/1768/1828/2349`) is guarded by
+`cfg.Orchestrator.Autopilot != nil && …Enabled`. All four skip. The daemon runs
+happily: poller dispatches, executor works, PRs get opened — and nothing adopts them.
+
+## The tell
+
+**`autopilot_pr_state` table absent from the ledger** (only `autopilot_metrics`
+present). Diagnostics that query `select … from autopilot_pr_state` and reason
+about empty results miss this — the correct first probe is `.tables`. Table
+missing = subsystem never ran; table present but empty = never adopted.
+
+## How to avoid
+
+1. Debugging "PRs open but never merge": run `.tables` on the ledger BEFORE
+   theorizing about approvals, CI checks, or rate limits. Then check the
+   process's actual argv (`systemctl show pilot -p ExecStart`), not the config.
+2. Treat "config says X" as unverified until the decoded value is observed —
+   a silently-dropped block reads identically to a correct one in the file.
+3. `configs/pilot.example.yaml:553` documents the same dead top-level shape.
+   Copying the example gives an inert autopilot block. Strict decode
+   (`yaml.Decoder.KnownFields(true)`) would have turned all of this into a
+   startup error.
+4. Corollary for hosted tenants: rendered config correctness is not provable
+   from the renderer's tests — assert on the *running daemon's* behaviour
+   (does an `autopilot_pr_state` row appear for a fresh PR?).
+
+Related: [[required-checks-allowlist-makes-other-gates-decorative]] (same class:
+a config value quietly disabling a whole safety leg),
+[[board-sourced-repo-ignores-labeled-issues]] (config semantics invisible at
+runtime), [[require-approval-flip-doesnt-release-held-prs]].

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -796,7 +796,14 @@ Examples:
 					}
 
 					ctx := context.Background()
-					gwAlertsEngine = alerts.NewEngine(alertsCfg, alerts.WithDispatcher(alertsDispatcher), alerts.WithAlertMetrics(alertsMetrics))
+					gwEngineOpts := []alerts.EngineOption{alerts.WithDispatcher(alertsDispatcher), alerts.WithAlertMetrics(alertsMetrics)}
+					if gwStore != nil {
+						// GH-4562: lets the stuck-task evictor stall an orphan-evicted
+						// task's still-alive execution row instead of silently dropping
+						// the tracker entry and leaving a live-looking claim behind.
+						gwEngineOpts = append(gwEngineOpts, alerts.WithExecutionLifecycle(executor.NewExecutionLifecycle(gwStore)))
+					}
+					gwAlertsEngine = alerts.NewEngine(alertsCfg, gwEngineOpts...)
 					if alertErr := gwAlertsEngine.Start(ctx); alertErr != nil {
 						logging.WithComponent("start").Error("alert engine failed to start — downstream alerters will be silently disabled; check alerts config", slog.Any("error", alertErr))
 						gwAlertsEngine = nil
@@ -2417,7 +2424,14 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			}
 		}
 
-		alertsEngine = alerts.NewEngine(alertsCfg, alerts.WithDispatcher(alertsDispatcher), alerts.WithAlertMetrics(alertsMetrics))
+		engineOpts := []alerts.EngineOption{alerts.WithDispatcher(alertsDispatcher), alerts.WithAlertMetrics(alertsMetrics)}
+		if store != nil {
+			// GH-4562: lets the stuck-task evictor stall an orphan-evicted
+			// task's still-alive execution row instead of silently dropping
+			// the tracker entry and leaving a live-looking claim behind.
+			engineOpts = append(engineOpts, alerts.WithExecutionLifecycle(executor.NewExecutionLifecycle(store)))
+		}
+		alertsEngine = alerts.NewEngine(alertsCfg, engineOpts...)
 		if err := alertsEngine.Start(ctx); err != nil {
 			logging.WithComponent("start").Error("alert engine failed to start — downstream alerters will be silently disabled; check alerts config", slog.Any("error", err))
 			alertsEngine = nil

--- a/internal/alerts/engine.go
+++ b/internal/alerts/engine.go
@@ -2,6 +2,7 @@ package alerts
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -9,6 +10,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/qf-studio/pilot/internal/executor"
 )
 
 // Engine is the core alerting engine that processes events and triggers alerts
@@ -51,6 +54,16 @@ type Engine struct {
 	// Dispatcher via WithAlertMetrics+WithDispatcherMetrics so delivery counts appear
 	// in AlertSnapshot too.
 	metrics *AlertMetrics
+
+	// lifecycle transitions an orphan-evicted task's execution row to
+	// "stalled" via the ExecutionLifecycle chokepoint (GH-4562). nil (the
+	// zero value, and the default for every call site that doesn't pass
+	// WithExecutionLifecycle) makes evictStuckExecution a no-op — matching
+	// every other nil-store guard already established across
+	// executor.ExecutionLifecycle and epic.go's sweep helpers, and letting
+	// short-lived CLI callers (pilot alerts test, eval regression alerts)
+	// skip wiring a store for a code path they never meaningfully exercise.
+	lifecycle *executor.ExecutionLifecycle
 }
 
 // minOrphanEvictionThreshold floors evaluateStuckTasks' orphan-eviction window
@@ -184,6 +197,19 @@ func WithDispatcher(d *Dispatcher) EngineOption {
 func WithAlertMetrics(m *AlertMetrics) EngineOption {
 	return func(e *Engine) {
 		e.metrics = m
+	}
+}
+
+// WithExecutionLifecycle wires the ExecutionLifecycle chokepoint the
+// stuck-task evictor uses to transition an orphan-evicted task's still-alive
+// execution row to "stalled" (GH-4562), instead of dropping the in-memory
+// tracker entry and silently orphaning the row. Passing lifecycle through the
+// constructor — rather than the evictor reaching into internal/memory or
+// internal/executor ad hoc — keeps Engine's only executor-package dependency
+// at this one seam.
+func WithExecutionLifecycle(lifecycle *executor.ExecutionLifecycle) EngineOption {
+	return func(e *Engine) {
+		e.lifecycle = lifecycle
 	}
 }
 
@@ -701,6 +727,7 @@ func (e *Engine) evaluateStuckTasks(ctx context.Context) {
 					"stuck_for", stuckDuration.Round(time.Minute),
 					"orphan_threshold", orphanThreshold,
 				)
+				e.stallOrphanedExecution(taskID, stuckDuration)
 				continue
 			}
 
@@ -765,6 +792,57 @@ func (e *Engine) evaluateStuckTasks(ctx context.Context) {
 	// the delete in handleTaskCompleted, so without a TTL its counter leaks for the
 	// daemon lifetime. Mirror the GH-2204 orphan-eviction for taskLastProgress.
 	e.evictStaleRetryTrackers(now)
+}
+
+// stallOrphanedExecution transitions taskID's still-non-terminal execution
+// row to "stalled" via the ExecutionLifecycle chokepoint when the stuck-task
+// evictor drops its in-memory tracker entry (GH-4562). Without this, evicting
+// the tracker entry only removes the alerts engine's own bookkeeping — the
+// underlying execution row (and its claim on (task_id, project_path,
+// generation), per TASK-407) is left running/queued forever, since nothing
+// else observes the in-memory eviction. That mirrors the claim-release hazard
+// GH-4561/#4563 fixed for aborted epic parents' orphaned children: "stalled"
+// is itself a terminal status (dispatcher.go's terminalExecutionStatuses), so
+// this transition IS the claim release — the next dispatch pass grants a
+// fresh generation with no separate release call.
+//
+// e.lifecycle is nil for every call site that doesn't pass
+// WithExecutionLifecycle (short-lived CLI callers that never wire a store),
+// and LatestExecution returns (nil, nil) on a nil store or a lookup miss —
+// both cases are a silent no-op, matching epic.go's sweepStalledEpicChildren.
+//
+// Guarding on IsTerminalStatus before calling Finish makes a second eviction
+// sweep over an already-terminal row an explicit no-op rather than leaning
+// solely on Finish's CAS-guarded idempotency (GH-4423's
+// UpdateExecutionStatusIfNotTerminal) — belt-and-suspenders, since either one
+// alone is sufficient to prevent a double-Finish error.
+func (e *Engine) stallOrphanedExecution(taskID string, stuckFor time.Duration) {
+	if e.lifecycle == nil {
+		return
+	}
+	exec, err := e.lifecycle.LatestExecution(taskID, "")
+	if err != nil || exec == nil {
+		return
+	}
+	if executor.IsTerminalStatus(exec.Status) {
+		return
+	}
+
+	reason := fmt.Sprintf("orphan eviction after %s stuck", stuckFor.Round(time.Minute))
+	if _, finishErr := e.lifecycle.Finish(exec.ID, nil, errors.New(reason), 0, executor.ExecStatusStalled); finishErr != nil {
+		e.logger.Warn("stallOrphanedExecution: failed to stall orphaned execution",
+			"task_id", taskID,
+			"execution_id", exec.ID,
+			"error", finishErr,
+		)
+		return
+	}
+	e.logger.Warn("stallOrphanedExecution: stalled orphaned execution after stuck-task eviction",
+		"task_id", taskID,
+		"execution_id", exec.ID,
+		"prior_status", exec.Status,
+		"stuck_for", stuckFor.Round(time.Minute),
+	)
 }
 
 // retryTrackerTTL bounds how long an idle per-source retry counter is retained.

--- a/internal/alerts/engine_stuck_task_stall_test.go
+++ b/internal/alerts/engine_stuck_task_stall_test.go
@@ -1,0 +1,231 @@
+package alerts
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/executor"
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// stuckTaskStallTestConfig mirrors TestEngine_EvaluateStuckTasks_OrphanEviction's
+// config: a single enabled task_stuck rule is all evaluateStuckTasks needs to
+// enter its orphan-eviction branch.
+func stuckTaskStallTestConfig() *AlertConfig {
+	return &AlertConfig{
+		Enabled: true,
+		Channels: []ChannelConfig{
+			{Name: "test-channel", Type: "webhook", Enabled: true},
+		},
+		Rules: []AlertRule{
+			{
+				Name:    "task_stuck",
+				Type:    AlertTypeTaskStuck,
+				Enabled: true,
+				Condition: RuleCondition{
+					ProgressUnchangedFor: 10 * time.Minute,
+				},
+				Severity: SeverityWarning,
+				Channels: []string{"test-channel"},
+				Cooldown: 0,
+			},
+		},
+	}
+}
+
+// TestEngine_EvaluateStuckTasks_StallsOrphanedExecutionViaLifecycle is the
+// GH-4562 acceptance test (a): a task's execution row still sitting "running"
+// when the stuck-task evictor drops its in-memory taskLastProgress entry must
+// be transitioned to "stalled" through the ExecutionLifecycle chokepoint —
+// not just silently forgotten by the alerts engine's own bookkeeping, which
+// would leave the row (and its execution_claims generation, TASK-407) live
+// forever with no owner left to reconcile it.
+func TestEngine_EvaluateStuckTasks_StallsOrphanedExecutionViaLifecycle(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const projectPath = "/proj"
+	lifecycle := executor.NewExecutionLifecycle(store)
+
+	task := &executor.Task{ID: "GH-9001", ProjectPath: projectPath}
+	execID, err := lifecycle.Begin(task, executor.ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if err := lifecycle.Transition(execID, executor.ExecStatusRunning); err != nil {
+		t.Fatalf("Transition(running): %v", err)
+	}
+
+	config := stuckTaskStallTestConfig()
+	mockCh := newMockChannel("test-channel", "webhook")
+	dispatcher := NewDispatcher(config)
+	dispatcher.RegisterChannel(mockCh)
+
+	engine := NewEngine(config, WithDispatcher(dispatcher), WithExecutionLifecycle(lifecycle))
+
+	// Seed an orphaned taskLastProgress entry: stuck for 130 min >
+	// minOrphanEvictionThreshold (120m).
+	engine.mu.Lock()
+	engine.taskLastProgress[task.ID] = progressState{
+		Progress:  10,
+		UpdatedAt: time.Now().Add(-130 * time.Minute),
+	}
+	engine.mu.Unlock()
+
+	engine.evaluateStuckTasks(context.Background())
+
+	// The in-memory tracker entry is evicted, as before this change.
+	engine.mu.RLock()
+	_, stillTracked := engine.taskLastProgress[task.ID]
+	engine.mu.RUnlock()
+	if stillTracked {
+		t.Error("expected orphaned taskLastProgress entry to be evicted")
+	}
+
+	// The execution row is now "stalled" with an error naming the eviction
+	// and how long the task was stuck.
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != string(executor.ExecStatusStalled) {
+		t.Fatalf("execution status = %q, want %q", exec.Status, executor.ExecStatusStalled)
+	}
+	if !strings.Contains(exec.Error, "orphan eviction after") {
+		t.Errorf("execution error = %q, want it to mention orphan eviction", exec.Error)
+	}
+	if !strings.Contains(exec.Error, "h") && !strings.Contains(exec.Error, "m") {
+		t.Errorf("execution error = %q, want it to carry the stuck duration", exec.Error)
+	}
+
+	// Claim release, verified the same way as GH-4561/#4563 (subtask 1):
+	// nextRetryGeneration (internal/executor/dispatcher.go, unexported) grants
+	// a fresh generation once (1) the claimed generation's execution is
+	// terminal and (2) the task is not yet "done" per HasTerminalCompletion.
+	// That method isn't reachable from this package, so its two preconditions
+	// are asserted directly here via the exported surface it's built from —
+	// together they guarantee nextRetryGeneration would return (gen=1,
+	// retry=true), i.e. the stall IS the claim release, no separate release
+	// call needed.
+	gen, claimExecID, found, err := store.LatestClaimGeneration(task.ID, projectPath)
+	if err != nil {
+		t.Fatalf("LatestClaimGeneration: %v", err)
+	}
+	if !found || gen != 0 || claimExecID != execID {
+		t.Fatalf("LatestClaimGeneration = (gen=%d, execID=%q, found=%v), want (0, %q, true)", gen, claimExecID, found, execID)
+	}
+	if !executor.IsTerminalStatus(exec.Status) {
+		t.Errorf("expected stalled status %q to be terminal (precondition for nextRetryGeneration's retry grant)", exec.Status)
+	}
+	done, err := executor.HasTerminalCompletion(store, task.ID, projectPath)
+	if err != nil {
+		t.Fatalf("HasTerminalCompletion: %v", err)
+	}
+	if done {
+		t.Error("expected HasTerminalCompletion=false for a stalled task with no PR/commit — a stalled task must remain re-dispatchable")
+	}
+}
+
+// TestEngine_EvaluateStuckTasks_OrphanEvictionOnTerminalRowIsNoOp is the
+// GH-4562 acceptance test (b): evicting a taskLastProgress entry whose
+// execution row already reached a terminal status — either because the task
+// genuinely finished around the same time the tracker went stale, or because
+// a second eviction sweep re-examines a row this same mechanism already
+// stalled — must be a no-op. It must not error, and it must not overwrite the
+// row's already-terminal status/error with a fresh orphan-eviction reason.
+func TestEngine_EvaluateStuckTasks_OrphanEvictionOnTerminalRowIsNoOp(t *testing.T) {
+	tests := []struct {
+		name          string
+		terminalizeFn func(t *testing.T, lifecycle *executor.ExecutionLifecycle, execID string)
+	}{
+		{
+			name: "already completed",
+			terminalizeFn: func(t *testing.T, lifecycle *executor.ExecutionLifecycle, execID string) {
+				t.Helper()
+				if _, err := lifecycle.Finish(execID, &executor.ExecutionResult{Success: true}, nil, 0, executor.ExecStatusCompleted); err != nil {
+					t.Fatalf("Finish(completed): %v", err)
+				}
+			},
+		},
+		{
+			name: "already stalled by a prior eviction sweep",
+			terminalizeFn: func(t *testing.T, lifecycle *executor.ExecutionLifecycle, execID string) {
+				t.Helper()
+				if _, err := lifecycle.Finish(execID, nil, errors.New("orphan eviction after 2h10m0s stuck"), 0, executor.ExecStatusStalled); err != nil {
+					t.Fatalf("Finish(stalled): %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, err := memory.NewStore(t.TempDir())
+			if err != nil {
+				t.Fatalf("memory.NewStore: %v", err)
+			}
+			defer func() { _ = store.Close() }()
+
+			const projectPath = "/proj"
+			lifecycle := executor.NewExecutionLifecycle(store)
+
+			task := &executor.Task{ID: "GH-9002", ProjectPath: projectPath}
+			execID, err := lifecycle.Begin(task, executor.ExecStatusQueued)
+			if err != nil {
+				t.Fatalf("Begin: %v", err)
+			}
+			if err := lifecycle.Transition(execID, executor.ExecStatusRunning); err != nil {
+				t.Fatalf("Transition(running): %v", err)
+			}
+			tt.terminalizeFn(t, lifecycle, execID)
+
+			before, err := store.GetExecution(execID)
+			if err != nil {
+				t.Fatalf("GetExecution (before): %v", err)
+			}
+
+			config := stuckTaskStallTestConfig()
+			mockCh := newMockChannel("test-channel", "webhook")
+			dispatcher := NewDispatcher(config)
+			dispatcher.RegisterChannel(mockCh)
+			engine := NewEngine(config, WithDispatcher(dispatcher), WithExecutionLifecycle(lifecycle))
+
+			engine.mu.Lock()
+			engine.taskLastProgress[task.ID] = progressState{
+				Progress:  10,
+				UpdatedAt: time.Now().Add(-130 * time.Minute),
+			}
+			engine.mu.Unlock()
+
+			// Fire the evictor twice — once via evaluateStuckTasks (the real
+			// call path) and once more directly, to explicitly exercise "a
+			// second eviction of an already-terminal row" per the task spec.
+			engine.evaluateStuckTasks(context.Background())
+			engine.stallOrphanedExecution(task.ID, 130*time.Minute)
+
+			after, err := store.GetExecution(execID)
+			if err != nil {
+				t.Fatalf("GetExecution (after): %v", err)
+			}
+			if after.Status != before.Status {
+				t.Errorf("status changed on terminal-row eviction: before=%q after=%q", before.Status, after.Status)
+			}
+			if after.Error != before.Error {
+				t.Errorf("error text changed on terminal-row eviction: before=%q after=%q", before.Error, after.Error)
+			}
+
+			engine.mu.RLock()
+			_, stillTracked := engine.taskLastProgress[task.ID]
+			engine.mu.RUnlock()
+			if stillTracked {
+				t.Error("expected taskLastProgress entry to still be evicted regardless of execution row terminality")
+			}
+		})
+	}
+}

--- a/internal/executor/lifecycle.go
+++ b/internal/executor/lifecycle.go
@@ -287,3 +287,33 @@ func (l *ExecutionLifecycle) Finish(execID string, result *ExecutionResult, exec
 	err := l.Persist(execID, outcome, result, duration)
 	return outcome, err
 }
+
+// LatestExecution returns the most recent execution row for taskID, scoped to
+// projectPath the same way memory.Store.GetLatestExecutionByTaskID is (empty
+// projectPath skips the filter). It exists so callers outside the executor
+// package (GH-4562: alerts.Engine's stuck-task evictor) can resolve a taskID
+// to the execID Finish needs without importing internal/memory and reaching
+// past this chokepoint to call Store methods directly. A nil store or a
+// lookup miss (including sql.ErrNoRows) both return (nil, nil) — "nothing
+// found to transition" — mirroring epic.go's sweepStalledEpicChildren, which
+// treats any GetLatestExecutionByTaskID error the same way.
+func (l *ExecutionLifecycle) LatestExecution(taskID, projectPath string) (*memory.Execution, error) {
+	if l.store == nil {
+		return nil, nil
+	}
+	exec, err := l.store.GetLatestExecutionByTaskID(taskID, projectPath)
+	if err != nil {
+		return nil, nil
+	}
+	return exec, nil
+}
+
+// IsTerminalStatus reports whether status is one of the executions-table
+// terminal statuses (dispatcher.go's terminalExecutionStatuses). Exposed
+// alongside LatestExecution so a caller outside the executor package can
+// guard a Finish call on current status without duplicating the terminal
+// vocabulary (GH-4562) — see terminal_status_inventory_test.go's guard
+// against a second copy of this classification.
+func IsTerminalStatus(status string) bool {
+	return isTerminalExecutionStatus(status)
+}

--- a/internal/pilot/pilot.go
+++ b/internal/pilot/pilot.go
@@ -1562,6 +1562,10 @@ func (p *Pilot) initAlerts(cfg *config.Config) {
 	p.alertEngine = alerts.NewEngine(alertCfg,
 		alerts.WithLogger(log),
 		alerts.WithDispatcher(dispatcher),
+		// GH-4562: lets the stuck-task evictor stall an orphan-evicted
+		// task's still-alive execution row instead of silently dropping the
+		// tracker entry and leaving a live-looking claim behind.
+		alerts.WithExecutionLifecycle(executor.NewExecutionLifecycle(p.store)),
 	)
 
 	// Wire alerts engine to executor via adapter


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4562.

Closes #4562

## Changes

In internal/alerts/engine.go:699, extend the stuck-task eviction path so that when an evicted entry's execution row is still non-terminal, the evictor transitions that row through the ExecutionLifecycle.Finish API (status 'stalled', error noting 'orphan eviction after Xh stuck') before dropping the in-memory tracker entry. Wire the lifecycle dependency into the alerts engine via the existing engine constructor rather than reaching across packages ad-hoc. Ensure a second eviction of an already-terminal row is a no-op (no double-Finish error) — either guard on current status before calling, or rely on lifecycle idempotency and assert it. Verify claim release the same way as subtask 1. Add table-driven tests in internal/alerts/: (a) evictor fires on a row in 'running' → row becomes 'stalled' via lifecycle; (b) evictor fires on already-terminal row → no-op, no error. Ensure `go test ./internal/alerts/` passes.