### PR TITLE
GH-4570: fix(autopilot): 'PR closed externally' decided from one unverified read on a fresh PR — then acts destructively (branch delete, label churn, tracking drop)

### DIFF
--- a/.agent/tasks/gh-4570.md
+++ b/.agent/tasks/gh-4570.md
@@ -1,0 +1,95 @@
+# GH-4570
+
+**Created:** 2026-07-27
+
+## Problem
+
+GitHub Issue GH-4570: fix(autopilot): 'PR closed externally' decided from one unverified read on a fresh PR — then acts destructively (branch delete, label churn, tracking drop)
+
+## Problem
+
+Autopilot declared a 29-second-old OPEN PR "closed externally without merge" from a single API read, then immediately acted on the false belief. Live incident, founder box, 2026-07-27 (pointer GH-189 / PR #196):
+
+```
+11:15:17 Pull request created                       pr_url=.../pointer/pull/196
+11:15:19 PR registered for autopilot                pr=196 stage=pr_created
+11:15:46 reconciler: adopting untracked open PR     pr=196
+11:15:46 PR closed externally without merge         pr=196 issue=189   ← FALSE (PR was and is OPEN)
+11:15:49 corrected issue label on PR close          issue=189 label=pilot-retry-ready
+11:15:50 deleted branch on PR removal               branch=pilot/GH-189 pr=196
+11:15:50 PR removed from tracking                   pr=196 branch_deleted=true
+11:15:57 PR stage transition                        pr=196 pr_created → waiting_ci   ← surviving duplicate row
+11:17:21 CI passed → ci_passed                      pr=196
+```
+
+GitHub ground truth: PR #196 OPEN the whole time, CI green after the "deletion", branch intact (the delete evidently failed or was reported optimistically — `branch_deleted=true` was logged regardless). GitHub reads on fresh PRs are eventually consistent — the same window shows PR #195 returning 404 with `not_found_count=3,4` right after creation, and the FETCH path already tolerates that. The closed-detection path does not.
+
+Consequences of one false read: issue relabeled `pilot-retry-ready` (retry bait), head-branch deletion attempted on an open PR (destructive — only luck/API failure preserved it), tracking row dropped (a duplicate registration happened to survive and carried the PR forward; without it the PR would be orphaned — the `bug_autopilot_epic_orphan_child_prs` class).
+
+## Fix
+
+1. **Verify before believing "closed".** Treat closed/not-found on a PR younger than a grace window (e.g. 5 min) or with fewer than N consecutive confirming reads as transient — reuse the `not_found_count` tolerance pattern from the fetch path. Only after N consecutive closed reads (or `closed_at` present in the payload) proceed.
+2. **Order actions by reversibility.** Even after confirmation: drop tracking first, relabel second, and delete the branch ONLY after a final fresh read confirms the PR is not open. Never delete the head branch of a PR whose latest read says OPEN.
+3. **Log truthfully.** `branch_deleted=true` must reflect the API result, not the attempt.
+4. Investigate the secondary smell in the same window: dual registration (executor 11:15:19 + reconciler adoption 11:15:46 with two execution_ids, both warning `execution row has no started_at` — GH-4211) which is what accidentally saved this PR.
+
+## Acceptance
+
+- Unit test: closed/404 read on a PR younger than grace window → no state change, no label, no branch delete; verified-closed after N reads → current behavior.
+- Test: branch deletion path re-reads PR state first; open → abort with warning.
+- Incident replay (mock returning open→closed→open flapping) → tracking stable, no destructive action.
+- `go test ./internal/autopilot/` green.
+
+## Refs
+
+- Incident log: founder box daemon.log 2026-07-27 11:15Z window
+- Related: GH-4211 (missing started_at), memory `bug_autopilot_epic_orphan_child_prs`
+
+## Acceptance Criteria
+
+## Investigation: item 4 (dual registration / GH-4211 smell)
+
+Investigated (not fixed, per the task's own framing — this is a distinct,
+lower-severity finding, and the primary grace-window fix below already
+removes the trigger condition for this incident going forward).
+
+**What actually happened, reading the code (`OnPRCreated`,
+`reconcileOrphanPRs`, `removePRTracking`, `ProcessPR` in
+`internal/autopilot/controller.go`):** the 27s gap between the 11:15:19
+registration and the 11:15:46 reconciler log is too short to be a later
+60s-ticker sweep. It's the known GH-3828 TOCTOU: `reconcileOrphanPRs` checks
+`c.activePRs[pr.Number]` and calls `OnPRCreated` as two separate lock
+acquisitions, so it re-registered PR 196 as "untracked" a second time.
+`removePRTracking` deletes by PR-number map key, not pointer identity — so
+when the false-close path called `removePR` at 11:15:50, it evicted whichever
+`*PRState` occupied that key at that instant. But an *already in-flight*
+`ProcessPR` iteration was holding its own `*PRState` pointer from before that
+map mutation, and neither `ProcessPR` nor `persistPRState` re-checks map
+membership before persisting — so that stale goroutine kept driving
+`pr_created → waiting_ci` and persisting to SQLite regardless of the map
+having been emptied 7s earlier. That's the "surviving duplicate row": not a
+retry dispatch, a leftover goroutine from an earlier registration that
+outlived its own removal.
+
+**The "two execution_ids, no started_at" detail** does not appear to be
+GH-4211 as currently scoped in the code — that bug (`exec.StartedAt` never
+populated, "D1") is already fixed and tested (`started_at` is selected and
+scanned in `scanExecutionDetail`, and covered by
+`poller_github_gh4211_test.go`). A row still `"queued"` legitimately has a
+NULL `started_at` regardless of D1. The more likely source is
+`GetLatestExecutionByTaskID`'s substring-fallback (`store.go` ~770-779)
+matching a different, concurrently-tracked execution row for an epic
+sub-issue (GH-4141/GH-3786 territory) — a fresh, unexplained loose end, not
+covered by any existing ledger entry.
+
+**Disposition:** no in-memory dispatch lock exists beyond the
+`pilot-in-progress` label (an external gate, not a concurrency lock), and it
+stayed on issue #189 until after both execution_id warnings fired, ruling out
+"double dispatch of #189" as the cause in this window. Recommending this be
+filed as its own follow-up (map-membership re-check gap in
+`ProcessPR`/`persistPRState`, plus the unexplained second execution_id) rather
+than folded into this fix — it's orthogonal to the false-positive-close bug
+this issue targets, and the grace-window fix below removes the specific
+trigger (false close on a freshly-adopted PR) that surfaced it in this
+incident.
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -4505,17 +4505,23 @@ func (c *Controller) removePRTracking(prNumber int, deleteBranch bool) {
 	c.mu.Unlock()
 
 	// Clean up remote branch for closed/failed PRs (merged PRs already handled in handleMerging)
+	// GH-4570: branchDeleted reflects the actual DeleteBranch outcome, not merely
+	// whether deletion was requested — logging deleteBranch unconditionally here
+	// claimed a successful delete even when the API call itself failed (observed
+	// in the 2026-07-27 incident: branch_deleted=true was logged regardless).
+	branchDeleted := false
 	if deleteBranch && branchName != "" && c.ghClient != nil {
 		if err := c.ghClient.DeleteBranch(context.Background(), c.owner, c.repo, branchName); err != nil {
 			c.log.Debug("branch cleanup on PR removal", "branch", branchName, "pr", prNumber, "error", err)
 		} else {
+			branchDeleted = true
 			c.log.Info("deleted branch on PR removal", "branch", branchName, "pr", prNumber)
 		}
 	}
 
 	c.persistRemovePR(prNumber)
 	c.removePRFailures(prNumber)
-	c.log.Info("PR removed from tracking", "pr", prNumber, "branch_deleted", deleteBranch)
+	c.log.Info("PR removed from tracking", "pr", prNumber, "branch_deleted", branchDeleted)
 }
 
 // GetActivePRs returns detached snapshots of all tracked PRs.
@@ -5665,6 +5671,27 @@ func isNotFoundError(err error) bool {
 // retry loop.
 const notFoundEvictionThreshold = 5
 
+// externalCloseGraceWindow bounds how long after a PR enters tracking
+// (real OnPRCreated registration, or the reconciler's adoption of an
+// untracked orphan PR — both set CreatedAt to time.Now()) a single "closed"
+// read from GitHub is trusted at face value. GH-4570: a PR adopted by the
+// reconciler was read as closed exactly once, seconds later, and autopilot
+// destructively acted on that single read (attempted branch delete, issue
+// relabel) while the PR was open on GitHub the entire time — GitHub does
+// not guarantee read-after-write consistency immediately after a PR is
+// created (the same window saw a sibling PR 404 three times in a row on
+// fresh reads). Chosen generously above the observed propagation delay.
+const externalCloseGraceWindow = 5 * time.Minute
+
+// externalCloseConfirmThreshold is how many consecutive "closed" reads,
+// while still inside externalCloseGraceWindow, are required before
+// checkExternalMergeOrClose believes a PR is genuinely closed and proceeds
+// with the destructive close flow. Mirrors notFoundEvictionThreshold's
+// tolerance for repeated 404s on the fetch path — GH-4570 applies that same
+// reasoning to the closed-detection path, which previously acted on a
+// single read.
+const externalCloseConfirmThreshold = 3
+
 // evictNotFoundPR drops a PR that has 404'd repeatedly from in-memory
 // tracking and the persisted state store. Unlike removePR, it deliberately
 // does NOT attempt remote branch cleanup: a repeated 404 means this
@@ -5833,7 +5860,38 @@ func (c *Controller) checkExternalMergeOrClose(ctx context.Context, prState *PRS
 			return true
 		}
 
+		// GH-4570: inside the grace window since this PR entered tracking, a
+		// single "closed" read is not enough evidence — require
+		// externalCloseConfirmThreshold consecutive closed reads before
+		// believing it. A read of "open" anywhere resets the counter (below),
+		// so a flapping open/closed/open sequence never accumulates enough
+		// confirmations to trigger the destructive path. Past the grace
+		// window a single read is trusted, same as before this fix.
+		if age := time.Since(prState.CreatedAt); age < externalCloseGraceWindow {
+			prState.ClosedReadCount++
+			if prState.ClosedReadCount < externalCloseConfirmThreshold {
+				c.log.Warn("PR read as closed within grace window — not yet confirmed, treating as transient",
+					"pr", prState.PRNumber,
+					"age", age.Round(time.Second),
+					"closed_read_count", prState.ClosedReadCount,
+					"confirm_threshold", externalCloseConfirmThreshold,
+				)
+				return false
+			}
+			c.log.Info("PR closed read confirmed after repeated reads within grace window",
+				"pr", prState.PRNumber, "closed_read_count", prState.ClosedReadCount)
+		}
+
 		c.log.Info("PR closed externally, removing from tracking", "pr", prState.PRNumber)
+
+		// GH-4570: order the remaining actions by reversibility. Dropping
+		// tracking and relabeling are both cheap to have wrong — tracking
+		// self-heals via the reconciler's orphan-PR adoption, and labels can
+		// be corrected by hand. Deleting the head branch cannot be undone,
+		// so it happens last, in finalizeExternalClose, and only after one
+		// more fresh read confirms the PR is not open.
+		branchName := prState.BranchName
+		c.removePRTracking(prState.PRNumber, false)
 		c.notifyExternalClose(ctx, prState)
 
 		// GH-4475: Sync board card to the failed status on external close
@@ -5846,11 +5904,44 @@ func (c *Controller) checkExternalMergeOrClose(ctx context.Context, prState *PRS
 			}
 		}
 
-		c.removePR(prState.PRNumber)
+		c.finalizeExternalClose(ctx, prState.PRNumber, branchName)
 		return true
 	}
 
