### PR TITLE
GH-4610: feat(autopilot): re-adopt held needs-manual-rebase PRs when their branch is updated — 5x recurrence in one wave

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-28 (v2.151.0)
+**Last Updated:** 2026-07-29 (v2.151.0)
 
 ## Legend
 

--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-29 (v2.151.0)
+**Last Updated:** 2026-07-28 (v2.151.0)
 
 ## Legend
 
@@ -186,6 +186,7 @@
 | Deadlock detector | ✅ | autopilot | - | - | Alert after 1h with no progress on PR (v0.38.0, GH-849) |
 | Lane-starvation detector | ✅ | autopilot/alerts | - | `alerts.rules[].condition.lane_starvation_poll_cycles` | Alert when a project lane has open non-blocked pilot-labeled issues but 0 queued/running executions for N consecutive poll cycles (default 3, cooldown 30m) — catches wedged/stalled issues that never produce a PR or execution row for the other health checks to watch (v2.241.2, GH-4454) |
 | Self-close marker + escalateAndHold (rung foundation) | ✅ | autopilot | - | - | `markSelfClosed`/`consumeSelfClosedMarker` (10m TTL) let the external-close poll path tell autopilot's own PR closes apart from real human rejections, skipping the GH-3818/D10 reclassify+branch-delete for stamped closes; `escalateAndHold` is a reusable give-up helper (StageFailed + pilot-needs-human + caller labels + PR comment + alert, no close/branch-delete/re-execution) for future conflict/CI-recovery rungs to call (v2.241.3, GH-4458) |
