### PR TITLE
GH-4566: fix(executor): no-commits guards diff against stale local base ref — decomposed epics die 'No commits between main and pilot/GH-N' at umbrella-PR creation

### DIFF
--- a/internal/executor/git.go
+++ b/internal/executor/git.go
@@ -882,6 +882,35 @@ func (g *GitOperations) CountNewCommits(ctx context.Context, baseBranch string) 
 	return count, nil
 }
 
+// CountNewCommitsAgainstOrigin is CountNewCommits compared against the
+// origin-tracked base branch instead of the local base branch ref. GH-4566:
+// every worktree (parent epic's and children's alike) is cut from a freshly
+// fetched origin/<base> (worktree.go), but nothing fast-forwards the shared
+// clone's local <base> ref during a sequential epic run — so on a stale local
+// <base>, CountNewCommits(ctx, "main") counts commits that landed on origin
+// via other sessions, not commits this branch actually added, and the
+// no-commits guard fires open on an empty umbrella branch.
+//
+// Fetches origin/<baseBranch> first so the comparison reflects the ref the
+// branch was actually cut from. The fetch is best-effort: on failure this
+// still compares against whatever origin/<baseBranch> already resolves to
+// locally, which is strictly fresher than the local <baseBranch> branch in
+// this codepath (worktree creation already fetched it before cutting the
+// branch). If origin/<baseBranch> doesn't resolve at all (no "origin" remote
+// configured — bare local repos, some unit tests), falls back to comparing
+// against the local <baseBranch> ref, preserving CountNewCommits' original
+// behavior in that environment.
+func (g *GitOperations) CountNewCommitsAgainstOrigin(ctx context.Context, baseBranch string) (int, error) {
+	fetchCmd := exec.CommandContext(ctx, "git", "fetch", "origin", baseBranch)
+	fetchCmd.Dir = g.projectPath
+	_ = fetchCmd.Run() // best-effort; fall back to the existing tracking ref on failure
+
+	if count, err := g.CountNewCommits(ctx, "origin/"+baseBranch); err == nil {
+		return count, nil
+	}
+	return g.CountNewCommits(ctx, baseBranch)
+}
+
 // GetCurrentCommitSHA returns the SHA of the current HEAD commit
 func (g *GitOperations) GetCurrentCommitSHA(ctx context.Context) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", "rev-parse", "HEAD")