+	// PR observed in any other state (i.e. still open): clear any pending
+	// closed-read streak so a later transient closed read starts counting
+	// from zero again (GH-4570 flapping protection).
+	prState.ClosedReadCount = 0
 	return false
+}
+
+// finalizeExternalClose performs the last, irreversible step of the
+// external-close flow: deleting the PR's head branch. GH-4570: by the time
+// this runs, tracking has already been dropped and the issue relabeled —
+// both cheap to have gotten wrong. A branch delete is not, so this re-reads
+// the PR fresh one more time immediately before acting: if GitHub now
+// reports it open, the delete is aborted entirely instead of trusting the
+// earlier confirmed-closed read.
+func (c *Controller) finalizeExternalClose(ctx context.Context, prNumber int, branchName string) {
+	if branchName == "" || c.ghClient == nil {
+		return
+	}
+	fresh, err := c.ghClient.GetPullRequest(ctx, c.owner, c.repo, prNumber)
+	if err != nil {
+		c.log.Warn("GH-4570: could not re-verify PR state before branch delete, skipping delete",
+			"pr", prNumber, "branch", branchName, "error", err)
+		return
+	}
+	if fresh.State == "open" {
+		c.log.Warn("GH-4570: PR re-read as open immediately before branch delete — aborting delete",
+			"pr", prNumber, "branch", branchName)
+		return
+	}
+	if err := c.ghClient.DeleteBranch(ctx, c.owner, c.repo, branchName); err != nil {
+		c.log.Debug("branch cleanup on PR removal", "branch", branchName, "pr", prNumber, "error", err)
+		return
+	}
+	c.log.Info("deleted branch on PR removal", "branch", branchName, "pr", prNumber)
 }
 
 // notifyExternalMerge sends notification when a PR is merged externally.

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -1663,6 +1663,14 @@ func TestController_CheckExternalClose(t *testing.T) {
 		t.Fatal("PR should be tracked initially")
 	}
 
