### PR TITLE
GH-4598: fix(autopilot): fix restart/poller replay and idempotency for parked PRs

### DIFF
--- a/.agent/tasks/gh-4598.md
+++ b/.agent/tasks/gh-4598.md
@@ -1,0 +1,54 @@
+# GH-4598
+
+**Created:** 2026-07-28
+
+## Problem
+
+Ensure restart/poller replay re-hydrates parked PRs as awaiting_approval (parked) rather than re-classifying as failed, and make the CI-passed handler idempotent so parked PRs are not re-alerted or re-commented; preserve the existing GH-4383 approval-submit path when an approval channel is configured.
+
+## Root Cause
+
+GH-4596/#4602 stopped the misconfig branch of `submitAsyncApprovalRequest`
+from transitioning a parked PR to `StageFailed` (Stage already survives a
+restart correctly via `LoadAllPRStates`). But the new `PRState.Parked` and
+the existing `EscalationReason` field were both **in-memory only** — not
+in the `autopilot_pr_state` schema, not in `SavePRState`/`GetPRState`/
+`LoadAllPRStates`. A daemon restart (or any poller replay that reloads
+`activePRs` from the store) rehydrated a parked PR with `Parked=false` and
+`EscalationReason=""`. The first post-restart tick then ran
+`submitAsyncApprovalRequest` again, treated the still-true misconfig as
+brand new, re-logged the WARN, discarded the specific gate reason in favor
+of the generic env fallback, and re-invoked `postMisconfigComment` (a
+wasted `ListIssueComments`/re-check round-trip on every restart even though
+the marker-comment check itself already stopped an actual duplicate
+GitHub comment).
+
+## Fix
+
+- Added `parked` (INTEGER) and `escalation_reason` (TEXT) columns to
+  `autopilot_pr_state`, wired through `SavePRState`, `GetPRState`,
+  `LoadAllPRStates`, and the GH-3903 repo-scoping rebuild migration
+  (`migratePRStateRepoScoping`), which has its own hardcoded column list
+  and would otherwise silently drop any new column added only via
+  `ALTER TABLE`.
+- No changes needed to `submitAsyncApprovalRequest`/`handleAwaitApproval`
+  themselves — dispatch is stage-based, so once `Parked`/`EscalationReason`
+  round-trip correctly, the existing `if prState.Parked { return nil }`
+  dedup guard (from #4602) now fires correctly on the very first
+  post-restart tick instead of only from the second tick onward.
+- The normal GH-4383/GH-4380 approval-submit path (approval channel
+  configured) is untouched — it lives entirely below the misconfig branch
+  in `submitAsyncApprovalRequest` and its existing regression tests
+  (`TestRestartApprovalFlow_*`, `TestSubmitAsyncApprovalRequest_PreferredChannelRoutesToConfiguredEnvSource`)
+  stay green.
+
+## Acceptance Criteria
+
+- [x] `PRState.Parked` and `PRState.EscalationReason` persist across a
+      simulated daemon restart (new `StateStore`-backed `Controller`,
+      `RestoreState`) via both `GetPRState` and `LoadAllPRStates`.
+- [x] A parked PR's first post-restart tick stays in `StageAwaitApproval`
+      (never `StageFailed`) and does not re-post the misconfig PR comment.
+- [x] Existing approval-submit-path regression tests (GH-4383/GH-4380)
+      remain green — no behavior change to the configured-channel path.
+- [x] `make build`, `make test`, `make lint` green.

--- a/internal/autopilot/gh4598_test.go
+++ b/internal/autopilot/gh4598_test.go
@@ -1,0 +1,122 @@
+package autopilot
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestRestartReplay_ParkedPR_StaysParkedAndDoesNotReComment is the GH-4598
+// regression test. It simulates a full daemon restart for a PR that got
+// parked (GH-4596/#4602: approval required, no approval channel wired) on
+// the pre-restart controller:
+//
+//  1. Controller A parks PR #57 via submitAsyncApprovalRequest (one comment
+//     POST, Parked=true, Stage stays StageAwaitApproval) and persists it —
+//     mirroring ProcessPR's unconditional persistPRState call.
+//  2. Controller B ("after restart") loads the same on-disk store fresh via
+//     RestoreState and re-ticks the PR through the ordinary ProcessPR
+//     dispatch (Stage-based, exactly what the poller does).
+//
+// Before GH-4598, Parked/EscalationReason were in-memory only, so step 2
+// would rehydrate Parked=false — the tick would then treat the still-true
+// misconfig as brand new, re-log the WARN and call postMisconfigComment
+// again (a wasted GitHub round-trip even though the marker check itself
+// stopped the actual duplicate comment). It must now recognize the PR as
+// already parked and stay quiet: no second comment POST, and the PR must
+// never transition to StageFailed on replay.
+func TestRestartReplay_ParkedPR_StaysParkedAndDoesNotReComment(t *testing.T) {
+	commentPosts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/comments") {
+			commentPosts++
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":1,"body":"posted"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+
+	store := newTestStateStore(t)
+
+	// Step 1: controller A parks the PR (approvalMgr nil -> misconfig branch).
+	controllerA := NewController(cfg, ghClient, nil, "owner", "repo")
+	controllerA.SetStateStore(store)
+
+	prState := &PRState{
+		PRNumber:         57,
+		PRURL:            "https://github.com/owner/repo/pull/57",
+		IssueNumber:      22,
+		BranchName:       "pilot/GH-22",
+		HeadSHA:          "sha57",
+		Stage:            StageAwaitApproval,
+		EscalationReason: "PR adds 656 net lines (> 500 threshold)",
+	}
+	controllerA.mu.Lock()
+	controllerA.activePRs[57] = prState
+	controllerA.mu.Unlock()
+
+	if err := controllerA.ProcessPR(context.Background(), 57, nil); err != nil {
+		t.Fatalf("controller A ProcessPR: %v", err)
+	}
+	if prState.Stage != StageAwaitApproval {
+		t.Fatalf("after tick 1: Stage = %v, want StageAwaitApproval", prState.Stage)
+	}
+	if !prState.Parked {
+		t.Fatalf("after tick 1: Parked = false, want true")
+	}
+	if commentPosts != 1 {
+		t.Fatalf("after tick 1: comment POSTs = %d, want 1", commentPosts)
+	}
+
+	// Step 2: "restart" — a brand new controller loads the same on-disk store.
+	controllerB := NewController(cfg, ghClient, nil, "owner", "repo")
+	controllerB.SetStateStore(store)
+
+	restored, err := controllerB.RestoreState()
+	if err != nil {
+		t.Fatalf("RestoreState: %v", err)
+	}
+	if restored != 1 {
+		t.Fatalf("RestoreState restored %d PRs, want 1", restored)
+	}
+
+	controllerB.mu.RLock()
+	restoredPR, ok := controllerB.activePRs[57]
+	controllerB.mu.RUnlock()
+	if !ok {
+		t.Fatalf("PR 57 not present in controller B's activePRs after RestoreState")
+	}
+	if restoredPR.Stage != StageAwaitApproval {
+		t.Fatalf("restored Stage = %v, want StageAwaitApproval (not re-classified as failed)", restoredPR.Stage)
+	}
+	if !restoredPR.Parked {
+		t.Fatalf("restored Parked = false, want true — restart must rehydrate the parked flag")
+	}
+	if restoredPR.EscalationReason != prState.EscalationReason {
+		t.Fatalf("restored EscalationReason = %q, want %q", restoredPR.EscalationReason, prState.EscalationReason)
+	}
+
+	// First post-restart tick (the poller's replay of this PR) must stay
+	// parked quietly: no re-alert, no re-comment, no failed transition.
+	if err := controllerB.ProcessPR(context.Background(), 57, nil); err != nil {
+		t.Fatalf("controller B ProcessPR (post-restart tick): %v", err)
+	}
+	if restoredPR.Stage != StageAwaitApproval {
+		t.Errorf("after restart replay tick: Stage = %v, want StageAwaitApproval", restoredPR.Stage)
+	}
+	if commentPosts != 1 {
+		t.Errorf("after restart replay tick: comment POSTs = %d, want still 1 (idempotent across restart)", commentPosts)
+	}
+}

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -168,6 +168,20 @@ func (s *StateStore) migrate() error {
 		// grant a fresh 2-retry budget on the same SHA.
 		`ALTER TABLE autopilot_pr_state ADD COLUMN infra_rerun_count INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE autopilot_pr_state ADD COLUMN infra_rerun_sha TEXT NOT NULL DEFAULT ''`,
+		// GH-4598: persist Parked + EscalationReason. Both were in-memory-only
+		// (GH-4596/#4602), which meant every daemon restart (or poller replay
+		// re-registering the PR) reset Parked to false and EscalationReason to
+		// "" for a PR already sitting quietly in awaiting_approval with no
+		// approval channel wired. The next tick's submitAsyncApprovalRequest
+		// would then treat the misconfig as brand-new: re-log the WARN, blow
+		// the specific gate reason away in favor of the generic
+		// environments.<env>.require_approval=true fallback, and re-invoke
+		// postMisconfigComment (itself idempotent about the actual GitHub
+		// comment via the marker check, but not free — a wasted
+		// ListIssueComments round-trip every restart). Persisting both fields
+		// lets a restored PR recognize itself as already parked on tick 1.
+		`ALTER TABLE autopilot_pr_state ADD COLUMN parked INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE autopilot_pr_state ADD COLUMN escalation_reason TEXT NOT NULL DEFAULT ''`,
 	}
 
 	for _, m := range migrations {
@@ -425,6 +439,8 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			merge_followup_posted INTEGER NOT NULL DEFAULT 0,
 			infra_rerun_count INTEGER NOT NULL DEFAULT 0,
 			infra_rerun_sha TEXT NOT NULL DEFAULT '',
+			parked INTEGER NOT NULL DEFAULT 0,
+			escalation_reason TEXT NOT NULL DEFAULT '',
 			PRIMARY KEY (repo, pr_number)
 		)
 	`); err != nil {
@@ -438,7 +454,8 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
 			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key,
-			pr_title, merge_followup_posted, infra_rerun_count, infra_rerun_sha
+			pr_title, merge_followup_posted, infra_rerun_count, infra_rerun_sha,
+			parked, escalation_reason
 		)
 		SELECT
 			pr_number, repo, pr_url, issue_number, branch_name, head_sha,
@@ -447,7 +464,8 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
 			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key,
-			pr_title, merge_followup_posted, infra_rerun_count, infra_rerun_sha
+			pr_title, merge_followup_posted, infra_rerun_count, infra_rerun_sha,
+			parked, escalation_reason
 		FROM autopilot_pr_state
 	`); err != nil {
 		return fmt.Errorf("copy autopilot_pr_state rows: %w", err)
@@ -591,8 +609,9 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
 			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key,
-			pr_title, merge_followup_posted, infra_rerun_count, infra_rerun_sha
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			pr_title, merge_followup_posted, infra_rerun_count, infra_rerun_sha,
+			parked, escalation_reason
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(repo, pr_number) DO UPDATE SET
 			pr_url = excluded.pr_url,
 			issue_number = excluded.issue_number,
@@ -618,7 +637,9 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 			pr_title = excluded.pr_title,
 			merge_followup_posted = excluded.merge_followup_posted,
 			infra_rerun_count = excluded.infra_rerun_count,
-			infra_rerun_sha = excluded.infra_rerun_sha
+			infra_rerun_sha = excluded.infra_rerun_sha,
+			parked = excluded.parked,
+			escalation_reason = excluded.escalation_reason
 	`,
 		pr.PRNumber, repo, pr.PRURL, pr.IssueNumber, pr.BranchName, pr.HeadSHA,
 		string(pr.Stage), string(pr.CIStatus),
@@ -628,6 +649,7 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 		pr.ApprovalRequestID, pr.ApprovalDecision, nullTime(pr.ApprovalRequestedAt),
 		pr.PostMergeSHA, nullTime(pr.PostMergeCIStartedAt), pr.RebaseAttempts, pr.ScopeKey,
 		pr.PRTitle, pr.MergeFollowupPosted, pr.InfraRerunCount, pr.InfraRerunSHA,
+		pr.Parked, pr.EscalationReason,
 	)
 	return err
 }
@@ -642,7 +664,8 @@ func (s *StateStore) GetPRState(repo string, prNumber int) (*PRState, error) {
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
 			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key,
-			pr_title, merge_followup_posted, infra_rerun_count, infra_rerun_sha
+			pr_title, merge_followup_posted, infra_rerun_count, infra_rerun_sha,
+			parked, escalation_reason
 		FROM autopilot_pr_state WHERE repo = ? AND pr_number = ?
 	`, repo, prNumber)
 