+| Needs-manual-rebase re-adoption | ✅ | autopilot | - | - | `escalateAndHold`'s needs-manual-rebase hold (StageFailed) previously required a fully manual `gh pr merge` even after an operator pushed a fix — the poll loop treated StageFailed as terminal and never looked again. `reAdoptHeldRebasePR` runs every `processAllPRs` tick before `ProcessPR`: for a PR with `RebaseHoldActive=true` whose GitHub head SHA no longer matches the stored `HeadSHA`, it re-enters the pipeline at `StageWaitingCI` (fresh CI on the new head), preserving `MergeAttempts`/`RebaseAttempts` and posting a re-adoption comment; capped at `maxReadoptAttempts=2` via `PRState.ReadoptCount` (persisted) so a repeatedly-conflicting branch can't ping-pong forever — it stays parked past the cap. `RebaseHoldActive`/`ReadoptCount` are both persisted (`autopilot_pr_state.rebase_hold_active`/`readopt_count`) so the flag and budget survive a daemon restart. The external-merge scan remains the fallback for PRs merged by hand. Fixes a 5x-in-one-wave recurrence on 2026-07-29 (pilot-console PRs #67/#68/#70/#74/#75, all requiring manual operator rebase + merge) (v2.249.0, GH-4610) |
 | Alert dispatch metrics | ✅ | alerts/gateway | - | - | alerts_fired_total, alert_delivery_total, alert_events_dropped_total, alert_queue_depth on /metrics (TASK-332) |
 | Rate limit detection | ✅ | executor | - | - | Detect GitHub API rate limits, pause + resume at reset time (v0.34.0) |
 | GitHub token fallback + live validation | ✅ | cmd/pilot, health | `pilot doctor` | `adapters.github.token` | config → `GITHUB_TOKEN` env → `gh auth token` fallback; authenticated startup check logs ERROR + fires `config_error` alert on a dead/expired token (GH-3718) |

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -4611,6 +4612,11 @@ const labelParkedAwaitingApproval = "autopilot/parked-awaiting-approval"
 func (c *Controller) escalateAndHold(ctx context.Context, prState *PRState, reason string, labels []string, comment string) {
 	prState.Stage = StageFailed
 	prState.Error = reason
+	// GH-4610: narrow re-adoption's re-entry scan to holds it can actually
+	// resolve (a rebase an operator fixed by pushing to the branch) rather
+	// than every StageFailed PR — other holds (CI-fix size guard, rebase-
+	// oscillation cap, CI timeout) stay parked even if their branch moves.
+	prState.RebaseHoldActive = slices.Contains(labels, "needs-manual-rebase")
 
 	if prState.IssueNumber > 0 {
 		allLabels := append([]string{labelNeedsHuman}, labels...)
@@ -4645,6 +4651,74 @@ func (c *Controller) escalateAndHold(ctx context.Context, prState *PRState, reas
 	}
 
 	c.log.Warn("escalateAndHold: PR held for human review, branch intact", "pr", prState.PRNumber, "issue", prState.IssueNumber, "reason", reason, "labels", labels)
+}
+
+// maxReadoptAttempts caps how many times reAdoptHeldRebasePR (GH-4610) may
+// revive a single PR from a needs-manual-rebase hold. Without a cap, a
+// branch that keeps re-conflicting after every push would ping-pong
+// autopilot between StageFailed and StageWaitingCI forever instead of
+// eventually staying parked for a human — mirrors the reasoning behind
+// MaxRebaseAttempts (GH-3715) for the auto-rebase oscillation cap.
+const maxReadoptAttempts = 2
+
+// reAdoptHeldRebasePR is GH-4610: escalateAndHold's needs-manual-rebase hold
+// sets StageFailed, which ProcessPR treats as terminal (case StageFailed:
+// "no processing"). Before this, the only way off that hold was a fully
+// manual `gh pr merge` after an operator rebased the branch by hand —
+// autopilot never looked at the PR again even though the branch had been
+// updated to resolve the conflict. This recurred 5x in one wave on
+// 2026-07-29 (pilot-console PRs #67/#68/#70/#74/#75, all parked after
+// sibling-PR merges), every one requiring an operator rebase plus a manual
+// merge.
+//
+// Detection rides the existing PR poll in processAllPRs: compare the stored
+// HeadSHA against the freshly-fetched ghPR head. A changed SHA on a PR held
+// specifically via RebaseHoldActive (not any other StageFailed reason — CI-
+// fix size guard, rebase-oscillation cap, CI timeout, etc. all stay parked)
+// means someone pushed a fix, so re-enter the pipeline at StageWaitingCI for
+// fresh CI on the new head. MergeAttempts/RebaseAttempts are preserved (not
+// reset) so their own caps still apply if the PR conflicts again; the
+// external-merge scan (checkExternalMergeOrClose) remains the fallback for
+// PRs an operator merges by hand instead of pushing a fix.
+func (c *Controller) reAdoptHeldRebasePR(ctx context.Context, prState *PRState, ghPR *github.PullRequest) {
+	if ghPR == nil || prState.Stage != StageFailed || !prState.RebaseHoldActive {
+		return
+	}
+	newHead := ghPR.Head.SHA
+	if newHead == "" || newHead == prState.HeadSHA {
+		return
+	}
+	if prState.ReadoptCount >= maxReadoptAttempts {
+		c.log.Warn("reAdoptHeldRebasePR: re-adoption cap reached, leaving PR parked for manual merge",
+			"pr", prState.PRNumber, "issue", prState.IssueNumber,
+			"readopt_count", prState.ReadoptCount, "max", maxReadoptAttempts,
+		)
+		return
+	}
+
+	prevHold := prState.Error
+	prState.ReadoptCount++
+	prState.RebaseHoldActive = false
+	prState.HeadSHA = newHead
+	prState.Stage = StageWaitingCI
+	prState.CIWaitStartedAt = time.Now()
+	prState.Error = ""
+
+	c.log.Info("reAdoptHeldRebasePR: branch updated on held PR, re-entering pipeline",
+		"pr", prState.PRNumber, "issue", prState.IssueNumber,
+		"new_head", ShortSHA(newHead), "readopt_count", prState.ReadoptCount,
+		"max", maxReadoptAttempts, "prior_hold_reason", prevHold,
+	)
+
+	if prState.IssueNumber > 0 {
+		comment := fmt.Sprintf(
+			"🔄 **Re-adopted**: branch updated (new head `%s`) while held for manual rebase — autopilot is re-entering the pipeline for fresh CI (re-adoption %d/%d).",
+			ShortSHA(newHead), prState.ReadoptCount, maxReadoptAttempts,
+		)
+		if _, err := c.ghClient.AddPRComment(ctx, c.owner, c.repo, prState.PRNumber, comment); err != nil {
+			c.log.Warn("reAdoptHeldRebasePR: failed to post PR comment", "pr", prState.PRNumber, "error", err)
+		}
+	}
 }
 
 // removePR removes PR from tracking and cleans up the remote branch.
@@ -5807,6 +5881,13 @@ func (c *Controller) processAllPRs(ctx context.Context) {
 				pr.mu.Unlock()
 				continue
 			}
+
+			// GH-4610: revive a needs-manual-rebase hold back into the pipeline
+			// once its branch has moved (operator pushed a fix) — a no-op for
+			// every PR not currently held in exactly that state. Must run before
+			// ProcessPR, which treats StageFailed as terminal and would never
+			// look at this PR again otherwise.
+			c.reAdoptHeldRebasePR(ctx, pr, ghPR)
 
 			// Detect changes_requested reviews in polling mode (webhook mode uses OnReviewRequested).
 			// Only check PRs that haven't already been transitioned to review_requested.

--- a/internal/autopilot/gh4610_test.go
+++ b/internal/autopilot/gh4610_test.go
@@ -1,0 +1,336 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestEscalateAndHold_SetsRebaseHoldActive covers the GH-4610 wiring:
+// escalateAndHold must flag RebaseHoldActive only when the caller-supplied
+// labels include "needs-manual-rebase" — every other escalation reason
+// (CI-fix size guard, rebase-oscillation cap, etc.) must leave the PR
+// ineligible for re-adoption.
+func TestEscalateAndHold_SetsRebaseHoldActive(t *testing.T) {
+	tests := []struct {
+		name       string
+		labels     []string
+		wantActive bool
+	}{
+		{"needs-manual-rebase label present", []string{"needs-manual-rebase"}, true},
+		{"needs-manual-rebase among other labels", []string{"foo", "needs-manual-rebase"}, true},
+		{"unrelated label only", []string{"pilot-blocked"}, false},
+		{"no labels", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, srv := newRecordingGHServer()
+			defer srv.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+			c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+			prState := &PRState{PRNumber: 50, IssueNumber: 5, BranchName: "pilot/GH-5"}
+			c.escalateAndHold(context.Background(), prState, "some reason", tt.labels, "comment")
+
+			if prState.RebaseHoldActive != tt.wantActive {
+				t.Errorf("RebaseHoldActive = %v, want %v", prState.RebaseHoldActive, tt.wantActive)
+			}
+		})
+	}
+}
+
+// TestReAdoptHeldRebasePR_RevivesOnNewHead covers the GH-4610 fix itself: a
+// PR held via escalateAndHold's needs-manual-rebase hold, once its branch
+// receives a new commit (operator resolved the conflict and pushed), must
+// be revived to StageWaitingCI for fresh CI — not left stranded requiring a
+// fully manual `gh pr merge` as it was before this fix (5x recurrence in one
+// wave, pilot-console PRs #67/#68/#70/#74/#75).
+func TestReAdoptHeldRebasePR_RevivesOnNewHead(t *testing.T) {
+	rec, srv := newRecordingGHServer()
+	defer srv.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:         67,
+		IssueNumber:      67,
+		BranchName:       "pilot/GH-67",
+		HeadSHA:          "old-sha",
+		Stage:            StageFailed,
+		Error:            "auto-rebase failed",
+		RebaseHoldActive: true,
+		RebaseAttempts:   1,
+		MergeAttempts:    2,
+	}
+
+	ghPR := &github.PullRequest{Number: 67, Head: github.PRRef{SHA: "new-sha"}}
+	c.reAdoptHeldRebasePR(context.Background(), prState, ghPR)
+
+	if prState.Stage != StageWaitingCI {
+		t.Errorf("Stage = %v, want StageWaitingCI", prState.Stage)
+	}
+	if prState.HeadSHA != "new-sha" {
+		t.Errorf("HeadSHA = %q, want %q", prState.HeadSHA, "new-sha")
+	}
+	if prState.RebaseHoldActive {
+		t.Error("RebaseHoldActive should be cleared after re-adoption")
+	}
+	if prState.Error != "" {
+		t.Errorf("Error = %q, want empty after re-adoption", prState.Error)
+	}
+	if prState.ReadoptCount != 1 {
+		t.Errorf("ReadoptCount = %d, want 1", prState.ReadoptCount)
+	}
+	// Preserved attempt counters — GH-4610 requires these survive re-adoption
+	// so their own caps (MaxRebaseAttempts, merge attempt cap) still apply.
+	if prState.RebaseAttempts != 1 {
+		t.Errorf("RebaseAttempts = %d, want 1 (preserved)", prState.RebaseAttempts)
+	}
+	if prState.MergeAttempts != 2 {
+		t.Errorf("MergeAttempts = %d, want 2 (preserved)", prState.MergeAttempts)
+	}
+	if prState.CIWaitStartedAt.IsZero() {
+		t.Error("CIWaitStartedAt should be reset for fresh CI monitoring")
+	}
+	if n := rec.count(http.MethodPost, "/repos/owner/repo/issues/67/comments"); n != 1 {
+		t.Errorf("PR comment calls = %d, want 1 (re-adoption notice)", n)
+	}
+}
+
+// TestReAdoptHeldRebasePR_IgnoresNonRebaseHolds covers the negative case: a
+// StageFailed PR held for any reason OTHER than needs-manual-rebase
+// (RebaseHoldActive=false) must stay parked even if its branch moved — e.g.
+// a CI-timeout or rebase-oscillation-cap hold is not something a bare branch
+// push resolves.
+func TestReAdoptHeldRebasePR_IgnoresNonRebaseHolds(t *testing.T) {
+	_, srv := newRecordingGHServer()
+	defer srv.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:         68,
+		HeadSHA:          "old-sha",
+		Stage:            StageFailed,
+		Error:            "CI timeout after 1h0m0s",
+		RebaseHoldActive: false,
+	}
+
+	ghPR := &github.PullRequest{Number: 68, Head: github.PRRef{SHA: "new-sha"}}
+	c.reAdoptHeldRebasePR(context.Background(), prState, ghPR)
+
+	if prState.Stage != StageFailed {
+		t.Errorf("Stage = %v, want StageFailed (unrelated hold must not be revived)", prState.Stage)
+	}
+	if prState.HeadSHA != "old-sha" {
+		t.Errorf("HeadSHA = %q, want unchanged %q", prState.HeadSHA, "old-sha")
+	}
+	if prState.ReadoptCount != 0 {
+		t.Errorf("ReadoptCount = %d, want 0", prState.ReadoptCount)
+	}
+}
+
+// TestReAdoptHeldRebasePR_SameHeadSHA_NoOp covers the no-branch-update case:
+// a held PR whose head SHA is unchanged (no push happened) must stay parked
+// — this is what makes detection safe to run on every poll tick.
+func TestReAdoptHeldRebasePR_SameHeadSHA_NoOp(t *testing.T) {
+	_, srv := newRecordingGHServer()
+	defer srv.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:         70,
+		HeadSHA:          "same-sha",
+		Stage:            StageFailed,
+		RebaseHoldActive: true,
+	}
+
+	ghPR := &github.PullRequest{Number: 70, Head: github.PRRef{SHA: "same-sha"}}
+	c.reAdoptHeldRebasePR(context.Background(), prState, ghPR)
+
+	if prState.Stage != StageFailed {
+		t.Errorf("Stage = %v, want StageFailed (no branch update, no revival)", prState.Stage)
+	}
+	if prState.ReadoptCount != 0 {
+		t.Errorf("ReadoptCount = %d, want 0", prState.ReadoptCount)
+	}
+}
+
+// TestReAdoptHeldRebasePR_CapReached covers the ping-pong guard: once
+// ReadoptCount reaches maxReadoptAttempts, a further branch update must NOT
+// trigger another revival — the PR stays parked for a human even though its
+// head SHA changed again, so a repeatedly-conflicting branch can't cycle
+// autopilot between held and waiting_ci forever.
+func TestReAdoptHeldRebasePR_CapReached(t *testing.T) {
+	_, srv := newRecordingGHServer()
+	defer srv.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:         74,
+		HeadSHA:          "sha-at-cap",
+		Stage:            StageFailed,
+		RebaseHoldActive: true,
+		ReadoptCount:     maxReadoptAttempts,
+	}
+
+	ghPR := &github.PullRequest{Number: 74, Head: github.PRRef{SHA: "yet-another-sha"}}
+	c.reAdoptHeldRebasePR(context.Background(), prState, ghPR)
+
+	if prState.Stage != StageFailed {
+		t.Errorf("Stage = %v, want StageFailed (cap reached, must stay parked)", prState.Stage)
+	}
+	if prState.HeadSHA != "sha-at-cap" {
+		t.Errorf("HeadSHA = %q, want unchanged %q", prState.HeadSHA, "sha-at-cap")
+	}
+	if prState.ReadoptCount != maxReadoptAttempts {
+		t.Errorf("ReadoptCount = %d, want unchanged %d", prState.ReadoptCount, maxReadoptAttempts)
+	}
+}
+
+// TestController_ProcessAllPRs_ReAdoptsHeldRebasePR is an end-to-end check
+// through processAllPRs (the real poll loop entry point, GH-4610): a held
+// PR whose branch was pushed must be revived AND actually re-enter
+// StageWaitingCI processing within the same tick, not just have its stage
+// flipped with no follow-through.
+func TestController_ProcessAllPRs_ReAdoptsHeldRebasePR(t *testing.T) {
+	var mu sync.Mutex
+	var commentPosts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/75" && r.Method == http.MethodGet:
+			resp := github.PullRequest{
+				Number:  75,
+				State:   "open",
+				HTMLURL: "https://github.com/owner/repo/pull/75",
+				Head:    github.PRRef{SHA: "new-sha", Ref: "pilot/GH-75"},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/repos/owner/repo/issues/75/comments" && r.Method == http.MethodPost:
+			mu.Lock()
+			commentPosts++
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer srv.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	cfg := DefaultConfig()
+	cfg.CIWaitTimeout = time.Hour
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:         75,
+		IssueNumber:      75,
+		PRURL:            "https://github.com/owner/repo/pull/75",
+		BranchName:       "pilot/GH-75",
+		HeadSHA:          "old-sha",
+		Stage:            StageFailed,
+		Error:            "auto-rebase failed",
+		RebaseHoldActive: true,
+		CreatedAt:        time.Now(),
+	}
+	c.mu.Lock()
+	c.activePRs[75] = prState
+	c.mu.Unlock()
+
+	c.processAllPRs(context.Background())
+
+	got, ok := c.GetPRState(75)
+	if !ok {
+		t.Fatal("PR 75 should still be tracked")
+	}
+	if got.Stage != StageWaitingCI {
+		t.Errorf("Stage = %v, want StageWaitingCI (re-adopted and processed in the same tick)", got.Stage)
+	}
+	if got.HeadSHA != "new-sha" {
+		t.Errorf("HeadSHA = %q, want %q", got.HeadSHA, "new-sha")
+	}
+	if got.ReadoptCount != 1 {
+		t.Errorf("ReadoptCount = %d, want 1", got.ReadoptCount)
+	}
+	mu.Lock()
+	gotComments := commentPosts
+	mu.Unlock()
+	if gotComments != 1 {
+		t.Errorf("PR comment calls = %d, want 1 (re-adoption notice)", gotComments)
+	}
+}
+
+// TestStateStore_RebaseHoldActiveAndReadoptCount_SurviveRestart is the
+// GH-4610 persistence regression test: without this, a daemon restart while
+// a PR sat held for needs-manual-rebase would reload it with
+// RebaseHoldActive=false, permanently disqualifying it from re-adoption even
+// though the branch push it's waiting on hasn't happened yet, and would
+// reset ReadoptCount to 0, silently granting a fresh re-adoption budget on
+// every restart. Both fields must round-trip through SavePRState via both
+// read paths a restart uses: GetPRState and LoadAllPRStates.
+func TestStateStore_RebaseHoldActiveAndReadoptCount_SurviveRestart(t *testing.T) {
+	store := newTestStateStore(t)
+
+	pr := &PRState{
+		PRNumber:         75,
+		PRURL:            "https://github.com/owner/repo/pull/75",
+		IssueNumber:      75,
+		BranchName:       "pilot/GH-75",
+		HeadSHA:          "sha75",
+		Stage:            StageFailed,
+		Error:            "auto-rebase failed",
+		RebaseHoldActive: true,
+		ReadoptCount:     1,
+		CreatedAt:        time.Now().Truncate(time.Second),
+	}
+
+	if err := store.SavePRState("owner/repo", pr); err != nil {
+		t.Fatalf("SavePRState failed: %v", err)
+	}
+
+	loaded, err := store.GetPRState("owner/repo", 75)
+	if err != nil {
+		t.Fatalf("GetPRState failed: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("GetPRState returned nil")
+	}
+	if !loaded.RebaseHoldActive {
+		t.Error("GetPRState: RebaseHoldActive = false, want true")
+	}
+	if loaded.ReadoptCount != 1 {
+		t.Errorf("GetPRState: ReadoptCount = %d, want 1", loaded.ReadoptCount)
+	}
+
+	all, err := store.LoadAllPRStates("owner/repo")
+	if err != nil {
+		t.Fatalf("LoadAllPRStates failed: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("LoadAllPRStates returned %d states, want 1", len(all))
+	}
+	if !all[0].RebaseHoldActive {
+		t.Error("LoadAllPRStates: RebaseHoldActive = false, want true")
+	}
+	if all[0].ReadoptCount != 1 {
+		t.Errorf("LoadAllPRStates: ReadoptCount = %d, want 1", all[0].ReadoptCount)
+	}
+}

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -182,6 +182,11 @@ func (s *StateStore) migrate() error {
 		// lets a restored PR recognize itself as already parked on tick 1.
 		`ALTER TABLE autopilot_pr_state ADD COLUMN parked INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE autopilot_pr_state ADD COLUMN escalation_reason TEXT NOT NULL DEFAULT ''`,
+		// GH-4610: persist the needs-manual-rebase hold flag and the re-adoption
+		// counter so a daemon restart doesn't lose track of which held PRs are
+		// eligible for re-adoption, or reset an already-spent re-adoption budget.
+		`ALTER TABLE autopilot_pr_state ADD COLUMN rebase_hold_active INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE autopilot_pr_state ADD COLUMN readopt_count INTEGER NOT NULL DEFAULT 0`,
 	}
 
 	for _, m := range migrations {
@@ -441,6 +446,8 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			infra_rerun_sha TEXT NOT NULL DEFAULT '',
 			parked INTEGER NOT NULL DEFAULT 0,
 			escalation_reason TEXT NOT NULL DEFAULT '',
+			rebase_hold_active INTEGER NOT NULL DEFAULT 0,
+			readopt_count INTEGER NOT NULL DEFAULT 0,
 			PRIMARY KEY (repo, pr_number)
 		)
 	`); err != nil {
@@ -455,7 +462,7 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			approval_request_id, approval_decision, approval_requested_at,
 			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key,
 			pr_title, merge_followup_posted, infra_rerun_count, infra_rerun_sha,
-			parked, escalation_reason
+			parked, escalation_reason, rebase_hold_active, readopt_count
 		)
 		SELECT
 			pr_number, repo, pr_url, issue_number, branch_name, head_sha,
@@ -465,7 +472,7 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			approval_request_id, approval_decision, approval_requested_at,
 			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key,
 			pr_title, merge_followup_posted, infra_rerun_count, infra_rerun_sha,
-			parked, escalation_reason
+			parked, escalation_reason, rebase_hold_active, readopt_count
 		FROM autopilot_pr_state
 	`); err != nil {
 		return fmt.Errorf("copy autopilot_pr_state rows: %w", err)
@@ -610,8 +617,8 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 			approval_request_id, approval_decision, approval_requested_at,
 			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key,
 			pr_title, merge_followup_posted, infra_rerun_count, infra_rerun_sha,
-			parked, escalation_reason
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			parked, escalation_reason, rebase_hold_active, readopt_count
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(repo, pr_number) DO UPDATE SET
 			pr_url = excluded.pr_url,
 			issue_number = excluded.issue_number,
@@ -639,7 +646,9 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 			infra_rerun_count = excluded.infra_rerun_count,
 			infra_rerun_sha = excluded.infra_rerun_sha,
 			parked = excluded.parked,
-			escalation_reason = excluded.escalation_reason
+			escalation_reason = excluded.escalation_reason,
+			rebase_hold_active = excluded.rebase_hold_active,
+			readopt_count = excluded.readopt_count
 	`,
 		pr.PRNumber, repo, pr.PRURL, pr.IssueNumber, pr.BranchName, pr.HeadSHA,
 		string(pr.Stage), string(pr.CIStatus),
@@ -649,7 +658,7 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 		pr.ApprovalRequestID, pr.ApprovalDecision, nullTime(pr.ApprovalRequestedAt),
 		pr.PostMergeSHA, nullTime(pr.PostMergeCIStartedAt), pr.RebaseAttempts, pr.ScopeKey,
 		pr.PRTitle, pr.MergeFollowupPosted, pr.InfraRerunCount, pr.InfraRerunSHA,
-		pr.Parked, pr.EscalationReason,
+		pr.Parked, pr.EscalationReason, pr.RebaseHoldActive, pr.ReadoptCount,
 	)
 	return err
 }
@@ -665,7 +674,7 @@ func (s *StateStore) GetPRState(repo string, prNumber int) (*PRState, error) {
 			approval_request_id, approval_decision, approval_requested_at,
 			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key,
 			pr_title, merge_followup_posted, infra_rerun_count, infra_rerun_sha,
-			parked, escalation_reason
+			parked, escalation_reason, rebase_hold_active, readopt_count
 		FROM autopilot_pr_state WHERE repo = ? AND pr_number = ?
 	`, repo, prNumber)
 
@@ -690,7 +699,7 @@ func (s *StateStore) LoadAllPRStates(repo string) ([]*PRState, error) {
 			approval_request_id, approval_decision, approval_requested_at,
 			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key,
 			pr_title, merge_followup_posted, infra_rerun_count, infra_rerun_sha,
-			parked, escalation_reason
+			parked, escalation_reason, rebase_hold_active, readopt_count
 		FROM autopilot_pr_state WHERE repo = ?
 	`, repo)
 	if err != nil {
@@ -712,7 +721,7 @@ func (s *StateStore) LoadAllPRStates(repo string) ([]*PRState, error) {
 			&pr.ApprovalRequestID, &pr.ApprovalDecision, &approvalRequestedAt,
 			&pr.PostMergeSHA, &postMergeCIStartedAt, &pr.RebaseAttempts, &pr.ScopeKey,
 			&pr.PRTitle, &pr.MergeFollowupPosted, &pr.InfraRerunCount, &pr.InfraRerunSHA,
-			&pr.Parked, &pr.EscalationReason,
+			&pr.Parked, &pr.EscalationReason, &pr.RebaseHoldActive, &pr.ReadoptCount,
 		); err != nil {
 			return nil, err
 		}
@@ -968,7 +977,7 @@ func scanPRState(row *sql.Row) (*PRState, error) {
 		&pr.ApprovalRequestID, &pr.ApprovalDecision, &approvalRequestedAt,
 		&pr.PostMergeSHA, &postMergeCIStartedAt, &pr.RebaseAttempts, &pr.ScopeKey,
 		&pr.PRTitle, &pr.MergeFollowupPosted, &pr.InfraRerunCount, &pr.InfraRerunSHA,
-		&pr.Parked, &pr.EscalationReason,
+		&pr.Parked, &pr.EscalationReason, &pr.RebaseHoldActive, &pr.ReadoptCount,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -1093,6 +1093,22 @@ type PRState struct {
 	// to. When it no longer matches the PR's current HeadSHA, the effective
 	// retry budget is treated as 0 (GH-4533). Persisted.
 	InfraRerunSHA string
+	// RebaseHoldActive is true while this PR is parked at StageFailed
+	// specifically via escalateAndHold's "needs-manual-rebase" label (GH-4610).
+	// escalateAndHold sets StageFailed for many unrelated reasons (CI-fix size
+	// guard, rebase-oscillation cap, etc.); this flag narrows the re-adoption
+	// scan in reAdoptHeldRebasePR to the one hold an operator's branch push
+	// can actually resolve. Cleared once re-adoption fires (or a fresh
+	// escalateAndHold call supersedes it with a different label set).
+	// Persisted so the flag survives a daemon restart while the PR sits held.
+	RebaseHoldActive bool
+	// ReadoptCount tracks how many times reAdoptHeldRebasePR (GH-4610) has
+	// revived this PR from a needs-manual-rebase hold back to StageWaitingCI
+	// after observing a new head SHA. Capped at maxReadoptAttempts so a
+	// branch that keeps re-conflicting after every push can't ping-pong
+	// between held and waiting_ci forever — it eventually stays parked for a
+	// human. Never reset (lifetime counter for the PR). Persisted.
+	ReadoptCount int
 }
 
 // snapshot returns a detached, field-by-field copy of the PRState with a fresh
@@ -1143,6 +1159,8 @@ func (ps *PRState) snapshot() *PRState {
 		MergeFollowupPosted:     ps.MergeFollowupPosted,
 		InfraRerunCount:         ps.InfraRerunCount,
 		InfraRerunSHA:           ps.InfraRerunSHA,
+		RebaseHoldActive:        ps.RebaseHoldActive,
+		ReadoptCount:            ps.ReadoptCount,
 	}
 	// DiscoveredChecks and ScopeMemberPRs are slices — copy the backing arrays
 	// so consumers can't mutate the live PR's slice through the snapshot.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4610.

Closes #4610

## Changes

GitHub Issue GH-4610: feat(autopilot): re-adopt held needs-manual-rebase PRs when their branch is updated — 5x recurrence in one wave

## Context

`escalateAndHold` (needs-manual-rebase) sets stage=failed, which is terminal in-memory: after an operator (or anyone) force-pushes a resolved rebase to the PR branch, autopilot never re-examines the PR. The only recovery is a fully manual `gh pr merge` (the external-merge scan then self-cleans tracking — that leg works).

Predicted in the 2026-07-28 close-out ("file a re-adopt-on-branch-update defect if this recurs often"). It recurred ×5 within one wave on 2026-07-29: pilot-console PRs #67, #68, #70, #74, #75 all parked needs-manual-rebase after sibling merges (parallel sub-issue PRs sharing main.go/config.go/go.mod), and every one needed operator rebase + manual merge (#67/#74 closed superseded; #68/#70/#75 rebased, CI green, merged manually).

## Fix

On push to a tracked-but-held PR branch (stage=failed with reason needs-manual-rebase, branch intact):
- re-enter the PR at `waiting_ci` (fresh CI on the new head), preserving attempt counters and the escalation audit trail;
- cap re-adoptions (e.g. 2) to avoid ping-ponging with a repeatedly-conflicting branch;
- the existing external-merge scan behavior stays as the fallback.

Detection can ride the existing PR poll (compare stored head SHA vs current) — no webhook needed.

## Why it matters

Multi-PR waves in one repo are now the normal S3+ dispatch shape; without re-adoption every sibling-merge cascade converts autopilot holds into serial operator merge work.