+	// GH-4570: back-date CreatedAt past externalCloseGraceWindow so this test
+	// exercises the "current behavior" (single closed read trusted) branch
+	// rather than the new grace-window confirmation gate, which is covered
+	// separately.
+	c.mu.Lock()
+	c.activePRs[42].CreatedAt = time.Now().Add(-10 * time.Minute)
+	c.mu.Unlock()
+
 	// Process PRs - should detect external close and remove
 	c.processAllPRs(context.Background())
 
@@ -1759,6 +1767,13 @@ func TestController_CheckExternalClose_BoardSync(t *testing.T) {
 	// OnPRCreated itself fires a reviewStatus sync — reset so we only observe
 	// the external-close sync under test.
 	mock.calls = nil
+
+	// GH-4570: back-date CreatedAt past externalCloseGraceWindow so a single
+	// closed read is trusted (this test targets board-sync behavior, not the
+	// grace-window confirmation gate, which is covered separately).
+	c.mu.Lock()
+	c.activePRs[42].CreatedAt = time.Now().Add(-10 * time.Minute)
+	c.mu.Unlock()
 
 	c.processAllPRs(context.Background())
 
@@ -2061,6 +2076,14 @@ func TestController_CheckExternalMerge_MultiplePRs(t *testing.T) {
 	c.OnPRCreated(1, "url1", 10, "sha1", "pilot/GH-10", "")
 	c.OnPRCreated(2, "url2", 20, "sha2", "pilot/GH-20", "")
 	c.OnPRCreated(3, "url3", 30, "sha3", "pilot/GH-30", "")
+
+	// GH-4570: back-date PR 3's CreatedAt past externalCloseGraceWindow so its
+	// closed-without-merge read is trusted immediately (this test targets
+	// multi-PR processing, not the grace-window confirmation gate, which is
+	// covered separately).
+	c.mu.Lock()
+	c.activePRs[3].CreatedAt = time.Now().Add(-10 * time.Minute)
+	c.mu.Unlock()
 
 	// Process PRs
 	c.processAllPRs(context.Background())
@@ -4077,6 +4100,13 @@ func TestController_CIFailedClose_PostsCommentsAndCorrectsLabels(t *testing.T) {
 	// Next poll: the poller observes the PR is now closed on GitHub and runs
 	// notifyExternalClose — this is where GH-3806's audit trail is written.
 	prState, _ := c.GetPRState(42)
+	// GH-4570: back-date CreatedAt past externalCloseGraceWindow so this
+	// single closed read is trusted (this test targets notifyExternalClose's
+	// audit trail, not the grace-window confirmation gate, which is covered
+	// separately).
+	c.mu.Lock()
+	c.activePRs[42].CreatedAt = time.Now().Add(-10 * time.Minute)
+	c.mu.Unlock()
 	ghPR, err := ghClient.GetPullRequest(ctx, "owner", "repo", 42)
 	if err != nil {
 		t.Fatalf("GetPullRequest: %v", err)

--- a/internal/autopilot/gh4570_test.go
+++ b/internal/autopilot/gh4570_test.go
@@ -1,0 +1,209 @@
+package autopilot
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestGH4570_ClosedReadWithinGraceWindow_NotYetConfirmed covers the core
+// GH-4570 incident: a PR that entered tracking moments ago (well inside
+// externalCloseGraceWindow) reads as "closed" exactly once. That single read
+// must not be believed — no label change, no branch delete, no drop from
+// tracking — because GitHub's eventual consistency can surface a stale
+// "closed" read on a PR that is genuinely still open (the 2026-07-27
+// incident: PR #196 read closed 29s after creation while open the entire
+// time).
+func TestGH4570_ClosedReadWithinGraceWindow_NotYetConfirmed(t *testing.T) {
+	rec, srv := newRecordingGHServer()
+	defer srv.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:    50,
+		IssueNumber: 15,
+		BranchName:  "pilot/GH-15",
+		CreatedAt:   time.Now(), // fresh — inside externalCloseGraceWindow
+	}
+	c.mu.Lock()
+	c.activePRs[50] = prState
+	c.mu.Unlock()
+
+	ghPR := &github.PullRequest{Number: 50, State: "closed", Merged: false}
+	resolved := c.checkExternalMergeOrClose(context.Background(), prState, ghPR)
+
+	if resolved {
+		t.Fatal("a single closed read within the grace window must not resolve the PR")
+	}
+	if _, ok := c.GetPRState(50); !ok {
+		t.Error("PR must remain tracked after an unconfirmed closed read")
+	}
+	if prState.ClosedReadCount != 1 {
+		t.Errorf("ClosedReadCount = %d, want 1", prState.ClosedReadCount)
+	}
+	if n := rec.count(http.MethodPost, "/repos/owner/repo/issues/15/labels"); n != 0 {
+		t.Errorf("must not relabel the issue on an unconfirmed closed read, got %d calls", n)
+	}
+	if n := rec.count(http.MethodDelete, "/repos/owner/repo/git/refs/heads/"); n != 0 {
+		t.Errorf("must not delete the branch on an unconfirmed closed read, got %d calls", n)
+	}
+	if n := rec.count(http.MethodPost, "/repos/owner/repo/issues/50/comments"); n != 0 {
+		t.Errorf("must not post the external-close PR comment on an unconfirmed closed read, got %d calls", n)
+	}
+}
+
+// TestGH4570_ClosedReadConfirmedAfterThreshold covers the "current behavior"
+// half of the acceptance criteria: once a PR still inside the grace window
+// has been read closed externalCloseConfirmThreshold times in a row, it must
+// be treated exactly as before this fix — removed from tracking, relabeled,
+// and its branch deleted.
+func TestGH4570_ClosedReadConfirmedAfterThreshold(t *testing.T) {
+	rec, srv := newRecordingGHServer()
+	defer srv.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:    51,
+		IssueNumber: 16,
+		BranchName:  "pilot/GH-16",
+		CreatedAt:   time.Now(),
+	}
+	c.mu.Lock()
+	c.activePRs[51] = prState
+	c.mu.Unlock()
+
+	ghPR := &github.PullRequest{Number: 51, State: "closed", Merged: false}
+
+	var resolved bool
+	for i := 1; i <= externalCloseConfirmThreshold; i++ {
+		resolved = c.checkExternalMergeOrClose(context.Background(), prState, ghPR)
+		if i < externalCloseConfirmThreshold {
+			if resolved {
+				t.Fatalf("read %d/%d must not yet resolve the PR", i, externalCloseConfirmThreshold)
+			}
+			if _, ok := c.GetPRState(51); !ok {
+				t.Fatalf("PR must remain tracked before the confirm threshold is reached (read %d)", i)
+			}
+		}
+	}
+
+	if !resolved {
+		t.Fatal("the confirming read must resolve the PR as closed")
+	}
+	if _, ok := c.GetPRState(51); ok {
+		t.Error("PR must no longer be tracked once the closed read is confirmed")
+	}
+	if n := rec.count(http.MethodPost, "/repos/owner/repo/issues/16/labels"); n != 1 {
+		t.Errorf("AddLabels calls = %d, want 1 once confirmed", n)
+	}
+	if n := rec.count(http.MethodDelete, "/repos/owner/repo/git/refs/heads/"); n != 1 {
+		t.Errorf("DELETE branch calls = %d, want 1 once confirmed", n)
+	}
+}
+
+// TestGH4570_FinalizeExternalClose_ReReadsBeforeDelete directly covers the
+// acceptance criterion "branch deletion path re-reads PR state first; open ->
+// abort with warning". finalizeExternalClose is the sole remaining path that
+// deletes a branch after an external close is confirmed — it must take one
+// more fresh read immediately before the irreversible delete and bail out if
+// that read now says the PR is open.
+func TestGH4570_FinalizeExternalClose_ReReadsBeforeDelete(t *testing.T) {
+	tests := []struct {
+		name       string
+		freshState string
+		wantDelete bool
+	}{
+		{name: "fresh read still closed -> deletes", freshState: "closed", wantDelete: true},
+		{name: "fresh read now open -> aborts delete", freshState: "open", wantDelete: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var deleteCalled bool
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/pulls/70":
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"number":70,"state":"` + tt.freshState + `"}`))
+				case r.Method == http.MethodDelete && r.URL.Path == "/repos/owner/repo/git/refs/heads/pilot/GH-70":
+					deleteCalled = true
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("{}"))
+				default:
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("{}"))
+				}
+			}))
+			defer srv.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+			cfg := DefaultConfig()
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+			c.finalizeExternalClose(context.Background(), 70, "pilot/GH-70")
+
+			if deleteCalled != tt.wantDelete {
+				t.Errorf("branch delete called = %v, want %v", deleteCalled, tt.wantDelete)
+			}
+		})
+	}
+}
+
+// TestGH4570_FlappingCloseOpen_NeverAccumulatesConfirmation is the incident
+// replay: a mock that alternates open/closed reads (mirroring GitHub's
+// eventual-consistency flapping observed in the GH-189 incident window) must
+// never trigger the destructive close path, because any "open" read resets
+// the consecutive-closed-read counter to zero.
+func TestGH4570_FlappingCloseOpen_NeverAccumulatesConfirmation(t *testing.T) {
+	rec, srv := newRecordingGHServer()
+	defer srv.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:    52,
+		IssueNumber: 17,
+		BranchName:  "pilot/GH-17",
+		CreatedAt:   time.Now(),
+	}
+	c.mu.Lock()
+	c.activePRs[52] = prState
+	c.mu.Unlock()
+
+	// closed, closed, open, closed, closed, open, closed, closed, open —
+	// never externalCloseConfirmThreshold (3) consecutive closed reads.
+	states := []string{"closed", "closed", "open", "closed", "closed", "open", "closed", "closed", "open"}
+	for i, state := range states {
+		ghPR := &github.PullRequest{Number: 52, State: state, Merged: false}
+		resolved := c.checkExternalMergeOrClose(context.Background(), prState, ghPR)
+		if resolved {
+			t.Fatalf("flapping sequence must never resolve the PR (resolved at step %d, state=%s)", i, state)
+		}
+	}
+
+	if _, ok := c.GetPRState(52); !ok {
+		t.Error("PR must remain tracked throughout a flapping open/closed sequence")
+	}
+	if prState.ClosedReadCount != 0 {
+		t.Errorf("ClosedReadCount = %d, want 0 after the sequence ends on an open read", prState.ClosedReadCount)
+	}
+	if n := rec.count(http.MethodPost, "/repos/owner/repo/issues/17/labels"); n != 0 {
+		t.Errorf("must not relabel the issue during flapping, got %d calls", n)
+	}
+	if n := rec.count(http.MethodDelete, "/repos/owner/repo/git/refs/heads/"); n != 0 {
+		t.Errorf("must not delete the branch during flapping, got %d calls", n)
+	}
+}

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -968,6 +968,17 @@ type PRState struct {
 	// the counter anyway, giving a freshly-restored row a few more tries before
 	// eviction (GH-3903 404-eviction guard).
 	NotFoundCount int
+	// ClosedReadCount tracks consecutive "closed" reads observed by
+	// checkExternalMergeOrClose since the PR was last read as open.
+	// In-memory only — reset to 0 the moment a poll sees the PR open again
+	// (flapping protection), and naturally reset by a daemon restart.
+	// Required to reach externalCloseConfirmThreshold before a "closed"
+	// read inside externalCloseGraceWindow of CreatedAt is believed
+	// (GH-4570: a PR read closed exactly once, 29s after it was
+	// created/adopted, was destructively acted on — branch delete attempt,
+	// issue relabel — while every other read that same minute showed it
+	// still open).
+	ClosedReadCount int
 	// PersistFailureCount tracks consecutive SavePRState errors for this PR
 	// (e.g. a schema/ON CONFLICT mismatch on an adopted or otherwise
 	// irregular row). Reset to 0 on a successful persist. In-memory only:
@@ -1091,6 +1102,7 @@ func (ps *PRState) snapshot() *PRState {
 		ReleaseBumpType:         ps.ReleaseBumpType,
 		ConsecutiveAPIFailures:  ps.ConsecutiveAPIFailures,
 		NotFoundCount:           ps.NotFoundCount,
+		ClosedReadCount:         ps.ClosedReadCount,
 		PersistFailureCount:     ps.PersistFailureCount,
 		EnvironmentName:         ps.EnvironmentName,
 		PRTitle:                 ps.PRTitle,


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4570.

Closes #4570

## Changes

GitHub Issue GH-4570: fix(autopilot): 'PR closed externally' decided from one unverified read on a fresh PR — then acts destructively (branch delete, label churn, tracking drop)

## Problem

Autopilot declared a 29-second-old OPEN PR "closed externally without merge" from a single API read, then immediately acted on the false belief. Live incident, founder box, 2026-07-27 (pointer GH-189 / PR #196):

```
11:15:17 Pull request created                       pr_url=.../pointer/pull/196
11:15:19 PR registered for autopilot                pr=196 stage=pr_created
11:15:46 reconciler: adopting untracked open PR     pr=196
11:15:46 PR closed externally without merge         pr=196 issue=189   ← FALSE (PR was and is OPEN)
11:15:49 corrected issue label on PR close          issue=189 label=pilot-retry-ready
11:15:50 deleted branch on PR removal               branch=pilot/GH-189 pr=196
11:15:50 PR removed from tracking                   pr=196 branch_deleted=true
11:15:57 PR stage transition                        pr=196 pr_created → waiting_ci   ← surviving duplicate row
11:17:21 CI passed → ci_passed                      pr=196
```

GitHub ground truth: PR #196 OPEN the whole time, CI green after the "deletion", branch intact (the delete evidently failed or was reported optimistically — `branch_deleted=true` was logged regardless). GitHub reads on fresh PRs are eventually consistent — the same window shows PR #195 returning 404 with `not_found_count=3,4` right after creation, and the FETCH path already tolerates that. The closed-detection path does not.

Consequences of one false read: issue relabeled `pilot-retry-ready` (retry bait), head-branch deletion attempted on an open PR (destructive — only luck/API failure preserved it), tracking row dropped (a duplicate registration happened to survive and carried the PR forward; without it the PR would be orphaned — the `bug_autopilot_epic_orphan_child_prs` class).

## Fix

1. **Verify before believing "closed".** Treat closed/not-found on a PR younger than a grace window (e.g. 5 min) or with fewer than N consecutive confirming reads as transient — reuse the `not_found_count` tolerance pattern from the fetch path. Only after N consecutive closed reads (or `closed_at` present in the payload) proceed.
2. **Order actions by reversibility.** Even after confirmation: drop tracking first, relabel second, and delete the branch ONLY after a final fresh read confirms the PR is not open. Never delete the head branch of a PR whose latest read says OPEN.
3. **Log truthfully.** `branch_deleted=true` must reflect the API result, not the attempt.
4. Investigate the secondary smell in the same window: dual registration (executor 11:15:19 + reconciler adoption 11:15:46 with two execution_ids, both warning `execution row has no started_at` — GH-4211) which is what accidentally saved this PR.

## Acceptance

- Unit test: closed/404 read on a PR younger than grace window → no state change, no label, no branch delete; verified-closed after N reads → current behavior.
- Test: branch deletion path re-reads PR state first; open → abort with warning.
- Incident replay (mock returning open→closed→open flapping) → tracking stable, no destructive action.
- `go test ./internal/autopilot/` green.

## Refs

- Incident log: founder box daemon.log 2026-07-27 11:15Z window
- Related: GH-4211 (missing started_at), memory `bug_autopilot_epic_orphan_child_prs`