### PR TITLE
GH-4574: feat(tooling): graph drift local prevention — check-graph in pre-commit/pre-push gates + --fix auto-index

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -199,6 +199,7 @@
 | Lint gates | ✅ | quality | - | `quality.gates[].type=lint` | Run lint commands |
 | Build gates | ✅ | quality | - | `quality.gates[].type=build` | Compile check |
 | Retry on failure | ✅ | quality | - | `quality.max_retries` | Auto-retry with feedback |
+| Knowledge-graph drift local prevention | ✅ | scripts | `python3 scripts/check-graph.py --fix` | - | Pre-commit (blocks commits staging `.agent/knowledge/` paths) and pre-push gate (`[5/6] Knowledge Graph`) now run `check-graph.py` locally, so drift is caught before push instead of first surfacing on CI's Knowledge Graph Drift Gate. `--fix` auto-repairs class-2 findings only (unindexed memory files — stub node generated from the file's frontmatter `name`/`type`/`description`); broken links and dangling edges still fail and need human judgment. No-`--fix` behavior (used by CI) is unchanged (GH-4574, follow-up to the 88fad61c red-main incident) |
 
 ## Memory & Learning
 

--- a/scripts/check-graph.py
+++ b/scripts/check-graph.py
@@ -12,7 +12,16 @@ v6.17.0's graph_maintenance.py (reimplemented, not vendored):
   4. Invalid concept refs — node concepts with no matching concept key (WARN)
 
 Exit 0 when classes 1-3 are empty (regardless of class 4). Exit 1 otherwise.
