### PR TITLE
GH-4599: fix(autopilot): resolve PR's own issue in title-type gate instead of epic parent

### DIFF
--- a/.agent/tasks/gh-4599.md
+++ b/.agent/tasks/gh-4599.md
@@ -1,0 +1,10 @@
+# GH-4599
+
+**Created:** 2026-07-28
+
+## Problem
+
+In scope_guard.go and its caller, derive the issue number from the PR's branch (pilot/GH-N → issue N) instead of walking to the epic parent; fall back to current behavior with an explicit log line when the branch has no pilot/GH-N pattern; keep the reason string format unchanged.
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1938,10 +1938,14 @@ func (c *Controller) handleCIPassed(ctx context.Context, prState *PRState) error
 	}
 
 	if escalateReason == "" && prState.IssueNumber > 0 {
-		issue, issueErr := c.ghClient.GetIssue(ctx, c.owner, c.repo, prState.IssueNumber)
+		// GH-4599: derive the issue to compare from the PR's own "pilot/GH-N"
+		// branch rather than prState.IssueNumber directly — for scope-release
+		// carrier PRs that field is the epic parent (see scopeDriftIssueNumber).
+		driftIssueNum := scopeDriftIssueNumber(c.log, prState.BranchName, prState.IssueNumber)
+		issue, issueErr := c.ghClient.GetIssue(ctx, c.owner, c.repo, driftIssueNum)
 		if issueErr != nil {
 			c.log.Warn("handleCIPassed: GetIssue failed, skipping scope-drift gate (fail-open)",
-				"pr", prState.PRNumber, "issue", prState.IssueNumber, "error", issueErr)
+				"pr", prState.PRNumber, "issue", driftIssueNum, "error", issueErr)
 		} else if reason := ScopeDriftReason(c.log, prState.PRTitle, issue.Title); reason != "" {
 			escalateReason = reason
 		}

--- a/internal/autopilot/scope_guard.go
+++ b/internal/autopilot/scope_guard.go
@@ -92,6 +92,51 @@ func ScopeDriftReason(logger *slog.Logger, prTitle, issueTitle string) string {
 	return ""
 }
 
+// pilotBranchPrefix is the branch-name convention Pilot worker branches use
+// for issue-scoped PRs (e.g. "pilot/GH-4599").
+const pilotBranchPrefix = "pilot/GH-"
+
+// issueNumberFromBranch extracts the issue number from a "pilot/GH-N" branch
+// name, using the same fmt.Sscanf convention as resolveIssueNumFromPR
+// (controller.go). Returns 0, false if branchName doesn't carry the prefix or
+// no digits follow it — e.g. a scope-release carrier's empty BranchName, or a
+// human-authored branch.
+func issueNumberFromBranch(branchName string) (int, bool) {
+	if !strings.HasPrefix(branchName, pilotBranchPrefix) {
+		return 0, false
+	}
+	var n int
+	if _, err := fmt.Sscanf(branchName, pilotBranchPrefix+"%d", &n); err != nil || n == 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// scopeDriftIssueNumber resolves which issue number handleCIPassed should
+// fetch for ScopeDriftReason's comparison against the PR title. GH-4599: the
+// caller used to pass prState.IssueNumber straight through, but for a
+// scope-release carrier PR (see epicParentFromScopeKey in scope_release.go)
+// that value is the EPIC PARENT's issue number, not the PR's own originating
+// issue — walking to the epic parent compared the carrier's title against
+// the epic's title, the wrong signal for scope drift. Deriving the number
+// from the "pilot/GH-N" branch-name convention instead targets the PR's own
+// issue. Falls back to fallbackIssueNumber (the walk-to-epic-parent value)
+// with an INFO log line when branchName doesn't match the convention —
+// carrier PRs have no BranchName set, and human-authored PRs use arbitrary
+// branch names, so the fallback preserves prior behavior there. The reason
+// string ScopeDriftReason returns is unaffected: only the issue we compare
+// against changes, not the format of the drift message.
+func scopeDriftIssueNumber(logger *slog.Logger, branchName string, fallbackIssueNumber int) int {
+	if n, ok := issueNumberFromBranch(branchName); ok {
+		return n
+	}
+	if logger != nil {
+		logger.Info("scope-drift issue resolution: branch has no pilot/GH-N pattern, falling back to linked issue number",
+			"branch", branchName, "fallback_issue", fallbackIssueNumber)
+	}
+	return fallbackIssueNumber
+}
+
 // SizeFloorThreshold is the net-additions threshold above which a PR escalates
 // to human approval regardless of env config. Cascade #2's bad PR was 512 LoC.
 // GH-3570: raised from 200 to 500 — routine well-scoped Pilot PRs with tests

--- a/internal/autopilot/scope_guard_test.go
+++ b/internal/autopilot/scope_guard_test.go
@@ -126,6 +126,68 @@ func TestScopeDriftReason_AbstainLogsReason(t *testing.T) {
 	}
 }
 
