### PR TITLE
GH-4569: feat(cli): staleness banner + archive sentinel — refuse to silently serve a frozen ledger

### DIFF
--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -438,6 +438,19 @@ func newVersionCmd() *cobra.Command {
 			if buildTime != "unknown" {
 				fmt.Printf("Built: %s\n", buildTime)
 			}
+
+			// GH-4569/GH-4393: always show the resolved absolute ledger DB
+			// path in diagnostics — path ambiguity (configured path vs.
+			// where it actually resolves on disk) was half of the #4393
+			// split-brain incident.
+			configPath := cfgFile
+			if configPath == "" {
+				configPath = config.DefaultConfigPath()
+			}
+			if cfg, err := config.Load(configPath); err == nil {
+				dbPath := resolveMemoryDBPath(daemonLockDir(cfg))
+				fmt.Printf("Ledger DB: %s\n", dbPath)
+			}
 		},
 	}
 }

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -258,6 +258,7 @@ func newStartCmd() *cobra.Command {
 		teamMember     string // Member email for project access scoping
 		logFormat      string // Log output format: text or json (GH-847)
 		dashboardScope string // Dashboard metrics scope: "project" (default) or "all" (GH-3534)
+		allowArchived  bool   // GH-4569: override the archive-sentinel start refusal
 	)
 
 	cmd := &cobra.Command{
@@ -458,7 +459,7 @@ Examples:
 
 			hasPollingAdapter := hasTelegram || hasGithubPolling
 			if noGateway || hasPollingAdapter {
-				return runPollingMode(cmd, cfg, projectPath, replace, dashboardMode, noGateway, bootReconcile)
+				return runPollingMode(cmd, cfg, projectPath, replace, dashboardMode, noGateway, allowArchived, bootReconcile)
 			}
 
 			// Full daemon mode with gateway
@@ -1208,6 +1209,7 @@ Examples:
 	cmd.Flags().StringVarP(&projectPath, "project", "p", "", "Project path (default: config default or cwd)")
 	cmd.Flags().BoolVar(&replace, "replace", false, "Kill existing bot instance before starting")
 	cmd.Flags().BoolVar(&noGateway, "no-gateway", false, "Run polling adapters only (no HTTP gateway)")
+	cmd.Flags().BoolVar(&allowArchived, "i-know-this-is-an-archive", false, "Override the refusal to start against a ledger marked archived (LEDGER-ARCHIVED sentinel) — forensics only")
 	cmd.Flags().BoolVar(&sequential, "sequential", false, "Sequential execution: wait for PR merge before next issue")
 	cmd.Flags().StringVar(&envFlag, "env", "",
 		"Environment name: dev, stage, prod, or custom configured environment")
@@ -1549,7 +1551,7 @@ func acquireDaemonLock(cfg *config.Config, replace bool) (*singleton.Lock, error
 // desktop app (and any other client hitting /health) can reach the daemon.
 // bootReconcile carries the GH-3600 upgrade verification outcome for the
 // dashboard to surface; may be nil.
-func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, replace, dashboardMode, noGateway bool, bootReconcile *upgrade.BootReconcileResult) error {
+func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, replace, dashboardMode, noGateway, allowArchived bool, bootReconcile *upgrade.BootReconcileResult) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -1867,11 +1869,16 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 	// a different failure mode than "couldn't open the DB" — it looks
 	// healthy, so unlike an ordinary store error it must abort startup
 	// rather than degrade gracefully with store=nil.
-	store, err := memory.NewStoreGuarded(cfg.Memory.Path)
+	store, err := memory.NewStoreGuarded(cfg.Memory.Path, allowArchived)
 	if err != nil {
 		var splitBrain *memory.ErrSplitBrainLedger
 		if errors.As(err, &splitBrain) {
 			logging.WithComponent("start").Error("refusing to start: possible shadow ledger detected", slog.Any("error", err))
+			return err
+		}
+		var archived *memory.ErrLedgerArchived
+		if errors.As(err, &archived) {
+			logging.WithComponent("start").Error("refusing to start: ledger marked archived", slog.Any("error", err))
 			return err
 		}
 		logging.WithComponent("start").Warn("Failed to open memory store", slog.Any("error", err))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,7 @@ import (
 	"github.com/qf-studio/pilot/internal/executor"
 	"github.com/qf-studio/pilot/internal/gateway"
 	"github.com/qf-studio/pilot/internal/logging"
+	"github.com/qf-studio/pilot/internal/memory"
 	"github.com/qf-studio/pilot/internal/quality"
 	"github.com/qf-studio/pilot/internal/tunnel"
 	"github.com/qf-studio/pilot/internal/webhooks"
@@ -60,6 +61,17 @@ type Config struct {
 	Team           *TeamConfig             `yaml:"team"`
 	Bot            *BotConfig              `yaml:"bot"`
 	Upgrade        *UpgradeConfig          `yaml:"upgrade"`
+	Ledger         *LedgerConfig           `yaml:"ledger"`
+}
+
+// LedgerConfig controls staleness detection for the executions ledger
+// (GH-4569): a ledger DB that silently stops being written to (wrong path,
+// stale copy, retired archive) answers every query successfully with wrong
+// data — the worst failure shape. StalenessWarnAfter sets how old the
+// newest execution row must be before ledger-reading commands print a loud
+// stderr/dashboard warning.
+type LedgerConfig struct {
+	StalenessWarnAfter time.Duration `yaml:"staleness_warn_after"`
 }
 
 // UpgradeConfig controls self-upgrade behavior (GH-3790). Self-upgrade
@@ -463,6 +475,9 @@ func DefaultConfig() *Config {
 			CrossProject: true,
 			Learning:     DefaultLearningConfig(),
 		},
+		Ledger: &LedgerConfig{
+			StalenessWarnAfter: memory.DefaultStalenessWarnAfter,
+		},
 		Projects: []*ProjectConfig{},
 		Dashboard: &DashboardConfig{
 			RefreshInterval: 1000,
@@ -629,6 +644,7 @@ func Load(path string) (*Config, error) {
 			if err := config.AssertHostedInvariants(); err != nil {
 				return nil, err
 			}
+			applyLedgerStalenessThreshold(config)
 			return config, nil // Return defaults if no config file
 		}
 		return nil, fmt.Errorf("failed to read config: %w", err)
@@ -672,7 +688,20 @@ func Load(path string) (*Config, error) {
 		return nil, err
 	}
 
+	applyLedgerStalenessThreshold(config)
+
 	return config, nil
+}
+
+// applyLedgerStalenessThreshold wires config.Ledger.StalenessWarnAfter
+// (ledger.staleness_warn_after in YAML) into the memory package's
+// staleness-banner check (GH-4569). A non-positive value is ignored by
+// SetStalenessThreshold, leaving memory.DefaultStalenessWarnAfter in
+// effect.
+func applyLedgerStalenessThreshold(config *Config) {
+	if config.Ledger != nil {
+		memory.SetStalenessThreshold(config.Ledger.StalenessWarnAfter)
+	}
 }
 
 // hostedEnvVar gates hosted mode (SaaS S0.7, GH-4274): a control-plane-

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/qf-studio/pilot/internal/adapters/github"
 	"github.com/qf-studio/pilot/internal/gateway"
+	"github.com/qf-studio/pilot/internal/memory"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -330,6 +331,36 @@ dashboard:
 		}
 		if config.Dashboard.ShowLogs != false {
 			t.Error("Dashboard.ShowLogs should be false")
+		}
+	})
+
+	t.Run("LedgerStalenessWiring", func(t *testing.T) {
+		// GH-4569: ledger.staleness_warn_after must flow YAML -> Load() ->
+		// Config.Ledger -> memory.StalenessThreshold(), not just sit unused
+		// on the struct.
+		defer memory.SetStalenessThreshold(memory.DefaultStalenessWarnAfter)
+
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+
+		configContent := `
+version: "1.0"
+ledger:
+  staleness_warn_after: 48h
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("Failed to write test config: %v", err)
+		}
+
+		cfg, err := Load(configPath)
+		if err != nil {
+			t.Fatalf("Load failed: %v", err)
+		}
+		if cfg.Ledger == nil || cfg.Ledger.StalenessWarnAfter != 48*time.Hour {
+			t.Fatalf("Ledger.StalenessWarnAfter = %v, want 48h", cfg.Ledger)
+		}
+		if got := memory.StalenessThreshold(); got != 48*time.Hour {
+			t.Errorf("memory.StalenessThreshold() = %v, want 48h (config not wired through)", got)
 		}
 	})
 

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -479,6 +479,11 @@ type Model struct {
 	// Banner toggle (GH-1520)
 	showBanner bool
 
+	// stalenessBanner holds the formatted stale/archived-ledger warning
+	// (GH-4569), computed once from the store on hydrate. Empty means the
+	// ledger looks healthy — nothing to show.
+	stalenessBanner string
+
 	// Banner metadata (GH-2455 / GH-2459 rework): env name, model stack, adapter
 	// status list.
 	startTime      time.Time
@@ -660,6 +665,16 @@ func NewModelWithStoreAndAutopilot(version string, store *memory.Store, controll
 func (m *Model) hydrateFromStore() {
 	if m.store == nil {
 		return
+	}
+
+	// GH-4569: check for a stale/archived ledger before anything else reads
+	// it — a frozen ledger answers every query successfully with wrong
+	// data, so this must be visible in the header regardless of what else
+	// hydration does below.
+	if info, err := m.store.CheckStaleness(memory.StalenessThreshold()); err != nil {
+		slog.Warn("failed to check ledger staleness", slog.Any("error", err))
+	} else {
+		m.stalenessBanner = info.Banner()
 	}
 
 	// GH-4368: one-shot archaeology heal, before anything below reads
@@ -1563,6 +1578,13 @@ func (m Model) renderChromeHeader() string {
 	// uses the compact banner frame to keep header real-estate small.
 	if m.showBanner {
 		b.WriteString(m.renderBanner())
+		b.WriteString("\n")
+	}
+
+	// Stale/archived ledger warning (GH-4569) — shown above the update
+	// notification so a frozen ledger is the first thing an operator sees.
+	if m.stalenessBanner != "" {
+		b.WriteString(m.renderStalenessBanner())
 		b.WriteString("\n")
 	}
 
@@ -2755,6 +2777,19 @@ func AddCompletedTask(id, title, status, duration string, parentID string, isEpi
 			IsEpic:      isEpic,
 		})
 	}
+}
+
+// renderStalenessBanner renders the stale/archived-ledger warning card
+// (GH-4569): a ledger DB that silently stopped being written to (wrong
+// path, stale copy, retired archive) answers every query successfully with
+// wrong data, so this uses the same loud amber chrome as the update
+// notification.
+func (m Model) renderStalenessBanner() string {
+	tw := m.effectivePanelTotalWidth()
+	iw := tw - 4
+	var content strings.Builder
+	content.WriteString(formatPanelRow(m.stalenessBanner, "", iw))
+	return renderPanelStyled("ledger stale", "", content.String(), tw, warnChrome)
 }
 
 // renderUpdateNotification renders the update notification panel (amber

--- a/internal/dashboard/tui_test.go
+++ b/internal/dashboard/tui_test.go
@@ -353,6 +353,72 @@ func TestHydrateFromStore_LifetimeTokens(t *testing.T) {
 	}
 }
 
+// TestHydrateFromStore_StaleLedgerShowsBanner is the GH-4569 regression: a
+// ledger whose newest execution is far older than the staleness threshold
+// must surface a warning in the dashboard header, not just answer queries
+// silently with stale data.
+func TestHydrateFromStore_StaleLedgerShowsBanner(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pilot-dash-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "exec-1", TaskID: "TASK-1", ProjectPath: "/test", Status: "completed",
+		CreatedAt: time.Now().Add(-10 * 24 * time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	m := NewModelWithStore("test", store)
+	if m.stalenessBanner == "" {
+		t.Fatal("expected stalenessBanner to be set for a 10-day-old ledger")
+	}
+	if !strings.Contains(m.stalenessBanner, "LEDGER STALE") {
+		t.Errorf("stalenessBanner = %q, want it to mention LEDGER STALE", m.stalenessBanner)
+	}
+
+	header := m.renderChromeHeader()
+	if !strings.Contains(header, "ledger stale") {
+		t.Errorf("renderChromeHeader() does not surface the stale-ledger card; header:\n%s", header)
+	}
+}
+
+// TestHydrateFromStore_FreshLedgerNoBanner is the healthy-path counterpart:
+// a recently-written ledger must not show any staleness banner.
+func TestHydrateFromStore_FreshLedgerNoBanner(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pilot-dash-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "exec-1", TaskID: "TASK-1", ProjectPath: "/test", Status: "completed",
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	m := NewModelWithStore("test", store)
+	if m.stalenessBanner != "" {
+		t.Fatalf("expected no stalenessBanner for a fresh ledger, got %q", m.stalenessBanner)
+	}
+}
+
 // TestHydrateFromStore_HealsFrozenLadderRow is the GH-4368 regression: a row
 // that predates the H4 heal fixes (GH-4277/GH-4298) sits at status='completed'
 // with its execution_events ladder frozen at a non-terminal rung (e.g.

--- a/internal/memory/split_brain.go
+++ b/internal/memory/split_brain.go
@@ -114,7 +114,13 @@ func dirExists(path string) bool {
 // On a healthy open — including a genuine first run, where no marker exists
 // yet — the marker is (re)written with the resolved path and current
 // execution count so future starts can detect divergence.
-func NewStoreGuarded(dataPath string) (*Store, error) {
+//
+// GH-4569: it also refuses to start against a ledger marked archived (an
+// ArchiveSentinelFilename file next to the DB) unless allowArchived is set
+// (the --i-know-this-is-an-archive escape hatch, for forensics only). The
+// staleness/archive banner itself is still printed unconditionally by the
+// underlying NewStore call, warn-only, regardless of allowArchived.
+func NewStoreGuarded(dataPath string, allowArchived bool) (*Store, error) {
 	preExisted := dirExists(dataPath)
 
 	resolved, err := filepath.EvalSymlinks(dataPath)
@@ -134,6 +140,15 @@ func NewStoreGuarded(dataPath string) (*Store, error) {
 	store, err := NewStore(dataPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if archiveMsg, archived, sentinelErr := readArchiveSentinel(dataPath); sentinelErr == nil && archived && !allowArchived {
+		_ = store.Close()
+		return nil, &ErrLedgerArchived{
+			DataPath: dataPath,
+			DBPath:   dbPath,
+			Message:  archiveMsg,
+		}
 	}
 
 	if !preExisted && lkgErr == nil && lkg != nil && lkg.ExecutionCount > 0 && lkg.DBPath != dbPath {

--- a/internal/memory/split_brain_test.go
+++ b/internal/memory/split_brain_test.go
@@ -21,7 +21,7 @@ func TestNewStoreGuarded_FirstRunNoMarker(t *testing.T) {
 	withIsolatedHome(t)
 	dataPath := filepath.Join(t.TempDir(), "data")
 
-	store, err := NewStoreGuarded(dataPath)
+	store, err := NewStoreGuarded(dataPath, false)
 	if err != nil {
 		t.Fatalf("NewStoreGuarded failed on genuine first run: %v", err)
 	}
@@ -43,7 +43,7 @@ func TestNewStoreGuarded_HealthyReopenSamePath(t *testing.T) {
 	withIsolatedHome(t)
 	dataPath := filepath.Join(t.TempDir(), "data")
 
-	store, err := NewStoreGuarded(dataPath)
+	store, err := NewStoreGuarded(dataPath, false)
 	if err != nil {
 		t.Fatalf("NewStoreGuarded (first open) failed: %v", err)
 	}
@@ -56,7 +56,7 @@ func TestNewStoreGuarded_HealthyReopenSamePath(t *testing.T) {
 
 	// Reopen the SAME directory — this must succeed even though the marker
 	// now records non-zero history, because the directory pre-existed.
-	store2, err := NewStoreGuarded(dataPath)
+	store2, err := NewStoreGuarded(dataPath, false)
 	if err != nil {
 		t.Fatalf("NewStoreGuarded (reopen) failed: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestNewStoreGuarded_DetectsShadowLedger(t *testing.T) {
 	canonicalPath := filepath.Join(root, "canonical")
 
 	// Simulate a healthy daemon run with real history at the canonical path.
-	store, err := NewStoreGuarded(canonicalPath)
+	store, err := NewStoreGuarded(canonicalPath, false)
 	if err != nil {
 		t.Fatalf("NewStoreGuarded (canonical) failed: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestNewStoreGuarded_DetectsShadowLedger(t *testing.T) {
 	// normal restart against the same (already-populated) canonical path —
 	// this is what makes the marker reflect real history, exactly as it
 	// would after the daemon's first real restart in production.
-	store, err = NewStoreGuarded(canonicalPath)
+	store, err = NewStoreGuarded(canonicalPath, false)
 	if err != nil {
 		t.Fatalf("NewStoreGuarded (canonical restart) failed: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestNewStoreGuarded_DetectsShadowLedger(t *testing.T) {
 	// migration shim), distinct from the canonical path that has history.
 	shadowPath := filepath.Join(root, "shadow")
 
-	_, err = NewStoreGuarded(shadowPath)
+	_, err = NewStoreGuarded(shadowPath, false)
 	if err == nil {
 		t.Fatal("expected NewStoreGuarded to refuse opening a shadow ledger, got nil error")
 	}
@@ -133,7 +133,7 @@ func TestNewStoreGuarded_NoFalsePositiveWhenMarkerHasNoHistory(t *testing.T) {
 	// and never actually ran a task) — a fresh directory elsewhere should
 	// not be treated as a shadow ledger.
 	firstPath := filepath.Join(root, "first")
-	store, err := NewStoreGuarded(firstPath)
+	store, err := NewStoreGuarded(firstPath, false)
 	if err != nil {
 		t.Fatalf("NewStoreGuarded (first) failed: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestNewStoreGuarded_NoFalsePositiveWhenMarkerHasNoHistory(t *testing.T) {
 	}
 
 	secondPath := filepath.Join(root, "second")
-	store2, err := NewStoreGuarded(secondPath)
+	store2, err := NewStoreGuarded(secondPath, false)
 	if err != nil {
 		t.Fatalf("expected no split-brain error when prior marker has zero executions, got: %v", err)
 	}

--- a/internal/memory/staleness.go
+++ b/internal/memory/staleness.go
@@ -1,0 +1,217 @@
+package memory
+
+import (
+	"bufio"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// GH-4569: a stale ledger answers every query successfully with wrong
+// data — the worst failure shape. After the S6-lite cutover (TASK-409) a
+// laptop's ~/.pilot/data/pilot.db sat frozen for 11 days while looking
+// perfectly healthy; a session reading it confidently misdiagnosed
+// merged/healthy tasks as failed. This file gives every ledger-reading
+// entry point a way to notice and say so loudly, and gives operators a way
+// to permanently retire a DB so the next copy of it (backup, restored
+// snapshot, second machine) can't spring the same trap.
+
+// DefaultStalenessWarnAfter is the default age (measured from the newest
+// execution row's created_at to now) after which a ledger is considered
+// stale enough to warn about. Configurable via config.Ledger.StalenessWarnAfter
+// (ledger.staleness_warn_after in YAML), wired through SetStalenessThreshold.
+const DefaultStalenessWarnAfter = 72 * time.Hour
+
+// ArchiveSentinelFilename is the marker file operators drop next to a
+// retired ledger DB (sibling of pilot.db, i.e. directly inside the
+// configured data directory) to mark it as permanently archived. Its
+// presence unconditionally triggers the staleness banner on every
+// ledger-reading command, and makes NewStoreGuarded (pilot start) refuse to
+// run against it outright.
+const ArchiveSentinelFilename = "LEDGER-ARCHIVED"
+
+var (
+	stalenessMu        sync.RWMutex
+	stalenessWarnAfter = DefaultStalenessWarnAfter
+)
+
+// SetStalenessThreshold overrides the default staleness age threshold
+// (config.Ledger.StalenessWarnAfter / ledger.staleness_warn_after). A
+// non-positive duration is ignored — it must not be possible to silently
+// disable the banner via a zero-value config field left over from a
+// partially-filled YAML block.
+func SetStalenessThreshold(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	stalenessMu.Lock()
+	defer stalenessMu.Unlock()
+	stalenessWarnAfter = d
+}
+
+// StalenessThreshold returns the currently configured staleness age
+// threshold.
+func StalenessThreshold() time.Duration {
+	stalenessMu.RLock()
+	defer stalenessMu.RUnlock()
+	return stalenessWarnAfter
+}
+
+// Path returns the data directory this Store was opened with (the
+// directory containing pilot.db, not the db file itself).
+func (s *Store) Path() string {
+	return s.path
+}
+
+// DBFilePath returns the path to the pilot.db file itself.
+func (s *Store) DBFilePath() string {
+	return filepath.Join(s.path, "pilot.db")
+}
+
+// ArchiveSentinelPath returns the path checked for the archive marker file.
+func (s *Store) ArchiveSentinelPath() string {
+	return filepath.Join(s.path, ArchiveSentinelFilename)
+}
+
+// newestExecutionCreatedAt returns the created_at of the most recent
+// execution row, and false if the executions table is empty (a genuine
+// fresh-init ledger, which must never be flagged stale).
+//
+// Deliberately uses ORDER BY created_at DESC LIMIT 1 rather than
+// SELECT MAX(created_at): the sqlite driver only maps declared-typed
+// columns back to time.Time, not aggregate expressions (see the identical
+// note on ListProjectsForTask in store.go).
+func (s *Store) newestExecutionCreatedAt() (time.Time, bool, error) {
+	var createdAt time.Time
+	err := s.db.QueryRow(`SELECT created_at FROM executions ORDER BY created_at DESC LIMIT 1`).Scan(&createdAt)
+	if err == sql.ErrNoRows {
+		return time.Time{}, false, nil
+	}
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	return createdAt, true, nil
+}
+
+// readArchiveSentinel reports whether an archive sentinel file exists in
+// dataPath, returning its first line (trimmed) as a human-authored note.
+func readArchiveSentinel(dataPath string) (firstLine string, exists bool, err error) {
+	f, err := os.Open(filepath.Join(dataPath, ArchiveSentinelFilename))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	if scanner.Scan() {
+		firstLine = strings.TrimSpace(scanner.Text())
+	}
+	return firstLine, true, nil
+}
+
+// StalenessInfo describes what CheckStaleness found.
+type StalenessInfo struct {
+	// Stale is true when the newest execution row is older than the
+	// configured threshold.
+	Stale bool
+	// Archived is true when an ArchiveSentinelFilename marker sits next to
+	// the DB.
+	Archived       bool
+	ArchiveMessage string
+	// HasHistory is false for a genuinely empty (fresh-init) ledger.
+	HasHistory      bool
+	NewestExecution time.Time
+	Age             time.Duration
+	DBPath          string
+}
+
+// Banner formats the loud stderr/dashboard warning for a StalenessInfo. It
+// returns "" if there is nothing to warn about (fresh or healthy ledger).
+func (info *StalenessInfo) Banner() string {
+	if info == nil || (!info.Stale && !info.Archived) {
+		return ""
+	}
+	if info.Archived {
+		msg := fmt.Sprintf("\u26a0 LEDGER ARCHIVED — %s", info.DBPath)
+		if info.ArchiveMessage != "" {
+			msg += fmt.Sprintf(" — %s", info.ArchiveMessage)
+		} else {
+			msg += fmt.Sprintf(" (see %s)", ArchiveSentinelFilename)
+		}
+		return msg
+	}
+	days := int(info.Age.Hours() / 24)
+	return fmt.Sprintf("\u26a0 LEDGER STALE — newest execution %s (%d days ago). Are you reading an archive? %s",
+		info.NewestExecution.Format(time.RFC3339), days, info.DBPath)
+}
+
+// CheckStaleness inspects the store for both age-based staleness (newest
+// execution older than threshold) and an archive sentinel file. A
+// genuinely empty ledger (no execution rows yet, no sentinel) is always
+// reported as fresh — never stale.
+func (s *Store) CheckStaleness(threshold time.Duration) (*StalenessInfo, error) {
+	info := &StalenessInfo{DBPath: s.DBFilePath()}
+
+	firstLine, archived, err := readArchiveSentinel(s.path)
+	if err != nil {
+		return nil, err
+	}
+	info.Archived = archived
+	info.ArchiveMessage = firstLine
+
+	newest, ok, err := s.newestExecutionCreatedAt()
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		info.HasHistory = true
+		info.NewestExecution = newest
+		info.Age = time.Since(newest)
+		if threshold > 0 && info.Age > threshold {
+			info.Stale = true
+		}
+	}
+
+	return info, nil
+}
+
+// warnIfStale runs CheckStaleness with the configured threshold and prints
+// the banner to stderr (never stdout, so it can't corrupt machine-readable
+// command output) if warranted. Best-effort: a staleness-check failure
+// (e.g. a transient read error) must never block a store open.
+func (s *Store) warnIfStale() {
+	info, err := s.CheckStaleness(StalenessThreshold())
+	if err != nil || info == nil {
+		return
+	}
+	if banner := info.Banner(); banner != "" {
+		fmt.Fprintln(os.Stderr, banner)
+	}
+}
+
+// ErrLedgerArchived is returned by NewStoreGuarded when an
+// ArchiveSentinelFilename marker is present and the caller did not pass
+// allowArchived (the --i-know-this-is-an-archive escape hatch). Retiring a
+// DB with a sentinel is an explicit operator action; pilot start must not
+// quietly run against it as if it were live.
+type ErrLedgerArchived struct {
+	DataPath string
+	DBPath   string
+	Message  string
+}
+
+func (e *ErrLedgerArchived) Error() string {
+	msg := fmt.Sprintf("refusing to start: %s is marked archived (%s found in %s)",
+		e.DBPath, ArchiveSentinelFilename, e.DataPath)
+	if e.Message != "" {
+		msg += fmt.Sprintf(" — %q", e.Message)
+	}
+	return msg + " — pass --i-know-this-is-an-archive to override for forensics"
+}

--- a/internal/memory/staleness_test.go
+++ b/internal/memory/staleness_test.go
@@ -1,0 +1,195 @@
+package memory
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCheckStaleness_FreshDBNoBanner(t *testing.T) {
+	dataPath := filepath.Join(t.TempDir(), "data")
+	store, err := NewStore(dataPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	info, err := store.CheckStaleness(DefaultStalenessWarnAfter)
+	if err != nil {
+		t.Fatalf("CheckStaleness: %v", err)
+	}
+	if info.Stale || info.Archived {
+		t.Fatalf("expected fresh DB to report healthy, got %+v", info)
+	}
+	if banner := info.Banner(); banner != "" {
+		t.Fatalf("expected no banner for fresh DB, got %q", banner)
+	}
+}
+
+func TestCheckStaleness_EmptyDBTreatedAsFreshInit(t *testing.T) {
+	dataPath := filepath.Join(t.TempDir(), "data")
+	store, err := NewStore(dataPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// executions table has zero rows — must never be flagged stale just
+	// because there's no history yet.
+	info, err := store.CheckStaleness(1 * time.Hour)
+	if err != nil {
+		t.Fatalf("CheckStaleness: %v", err)
+	}
+	if info.HasHistory {
+		t.Fatal("expected HasHistory=false for an empty executions table")
+	}
+	if info.Stale {
+		t.Fatal("expected empty DB to never be flagged stale (fresh-init)")
+	}
+	if banner := info.Banner(); banner != "" {
+		t.Fatalf("expected no false-positive banner for empty DB, got %q", banner)
+	}
+}
+
+func TestCheckStaleness_OldNewestExecutionWarns(t *testing.T) {
+	dataPath := filepath.Join(t.TempDir(), "data")
+	store, err := NewStore(dataPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	old := time.Now().Add(-10 * 24 * time.Hour)
+	if err := store.SaveExecution(&Execution{
+		ID: "exec-1", TaskID: "TASK-1", ProjectPath: "/p", Status: "completed",
+		CreatedAt: old,
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	info, err := store.CheckStaleness(DefaultStalenessWarnAfter)
+	if err != nil {
+		t.Fatalf("CheckStaleness: %v", err)
+	}
+	if !info.Stale {
+		t.Fatalf("expected a 10-day-old newest execution to be flagged stale (threshold %s), got %+v", DefaultStalenessWarnAfter, info)
+	}
+	banner := info.Banner()
+	if banner == "" {
+		t.Fatal("expected a non-empty banner for a stale ledger")
+	}
+	if !containsAll(banner, "LEDGER STALE", "days ago", store.DBFilePath()) {
+		t.Fatalf("banner missing expected fragments: %q", banner)
+	}
+}
+
+func TestCheckStaleness_RecentExecutionNoBanner(t *testing.T) {
+	dataPath := filepath.Join(t.TempDir(), "data")
+	store, err := NewStore(dataPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	if err := store.SaveExecution(&Execution{
+		ID: "exec-1", TaskID: "TASK-1", ProjectPath: "/p", Status: "completed",
+		CreatedAt: time.Now().Add(-1 * time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	info, err := store.CheckStaleness(DefaultStalenessWarnAfter)
+	if err != nil {
+		t.Fatalf("CheckStaleness: %v", err)
+	}
+	if info.Stale {
+		t.Fatalf("expected a 1-hour-old newest execution to NOT be stale, got %+v", info)
+	}
+	if banner := info.Banner(); banner != "" {
+		t.Fatalf("expected no banner for a fresh execution, got %q", banner)
+	}
+}
+
+func TestCheckStaleness_ArchiveSentinelAlwaysWarns(t *testing.T) {
+	dataPath := filepath.Join(t.TempDir(), "data")
+	store, err := NewStore(dataPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// Fresh execution, well within threshold — without a sentinel this
+	// would not warn.
+	if err := store.SaveExecution(&Execution{
+		ID: "exec-1", TaskID: "TASK-1", ProjectPath: "/p", Status: "completed",
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	sentinelMsg := "retired 2026-07-27 after S6-lite cutover — see README-MOVED.md"
+	if err := os.WriteFile(store.ArchiveSentinelPath(), []byte(sentinelMsg+"\n"), 0644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	info, err := store.CheckStaleness(DefaultStalenessWarnAfter)
+	if err != nil {
+		t.Fatalf("CheckStaleness: %v", err)
+	}
+	if !info.Archived {
+		t.Fatalf("expected sentinel presence to set Archived=true, got %+v", info)
+	}
+	banner := info.Banner()
+	if banner == "" {
+		t.Fatal("expected a non-empty banner when archive sentinel is present")
+	}
+	if !containsAll(banner, "LEDGER ARCHIVED", sentinelMsg) {
+		t.Fatalf("banner missing expected fragments: %q", banner)
+	}
+}
+
+func TestNewStoreGuarded_ArchiveSentinelRefusesStart(t *testing.T) {
+	withIsolatedHome(t)
+	dataPath := filepath.Join(t.TempDir(), "data")
+
+	// First open (no sentinel yet) to create the DB.
+	store, err := NewStoreGuarded(dataPath, false)
+	if err != nil {
+		t.Fatalf("NewStoreGuarded (initial): %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dataPath, ArchiveSentinelFilename), []byte("archived for forensics\n"), 0644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	_, err = NewStoreGuarded(dataPath, false)
+	if err == nil {
+		t.Fatal("expected NewStoreGuarded to refuse starting against an archived ledger")
+	}
+	var archived *ErrLedgerArchived
+	if !errors.As(err, &archived) {
+		t.Fatalf("expected *ErrLedgerArchived, got %T: %v", err, err)
+	}
+
+	// The override flag must let it through for forensics.
+	store2, err := NewStoreGuarded(dataPath, true)
+	if err != nil {
+		t.Fatalf("NewStoreGuarded with allowArchived=true should succeed, got: %v", err)
+	}
+	defer func() { _ = store2.Close() }()
+}
+
+func containsAll(s string, substrs ...string) bool {
+	for _, sub := range substrs {
+		if !strings.Contains(s, sub) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -76,6 +76,12 @@ func NewStore(dataPath string) (*Store, error) {
 		return nil, fmt.Errorf("failed to migrate database: %w", err)
 	}
 
+	// GH-4569: warn (stderr only, never stdout) on every open if the ledger
+	// looks stale or is marked archived — every NewStore caller (CLI
+	// queries, dashboard, pilot start) routes through here, so this is the
+	// one place that reliably covers "any ledger-reading entry point".
+	store.warnIfStale()
+
 	return store, nil
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4569.

Closes #4569

## Changes

GitHub Issue GH-4569: feat(cli): staleness banner + archive sentinel — refuse to silently serve a frozen ledger

## Problem

The ledger DB is trusted wherever it is found. After the S6-lite cutover (TASK-409) the laptop's `~/.pilot/data/pilot.db` sat frozen at 2026-07-16 while looking perfectly healthy; on 2026-07-27 a session read it and confidently misdiagnosed merged/healthy tasks as failed (invented mechanism, wrong remediation). A stale ledger answers every query successfully with wrong data — the worst failure shape. Operator mitigation so far: the file was renamed to an archive + README breadcrumb, but nothing in the software defends against the next copy of this trap (old backups, restored snapshots, second machines).

## Fix

1. **Staleness banner.** On open, any ledger-reading entry point (`pilot start`, `pilot dashboard`, status/CLI queries) computes `max(created_at)` over `executions`; if older than a threshold (default 72h, configurable `ledger.staleness_warn_after`), print a loud banner to stderr and the dashboard header: `⚠ LEDGER STALE — newest execution <ts> (<N> days ago). Are you reading an archive? <db path>`. Warn-only for read paths.
2. **Archive sentinel.** If a file named `LEDGER-ARCHIVED` exists next to the DB, read-only commands show the banner with the sentinel's first line, and `pilot start` REFUSES to run against it (hard error, override flag `--i-know-this-is-an-archive` for forensics). Sentinel is written by operators when retiring a DB.
3. Always print the resolved absolute DB path at daemon startup and in `pilot version`-style diagnostics — path ambiguity was half of the #4393 split-brain incident too.

## Acceptance

- Unit tests: fresh DB → no banner; old max(created_at) → banner; sentinel present → banner + start refusal + override flag works; empty DB (no rows) → treated as fresh-init, no false banner.
- Banner goes to stderr (not stdout) so it never corrupts machine-readable output; dashboard shows it in the header bar.
- `go test ./internal/memory/ ./internal/dashboard/` green.

## Refs

- Incident: 2026-07-27 stale-ledger misdiagnosis (memory `stale-ledger-misdiagnosis`, pilot-aws skill hard rule 6)
- Related: #4393 split-brain (DB-path ambiguity), TASK-409 cutover