@@ -666,7 +689,8 @@ func (s *StateStore) LoadAllPRStates(repo string) ([]*PRState, error) {
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
 			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key,
-			pr_title, merge_followup_posted, infra_rerun_count, infra_rerun_sha
+			pr_title, merge_followup_posted, infra_rerun_count, infra_rerun_sha,
+			parked, escalation_reason
 		FROM autopilot_pr_state WHERE repo = ?
 	`, repo)
 	if err != nil {
@@ -688,6 +712,7 @@ func (s *StateStore) LoadAllPRStates(repo string) ([]*PRState, error) {
 			&pr.ApprovalRequestID, &pr.ApprovalDecision, &approvalRequestedAt,
 			&pr.PostMergeSHA, &postMergeCIStartedAt, &pr.RebaseAttempts, &pr.ScopeKey,
 			&pr.PRTitle, &pr.MergeFollowupPosted, &pr.InfraRerunCount, &pr.InfraRerunSHA,
+			&pr.Parked, &pr.EscalationReason,
 		); err != nil {
 			return nil, err
 		}
@@ -943,6 +968,7 @@ func scanPRState(row *sql.Row) (*PRState, error) {
 		&pr.ApprovalRequestID, &pr.ApprovalDecision, &approvalRequestedAt,
 		&pr.PostMergeSHA, &postMergeCIStartedAt, &pr.RebaseAttempts, &pr.ScopeKey,
 		&pr.PRTitle, &pr.MergeFollowupPosted, &pr.InfraRerunCount, &pr.InfraRerunSHA,
+		&pr.Parked, &pr.EscalationReason,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/autopilot/state_store_test.go
+++ b/internal/autopilot/state_store_test.go
@@ -144,6 +144,63 @@ func TestStateStore_InfraRerunFields_SurvivesRestart(t *testing.T) {
 	}
 }
 
+// TestStateStore_ParkedAndEscalationReason_SurviveRestart is the GH-4598
+// regression test: before this, Parked and EscalationReason were in-memory
+// only (GH-4596/#4602), so a daemon restart reloaded an already-parked PR
+// with Parked=false and EscalationReason="" — the very next tick then
+// treated the still-true misconfig as brand new, re-logging the WARN and
+// re-invoking postMisconfigComment instead of staying quiet. Both fields
+// must now round-trip through SavePRState via both read paths a restart
+// actually uses: GetPRState (single-PR lookups) and LoadAllPRStates (the
+// path RestoreState calls to rehydrate activePRs).
+func TestStateStore_ParkedAndEscalationReason_SurviveRestart(t *testing.T) {
+	store := newTestStateStore(t)
+
+	pr := &PRState{
+		PRNumber:         57,
+		PRURL:            "https://github.com/owner/repo/pull/57",
+		IssueNumber:      22,
+		BranchName:       "pilot/GH-22",
+		HeadSHA:          "sha57",
+		Stage:            StageAwaitApproval,
+		Parked:           true,
+		EscalationReason: "PR adds 656 net lines (> 500 threshold)",
+		CreatedAt:        time.Now().Truncate(time.Second),
+	}
+
+	if err := store.SavePRState("owner/repo", pr); err != nil {
+		t.Fatalf("SavePRState failed: %v", err)
+	}
+
+	loaded, err := store.GetPRState("owner/repo", 57)
+	if err != nil {
+		t.Fatalf("GetPRState failed: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("GetPRState returned nil")
+	}
+	if !loaded.Parked {
+		t.Error("GetPRState: Parked = false, want true")
+	}
+	if loaded.EscalationReason != pr.EscalationReason {
+		t.Errorf("GetPRState: EscalationReason = %q, want %q", loaded.EscalationReason, pr.EscalationReason)
+	}
+
+	all, err := store.LoadAllPRStates("owner/repo")
+	if err != nil {
+		t.Fatalf("LoadAllPRStates failed: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("LoadAllPRStates returned %d states, want 1", len(all))
+	}
+	if !all[0].Parked {
+		t.Error("LoadAllPRStates: Parked = false, want true")
+	}
+	if all[0].EscalationReason != pr.EscalationReason {
+		t.Errorf("LoadAllPRStates: EscalationReason = %q, want %q", all[0].EscalationReason, pr.EscalationReason)
+	}
+}
+
 func TestStateStore_LoadAllPRStates(t *testing.T) {
 	store := newTestStateStore(t)
 

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -1016,8 +1016,9 @@ type PRState struct {
 	ReleasingFirstAt time.Time
 	// EscalationReason records why the PR entered StageAwaitApproval (size-floor
 	// gate, scope-drift gate, or env require_approval) so misconfig reporting
-	// names the actual trigger (GH-3569). In-memory only; lost on restart, which
-	// degrades to the env-based fallback wording.
+	// names the actual trigger (GH-3569). Persisted (GH-4598): a restart-time
+	// reload of an already-parked PR must see the actual gate reason rather
+	// than degrading to the generic env-based fallback wording.
 	EscalationReason string
 	// Parked is true once submitAsyncApprovalRequest has determined a gate
 	// demands approval but no approval channel is wired (approvalMgr is nil,
@@ -1029,9 +1030,12 @@ type PRState struct {
 	// write-back to pick back up. The PR now stays in StageAwaitApproval
 	// ("parked") with EscalationReason recording the gate that fired;
 	// Parked itself just dedupes the one-time misconfig log line/PR comment
-	// across repeated ticks. In-memory only; lost on restart, which simply
-	// re-derives Parked=true on the next tick since the underlying
-	// misconfig condition is still true.
+	// across repeated ticks. Persisted (GH-4598): without this, every daemon
+	// restart (or poller re-registration) rehydrated a parked PR with
+	// Parked=false, so the very first post-restart tick treated the still-true
+	// misconfig as brand new — re-logging the WARN and re-invoking
+	// postMisconfigComment (a wasted GitHub round-trip; the comment itself was
+	// already idempotent via its marker check) — instead of staying quiet.
 	Parked bool
 	// TerminalLabel overrides the default pilot-retry-ready label that
 	// notifyExternalClose applies once it observes this PR closed on GitHub.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4598.

Closes #4598

## Changes

Ensure restart/poller replay re-hydrates parked PRs as awaiting_approval (parked) rather than re-classifying as failed, and make the CI-passed handler idempotent so parked PRs are not re-alerted or re-commented; preserve the existing GH-4383 approval-submit path when an approval channel is configured.