### PR TITLE
GH-4597: feat(autopilot): add label, PR comment, and alert for parked PRs

### DIFF
--- a/.agent/tasks/gh-4597.md
+++ b/.agent/tasks/gh-4597.md
@@ -1,0 +1,20 @@
+# GH-4597
+
+**Created:** 2026-07-28
+
+## Problem
+
+Apply the 'autopilot/parked-awaiting-approval' GitHub label and post a one-time PR comment naming the gate reason and missing config key; emit a single deduped operator alert via the existing alerts engine keyed on {PR, reason}.
+
+## Acceptance Criteria
+
+- submitAsyncApprovalRequest's misconfig branch applies the
+  `autopilot/parked-awaiting-approval` label to the PR.
+- postMisconfigComment names both the escalation gate reason and the
+  specific missing config key (`approval.enabled` or
+  `approval.pre_merge.enabled`), and stays a one-time comment (idempotent
+  via the existing marker-comment check).
+- A single deduped `config_error` operator alert fires via the alerts
+  engine, keyed on {PR, reason} — repeated ticks for the same PR+reason do
+  not re-alert; a different reason on the same PR alerts again.
+

--- a/internal/autopilot/approval_misconfig_alert_test.go
+++ b/internal/autopilot/approval_misconfig_alert_test.go
@@ -1,0 +1,133 @@
+package autopilot
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/alerts"
+	"github.com/qf-studio/pilot/internal/approval"
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestApprovalMisconfigKey verifies approvalMisconfigKey names the specific
+// approval.* YAML key that's unset, distinguishing a nil manager / disabled
+// top-level gate (approval.enabled) from an enabled manager whose pre_merge
+// stage specifically is off (approval.pre_merge.enabled). GH-4597.
+func TestApprovalMisconfigKey(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+
+	t.Run("nil approvalMgr names approval.enabled", func(t *testing.T) {
+		c := NewController(cfg, ghClient, nil, "owner", "repo")
+		if got := c.approvalMisconfigKey(); got != "approval.enabled" {
+			t.Errorf("approvalMisconfigKey() = %q, want %q", got, "approval.enabled")
+		}
+	})
+
+	t.Run("manager present but top-level disabled names approval.enabled", func(t *testing.T) {
+		mgr := approval.NewManager(&approval.Config{Enabled: false})
+		c := NewController(cfg, ghClient, mgr, "owner", "repo")
+		if got := c.approvalMisconfigKey(); got != "approval.enabled" {
+			t.Errorf("approvalMisconfigKey() = %q, want %q", got, "approval.enabled")
+		}
+	})
+
+	t.Run("top-level enabled but pre_merge disabled names approval.pre_merge.enabled", func(t *testing.T) {
+		mgr := approval.NewManager(&approval.Config{
+			Enabled:  true,
+			PreMerge: &approval.StageConfig{Enabled: false},
+		})
+		c := NewController(cfg, ghClient, mgr, "owner", "repo")
+		if got := c.approvalMisconfigKey(); got != "approval.pre_merge.enabled" {
+			t.Errorf("approvalMisconfigKey() = %q, want %q", got, "approval.pre_merge.enabled")
+		}
+	})
+}
+
+// TestSubmitAsyncApprovalRequest_MisconfigAlertsOncePerReason is the GH-4597
+// regression test: the approval-misconfig config_error alert must fire
+// exactly once per {PR, reason} pair. Steady-state ticks are cut off by the
+// Parked guard (GH-4596); the {PR, reason} map dedupes across fresh
+// escalation cycles (Parked reset via re-registration), while a DIFFERENT
+// escalation reason on a fresh cycle still gets its own alert.
+func TestSubmitAsyncApprovalRequest_MisconfigAlertsOncePerReason(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+	// approvalMgr nil -> IsStageEnabled false -> misconfig branch.
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	prState := &PRState{
+		PRNumber:         96,
+		Stage:            StageAwaitApproval,
+		EscalationReason: "PR adds 656 net lines (> 500 threshold)",
+	}
+
+	// Ticks 1-3 with the same reason: exactly one alert.
+	for i := 0; i < 3; i++ {
+		if err := c.submitAsyncApprovalRequest(context.Background(), prState); err != nil {
+			t.Fatalf("tick %d: submitAsyncApprovalRequest returned error: %v", i, err)
+		}
+	}
+	if len(sink.events) != 1 {
+		t.Fatalf("after 3 ticks with the same reason: got %d alerts, want 1", len(sink.events))
+	}
+	ev := sink.events[0]
+	if ev.Type != alerts.EventTypeConfigError {
+		t.Errorf("alert Type = %q, want %q", ev.Type, alerts.EventTypeConfigError)
+	}
+	if !strings.Contains(ev.Error, "96") {
+		t.Errorf("alert Error %q should mention the PR number", ev.Error)
+	}
+	if !strings.Contains(ev.Error, "PR adds 656 net lines") {
+		t.Errorf("alert Error %q should name the escalation reason", ev.Error)
+	}
+	if ev.Metadata["missing_config_key"] != "approval.enabled" {
+		t.Errorf("alert Metadata[missing_config_key] = %q, want %q", ev.Metadata["missing_config_key"], "approval.enabled")
+	}
+
+	// While parked, later ticks never reach the alert — even with a new
+	// reason, GH-4596's Parked guard short-circuits first.
+	prState.EscalationReason = "environments.stage.require_approval=true"
+	if err := c.submitAsyncApprovalRequest(context.Background(), prState); err != nil {
+		t.Fatalf("submitAsyncApprovalRequest returned error: %v", err)
+	}
+	if len(sink.events) != 1 {
+		t.Fatalf("after a new reason while parked: got %d alerts, want 1", len(sink.events))
+	}
+
+	// A fresh escalation cycle (Parked reset, e.g. PR re-registered) with the
+	// original reason must NOT re-alert — the {PR, reason} map dedupes across
+	// cycles.
+	prState.Parked = false
+	prState.EscalationReason = "PR adds 656 net lines (> 500 threshold)"
+	if err := c.submitAsyncApprovalRequest(context.Background(), prState); err != nil {
+		t.Fatalf("submitAsyncApprovalRequest returned error: %v", err)
+	}
+	if len(sink.events) != 1 {
+		t.Fatalf("after a repeat reason on a fresh cycle: got %d alerts, want 1", len(sink.events))
+	}
+
+	// A fresh cycle with a different reason must alert again (new {PR, reason} key).
+	prState.Parked = false
+	prState.EscalationReason = "environments.stage.require_approval=true"
+	if err := c.submitAsyncApprovalRequest(context.Background(), prState); err != nil {
+		t.Fatalf("submitAsyncApprovalRequest returned error: %v", err)
+	}
+	if len(sink.events) != 2 {
+		t.Fatalf("after a new reason on a fresh cycle: got %d alerts, want 2", len(sink.events))
+	}
+}

