### PR TITLE
GH-4583: fix(executor): intent judge fork/exec E2BIG — prompt with full diff passed via argv fails on diffs >128KB

### DIFF
--- a/internal/executor/intent_judge.go
+++ b/internal/executor/intent_judge.go
@@ -127,15 +127,46 @@ func newJudgeSubprocessError(ctx context.Context, err error, stderr string, peak
 	}
 }
 
+// extractStdinPrompt pulls the value following a "-p" flag out of args so it
+// can be delivered via stdin instead of argv. Linux caps a single argv
+// element at MAX_ARG_STRLEN (128KB, see proc(5)) — the intent judge's prompt
+// embeds the full issue body and git diff, which routinely exceeds that on
+// large PRs and made the subprocess fail before it even started
+// ("fork/exec ...: argument list too long"). GH-4583.
+//
+// The returned rest slice keeps a bare "-p" flag (no value) in place —
+// `claude -p` reads the prompt from stdin when invoked that way — so only
+// the oversized value is removed from argv, not the flag itself.
+func extractStdinPrompt(args []string) (rest []string, prompt string, ok bool) {
+	for i, a := range args {
+		if a == "-p" && i+1 < len(args) {
+			out := make([]string, 0, len(args)-1)
+			out = append(out, args[:i+1]...)
+			out = append(out, args[i+2:]...)
+			return out, args[i+1], true
+		}
+	}
+	return args, "", false
+}
+
 // defaultCmdRunner executes the claude command, sampling RSS and capturing a
 // bounded stderr tail so a kill can be diagnosed instead of surfacing as a
 // bare "signal: killed". GH-4377.