+// TestIssueNumberFromBranch covers GH-4599 branch-name issue extraction.
+func TestIssueNumberFromBranch(t *testing.T) {
+	cases := []struct {
+		branch  string
+		wantNum int
+		wantOK  bool
+	}{
+		{"pilot/GH-4599", 4599, true},
+		{"pilot/GH-1", 1, true},
+		{"pilot/GH-4393-5", 4393, true}, // decomposed subtask branch — parent number
+		{"", 0, false},
+		{"main", 0, false},
+		{"feature/some-human-branch", 0, false},
+		{"pilot/GH-", 0, false},
+		{"pilot/GH-abc", 0, false},
+	}
+	for _, tc := range cases {
+		gotNum, gotOK := issueNumberFromBranch(tc.branch)
+		if gotNum != tc.wantNum || gotOK != tc.wantOK {
+			t.Errorf("issueNumberFromBranch(%q) = (%d,%v), want (%d,%v)",
+				tc.branch, gotNum, gotOK, tc.wantNum, tc.wantOK)
+		}
+	}
+}
+
+// TestScopeDriftIssueNumber covers GH-4599: prefer the branch-derived issue
+// number over the caller-supplied fallback (which, for scope-release carrier
+// PRs, is the epic parent rather than the PR's own issue), and fall back —
+// with a logged reason — when the branch doesn't match the convention.
+func TestScopeDriftIssueNumber(t *testing.T) {
+	t.Run("branch matches pilot/GH-N — uses branch-derived issue, ignores fallback", func(t *testing.T) {
+		got := scopeDriftIssueNumber(nil, "pilot/GH-4599", 999)
+		if got != 4599 {
+			t.Errorf("got %d, want 4599", got)
+		}
+	})
+
+	t.Run("carrier PR with no BranchName — falls back to epic parent and logs", func(t *testing.T) {
+		var buf strings.Builder
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+		got := scopeDriftIssueNumber(logger, "", 1234)
+		if got != 1234 {
+			t.Errorf("got %d, want fallback 1234", got)
+		}
+		logged := buf.String()
+		if !strings.Contains(logged, "no pilot/GH-N pattern") {
+			t.Errorf("expected fallback to be logged, got: %q", logged)
+		}
+		if !strings.Contains(logged, "level=INFO") {
+			t.Errorf("expected log level INFO, got: %q", logged)
+		}
+	})
+
+	t.Run("human-authored branch name — falls back", func(t *testing.T) {
+		got := scopeDriftIssueNumber(nil, "feature/manual-fix", 42)
+		if got != 42 {
+			t.Errorf("got %d, want fallback 42", got)
+		}
+	})
+}
+
 func TestSizeFloorReason(t *testing.T) {
 	cases := []struct {
 		name  string


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4599.

Closes #4599

## Changes

In scope_guard.go and its caller, derive the issue number from the PR's branch (pilot/GH-N → issue N) instead of walking to the epic parent; fall back to current behavior with an explicit log line when the branch has no pilot/GH-N pattern; keep the reason string format unchanged.