+
+With `--fix`, class 2 (unindexed active memory files) is auto-repaired: a
+stub node is generated in graph.json under nodes.memories for each unindexed
+file, keyed by the file's frontmatter `name`. Classes 1 and 3 are never
+auto-fixed — they need human judgment (a broken link could mean the file
+moved or the node is stale; a dangling edge could mean either endpoint is
+wrong). Without `--fix`, behavior is byte-identical to running with no
+flags at all — this keeps the CI gate (which never passes --fix) read-only.
 """
+import datetime
 import glob
 import json
 import os
@@ -80,6 +89,54 @@ def find_unindexed_memory_files(graph, memories_base, repo_root):
     return sorted(unindexed)
 
 
+def parse_frontmatter(filepath):
+    """Parse the flat `key: value` YAML front-matter block memory files use
+    (--- / name / description / type / ---). Returns {} if the file has no
+    front-matter block. Deliberately avoids a PyYAML dependency since the
+    front-matter here is always flat scalars, and check-graph.py must stay
+    importable in the CI job with no extra installs."""
+    with open(filepath, "r", encoding="utf-8") as f:
+        content = f.read()
+    if not content.startswith("---"):
+        return {}
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return {}
+    meta = {}
+    for line in parts[1].splitlines():
+        line = line.strip()
+        if not line or ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        meta[key.strip()] = value.strip().strip('"').strip("'")
+    return meta
+
+
+def fix_unindexed(graph, unindexed, repo_root):
+    """Auto-repair class 2 (unindexed active memory files): add a stub node
+    under nodes.memories for each, keyed by the file's frontmatter `name`.
+    Files with no `name` in front-matter are left unindexed (still FAIL) —
+    there's no safe key to generate a node under. Returns the list of
+    (node_id, rel_path) actually added, in the same order as `unindexed`."""
+    memories = graph.setdefault("nodes", {}).setdefault("memories", {})
+    today = datetime.date.today().isoformat()
+    added = []
+    for rel_path in unindexed:
+        meta = parse_frontmatter(os.path.join(repo_root, rel_path))
+        node_id = meta.get("name")
+        if not node_id:
+            continue
+        memories[node_id] = {
+            "type": meta.get("type", ""),
+            "summary": meta.get("description", ""),
+            "file": rel_path,
+            "created": today,
+            "last_validated": today,
+        }
+        added.append((node_id, rel_path))
+    return added
+
+
 def find_dangling_edges(graph):
     node_ids = set()
     for category in graph.get("nodes", {}).values():
@@ -104,14 +161,34 @@ def find_invalid_concept_refs(graph):
 
 
 def main():
+    fix = "--fix" in sys.argv[1:]
+
     graph = load_graph(GRAPH_PATH)
 
     broken_links = find_broken_file_links(graph, REPO_ROOT)
     unindexed = find_unindexed_memory_files(graph, MEMORIES_BASE, REPO_ROOT)
+
+    fixed = []
+    if fix and unindexed:
+        fixed = fix_unindexed(graph, unindexed, REPO_ROOT)
+        if fixed:
+            fixed_paths = {rel_path for _, rel_path in fixed}
+            unindexed = [rel_path for rel_path in unindexed if rel_path not in fixed_paths]
+            with open(GRAPH_PATH, "w", encoding="utf-8") as f:
+                json.dump(graph, f, indent=2)
+
     dangling_edges = find_dangling_edges(graph)
     invalid_concepts = find_invalid_concept_refs(graph)
 
     fail = False
+
+    if fix:
+        print("== Auto-fixed (--fix) ==")
+        if fixed:
+            for node_id, rel_path in fixed:
+                print(f"  FIXED {node_id}: {rel_path}")
+        else:
+            print("  none")
 
     print("== Broken file links ==")
     if broken_links:

--- a/scripts/check_graph_test.py
+++ b/scripts/check_graph_test.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 """Table-driven tests for scripts/check-graph.py."""
+import contextlib
+import datetime
 import importlib.util
+import io
+import json
 import os
 import sys
 import tempfile
@@ -148,6 +152,56 @@ class InvalidConceptRefsTest(unittest.TestCase):
         self.assertEqual(cg.find_invalid_concept_refs(graph), [("mem-001", "nonexistent")])
 
 
+class ParseFrontmatterTest(unittest.TestCase):
+    def test_parses_flat_frontmatter(self):
+        with tempfile.TemporaryDirectory() as root:
+            path = os.path.join(root, "a.md")
+            _write(path, "---\nname: foo-bar\ndescription: does a thing\ntype: pattern\n---\n\n# Foo\n")
+            meta = cg.parse_frontmatter(path)
+            self.assertEqual(meta, {"name": "foo-bar", "description": "does a thing", "type": "pattern"})
+
+    def test_no_frontmatter_returns_empty_dict(self):
+        with tempfile.TemporaryDirectory() as root:
+            path = os.path.join(root, "a.md")
+            _write(path, "# Just a heading, no front-matter\n")
+            self.assertEqual(cg.parse_frontmatter(path), {})
+
+
+class FixUnindexedTest(unittest.TestCase):
+    def test_adds_stub_node_keyed_by_frontmatter_name(self):
+        with tempfile.TemporaryDirectory() as root:
+            rel_path = os.path.join(".agent", "knowledge", "memories", "patterns", "orphan.md")
+            _write(
+                os.path.join(root, rel_path),
+                "---\nname: orphan-pattern\ndescription: an orphan\ntype: pattern\n---\n\nbody\n",
+            )
+            graph = {"nodes": {"memories": {}}}
+            added = cg.fix_unindexed(graph, [rel_path], root)
+
+            self.assertEqual(added, [("orphan-pattern", rel_path)])
+            node = graph["nodes"]["memories"]["orphan-pattern"]
+            today = datetime.date.today().isoformat()
+            self.assertEqual(
+                node,
+                {
+                    "type": "pattern",
+                    "summary": "an orphan",
+                    "file": rel_path,
+                    "created": today,
+                    "last_validated": today,
+                },
+            )
+
+    def test_file_with_no_frontmatter_name_is_left_unindexed(self):
+        with tempfile.TemporaryDirectory() as root:
+            rel_path = os.path.join(".agent", "knowledge", "memories", "patterns", "orphan.md")
+            _write(os.path.join(root, rel_path), "no front-matter here\n")
+            graph = {"nodes": {"memories": {}}}
+            added = cg.fix_unindexed(graph, [rel_path], root)
+            self.assertEqual(added, [])
+            self.assertEqual(graph["nodes"]["memories"], {})
+
+
 class MainExitCodeTest(unittest.TestCase):
     def _build_repo(self, root):
         memories_base = os.path.join(root, ".agent", "knowledge", "memories")
@@ -168,11 +222,16 @@ class MainExitCodeTest(unittest.TestCase):
             json.dump(graph, f)
         return graph_path, memories_base
 
-    def _run_main(self, root, graph_path, memories_base):
+    def _run_main(self, root, graph_path, memories_base, argv=None):
         cg.REPO_ROOT = root
         cg.GRAPH_PATH = graph_path
         cg.MEMORIES_BASE = memories_base
-        return cg.main()
+        old_argv = sys.argv
+        sys.argv = argv if argv is not None else ["check-graph.py"]
+        try:
+            return cg.main()
+        finally:
+            sys.argv = old_argv
 
     def test_clean_repo_exits_zero(self):
         with tempfile.TemporaryDirectory() as root:
@@ -244,6 +303,78 @@ class MainExitCodeTest(unittest.TestCase):
             self.assertEqual(unindexed, [os.path.join(".agent", "knowledge", "memories", "patterns", "orphan.md")])
 
             self.assertEqual(self._run_main(root, graph_path, memories_base), 1)
+
+    def test_fix_indexes_unindexed_file_from_frontmatter(self):
+        with tempfile.TemporaryDirectory() as root:
+            graph_path, memories_base = self._build_repo(root)
+            orphan_path = os.path.join(memories_base, "patterns", "orphan.md")
+            _write(
+                orphan_path,
+                "---\nname: orphan-thing\ndescription: an orphan thing\ntype: learning\n---\n\nbody\n",
+            )
+
+            exit_code = self._run_main(root, graph_path, memories_base, argv=["check-graph.py", "--fix"])
+            self.assertEqual(exit_code, 0)
+
+            with open(graph_path, encoding="utf-8") as f:
+                graph = json.load(f)
+            self.assertIn("orphan-thing", graph["nodes"]["memories"])
+            node = graph["nodes"]["memories"]["orphan-thing"]
+            self.assertEqual(node["type"], "learning")
+            self.assertEqual(node["summary"], "an orphan thing")
+            self.assertEqual(node["file"], os.path.relpath(orphan_path, root))
+
+            # Re-running without --fix now passes clean since the node was
+            # persisted to graph.json on disk.
+            self.assertEqual(self._run_main(root, graph_path, memories_base), 0)
+
+    def test_fix_does_not_touch_broken_links_or_dangling_edges(self):
+        with tempfile.TemporaryDirectory() as root:
+            graph_path, memories_base = self._build_repo(root)
+            # Class 1: break the indexed file link.
+            os.remove(os.path.join(memories_base, "patterns", "a.md"))
+            # Class 3: add a dangling edge.
+            with open(graph_path, "r+", encoding="utf-8") as f:
+                graph = json.load(f)
+                graph["edges"].append({"from": "ghost", "to": "mem-001", "type": "uses"})
+                f.seek(0)
+                json.dump(graph, f)
+                f.truncate()
+
+            exit_code = self._run_main(root, graph_path, memories_base, argv=["check-graph.py", "--fix"])
+            # Neither class is auto-fixable — --fix must still exit 1.
+            self.assertEqual(exit_code, 1)
+
+            with open(graph_path, encoding="utf-8") as f:
+                graph = json.load(f)
+            self.assertEqual(
+                graph["nodes"]["memories"]["mem-001"]["file"],
+                ".agent/knowledge/memories/patterns/a.md",
+            )
+            self.assertIn({"from": "ghost", "to": "mem-001", "type": "uses"}, graph["edges"])
+
+    def test_no_fix_flag_output_is_unchanged(self):
+        with tempfile.TemporaryDirectory() as root:
+            graph_path, memories_base = self._build_repo(root)
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                exit_code = self._run_main(root, graph_path, memories_base, argv=["check-graph.py"])
+            output = buf.getvalue()
+
+            self.assertEqual(exit_code, 0)
+            self.assertNotIn("Auto-fixed", output)
+            self.assertEqual(
+                output,
+                "== Broken file links ==\n"
+                "  none\n"
+                "== Unindexed active memory files ==\n"
+                "  none\n"
+                "== Dangling edges ==\n"
+                "  none\n"
+                "== Invalid concept refs (warn only) ==\n"
+                "  none\n"
+                "\nOK: knowledge graph matches disk state\n",
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Install git hooks for the pilot project
 # Hooks installed:
-#   - pre-commit: Secret pattern detection
+#   - pre-commit: Secret pattern detection + knowledge-graph drift check
 #   - pre-push: Full validation gate (build, lint, test, secrets, integration)
 
 set -e
@@ -18,8 +18,10 @@ mkdir -p "$HOOKS_DIR"
 # Install pre-commit hook
 cat > "$HOOKS_DIR/pre-commit" << 'EOF'
 #!/bin/bash
-# Pre-commit hook to prevent realistic-looking secrets in test files
-# This helps avoid GitHub push protection blocks
+# Pre-commit hook to prevent realistic-looking secrets in test files, and to
+# catch knowledge-graph drift (unindexed/broken memory nodes) before it
+# reaches CI's Knowledge Graph Drift Gate.
+# This helps avoid GitHub push protection blocks and red-main drift incidents.
 
 set -e
 
@@ -27,10 +29,6 @@ echo "Checking for realistic secret patterns in staged files..."
 
 # Get list of staged Go test files
 STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '_test\.go$' || true)
-
-if [ -z "$STAGED_FILES" ]; then
-    exit 0
-fi
 
 # Patterns that look like real secrets (will trigger GitHub push protection)
 # These are regex patterns for grep -E
@@ -86,6 +84,39 @@ if [ $FOUND_SECRETS -eq 1 ]; then
 fi
 
 echo "✓ No realistic secret patterns found"
+
+# Knowledge-graph drift check: only run when a staged path touches
+# .agent/knowledge/, since check-graph.py walks the whole memories tree.
+STAGED_KNOWLEDGE=$(git diff --cached --name-only --diff-filter=ACMR | grep '^\.agent/knowledge/' || true)
+
+if [ -n "$STAGED_KNOWLEDGE" ]; then
+    HOOK_DIR="$(dirname "$0")"
+    PROJECT_ROOT="$(cd "$HOOK_DIR/../.." && pwd)"
+
+    echo ""
+    echo "Checking knowledge-graph drift (staged .agent/knowledge/ changes)..."
+
+    if ! python3 "$PROJECT_ROOT/scripts/check-graph.py"; then
+        echo ""
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo "COMMIT BLOCKED: knowledge graph drift detected"
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo ""
+        echo "Fix unindexed memory files automatically:"
+        echo "  python3 scripts/check-graph.py --fix"
+        echo ""
+        echo "Broken links / dangling edges need manual review — see the"
+        echo "FAIL lines above."
+        echo ""
+        echo "To bypass this check (not recommended):"
+        echo "  git commit --no-verify"
+        echo ""
+        exit 1
+    fi
+
+    echo "✓ Knowledge graph in sync"
+fi
+
 exit 0
 EOF
 
@@ -146,7 +177,7 @@ chmod +x "$HOOKS_DIR/pre-push"
 echo "✓ Pre-push hook installed"
 echo ""
 echo "Hooks installed:"
-echo "  • pre-commit: Checks for realistic secrets in test files"
-echo "  • pre-push:   Runs full validation gate (build, lint, test, secrets)"
+echo "  • pre-commit: Checks for realistic secrets in test files + knowledge-graph drift"
+echo "  • pre-push:   Runs full validation gate (build, lint, test, secrets, knowledge-graph)"
 echo ""
 echo "Use '--no-verify' to bypass hooks (not recommended)."

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -83,14 +83,14 @@ run_check_warn() {
 }
 
 # 1. BUILD
-echo -e "${BLUE}[1/5] Build${NC}"
+echo -e "${BLUE}[1/6] Build${NC}"
 if ! run_check "go build" "go build -o /dev/null ./cmd/pilot"; then
     FAILURES=$((FAILURES + 1))
 fi
 echo ""
 
 # 2. LINT
-echo -e "${BLUE}[2/5] Lint${NC}"
+echo -e "${BLUE}[2/6] Lint${NC}"
 if command -v golangci-lint >/dev/null 2>&1; then
     if ! run_check "golangci-lint" "golangci-lint run --timeout 60s"; then
         FAILURES=$((FAILURES + 1))
@@ -102,14 +102,14 @@ fi
 echo ""
 
 # 3. TEST (short mode for speed)
-echo -e "${BLUE}[3/5] Test (short)${NC}"
+echo -e "${BLUE}[3/6] Test (short)${NC}"
 if ! run_check "go test -short" "go test -short -race ./..."; then
     FAILURES=$((FAILURES + 1))
 fi
 echo ""
 
 # 4. SECRETS
-echo -e "${BLUE}[4/5] Secret Patterns${NC}"
+echo -e "${BLUE}[4/6] Secret Patterns${NC}"
 if [ -x "$SCRIPT_DIR/check-secret-patterns.sh" ]; then
     if ! run_check "check-secrets" "$SCRIPT_DIR/check-secret-patterns.sh"; then
         FAILURES=$((FAILURES + 1))
@@ -119,8 +119,15 @@ else
 fi
 echo ""
 
-# 5. INTEGRATION
-echo -e "${BLUE}[5/5] Integration${NC}"
+# 5. KNOWLEDGE GRAPH
+echo -e "${BLUE}[5/6] Knowledge Graph${NC}"
+if ! run_check "check-graph" "python3 $SCRIPT_DIR/check-graph.py"; then
+    FAILURES=$((FAILURES + 1))
+fi
+echo ""
+
+# 6. INTEGRATION
+echo -e "${BLUE}[6/6] Integration${NC}"
 if [ -x "$SCRIPT_DIR/check-integration.sh" ]; then
     if ! run_check "integration" "$SCRIPT_DIR/check-integration.sh"; then
         FAILURES=$((FAILURES + 1))


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4574.

Closes #4574

## Changes

GitHub Issue GH-4574: feat(tooling): graph drift local prevention — check-graph in pre-commit/pre-push gates + --fix auto-index

# TASK-425: Graph drift local prevention — check-graph in pre-commit/pre-push + `--fix` auto-index

**Created**: 2026-07-27 · **Status**: 🚀 Dispatched to Pilot · **Last Updated**: 2026-07-27

## Problem

Interactive sessions can commit a memory file under
`.agent/knowledge/memories/` without indexing it in
`.agent/knowledge/graph.json`. Nothing local catches it: the pre-commit hook
(`scripts/install-hooks.sh`) only greps `_test.go` files for secret
patterns, and `scripts/pre-push-gate.sh` never runs `scripts/check-graph.py`.
First detection is the Knowledge Graph Drift Gate on CI — after the push,
red on main (occurred 2026-07-27: commit `88fad61c` added a learning file
un-indexed; main CI red for ~55 minutes across 4 pushes).

## Required behavior

1. **`check-graph.py --fix`**: for each "unindexed active memory file"
   finding, generate a stub node in `graph.json` under `nodes.memories`,
   keyed by the file's frontmatter `name`, with `type` from frontmatter
   `type`, `summary` from frontmatter `description`, `file` set to the
   repo-relative path, and `created`/`last_validated` set to today. Print
   each node added. `--fix` only repairs class 2 (unindexed files); classes
   1 and 3 (broken links, dangling edges) still FAIL — they need human
   judgment. Without `--fix`, behavior is byte-identical to today (CI must
   stay read-only).
2. **Pre-commit**: in the hook installed by `scripts/install-hooks.sh`, when
   any staged path is under `.agent/knowledge/`, run
   `python3 scripts/check-graph.py`; on failure, block the commit and print
   the hint `python3 scripts/check-graph.py --fix`.
3. **Pre-push gate**: add a check-graph step to `scripts/pre-push-gate.sh`
   (fail closed, same as the other gate steps).
4. Keep `make check-graph` as the manual entry point (already exists,
   Makefile:133).

## Acceptance criteria

- [ ] `scripts/check_graph_test.py` extended: `--fix` indexes an unindexed
      file from its frontmatter; `--fix` does NOT touch broken links or
      dangling edges; no-`--fix` output unchanged.
- [ ] Fresh `make install-hooks` installs a pre-commit that blocks a commit
      staging an un-indexed memory file, and passes once indexed (or after
      `--fix`).
- [ ] `pre-push-gate.sh` fails when the graph drifts.
- [ ] CI workflow (`Knowledge Graph Drift Gate`) unchanged — still read-only.

## Refs

- Checker: `scripts/check-graph.py` (+ `scripts/check_graph_test.py`)
- Hooks: `scripts/install-hooks.sh`, `scripts/pre-push-gate.sh`, Makefile
  `check-graph` target
- Incident: `88fad61c` → fixed by `0c2392eb` (2026-07-27)
- Related: TASK-410 (executor-side deletions), TASK-424 (origin-relative
  guards)