--- a/internal/autopilot/auto_merger.go
+++ b/internal/autopilot/auto_merger.go
@@ -121,8 +121,12 @@ func (m *AutoMerger) MergePR(ctx context.Context, prState *PRState) error {
 
 // postMisconfigComment posts a single explanatory comment on the PR when
 // approval is required (by an escalation gate or the environment) but not
-// enabled in config. Idempotent: skips posting if the marker comment exists.
-func (m *AutoMerger) postMisconfigComment(ctx context.Context, prState *PRState) {
+// enabled in config, naming the specific unset config key (GH-4597). The
+// parked-awaiting-approval label lands on the linked issue in the
+// controller's park path, not here. Idempotent: the comment post is skipped
+// if the marker comment already exists, so a PR re-checked every poll tick
+// while parked only gets the one-time side effect once.
+func (m *AutoMerger) postMisconfigComment(ctx context.Context, prState *PRState, missingKey string) {
 	existing, err := m.ghClient.ListIssueComments(ctx, m.owner, m.repo, prState.PRNumber)
 	if err != nil {
 		m.log.Warn("postMisconfigComment: failed to list PR comments, will post anyway",
@@ -142,15 +146,19 @@ func (m *AutoMerger) postMisconfigComment(ctx context.Context, prState *PRState)
 	if reason == "" {
 		reason = fmt.Sprintf("environments.%s.require_approval=true", m.config.EnvironmentName())
 	}
+	// GH-4597: name the specific unset config key (approval.enabled vs
+	// approval.pre_merge.enabled) instead of just listing both as candidates —
+	// an operator staring at this comment should be able to flip one flag,
+	// not guess which of two.
 	body := fmt.Sprintf(`%s
 🚧 **Merge blocked: approval not wired**
 
-This PR requires pre-merge approval (**%s**) but the approval system is disabled (`+"`approval.enabled: false`"+` and/or `+"`approval.pre_merge.enabled: false`"+`).
+This PR requires pre-merge approval (**%s**) but the required config key is not set: `+"`%s`"+`.
 
-To unblock: either enable approval in `+"`~/.pilot/config.yaml`"+` (set `+"`approval.enabled: true`"+` + `+"`approval.pre_merge.enabled: true`"+` + add an approver), or merge manually with `+"`gh pr merge %d`"+`.
+To unblock: set `+"`%s: true`"+` in `+"`~/.pilot/config.yaml`"+` (add an approver if this is the first stage you're enabling), or merge manually with `+"`gh pr merge %d`"+`.
 
 Tracked in #2598.`,
-		misconfigCommentMarker, reason, prState.PRNumber)
+		misconfigCommentMarker, reason, missingKey, missingKey, prState.PRNumber)
 
 	if _, postErr := m.ghClient.AddPRComment(ctx, m.owner, m.repo, prState.PRNumber, body); postErr != nil {
 		m.log.Warn("postMisconfigComment: failed to post PR comment",

--- a/internal/autopilot/auto_merger_test.go
+++ b/internal/autopilot/auto_merger_test.go
@@ -921,6 +921,7 @@ func TestAutoMerger_PostMisconfigComment_Idempotent(t *testing.T) {
 	// Second call: marker present in comment list → posting is skipped.
 	postCount := 0
 	listCallCount := 0
+	labelCount := 0
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
@@ -943,6 +944,10 @@ func TestAutoMerger_PostMisconfigComment_Idempotent(t *testing.T) {
 			postCount++
 			w.WriteHeader(http.StatusCreated)
 			_, _ = w.Write([]byte(`{"id":1,"body":"posted"}`))
+		case r.Method == http.MethodPost && path == "/repos/owner/repo/issues/42/labels":
+			labelCount++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
 		default:
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
 			w.WriteHeader(http.StatusInternalServerError)
@@ -955,16 +960,23 @@ func TestAutoMerger_PostMisconfigComment_Idempotent(t *testing.T) {
 	merger := NewAutoMerger(ghClient, nil, nil, "owner", "repo", cfg)
 	prState := &PRState{PRNumber: 42}
 
-	// First call — should post the comment.
-	merger.postMisconfigComment(context.Background(), prState)
+	// First call — should post the comment. The parked label is applied to
+	// the linked issue by the controller's park path, never from here.
+	merger.postMisconfigComment(context.Background(), prState, "approval.enabled")
 	if postCount != 1 {
 		t.Errorf("first call: postCount = %d, want 1", postCount)
 	}
+	if labelCount != 0 {
+		t.Errorf("first call: labelCount = %d, want 0 (label is controller-side)", labelCount)
+	}
 
 	// Second call — marker in list, should NOT post again.
-	merger.postMisconfigComment(context.Background(), prState)
+	merger.postMisconfigComment(context.Background(), prState, "approval.enabled")
 	if postCount != 1 {
 		t.Errorf("second call: postCount = %d, want 1 (idempotent)", postCount)
+	}
+	if labelCount != 0 {
+		t.Errorf("second call: labelCount = %d, want 0 (label is controller-side)", labelCount)
 	}
 	if listCallCount != 2 {
 		t.Errorf("listCallCount = %d, want 2", listCallCount)

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -525,6 +525,15 @@ type Controller struct {
 	// once the per-PR circuit breaker opens, never alert at all (GH-4380).
 	alertedApprovalFailures map[int]bool
 
+	// alertedApprovalMisconfigs deduplicates approval_misconfig config_error
+	// alerts per "PRNumber:reason", guarded by mu. The Parked flag (GH-4596)
+	// cuts off steady-state ticks, but a fresh PRState (re-registration after
+	// manual intervention) starts a new cycle with Parked=false — without this
+	// map every such cycle would re-fire the same misconfig alert. Keyed on
+	// reason (not just PR) so a different gate firing on a later cycle for the
+	// same PR still alerts on its own (GH-4597).
+	alertedApprovalMisconfigs map[string]bool
+
 	// warnedUnsourcedIssues deduplicates the "labeled issue not board-sourced"
 	// WARN reconcileUnsourcedBoardIssues emits, per issue number, guarded by
 	// mu — logged once per poll-session (not every tick) while the issue
@@ -1266,6 +1275,70 @@ func (c *Controller) alertApprovalSubmitFailureOnce(ctx context.Context, prState
 	if _, cerr := c.ghClient.AddPRComment(ctx, c.owner, c.repo, prState.PRNumber, comment); cerr != nil {
 		c.log.Warn("failed to post approval-submit-failed PR comment", "pr", prState.PRNumber, "error", cerr)
 	}
+}
+
+// approvalMisconfigKey names the specific approval.* YAML key that is unset
+// on the submitAsyncApprovalRequest misconfig path, so the PR comment/alert
+// can tell an operator exactly which flag to flip instead of listing both
+// approval.enabled and approval.pre_merge.enabled as candidates (GH-4597).
+// c.approvalMgr == nil only happens via direct test/caller construction (see
+// approval.NewManager, which never returns/stores a nil *Manager) — treated
+// the same as the top-level gate being off since nothing downstream of it can
+// be enabled either.
+func (c *Controller) approvalMisconfigKey() string {
+	if c.approvalMgr == nil || !c.approvalMgr.IsEnabled() {
+		return "approval.enabled"
+	}
+	return "approval.pre_merge.enabled"
+}
+
+// alertApprovalMisconfigOnce fires a config_error alert the first time
+// submitAsyncApprovalRequest's approvalMgr-nil/pre_merge-disabled branch
+// hits a given {PR, reason} pair, deduplicated via alertedApprovalMisconfigs.
+// The Parked guard (GH-4596) covers steady-state ticks; this map covers
+// fresh cycles that pass the guard again with Parked=false (PR re-registered
+// after manual intervention) — without it each cycle would re-alert, or the
+// alerts engine's per-rule cooldown would absorb the noise and go silent,
+// leaving a parked PR just as invisible as the WARN-only logging GH-4380
+// already fixed for approval-submit failures. GH-4597.
+func (c *Controller) alertApprovalMisconfigOnce(prState *PRState, reason, missingKey string) {
+	key := fmt.Sprintf("%d:%s", prState.PRNumber, reason)
+
+	c.mu.Lock()
+	if c.alertedApprovalMisconfigs == nil {
+		c.alertedApprovalMisconfigs = make(map[string]bool)
+	}
+	if c.alertedApprovalMisconfigs[key] {
+		c.mu.Unlock()
+		return
+	}
+	c.alertedApprovalMisconfigs[key] = true
+	c.mu.Unlock()
+
+	msg := fmt.Sprintf(
+		"PR #%d (%s) requires approval (%s) but %s is not set — merge is blocked until an operator fixes config or merges manually",
+		prState.PRNumber, c.repoKey(), reason, missingKey,
+	)
+	if c.alertsEngine == nil {
+		c.log.Error("approval_misconfig alert not delivered: SetAlertsEngine was never called",
+			"pr", prState.PRNumber, "reason", reason, "missing_config_key", missingKey)
+		return
+	}
+	c.alertsEngine.ProcessEvent(alerts.Event{
+		Type:      alerts.EventTypeConfigError,
+		TaskID:    fmt.Sprintf("pr-%d-approval-misconfig", prState.PRNumber),
+		TaskTitle: fmt.Sprintf("Approval misconfig blocking PR #%d", prState.PRNumber),
+		Project:   c.repoKey(),
+		Error:     msg,
+		Timestamp: time.Now(),
+		Metadata: map[string]string{
+			"repo":               c.repoKey(),
+			"pr":                 strconv.Itoa(prState.PRNumber),
+			"issue":              strconv.Itoa(prState.IssueNumber),
+			"reason":             reason,
+			"missing_config_key": missingKey,
+		},
+	})
 }
 
 // evictPersistFailedPR drops a PR that has failed to persist
@@ -2561,46 +2634,32 @@ func (c *Controller) submitAsyncApprovalRequest(ctx context.Context, prState *PR
 		// merged manually), there was no live PR left in StageAwaitApproval for
 		// auto-merge/board write-back to resume driving. Stay parked in
 		// StageAwaitApproval instead — EscalationReason (recorded below) names
-		// the gate that fired, and Parked dedupes the one-time log/PR comment
-		// across every subsequent tick while the misconfig persists.
+		// the gate that fired, and Parked dedupes the one-time log/PR
+		// comment/alert across every subsequent tick while the misconfig
+		// persists.
 		prState.EscalationReason = reason
 		if prState.Parked {
 			// Already logged/commented on a prior tick — stay parked quietly.
 			return nil
 		}
+		missingKey := c.approvalMisconfigKey()
 		c.log.Warn("approval required but no approval channel is wired — parking PR in awaiting_approval",
-			"pr", prState.PRNumber, "env", c.config.EnvironmentName(), "escalation_reason", reason)
+			"pr", prState.PRNumber, "env", c.config.EnvironmentName(), "escalation_reason", reason, "missing_config_key", missingKey)
 		prState.Parked = true
-		// GH-4595/GH-4600: make the park visible to a human without them having
-		// to read daemon logs — a label on the linked issue (same convention as
-		// escalateAndHold's labelNeedsHuman), the misconfig PR comment below, and
-		// a single deduped operator alert. All three are one-time per PR: the
-		// `if prState.Parked` early-return above already guards this whole
-		// branch on every later tick, so there is no separate dedup map needed.
+		// GH-4595/GH-4600/GH-4597: make the park visible to a human without
+		// them having to read daemon logs — a label on the linked issue (same
+		// convention as escalateAndHold's labelNeedsHuman), the misconfig PR
+		// comment below (naming the exact unset config key), and a single
+		// deduped operator alert. The `if prState.Parked` early-return above
+		// guards every later tick; alertApprovalMisconfigOnce's {PR, reason}
+		// map additionally dedupes across fresh cycles where Parked resets.
 		if prState.IssueNumber > 0 {
 			if err := c.ghClient.AddLabels(ctx, c.owner, c.repo, prState.IssueNumber, []string{labelParkedAwaitingApproval}); err != nil {
 				c.log.Warn("failed to apply parked-awaiting-approval label", "issue", prState.IssueNumber, "pr", prState.PRNumber, "error", err)
 			}
 		}
-		c.autoMerger.postMisconfigComment(ctx, prState)
-		if c.alertsEngine == nil {
-			c.log.Error("parked_awaiting_approval alert not delivered: SetAlertsEngine was never called", "pr", prState.PRNumber, "reason", reason)
-		} else {
-			c.alertsEngine.ProcessEvent(alerts.Event{
-				Type:      alerts.EventTypeConfigError,
-				TaskID:    fmt.Sprintf("pr-%d-parked", prState.PRNumber),
-				TaskTitle: fmt.Sprintf("PR #%d parked awaiting approval config", prState.PRNumber),
-				Project:   c.repoKey(),
-				Error:     reason,
-				Timestamp: time.Now(),
-				Metadata: map[string]string{
-					"repo":   c.repoKey(),
-					"pr":     strconv.Itoa(prState.PRNumber),
-					"issue":  strconv.Itoa(prState.IssueNumber),
-					"reason": reason,
-				},
-			})
-		}
+		c.alertApprovalMisconfigOnce(prState, reason, missingKey)
+		c.autoMerger.postMisconfigComment(ctx, prState, missingKey)
 		return nil
 	}
 

--- a/internal/autopilot/escalation_reason_test.go
+++ b/internal/autopilot/escalation_reason_test.go
@@ -204,13 +204,107 @@ func TestPostMisconfigComment_NamesEscalationReason(t *testing.T) {
 		EscalationReason: "PR adds 656 net lines (> 500 threshold)",
 	}
 
-	merger.postMisconfigComment(context.Background(), prState)
+	merger.postMisconfigComment(context.Background(), prState, "approval.enabled")
 
 	if !strings.Contains(postedBody, "PR adds 656 net lines") {
 		t.Errorf("comment body does not name the escalation reason: %q", postedBody)
 	}
 	if strings.Contains(postedBody, "require_approval: true") {
 		t.Errorf("comment body still blames require_approval despite a gate reason: %q", postedBody)
+	}
+	if !strings.Contains(postedBody, "approval.enabled") {
+		t.Errorf("comment body does not name the missing config key: %q", postedBody)
+	}
+}
+
+// GH-4597: postMisconfigComment must name the specific missing config key in
+// the comment body (not just the escalation reason), and must NOT apply the
+// parked label itself — that lands on the linked issue via the controller's
+// park path (GH-4600), keeping exactly one labeling site.
+func TestPostMisconfigComment_NamesMissingKeyWithoutLabeling(t *testing.T) {
+	var postedBody string
+	var labeledWith []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/comments"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/comments"):
+			var payload struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+			postedBody = payload.Body
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":1}`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels"):
+			var payload struct {
+				Labels []string `json:"labels"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+			labeledWith = payload.Labels
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	merger := NewAutoMerger(ghClient, nil, nil, "owner", "repo", DefaultConfig())
+	prState := &PRState{
+		PRNumber:         94,
+		EscalationReason: "environments.prod.require_approval=true",
+	}
+
+	merger.postMisconfigComment(context.Background(), prState, "approval.pre_merge.enabled")
+
+	if len(labeledWith) != 0 {
+		t.Errorf("labels POSTed = %v, want none (label is controller-side)", labeledWith)
+	}
+	if !strings.Contains(postedBody, "approval.pre_merge.enabled") {
+		t.Errorf("comment body does not name the missing config key: %q", postedBody)
+	}
+}
+
+// GH-4597: postMisconfigComment must not re-apply the label or re-post the
+// comment once the marker comment already exists on the PR — the label add
+// is idempotent on GitHub's side but still an avoidable API call every tick.
+func TestPostMisconfigComment_SkipsLabelAndCommentWhenAlreadyPosted(t *testing.T) {
+	labelPosts, commentPosts := 0, 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/comments"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"id":1,"body":"` + misconfigCommentMarker + ` already posted"}]`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/comments"):
+			commentPosts++
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":2}`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels"):
+			labelPosts++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	merger := NewAutoMerger(ghClient, nil, nil, "owner", "repo", DefaultConfig())
+	prState := &PRState{PRNumber: 95, EscalationReason: "size-floor"}
+
+	merger.postMisconfigComment(context.Background(), prState, "approval.enabled")
+
+	if labelPosts != 0 {
+		t.Errorf("label POSTs = %d, want 0 (already parked)", labelPosts)
+	}
+	if commentPosts != 0 {
+		t.Errorf("comment POSTs = %d, want 0 (already parked)", commentPosts)
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4597.

Closes #4597

## Changes

Apply the 'autopilot/parked-awaiting-approval' GitHub label and post a one-time PR comment naming the gate reason and missing config key; emit a single deduped operator alert via the existing alerts engine keyed on {PR, reason}.