### PR TITLE
GH-4564: fix(executor): sweepStalledEpicChildren marks shipped children stalled — finalize by actual outcome (pr_created → completed)

### DIFF
--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -2513,15 +2513,15 @@ func createdIssueTaskIDs(issues []CreatedIssue) []string {
 	return ids
 }
 
-// sweepStalledEpicChildren marks every non-terminal execution among
-// childTaskIDs "stalled" via the ExecutionLifecycle chokepoint, carrying the
-// parent epic's failure text as the child's error (GH-4561). Each child
-// sub-issue is dispatched as its own independently-claimed GitHub issue
-// (GH-1471) and may already be running/queued on another dispatch channel —
-// the poller, a different ProjectWorker — at the moment the parent epic
-// aborts terminally: epic PR creation failing, the epic's title being
-// rejected, or CreateSubIssues itself aborting mid-decomposition with a
-// partial batch already created (see createdIssueTaskID's doc comment).
+// sweepStalledEpicChildren finalizes every non-terminal execution among
+// childTaskIDs on parent epic abort, via the ExecutionLifecycle chokepoint
+// (GH-4561, refined by GH-4564). Each child sub-issue is dispatched as its
+// own independently-claimed GitHub issue (GH-1471) and may already be
+// running/queued on another dispatch channel — the poller, a different
+// ProjectWorker — at the moment the parent epic aborts terminally: epic PR
+// creation failing, the epic's title being rejected, or CreateSubIssues
+// itself aborting mid-decomposition with a partial batch already created
+// (see createdIssueTaskID's doc comment).
 //
 // Left unswept, that child's execution row sits "running"/"queued" forever —
 // the parent that would have reconciled or retried it is already done, so