+//
+// GH-4583: the prompt value passed via "-p" is routed through stdin rather
+// than argv — see extractStdinPrompt — so diffs over Linux's 128KB
+// MAX_ARG_STRLEN no longer fail fork/exec with "argument list too long".
 func (j *IntentJudge) defaultCmdRunner(ctx context.Context, args ...string) ([]byte, error) {
+	args, prompt, hasPrompt := extractStdinPrompt(args)
+
 	cmd := exec.CommandContext(ctx, j.claudeCmd, args...)
 	var stdout bytes.Buffer
 	stderr := newBoundedBuffer(maxJudgeStderrCaptureBytes)
 	cmd.Stdout = &stdout
 	cmd.Stderr = stderr
+	if hasPrompt {
+		cmd.Stdin = strings.NewReader(prompt)
+	}
 
 	if err := cmd.Start(); err != nil {
 		return nil, err

--- a/internal/executor/intent_judge_test.go
+++ b/internal/executor/intent_judge_test.go
@@ -600,3 +600,76 @@ func TestDefaultCmdRunner_StderrCaptured(t *testing.T) {
 		t.Errorf("expected stderr tail to contain subprocess stderr, got: %q", jerr.StderrTail)
 	}
 }
+
+// --- GH-4583: prompt-via-stdin (fork/exec E2BIG on large diffs) ---
+
+// TestExtractStdinPrompt verifies the -p value is pulled out of the argv
+// slice for stdin delivery while a bare "-p" flag is preserved — `claude -p`
+// reads its prompt from stdin when invoked without a following value.
+func TestExtractStdinPrompt(t *testing.T) {
+	args := []string{"--print", "-p", "the prompt text", "--model", "x"}
+	rest, prompt, ok := extractStdinPrompt(args)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if prompt != "the prompt text" {
+		t.Errorf("expected extracted prompt %q, got %q", "the prompt text", prompt)
+	}
+	want := []string{"--print", "-p", "--model", "x"}
+	if len(rest) != len(want) {
+		t.Fatalf("expected rest args %v, got %v", want, rest)
+	}
+	for i := range want {
+		if rest[i] != want[i] {
+			t.Errorf("expected rest args %v, got %v", want, rest)
+			break
+		}
+	}
+}
+
+// TestExtractStdinPrompt_NoPromptFlag verifies args without a "-p" flag pass
+// through untouched.
+func TestExtractStdinPrompt_NoPromptFlag(t *testing.T) {
+	args := []string{"--print", "--model", "x"}
+	rest, prompt, ok := extractStdinPrompt(args)
+	if ok {
+		t.Fatal("expected ok=false when no -p flag is present")
+	}
+	if prompt != "" {
+		t.Errorf("expected empty prompt, got %q", prompt)
+	}
+	if len(rest) != len(args) {
+		t.Fatalf("expected args unchanged, got %v", rest)
+	}
+}
+
+// TestDefaultCmdRunner_LargePromptViaStdin is the regression test for
+// GH-4583: the intent judge's prompt (system prompt + issue body + full git
+// diff) was passed as a single argv element to `claude -p <prompt>`. Linux
+// caps a single argv element at MAX_ARG_STRLEN (128KB, see proc(5)); any
+// diff past that made fork/exec fail with "argument list too long" before
+// the judge subprocess ever ran.
+//
+// This drives the real defaultCmdRunner (not a mock) with a 200KB prompt —
+// well over the 128KB cap — through a shell script standing in for the
+// claude binary. The script ignores its positional args (mirroring the
+// flags Judge()/JudgeIssue() send alongside "-p") and echoes stdin back,
+// confirming the prompt now travels via stdin rather than argv and arrives
+// at the subprocess intact.
+func TestDefaultCmdRunner_LargePromptViaStdin(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available on this system")
+	}
+
+	prompt := strings.Repeat("A", 200*1024) // 200KB, over Linux's 128KB MAX_ARG_STRLEN
+
+	judge := NewIntentJudge("sh")
+	out, err := judge.defaultCmdRunner(context.Background(),
+		"-c", "cat", "--", "--print", "-p", prompt, "--model", "x", "--output-format", "text")
+	if err != nil {
+		t.Fatalf("defaultCmdRunner failed on a 200KB prompt (expected no E2BIG): %v", err)
+	}
+	if string(out) != prompt {
+		t.Errorf("prompt not passed through stdin intact: got %d bytes, want %d bytes", len(out), len(prompt))
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4583.

Closes #4583

## Changes

GitHub Issue GH-4583: fix(executor): intent judge fork/exec E2BIG — prompt with full diff passed via argv fails on diffs >128KB

## Problem

The intent judge passes its full prompt — system prompt + issue body + **entire git diff** — as a single argv element:

- `internal/executor/intent_judge.go:134` — `exec.CommandContext(ctx, j.claudeCmd, args...)`
- `internal/executor/intent_judge.go:303` — `fmt.Sprintf("%s ... %s", intentJudgeSystemPrompt, issueTitle, issueBody, diff)`

Linux caps a single exec argument at `MAX_ARG_STRLEN` = 128KB. Any diff over ~128KB makes the subprocess fail before it starts:

```
2026-07-27T17:17:09Z WARN Intent judge error (continuing to PR)
  task_id=GH-204 diff_len=723120
  error="intent judge subprocess: fork/exec /usr/bin/claude: argument list too long"
```

Non-fatal (execution continues to PR), but the judge silently never runs on exactly the large-diff executions where a scope check matters most. The preflight judge path (`intent_judge.go:429`) has the same shape and should be checked for the same limit.

## Fix

Pass the prompt via **stdin** instead of argv in `defaultCmdRunner` (or write to a temp file and pass the path). `claude -p` accepts the prompt on stdin. Keep argv for flags only.

## Tests

- Unit test with a >128KB (use ~200KB) synthetic prompt through the cmdRunner seam asserting no E2BIG and that the prompt reaches the subprocess intact (the existing `cmdRunner` injection point in `newIntentJudgeWithRunner` makes this testable without a real binary; add one integration-style test against `/bin/cat` if feasible).
- Existing intent judge tests unchanged.

## Acceptance

- Intent judge runs successfully on diffs >128KB (no `argument list too long`).
- Both judge paths (intent + preflight) use the stdin path.
- `make lint` and `make test` pass.