### PR TITLE
GH-4575: chore(lint): fix 4 findings failing the local pre-push gate — errcheck in scope_schedule_test, dead renderPanel chain

### DIFF
--- a/internal/autopilot/scope_schedule_test.go
+++ b/internal/autopilot/scope_schedule_test.go
@@ -93,7 +93,9 @@ func TestScheduleReleaseTick_EnqueuesTrainWithResolvedMembers(t *testing.T) {
 	c, stateStore := newScheduleController(t, server.URL, "0 21 * * FRI")
 
 	scheduledAt := time.Date(2026, 7, 10, 21, 0, 0, 0, time.UTC)
-	c.scheduleReleaseTick(context.Background(), scheduledAt)
+	if _, err := c.scheduleReleaseTick(context.Background(), scheduledAt); err != nil {
+		t.Fatalf("scheduleReleaseTick failed: %v", err)
+	}
 
 	row, err := stateStore.GetScopeRelease("owner/repo", "train:2026-07-10T21:00:00Z")
 	if err != nil {
@@ -126,7 +128,9 @@ func TestScheduleReleaseTick_DropsUnverifiablePRNumber(t *testing.T) {
 	c, stateStore := newScheduleController(t, server.URL, "0 21 * * FRI")
 
 	scheduledAt := time.Date(2026, 7, 10, 21, 0, 0, 0, time.UTC)
-	c.scheduleReleaseTick(context.Background(), scheduledAt)
+	if _, err := c.scheduleReleaseTick(context.Background(), scheduledAt); err != nil {
+		t.Fatalf("scheduleReleaseTick failed: %v", err)
+	}
 
 	row, err := stateStore.GetScopeRelease("owner/repo", "train:2026-07-10T21:00:00Z")
 	if err != nil || row == nil {
@@ -146,7 +150,9 @@ func TestScheduleReleaseTick_EmptyCompare_NoRow(t *testing.T) {
 	c, stateStore := newScheduleController(t, server.URL, "0 21 * * FRI")
 
 	scheduledAt := time.Date(2026, 7, 10, 21, 0, 0, 0, time.UTC)
-	c.scheduleReleaseTick(context.Background(), scheduledAt)
+	if _, err := c.scheduleReleaseTick(context.Background(), scheduledAt); err != nil {
+		t.Fatalf("scheduleReleaseTick failed: %v", err)
+	}
 
 	rows, err := stateStore.ListScopeReleases("owner/repo", "pending", "releasing", "done", "failed")
 	if err != nil {
@@ -171,7 +177,9 @@ func TestScheduleReleaseTick_DirectCommitOnlyTrain_NoRow(t *testing.T) {
 	c, stateStore := newScheduleController(t, server.URL, "0 21 * * FRI")
 
 	scheduledAt := time.Date(2026, 7, 10, 21, 0, 0, 0, time.UTC)
-	c.scheduleReleaseTick(context.Background(), scheduledAt)
+	if _, err := c.scheduleReleaseTick(context.Background(), scheduledAt); err != nil {
+		t.Fatalf("scheduleReleaseTick failed: %v", err)
+	}
 
 	rows, err := stateStore.ListScopeReleases("owner/repo", "pending", "releasing", "done", "failed")
 	if err != nil {
@@ -235,7 +243,9 @@ func TestScheduleReleaseTick_NoTags(t *testing.T) {
 		c, stateStore := newScheduleController(t, server.URL, "0 21 * * FRI")
 
 		scheduledAt := time.Date(2026, 7, 10, 21, 0, 0, 0, time.UTC)
-		c.scheduleReleaseTick(context.Background(), scheduledAt)
+		if _, err := c.scheduleReleaseTick(context.Background(), scheduledAt); err != nil {
+			t.Fatalf("scheduleReleaseTick failed: %v", err)
+		}
 
 		row, err := stateStore.GetScopeRelease("owner/repo", "train:2026-07-10T21:00:00Z")
 		if err != nil {
@@ -256,7 +266,9 @@ func TestScheduleReleaseTick_NoTags(t *testing.T) {
 		c, stateStore := newScheduleController(t, server.URL, "0 21 * * FRI")
 
 		scheduledAt := time.Date(2026, 7, 10, 21, 0, 0, 0, time.UTC)
-		c.scheduleReleaseTick(context.Background(), scheduledAt)
+		if _, err := c.scheduleReleaseTick(context.Background(), scheduledAt); err != nil {
+			t.Fatalf("scheduleReleaseTick failed: %v", err)
+		}
 
 		rows, err := stateStore.ListScopeReleases("owner/repo", "pending", "releasing", "done", "failed")
 		if err != nil {
@@ -276,7 +288,9 @@ func TestScheduleReleaseTick_NoTags(t *testing.T) {
 		c, stateStore := newScheduleController(t, server.URL, "0 21 * * FRI")
 
 		scheduledAt := time.Date(2026, 7, 10, 21, 0, 0, 0, time.UTC)
-		c.scheduleReleaseTick(context.Background(), scheduledAt)
+		if _, err := c.scheduleReleaseTick(context.Background(), scheduledAt); err != nil {
+			t.Fatalf("scheduleReleaseTick failed: %v", err)
+		}
 
 		row, err := stateStore.GetScopeRelease("owner/repo", "train:2026-07-10T21:00:00Z")
 		if err != nil || row == nil {

--- a/internal/dashboard/grom_chrome.go
+++ b/internal/dashboard/grom_chrome.go
@@ -45,14 +45,8 @@ var warnChrome = render.PanelStyle{
 	Title:  gromTheme.WarningStyle().Bold(true),
 }
 
-// renderPanel builds a grom-style card: lowercase title embedded in the top
-// border, one padding line above and below the content.
-func renderPanel(title, content string, tw int) string {
-	return renderPanelInfo(title, "", content, tw)
-}
-
-// renderPanelInfo is renderPanel with a legend embedded in the top-right
-// border: ╭─ title ────┤ info ├─╮.
+// renderPanelInfo builds a grom-style card with a legend embedded in the
+// top-right border: ╭─ title ────┤ info ├─╮.
 func renderPanelInfo(title, info, content string, tw int) string {
 	return renderPanelStyled(title, info, content, tw, panelChrome)
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4575.

Closes #4575

## Changes

GitHub Issue GH-4575: chore(lint): fix 4 findings failing the local pre-push gate — errcheck in scope_schedule_test, dead renderPanel chain

# TASK-426: Fix 4 lint findings blocking the local pre-push gate

**Created**: 2026-07-27 · **Status**: 🚀 Dispatched to Pilot · **Last Updated**: 2026-07-27

## Problem

`scripts/pre-push-gate.sh` (installed as the pre-push hook by
`make install-hooks`) fails on a clean main checkout: local golangci-lint
reports 4 findings that CI's pinned `v2.8.0` (ci.yml:92) does not. The gate
is supposed to pass on a clean tree; today every push needs `--no-verify`.

Findings:

1. `internal/autopilot/scope_schedule_test.go:96` — errcheck: return value
   of `c.scheduleReleaseTick(context.Background(), scheduledAt)` unchecked.
2. `internal/autopilot/scope_schedule_test.go:129` — same.
3. `internal/autopilot/scope_schedule_test.go:149` — same.
4. `internal/dashboard/grom_chrome.go:50` — unused: `func renderPanel` has
   no callers (all render paths call `renderPanelStyled` directly, see
   `internal/dashboard/zoom.go`).

## Required behavior

1. For each `scheduleReleaseTick` test call site: handle the returned error
   according to that test's intent — if the test expects success, fail the
   test on non-nil error (`if err := …; err != nil { t.Fatalf(…) }`); if it
   deliberately exercises an error path, assert on the error instead. Do
   not blanket `_ =` without checking intent.
2. Delete the unused `renderPanel` wrapper. If that leaves
   `renderPanelInfo` (grom_chrome.go:55) without callers, delete it too —
   remove the whole dead chain, verified by a clean `golangci-lint run`.
3. No behavior changes; test assertions may only get stricter.

## Acceptance criteria

- [ ] `make lint` green locally AND `golangci-lint run` reports 0 issues in
      `internal/autopilot/scope_schedule_test.go` and
      `internal/dashboard/grom_chrome.go`.
- [ ] `go test ./internal/autopilot/... ./internal/dashboard/...` green.
- [ ] CI lint (v2.8.0) stays green.

## Refs

- Gate: `scripts/pre-push-gate.sh`, `scripts/install-hooks.sh`
- CI pin: `.github/workflows/ci.yml:92` (`golangci-lint v2.8.0`)
- Context: TASK-425 (#4574) made the pre-push gate load-bearing for graph
  drift; a gate that cries wolf on a clean tree trains `--no-verify` habits.