@@ -2529,21 +2529,38 @@ func createdIssueTaskIDs(issues []CreatedIssue) []string {
 // Dispatcher.nextRetryGeneration) a live-looking claim blocks any fresh
 // re-pick of the child task indefinitely.
 //
+// GH-4564: a blanket "stalled" is wrong for a child that already shipped —
+// the reproducing incident (epic GH-431, 2026-07-26) had all three orphaned
+// children reach pr_created and merge to main; only their own Finish was
+// skipped because it was coupled to the parent's finalize. Stamping those as
+// stalled would mislabel merged work as failed on the dashboard/history and
+// pollute outcome metrics — the exact mislabel class this sweep exists to
+// fix. So before classifying a child as ExecStatusStalled, this checks
+// whether the child's execution_events ladder already reached StagePRCreated
+// (the poller/other dispatch channel records that event on the same
+// execution row as it drives the child to its own PR). If so, the child is
+// finished as ExecStatusCompleted instead, carrying a note that
+// finalization came from this parent-abort sweep rather than the child's own
+// terminal path. A child that never reached pr_created keeps the original
+// stall behavior, carrying the parent's failure text.
+//
 // Reuses ExecutionLifecycle.Classify/Persist (TASK-404/FK-787: no raw status
 // UPDATEs) with result=nil so Persist's metrics write is skipped entirely — a
 // child that already burned real tokens/cost before going silent must keep
 // that data, not have it zeroed by a synthetic all-empty ExecutionResult. The
-// reason is threaded through as execErr (rather than result.Error) so
+// stall reason is threaded through as execErr (rather than result.Error) so
 // Classify's nil-result path still lands override=ExecStatusStalled with
-// outcome.Error set to the parent-failure text. Classify/Persist are called
+// outcome.Error set to the parent-failure text; the completed path passes a
+// nil execErr with override=ExecStatusCompleted so Classify's error branch is
+// skipped and outcome.Error stays empty. Classify/Persist are called
 // directly instead of the Finish shortcut so the execution_events row can be
 // recorded between them, per Persist's own doc comment (GH-4259): recording
 // the event AFTER Persist would let a poller observe the terminal status via
 // GetExecution and read the (still-missing) event ledger before this write
 // lands.
 //
-// "stalled" is itself a terminal status (dispatcher.go's
-// terminalExecutionStatuses), so this transition IS the claim release: the
+// Both "stalled" and "completed" are terminal statuses (dispatcher.go's
+// terminalExecutionStatuses), so either transition IS the claim release: the
 // next scheduling pass sees a terminal-but-not-done claimed execution and
 // (per nextRetryGeneration) grants a fresh generation — no separate
 // claim-release call is needed.
@@ -2564,6 +2581,39 @@ func (r *Runner) sweepStalledEpicChildren(parentID, projectPath string, childTas
 		if isTerminalExecutionStatus(exec.Status) {
 			continue
 		}
+
+		shippedPR, prCheckErr := r.logStore.HasExecutionEventStage(exec.ID, memory.StagePRCreated)
+		if prCheckErr != nil {
+			r.log.Warn("sweepStalledEpicChildren: failed to check child pr_created ladder, defaulting to stall",
+				slog.String("parent_id", parentID),
+				slog.String("child_id", childID),
+				slog.String("execution_id", exec.ID),
+				slog.Any("error", prCheckErr),
+			)
+		}
+
+		if shippedPR {
+			note := fmt.Sprintf("child reached pr_created before parent epic %s aborted (%s) — finalized as completed via parent-abort sweep", parentID, parentFailureReason)
+			outcome := lifecycle.Classify(nil, nil, ExecStatusCompleted)
+			r.recordExecutionEvent(exec.ID, memory.StageCompleted, note)
+			if persistErr := lifecycle.Persist(exec.ID, outcome, nil, 0); persistErr != nil {
+				r.log.Warn("sweepStalledEpicChildren: failed to complete shipped child execution",
+					slog.String("parent_id", parentID),
+					slog.String("child_id", childID),
+					slog.String("execution_id", exec.ID),
+					slog.Any("error", persistErr),
+				)
+				continue
+			}
+			r.log.Info("sweepStalledEpicChildren: finalized shipped child execution as completed after parent epic abort",
+				slog.String("parent_id", parentID),
+				slog.String("child_id", childID),
+				slog.String("execution_id", exec.ID),
+				slog.String("prior_status", exec.Status),
+			)
+			continue
+		}
+
 		outcome := lifecycle.Classify(nil, errors.New(reason), ExecStatusStalled)
 		r.recordExecutionEvent(exec.ID, memory.StageStalled, reason)
 		if persistErr := lifecycle.Persist(exec.ID, outcome, nil, 0); persistErr != nil {

--- a/internal/executor/epic_abort_sweep_test.go
+++ b/internal/executor/epic_abort_sweep_test.go
@@ -250,3 +250,82 @@ func TestSweepStalledEpicChildren_SkipsAlreadyTerminalChildren(t *testing.T) {
 		t.Errorf("child PRUrl clobbered: got %q", childExec.PRUrl)
 	}
 }
+
+// TestSweepStalledEpicChildren_FinalizesByActualOutcome is the GH-4564
+// acceptance test: a single parent-abort sweep over two non-terminal
+// children must finalize each by its own actual outcome, not blanket-stall
+// both. The reproducing incident (epic GH-431, 2026-07-26) had orphaned
+// children that had already reached pr_created and merged to main — only
+// their Finish was skipped because it was coupled to the parent's finalize.
+// A child whose ladder shows StagePRCreated must be finalized "completed"
+// (shipped work, not a failure); a child whose ladder never reached
+// pr_created keeps the pre-GH-4564 "stalled" behavior, carrying the parent's
+// failure text.
+func TestSweepStalledEpicChildren_FinalizesByActualOutcome(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const projectPath = "/proj"
+	lifecycle := NewExecutionLifecycle(store)
+
+	// Child A: reached pr_created before the parent aborted — simulates
+	// auth-service#472/#474/#475 merging to main while the epic parent's own
+	// umbrella-PR finalize step failed independently.
+	shippedTask := &Task{ID: "GH-472", ProjectPath: projectPath}
+	shippedExecID, err := lifecycle.Begin(shippedTask, ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("Begin(shipped child): %v", err)
+	}
+	if err := store.RecordExecutionEvent(shippedExecID, memory.StageQueued, "queued"); err != nil {
+		t.Fatalf("RecordExecutionEvent(StageQueued): %v", err)
+	}
+	if err := store.RecordExecutionEvent(shippedExecID, memory.StagePRCreated, "opened PR auth-service#472"); err != nil {
+		t.Fatalf("RecordExecutionEvent(StagePRCreated): %v", err)
+	}
+
+	// Child B: never reached pr_created — genuinely orphaned, still running
+	// with no delivered work when the parent aborted.
+	orphanTask := &Task{ID: "GH-473", ProjectPath: projectPath}
+	orphanExecID, err := lifecycle.Begin(orphanTask, ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("Begin(orphan child): %v", err)
+	}
+	if err := store.RecordExecutionEvent(orphanExecID, memory.StageQueued, "queued"); err != nil {
+		t.Fatalf("RecordExecutionEvent(StageQueued): %v", err)
+	}
+
+	r := newSilentRunnerTask359()
+	r.logStore = store
+
+	const parentFailureReason = "epic PR creation failed: No commits between main and pilot/GH-431"
+	r.sweepStalledEpicChildren("GH-431", projectPath, []string{shippedTask.ID, orphanTask.ID}, parentFailureReason)
+
+	shippedExec, err := store.GetExecution(shippedExecID)
+	if err != nil {
+		t.Fatalf("GetExecution(shipped): %v", err)
+	}
+	if shippedExec.Status != string(ExecStatusCompleted) {
+		t.Errorf("shipped child status = %q, want %q", shippedExec.Status, ExecStatusCompleted)
+	}
+	if shippedExec.Error != "" {
+		t.Errorf("shipped child error = %q, want empty (not stamped as a failure)", shippedExec.Error)
+	}
+
+	orphanExec, err := store.GetExecution(orphanExecID)
+	if err != nil {
+		t.Fatalf("GetExecution(orphan): %v", err)
+	}
+	if orphanExec.Status != string(ExecStatusStalled) {
+		t.Errorf("orphan child status = %q, want %q", orphanExec.Status, ExecStatusStalled)
+	}
+	wantPrefix := "parent epic GH-431 aborted:"
+	if !strings.HasPrefix(orphanExec.Error, wantPrefix) {
+		t.Errorf("orphan child error = %q, want prefix %q", orphanExec.Error, wantPrefix)
+	}
+	if !strings.Contains(orphanExec.Error, parentFailureReason) {
+		t.Errorf("orphan child error = %q, want it to carry the parent's failure text %q", orphanExec.Error, parentFailureReason)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4564.

Closes #4564

## Changes

GitHub Issue GH-4564: fix(executor): sweepStalledEpicChildren marks shipped children stalled — finalize by actual outcome (pr_created → completed)

Follow-up to GH-4560 / PR #4563 (refinement comment https://github.com/qf-studio/pilot/issues/4560#issuecomment-5090160342 landed after the execution started and is not in the merged sweep).

## Problem

`sweepStalledEpicChildren` (added in #4563) marks EVERY non-terminal child execution `stalled` on parent epic abort. In the reproducing incident (auth-service epic GH-431, 2026-07-26) all three orphaned children had SUCCEEDED — PRs auth-service#472/#474/#475 merged to main; only their `Finish` was skipped because it was coupled to the parent's finalize. Blanket-stall would record shipped work as failed: false ✗ rows on the dashboard/history and polluted outcome metrics — the exact mislabel class the sweep exists to fix.

Note the parent's own failure in this flow — `epic PR creation failed: No commits between main and pilot/GH-NNN` — is EXPECTED when children merge directly to main (umbrella branch is empty by design). A benign parent outcome must not stamp failure onto successful children.

## Fix (one file: the sweep + its test)

In `sweepStalledEpicChildren`, before classifying a child as `ExecStatusStalled`, check the child's actual outcome:
- child reached `pr_created` (execution_events ladder, or an autopilot-registered PR for its branch) → `Finish` with `completed`; keep a note that finalization came from the parent-abort sweep.
- child never reached `pr_created` → `stalled` with the parent-failure reason (current behavior).

Keep everything routed through the `ExecutionLifecycle` chokepoint (TASK-404) — no second write path.

## Acceptance

- Table test: one epic abort with two non-terminal children — one with a `pr_created` event, one without → `completed` and `stalled` respectively.
- Existing #4563 tests stay green (no-PR children still stall).
- `go test ./internal/executor/` green.

## Scope fence

ONLY the sweep function and its tests. Do not touch the umbrella-PR creation flow (whether an epic should attempt an umbrella PR after children merged to main is a separate defect). Do not decompose — one-file fix.