### PR TITLE
GH-4596: feat(autopilot): park approval-less escalations instead of hard-failing

### DIFF
--- a/.agent/tasks/gh-4596.md
+++ b/.agent/tasks/gh-4596.md
@@ -1,0 +1,10 @@
+# GH-4596
+
+**Created:** 2026-07-28
+
+## Problem
+
+In controller.go's CI-passed → escalate path, when a gate demands approval but pre_merge.enabled=false and no approval channel is wired, keep state at awaiting_approval (tagged 'parked') instead of transitioning to failed, recording the gate reason.
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2550,16 +2550,24 @@ func (c *Controller) submitAsyncApprovalRequest(ctx context.Context, prState *PR
 		if reason == "" {
 			reason = fmt.Sprintf("environments.%s.require_approval=true", c.config.EnvironmentName())
 		}
-		c.log.Error("approval misconfig: approval required but pre_merge.enabled=false",
+		// GH-4596: a gate demanding approval with no approval channel wired is a
+		// config gap, not a PR failure — nothing about the PR's code is wrong.
+		// The old behavior transitioned straight to StageFailed, which is a
+		// terminal, un-recoverable state: once a human fixed the config (or
+		// merged manually), there was no live PR left in StageAwaitApproval for
+		// auto-merge/board write-back to resume driving. Stay parked in
+		// StageAwaitApproval instead — EscalationReason (recorded below) names
+		// the gate that fired, and Parked dedupes the one-time log/PR comment
+		// across every subsequent tick while the misconfig persists.
+		prState.EscalationReason = reason
+		if prState.Parked {
+			// Already logged/commented on a prior tick — stay parked quietly.
+			return nil
+		}
+		c.log.Warn("approval required but no approval channel is wired — parking PR in awaiting_approval",
 			"pr", prState.PRNumber, "env", c.config.EnvironmentName(), "escalation_reason", reason)
-		prState.Stage = StageFailed
-		prState.Error = fmt.Sprintf(
-			"approval-misconfig: PR requires approval (%s) but approval.pre_merge.enabled=false → deadlock until config fixed",
-			reason,
-		)
+		prState.Parked = true
 		c.autoMerger.postMisconfigComment(ctx, prState)
-		c.metrics.RecordPRFailed()
-		c.metrics.RecordIssueProcessed("failed")
 		return nil
 	}
 

--- a/internal/autopilot/escalation_reason_test.go
+++ b/internal/autopilot/escalation_reason_test.go
@@ -12,35 +12,40 @@ import (
 	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 )
 
-// GH-3569: the misconfig error must name the ACTUAL escalation trigger
-// (size-floor gate, scope-drift gate, or env require_approval) — the old
-// hardcoded message blamed require_approval=true even when the env had it
-// false and a defense-in-depth gate did the escalating (observed on PR #3559).
-func TestSubmitAsyncApprovalRequest_MisconfigErrorText(t *testing.T) {
+// GH-4596: when a gate demands approval but no approval channel is wired
+// (approvalMgr nil, or approval.pre_merge.enabled=false), the PR must stay
+// parked in StageAwaitApproval — not transition to StageFailed — with
+// EscalationReason recording the ACTUAL gate that fired (size-floor gate,
+// scope-drift gate, or env require_approval). Before GH-4596 this branch
+// blamed require_approval=true even when the env had it false and a
+// defense-in-depth gate did the escalating (observed on PR #3559), AND
+// terminated the PR into StageFailed, leaving no live PR for auto-merge/board
+// write-back to resume once the config was fixed.
+func TestSubmitAsyncApprovalRequest_MisconfigParksInsteadOfFailing(t *testing.T) {
 	tests := []struct {
 		name             string
 		escalationReason string
-		wantInError      string
+		wantInReason     string
 	}{
 		{
 			name:             "size-floor gate reason is reported verbatim",
 			escalationReason: "PR adds 656 net lines (> 500 threshold)",
-			wantInError:      "PR adds 656 net lines (> 500 threshold)",
+			wantInReason:     "PR adds 656 net lines (> 500 threshold)",
 		},
 		{
 			name:             "scope-drift gate reason is reported verbatim",
 			escalationReason: `PR title type "feat" diverges from issue title type "fix"`,
-			wantInError:      `PR title type "feat" diverges from issue title type "fix"`,
+			wantInReason:     `PR title type "feat" diverges from issue title type "fix"`,
 		},
 		{
 			name:             "env require_approval reason is reported verbatim",
 			escalationReason: "environments.prod.require_approval=true",
-			wantInError:      "environments.prod.require_approval=true",
+			wantInReason:     "environments.prod.require_approval=true",
 		},
 		{
 			name:             "zero-value falls back to env-based wording",
 			escalationReason: "",
-			wantInError:      "require_approval=true",
+			wantInReason:     "require_approval=true",
 		},
 	}
 
@@ -67,16 +72,56 @@ func TestSubmitAsyncApprovalRequest_MisconfigErrorText(t *testing.T) {
 			if err := c.submitAsyncApprovalRequest(context.Background(), prState); err != nil {
 				t.Fatalf("submitAsyncApprovalRequest returned error: %v", err)
 			}
-			if prState.Stage != StageFailed {
-				t.Errorf("Stage = %v, want StageFailed", prState.Stage)
+			if prState.Stage != StageAwaitApproval {
+				t.Errorf("Stage = %v, want StageAwaitApproval (parked, not failed)", prState.Stage)
 			}
-			if !strings.Contains(prState.Error, tt.wantInError) {
-				t.Errorf("Error %q does not contain %q", prState.Error, tt.wantInError)
+			if !prState.Parked {
+				t.Errorf("Parked = false, want true")
 			}
-			if tt.escalationReason != "" && !strings.Contains(prState.Error, tt.escalationReason) {
-				t.Errorf("Error %q must carry the escalation reason %q", prState.Error, tt.escalationReason)
+			if prState.Error != "" {
+				t.Errorf("Error = %q, want empty — a parked PR is not a failed PR", prState.Error)
+			}
+			if !strings.Contains(prState.EscalationReason, tt.wantInReason) {
+				t.Errorf("EscalationReason %q does not contain %q", prState.EscalationReason, tt.wantInReason)
 			}
 		})
+	}
+}
+
+// GH-4596: a second tick of the same parked PR must not re-post the misconfig
+// comment or otherwise re-run the one-time side effects — Parked dedupes it.
+func TestSubmitAsyncApprovalRequest_MisconfigParkIsIdempotent(t *testing.T) {
+	commentPosts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/comments") {
+			commentPosts++
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:         93,
+		Stage:            StageAwaitApproval,
+		EscalationReason: "PR adds 656 net lines (> 500 threshold)",
+	}
+
+	for i := 0; i < 3; i++ {
+		if err := c.submitAsyncApprovalRequest(context.Background(), prState); err != nil {
+			t.Fatalf("tick %d: submitAsyncApprovalRequest returned error: %v", i, err)
+		}
+		if prState.Stage != StageAwaitApproval {
+			t.Fatalf("tick %d: Stage = %v, want StageAwaitApproval", i, prState.Stage)
+		}
+	}
+	if commentPosts != 1 {
+		t.Errorf("comment POSTs = %d, want exactly 1 (deduped by Parked across ticks)", commentPosts)
 	}
 }
 

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -1019,6 +1019,20 @@ type PRState struct {
 	// names the actual trigger (GH-3569). In-memory only; lost on restart, which
 	// degrades to the env-based fallback wording.
 	EscalationReason string
+	// Parked is true once submitAsyncApprovalRequest has determined a gate
+	// demands approval but no approval channel is wired (approvalMgr is nil,
+	// or approval.pre_merge.enabled=false) — GH-4596. Before this field
+	// existed, that condition transitioned the PR straight to StageFailed,
+	// which is wrong: nothing about the PR itself failed, the approval
+	// plumbing is simply unconfigured, and a human fixing the config later
+	// (or merging manually) had no live PR left for auto-merge/board
+	// write-back to pick back up. The PR now stays in StageAwaitApproval
+	// ("parked") with EscalationReason recording the gate that fired;
+	// Parked itself just dedupes the one-time misconfig log line/PR comment
+	// across repeated ticks. In-memory only; lost on restart, which simply
+	// re-derives Parked=true on the next tick since the underlying
+	// misconfig condition is still true.
+	Parked bool
 	// TerminalLabel overrides the default pilot-retry-ready label that
 	// notifyExternalClose applies once it observes this PR closed on GitHub.
 	// Set by a close path that already determined the issue must NOT be
@@ -1117,6 +1131,7 @@ func (ps *PRState) snapshot() *PRState {
 		ReleasingAttempts:       ps.ReleasingAttempts,
 		ReleasingFirstAt:        ps.ReleasingFirstAt,
 		EscalationReason:        ps.EscalationReason,
+		Parked:                  ps.Parked,
 		TerminalLabel:           ps.TerminalLabel,
 		ScopeKey:                ps.ScopeKey,
 		ScopeTitle:              ps.ScopeTitle,


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4596.

Closes #4596

## Changes

In controller.go's CI-passed → escalate path, when a gate demands approval but pre_merge.enabled=false and no approval channel is wired, keep state at awaiting_approval (tagged 'parked') instead of transitioning to failed, recording the gate reason.