--- a/internal/executor/git_gh4566_test.go
+++ b/internal/executor/git_gh4566_test.go
@@ -1,0 +1,145 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCountNewCommitsAgainstOrigin_StaleLocalBaseFalsePositive reproduces the
+// GH-4566 false positive: the local `main` ref is behind `origin/main` (e.g.
+// other children's PRs merged after this clone last fetched), and the branch
+// under test was cut straight from origin/main (worktree.go semantics) with
+// zero commits of its own. The old CountNewCommits(ctx, "main") — comparing
+// against the stale local ref — counts the commits that landed on origin as
+// if they belonged to this branch. CountNewCommitsAgainstOrigin must not.
+func TestCountNewCommitsAgainstOrigin_StaleLocalBaseFalsePositive(t *testing.T) {
+	local, origin := setupSyncTestRepos(t, "main")
+
+	// Simulate other work (e.g. a sibling epic child's merged PR) landing on
+	// origin/main via a second clone. This clone's local `main` never learns
+	// about it — nothing fast-forwards it (TASK-402: independent-sibling
+	// dispatch never runs syncMainBranch mid-epic).
+	pushExtraCommitFromSecondClone(t, origin, "main", "sibling child PR merged")
+	pushExtraCommitFromSecondClone(t, origin, "main", "second sibling child PR merged")
+
+	// Cut the epic's umbrella branch straight from origin/main, exactly as
+	// worktree.go does (git fetch origin main; git worktree add -B <branch>
+	// <path> origin/main) — local `main` is deliberately left behind.
+	runGit(t, local, "fetch", "origin", "main")
+	runGit(t, local, "checkout", "-B", "pilot/GH-4566-epic", "origin/main")
+
+	git := NewGitOperations(local)
+	ctx := context.Background()
+
+	// Old behavior: comparing against the stale local `main` ref counts the
+	// two commits that landed on origin as if this branch produced them.
+	staleCount, err := git.CountNewCommits(ctx, "main")
+	if err != nil {
+		t.Fatalf("CountNewCommits: %v", err)
+	}
+	if staleCount == 0 {
+		t.Fatalf("test setup invalid: expected stale local `main` comparison to be nonzero (repro precondition), got 0")
+	}
+
+	// Fixed behavior: comparing against origin/main (freshly fetched) sees
+	// the branch carries zero commits of its own.
+	freshCount, err := git.CountNewCommitsAgainstOrigin(ctx, "main")
+	if err != nil {
+		t.Fatalf("CountNewCommitsAgainstOrigin: %v", err)
+	}
+	if freshCount != 0 {
+		t.Errorf("CountNewCommitsAgainstOrigin = %d, want 0 (branch has no commits vs the ref it was cut from)", freshCount)
+	}
+}
+
+// TestCountNewCommitsAgainstOrigin_RealCommitsSurviveStaleLocalMain is the
+// mirror-image check: a branch that DOES carry its own real commit must still
+// report a nonzero count via the origin-relative comparison, even while local
+// `main` is stale — the fix must not accidentally zero out legitimate content.
+func TestCountNewCommitsAgainstOrigin_RealCommitsSurviveStaleLocalMain(t *testing.T) {
+	local, origin := setupSyncTestRepos(t, "main")
+	pushExtraCommitFromSecondClone(t, origin, "main", "sibling child PR merged")
+
+	runGit(t, local, "fetch", "origin", "main")
+	runGit(t, local, "checkout", "-B", "pilot/GH-4566-work", "origin/main")
+
+	if err := os.WriteFile(filepath.Join(local, "feature.txt"), []byte("feature"), 0644); err != nil {
+		t.Fatalf("write feature.txt: %v", err)
+	}
+	runGit(t, local, "add", "feature.txt")
+	runGit(t, local, "commit", "-m", "feat: real work")
+
+	git := NewGitOperations(local)
+	count, err := git.CountNewCommitsAgainstOrigin(context.Background(), "main")
+	if err != nil {
+		t.Fatalf("CountNewCommitsAgainstOrigin: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("count = %d, want 1 (the branch's own real commit, not the sibling's)", count)
+	}
+}
+
+// TestCountNewCommitsAgainstOrigin_FetchFailureFallsBackToTrackingRef covers
+// the offline case: `git fetch origin <base>` fails (network down / origin
+// unreachable), but a previous fetch already populated the local
+// refs/remotes/origin/<base> tracking ref. CountNewCommitsAgainstOrigin must
+// fall back to that existing tracking ref instead of erroring out.
+func TestCountNewCommitsAgainstOrigin_FetchFailureFallsBackToTrackingRef(t *testing.T) {
+	local, origin := setupSyncTestRepos(t, "main")
+
+	// Cut the branch from origin/main with zero new commits, then make sure
+	// origin/main is resolvable locally (setupSyncTestRepos already fetched
+	// implicitly via clone, but fetch explicitly to be sure).
+	runGit(t, local, "fetch", "origin", "main")
+	runGit(t, local, "checkout", "-B", "pilot/GH-4566-offline", "origin/main")
+
+	// Go offline: the remote is gone, so `git fetch origin main` will fail,
+	// but origin/main is still resolvable from the last fetch.
+	if err := os.RemoveAll(origin); err != nil {
+		t.Fatalf("remove origin: %v", err)
+	}
+
+	git := NewGitOperations(local)
+	count, err := git.CountNewCommitsAgainstOrigin(context.Background(), "main")
+	if err != nil {
+		t.Fatalf("CountNewCommitsAgainstOrigin should fall back to the existing tracking ref, got error: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("count = %d, want 0 (no new commits vs the last-known origin/main)", count)
+	}
+}
+
+// TestCountNewCommitsAgainstOrigin_NoOriginRemoteFallsBackToLocalBranch
+// covers repos with no "origin" remote configured at all (bare local repos —
+// several existing unit tests, and conceivably some non-worktree deployments)
+// so CountNewCommitsAgainstOrigin doesn't regress CountNewCommits' original
+// behavior in that environment.
+func TestCountNewCommitsAgainstOrigin_NoOriginRemoteFallsBackToLocalBranch(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	runGit(t, dir, "config", "user.email", "test@test.com")
+	runGit(t, dir, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("init\n"), 0644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "-m", "initial")
+	runGit(t, dir, "checkout", "-b", "pilot/GH-4566-local")
+
+	if err := os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0644); err != nil {
+		t.Fatalf("write feature.txt: %v", err)
+	}
+	runGit(t, dir, "add", "feature.txt")
+	runGit(t, dir, "commit", "-m", "feat: local-only work")
+
+	git := NewGitOperations(dir)
+	count, err := git.CountNewCommitsAgainstOrigin(context.Background(), "main")
+	if err != nil {
+		t.Fatalf("CountNewCommitsAgainstOrigin: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("count = %d, want 1 (fallback to local `main` ref when no origin remote exists)", count)
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1663,7 +1663,10 @@ func (r *Runner) finalizeEpicBranchPR(ctx context.Context, task *Task, git *GitO
 	// GH-3779: classify the parent from its children's terminal states instead of
 	// always leaving Success untouched — a decomposed parent whose children ALL
 	// no-op'd shipped nothing anywhere and must record as no_op, not completed.
-	if guardCount, _ := git.CountNewCommits(ctx, baseBranch); guardCount == 0 {
+	//
+	// GH-4566: compares against origin/<base>, not the (possibly stale) local
+	// <base> ref — see CountNewCommitsAgainstOrigin's doc comment.
+	if guardCount, _ := git.CountNewCommitsAgainstOrigin(ctx, baseBranch); guardCount == 0 {
 		evaluateEmptyBranchPRGuard(true, childTerminalStates, result)
 		if result.Outcome == "no_op" {
 			r.log.Warn("Epic branch has no commits vs base and all children no-op'd, recording epic as no_op",
@@ -1811,6 +1814,37 @@ func (r *Runner) finalizeEpicBranchPR(ctx context.Context, task *Task, git *GitO
 	epicPRTitle := fmt.Sprintf("%s: %s", task.ID, normalizedEpicTitle)
 	prURL, prErr := git.CreatePR(ctx, epicPRTitle, prBody, baseBranch)
 	if prErr != nil {
+		// GH-4566 backstop: the origin-relative guard above (line ~1666) should
+		// already have caught an empty umbrella branch before we ever pushed.
+		// If GitHub itself still reports "No commits between" here — some
+		// stale-ref edge case the guard fix doesn't cover, or a push that
+		// landed nothing new — classify it the same way that guard would
+		// (evaluateEmptyBranchPRGuard/GH-3779, off the children's terminal
+		// states) instead of recording a false "infra" failure + alert on an
+		// epic whose work already shipped via child PRs. Defense in depth:
+		// this is a backstop for the guard, not a replacement for it.
+		if containsAny(prErr.Error(), []string{"no commits between"}) {
+			evaluateEmptyBranchPRGuard(true, childTerminalStates, result)
+			if result.Outcome == "no_op" {
+				r.log.Warn("Epic PR creation reported no commits and all children no-op'd, recording epic as no_op",
+					slog.String("task_id", task.ID),
+					slog.Any("error", prErr),
+					slog.String("summary", result.Error),
+				)
+				r.reportProgress(task.ID, "No-Op", 100, result.Error)
+			} else {
+				r.log.Warn("Epic PR creation reported no commits but children shipped, recording epic as completed",
+					slog.String("task_id", task.ID),
+					slog.Any("error", prErr),
+				)
+				r.reportProgress(task.ID, "Complete", 100, "epic branch had no commits at PR-create time; deliverables shipped via child sub-issue PRs")
+			}
+			// GH-4561: still sweep any child left genuinely non-terminal — this
+			// is a no-op for the (expected) case where every child already
+			// reached a terminal state, and a safety net otherwise.
+			r.sweepEpicChildrenOnAbort(task, fmt.Sprintf("epic PR creation reported no commits: %v", prErr))
+			return
+		}
 		result.Success = false
 		result.Error = fmt.Sprintf("epic PR creation failed: %v", prErr)
 		r.log.Warn("Epic PR creation failed",
@@ -3532,6 +3566,10 @@ retrySucceeded:
 		// No-commit detection and retry (GH-916)
 		// ~10% of failures are "No commits between main and pilot/GH-XXX"
 		// Claude runs successfully but makes no actual changes, then PR creation fails.
+		//
+		// GH-4566: both commit counts below compare against origin/<base>, not
+		// the (possibly stale) local <base> ref — see
+		// CountNewCommitsAgainstOrigin's doc comment.
 		if task.CreatePR && !task.DirectCommit && task.Branch != "" {
 			baseBranch := task.BaseBranch
 			if baseBranch == "" {
@@ -3541,7 +3579,7 @@ retrySucceeded:
 				}
 			}
 
-			commitCount, countErr := git.CountNewCommits(ctx, baseBranch)
+			commitCount, countErr := git.CountNewCommitsAgainstOrigin(ctx, baseBranch)
 			if countErr != nil {
 				log.Warn("Failed to count commits for no-commit check",
 					slog.String("task_id", task.ID),
@@ -3620,7 +3658,7 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 				}
 
 				// Check again after retry
-				commitCount, _ = git.CountNewCommits(ctx, baseBranch)
+				commitCount, _ = git.CountNewCommitsAgainstOrigin(ctx, baseBranch)
 				if commitCount == 0 {
 					result.Success = false
 
@@ -4312,7 +4350,10 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 			// task genuinely produced nothing, so it stays a hard failure (unlike the
 			// decomposed/epic guard in finalizeEpicBranchPR, which treats an empty parent
 			// branch as a legitimate success when children shipped their own PRs).
-			if guardCount, _ := git.CountNewCommits(ctx, baseBranch); guardCount == 0 {
+			//
+			// GH-4566: compares against origin/<base>, not the (possibly stale) local
+			// <base> ref — see CountNewCommitsAgainstOrigin's doc comment.
+			if guardCount, _ := git.CountNewCommitsAgainstOrigin(ctx, baseBranch); guardCount == 0 {
 				evaluateEmptyBranchPRGuard(false, nil, result)
 				if backendResult != nil {
 					backendResult.ErrorType = string(ErrorTypeNoChanges)

--- a/internal/executor/runner_gh4566_test.go
+++ b/internal/executor/runner_gh4566_test.go
@@ -1,0 +1,211 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestFinalizeEpicBranchPR_StaleLocalMainDoesNotFalsePositive is the
+// end-to-end GH-4566 acceptance test: an epic whose umbrella branch was cut
+// straight from origin/main (zero commits of its own) — because its children
+// shipped their own PRs — must take the clean skip/no-op path even when this
+// clone's local `main` ref is stale relative to origin/main. Before the fix,
+// finalizeEpicBranchPR's guard compared against the stale local `main` ref,
+// saw the sibling children's merged commits as if they belonged to the parent
+// branch, and fell through to push+CreatePR — which GitHub then rejected with
+// "No commits between main and pilot/GH-NNN", misclassified as an infra
+// failure on an epic whose work fully shipped (auth-service GH-431/GH-435,
+// 2026-07-26).
+func TestFinalizeEpicBranchPR_StaleLocalMainDoesNotFalsePositive(t *testing.T) {
+	local, origin := setupSyncTestRepos(t, "main")
+
+	// Children's PRs merging to origin/main while this clone's local `main`
+	// never fast-forwards (TASK-402: independent-sibling dispatch never runs
+	// syncMainBranch mid-epic).
+	pushExtraCommitFromSecondClone(t, origin, "main", "child #472 merged")
+	pushExtraCommitFromSecondClone(t, origin, "main", "child #474 merged")
+
+	// Cut the epic's umbrella branch straight from origin/main, exactly as
+	// worktree.go does — local `main` is deliberately left behind.
+	runGit(t, local, "fetch", "origin", "main")
+	runGit(t, local, "checkout", "-B", "pilot/GH-4566-epic", "origin/main")
+
+	// Sanity: prove this reproduces the bug precondition — the stale local
+	// `main` comparison the old guard used is nonzero.
+	git := NewGitOperations(local)
+	staleCount, err := git.CountNewCommits(context.Background(), "main")
+	if err != nil {
+		t.Fatalf("CountNewCommits: %v", err)
+	}
+	if staleCount == 0 {
+		t.Fatalf("test setup invalid: expected stale local `main` comparison to be nonzero (repro precondition), got 0")
+	}
+
+	r := newSilentRunnerTask359()
+	result := &ExecutionResult{TaskID: "GH-4566", Success: true, IsEpic: true}
+	task := &Task{ID: "GH-4566", Title: "epic", Description: "d", Branch: "pilot/GH-4566-epic", BaseBranch: "main", CreatePR: true}
+	childStates := []string{"completed", "completed"}
+
+	r.finalizeEpicBranchPR(context.Background(), task, git, result, childStates)
+
+	if !result.Success {
+		t.Errorf("expected Success=true (clean skip, children shipped), got false, error=%q", result.Error)
+	}
+	if result.Outcome != "" {
+		t.Errorf("Outcome = %q, want empty (completed)", result.Outcome)
+	}
+	if result.PRUrl != "" {
+		t.Errorf("expected no PR created — the guard must skip push+CreatePR entirely, got %q", result.PRUrl)
+	}
+	if result.CommitSHA != "" {
+		t.Errorf("expected no harvested SHA when the guard skips, got %q", result.CommitSHA)
+	}
+
+	// No push should have happened: the epic branch never reached origin.
+	checkCmd := exec.Command("git", "rev-parse", "--verify", "refs/heads/pilot/GH-4566-epic")
+	checkCmd.Dir = origin
+	if err := checkCmd.Run(); err == nil {
+		t.Errorf("epic branch must not have been pushed to origin")
+	}
+}
+
+// TestFinalizeEpicBranchPR_StaleLocalMainAllChildrenNoOp is the no_op-outcome
+// counterpart: when every child no-op'd (nothing shipped anywhere), the
+// stale-local-main guard must still classify the parent as no_op, not
+// silently as completed.
+func TestFinalizeEpicBranchPR_StaleLocalMainAllChildrenNoOp(t *testing.T) {
+	local, origin := setupSyncTestRepos(t, "main")
+	pushExtraCommitFromSecondClone(t, origin, "main", "unrelated main-branch commit")
+
+	runGit(t, local, "fetch", "origin", "main")
+	runGit(t, local, "checkout", "-B", "pilot/GH-4566-noop", "origin/main")
+
+	r := newSilentRunnerTask359()
+	result := &ExecutionResult{TaskID: "GH-4566", Success: true, IsEpic: true}
+	task := &Task{ID: "GH-4566", Title: "epic", Description: "d", Branch: "pilot/GH-4566-noop", BaseBranch: "main", CreatePR: true}
+	childStates := []string{"no_op", "no_op"}
+
+	r.finalizeEpicBranchPR(context.Background(), task, NewGitOperations(local), result, childStates)
+
+	if result.Success {
+		t.Errorf("expected Success=false for all-no_op children, got true")
+	}
+	if result.Outcome != "no_op" {
+		t.Errorf("Outcome = %q, want no_op", result.Outcome)
+	}
+	if result.PRUrl != "" {
+		t.Errorf("expected no PR created, got %q", result.PRUrl)
+	}
+	if !containsAny(result.Error, noOpErrorSignatures) {
+		t.Errorf("Error = %q does not match any recognized no-op signature; would be misclassified as a generic failure", result.Error)
+	}
+}
+
+// writeFakeGhPRCreateNoCommitsBetween writes a fake "gh" binary whose `pr
+// create` fails exactly the way GitHub's GraphQL API does when the branch
+// truly carries no commits relative to base: "No commits between <base> and
+// <branch> (createPullRequest)". Used to drive the GH-4566 backstop
+// classification at finalizeEpicBranchPR's CreatePR-failure exit.
+func writeFakeGhPRCreateNoCommitsBetween(t *testing.T, fakeBin string) {
+	t.Helper()
+	script := `#!/bin/sh
+case "$*" in
+  *"pr list"*) echo "[]" ;;
+  *"pr create"*) echo "GraphQL: No commits between main and pilot/GH-431 (createPullRequest)" >&2; exit 1 ;;
+  *) echo "[]" ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(fakeBin, "gh"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+}
+
+// TestFinalizeEpicBranchPR_NoCommitsBetweenBackstop is the GH-4566 backstop
+// acceptance test: if CreatePR itself still returns GitHub's "No commits
+// between" error (the origin-relative guard should have caught this first,
+// but this is defense in depth for any way it's wrong), the parent must be
+// classified the same way the guard classifies an empty branch — off the
+// children's terminal states — instead of a generic "infra" failure, and
+// TerminalStatus must not read as a genuine failure (no failure alert).
+func TestFinalizeEpicBranchPR_NoCommitsBetweenBackstop(t *testing.T) {
+	tests := []struct {
+		name        string
+		slug        string
+		childStates []string
+		wantSuccess bool
+		wantOutcome string
+	}{
+		{
+			name:        "children shipped: classified completed, no infra failure",
+			slug:        "shipped",
+			childStates: []string{"completed", "completed"},
+			wantSuccess: true,
+			wantOutcome: "",
+		},
+		{
+			name:        "all children no_op: classified no_op, no infra failure",
+			slug:        "noop",
+			childStates: []string{"no_op", "no_op"},
+			wantSuccess: false,
+			wantOutcome: "no_op",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeBin := t.TempDir()
+			writeFakeGhPRCreateNoCommitsBetween(t, fakeBin)
+			t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+os.Getenv("PATH"))
+
+			branch := "pilot/GH-431-backstop-" + tt.slug
+			dir := initRepoWithRemoteAndFeatureBranch(t, branch)
+
+			r := newSilentRunnerTask359()
+			result := &ExecutionResult{TaskID: "GH-431", Success: true, IsEpic: true}
+			task := &Task{ID: "GH-431", Title: "feat: epic work", Description: "d", Branch: branch, BaseBranch: "main", CreatePR: true}
+
+			r.finalizeEpicBranchPR(context.Background(), task, NewGitOperations(dir), result, tt.childStates)
+
+			if result.Success != tt.wantSuccess {
+				t.Errorf("Success = %v, want %v (error=%q)", result.Success, tt.wantSuccess, result.Error)
+			}
+			if result.Outcome != tt.wantOutcome {
+				t.Errorf("Outcome = %q, want %q", result.Outcome, tt.wantOutcome)
+			}
+			if result.PRUrl != "" {
+				t.Errorf("PRUrl = %q, want empty", result.PRUrl)
+			}
+			// The whole point of the backstop: this must never read as an
+			// infra/generic failure downstream (that's what drove the false
+			// failure alert on shipped epics).
+			if status := TerminalStatus(result); status == "infra" || status == "failed" {
+				t.Errorf("TerminalStatus = %q, want a non-failure classification (completed/no_op)", status)
+			}
+		})
+	}
+}
+
+// TestFinalizeEpicBranchPR_GenericPRCreateFailureStillInfra proves the
+// backstop is scoped narrowly to "No commits between" — any other PR-create
+// failure (rate limit, transient GitHub error, ...) must still classify as a
+// genuine failure exactly as before GH-4566.
+func TestFinalizeEpicBranchPR_GenericPRCreateFailureStillInfra(t *testing.T) {
+	setUpFakeGhPRCreateFailingPATH(t)
+	dir := initRepoWithRemoteAndFeatureBranch(t, "pilot/GH-431-generic-fail")
+
+	r := newSilentRunnerTask359()
+	result := &ExecutionResult{TaskID: "GH-431", Success: true, IsEpic: true}
+	task := &Task{ID: "GH-431", Title: "feat: epic work", Description: "d", Branch: "pilot/GH-431-generic-fail", BaseBranch: "main", CreatePR: true}
+
+	r.finalizeEpicBranchPR(context.Background(), task, NewGitOperations(dir), result, []string{"completed"})
+
+	if result.Success {
+		t.Errorf("expected Success=false for a generic PR-create failure, got true")
+	}
+	if status := TerminalStatus(result); status != "infra" {
+		t.Errorf("TerminalStatus = %q, want infra (unrelated PR-create failure must stay a genuine failure)", status)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4566.

Closes #4566

## Changes

GitHub Issue GH-4566: fix(executor): no-commits guards diff against stale local base ref — decomposed epics die 'No commits between main and pilot/GH-N' at umbrella-PR creation

# fix(executor): no-commits guards diff against stale local base ref — decomposed epics die "No commits between main and pilot/GH-N" at umbrella-PR creation

**Created**: 2026-07-27 · **Status**: Draft · **Last Updated**: 2026-07-27

## Problem

Decomposed epics whose children merge to main routinely end `infra` with
`epic PR creation failed: GraphQL: No commits between main and pilot/GH-NNN
(createPullRequest)` — a spurious failure on an epic whose work fully shipped.
Two live hits on auth-service 2026-07-26: GH-435 (18:37Z) and GH-431 (23:49Z,
all 4 child PRs #471/#472/#474/#475 merged). The parent issue is usually
already closed by then (`epic.go:3025-3031` closes it before finalize), so the
damage is a false `infra` ledger row + failure alert on shipped work — plus,
until #4563/#4564, orphaned child rows.

## Root cause (verified 2026-07-27)

The empty umbrella branch is **by design**: post-TASK-401, nothing can commit
to it (children run isolated worktrees on their own branches, `epic.go:2643-2646,
2829`; planning is read-only, `epic.go:272-277`; parent re-dispatch
re-implementation is short-circuited, `dispatcher.go:2230-2258`). The
no-commits guard at `runner.go:1666` exists precisely to turn that into a
clean skip/no-op (GH-2743/TASK-356, classification per GH-3779) — `CreatePR`
should never be reached.

**The guard is fooled by a stale local base ref:**

- Every worktree (parent's and children's) is cut from **freshly fetched
  `origin/main`**: `git fetch origin main` + `git worktree add -B <branch>
  <path> origin/main` (`internal/executor/worktree.go:548,559,571`).
- The guard calls `CountNewCommits(ctx, baseBranch)` with `baseBranch` = a
  **local branch name** ("main"), running `git rev-list --count main..HEAD`
  (`internal/executor/git.go:870-883`).
- Nothing fast-forwards the shared clone's local `refs/heads/main` during a
  sequential epic run: `syncMainBranch` (`runner_git.go:30`) only fires on the
  explicit-dependency `wait_for_merge` path (`epic.go:2952,2976`), not the
  TASK-402 default for independent siblings (`epic.go:2984-3002`).
- So when local `main` lags `origin/main`, `main..HEAD` on the frozen-at-epic-
  start parent branch counts commits that are NOT parent work → guard sees
  nonzero → `CreatePR` fires on a branch whose origin-relative diff is zero →
  GitHub answers "No commits" → classified `infra`
  (`infraErrorSignatures`, `runner.go:232-252`).

Same stale-ref mechanism plausibly feeds the direct path's long-standing
"~10% of failures are No commits" class (GH-916 retry, `runner.go:3532-3719`)
and its pre-CreatePR guard (`runner.go:4306-4322`).

## Fix

**Core — compare against the ref the branch was actually cut from.**

1. Add an origin-relative variant (extend `CountNewCommits` or add
   `CountNewCommitsAgainstOrigin`): `git fetch origin <base>` (best-effort;
   on fetch failure fall back to the tracking ref as-is — `refs/remotes/
   origin/<base>` is still strictly fresher than local `<base>` here, since
   worktree creation fetched it), then `git rev-list --count
   origin/<base>..HEAD`.
2. Use it at the epic finalize guard (`runner.go:1666`) — this alone makes the
   empty-umbrella case take the intended clean skip/no-op path, preserving the
   GH-3779 classification (`evaluateEmptyBranchPRGuard`) exactly as today.
3. Mirror at the direct-path guards (`runner.go:~3536` and `~4297-4315`) —
   same mechanism, same fix; expected to shrink the GH-916 retry class.

**Backstop — a real "No commits" from GitHub is not infra on a shipped epic.**

4. At `finalizeEpicBranchPR`'s CreatePR-failure exit (`runner.go:1812-1824`):
   when the error matches `No commits between` AND the children's terminal
   states show shipped/no_op work, classify via `evaluateEmptyBranchPRGuard`
   (completed / no_op per child states) instead of failing `infra`; skip the
   failure alert. Keep the #4563 sweep call for genuinely non-terminal
   children. Defense-in-depth for any future way the guard is wrong.

## Acceptance criteria

- Unit test reproducing the false positive: repo where local `main` is N
  commits behind `origin/main`, branch cut from `origin/main` with zero own
  commits → old guard counts N (>0), new guard counts 0. (Simulate origin
  with a second bare repo / `git update-ref`; no network.)
- Epic finalize with empty umbrella branch and stale local main → no
  `CreatePR` call, outcome per child states (completed when children shipped;
  `no_op` when all children no-op'd — existing GH-3779 tests stay green).
- Backstop test: `CreatePR` returns GraphQL "No commits between…" with all
  children shipped → result completed, no infra classification, no alert.
- Direct-path guards: branch WITH real commits vs stale local main still
  proceeds to PR (count via origin ref is still >0) — no behavior change for
  legitimate content; empty-branch retry (GH-916) unaffected semantics.
- Fetch-failure fallback covered (offline → tracking ref comparison).
- `go test ./internal/executor/` green.

## Out of scope

- Removing `finalizeEpicBranchPR`/umbrella-PR flow entirely (candidate
  redesign; not needed once the guard is truthful).
- Child finalization on parent abort (#4563 shipped, #4564 refines).
- Epic issue-close paths (`epic.go:3006-3031`, `controller.go:3033`,
  `epic_reconcile.go:322`) — already correct, three independent closers.
- The historical GH-916 "~10%" number — revisit after this ships.

## Scope fence

`internal/executor/git.go`, `internal/executor/runner.go` (guard call sites +
CreatePR-failure exit), matching tests. Do not decompose: the three guard
sites share one helper and one mechanism; splitting them re-creates the
GH-4544 same-file-conflict failure.

## Refs

- Incidents: auth-service GH-431 + GH-435, 2026-07-26
- Research: navigator-research session 2026-07-27 (epic flow map; verdict:
  guard fooled by stale local ref; three close paths independent of umbrella PR)
- Prior art: TASK-356 (guard origin), GH-3779 (no_op classification), TASK-401
  (parent re-implementation closed), TASK-402 (independent-sibling dispatch —
  why syncMainBranch doesn't run), GH-916 (direct-path retry), #4563/#4564
  (child sweep)
- Post-merge follow-up: write pitfall memory
  `epic-no-commits-guard-stale-local-ref` once the fix is proven live