### PR TITLE
GH-4613: fix(test): TestResolveMemoryDBPath fails on macOS — /var symlink canonicalization mismatch

### DIFF
--- a/cmd/pilot/startup_banner_test.go
+++ b/cmd/pilot/startup_banner_test.go
@@ -14,7 +14,14 @@ import (
 func TestResolveMemoryDBPath(t *testing.T) {
 	t.Run("plain directory resolves to itself", func(t *testing.T) {
 		dir := t.TempDir()
-		want := filepath.Join(dir, "pilot.db")
+		// On macOS, t.TempDir() returns a path under /var, which is itself
+		// a symlink to /private/var. resolveMemoryDBPath canonicalizes via
+		// EvalSymlinks, so the expectation must be canonicalized too.
+		canonicalDir, err := filepath.EvalSymlinks(dir)
+		if err != nil {
+			t.Fatalf("EvalSymlinks(%q): %v", dir, err)
+		}
+		want := filepath.Join(canonicalDir, "pilot.db")
 		if got := resolveMemoryDBPath(dir); got != want {
 			t.Errorf("resolveMemoryDBPath(%q) = %q, want %q", dir, got, want)
 		}
@@ -43,7 +50,14 @@ func TestResolveMemoryDBPath(t *testing.T) {
 			t.Fatalf("Symlink: %v", err)
 		}
 
-		want := filepath.Join(target, "pilot.db")
+		// Canonicalize target the same way resolveMemoryDBPath does, so this
+		// still passes when root itself sits under a symlinked path (e.g.
+		// macOS /var -> /private/var).
+		canonicalTarget, err := filepath.EvalSymlinks(target)
+		if err != nil {
+			t.Fatalf("EvalSymlinks(%q): %v", target, err)
+		}
+		want := filepath.Join(canonicalTarget, "pilot.db")
 		if got := resolveMemoryDBPath(link); got != want {
 			t.Errorf("resolveMemoryDBPath(%q) = %q, want %q (target of symlink)", link, got, want)
 		}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4613.

Closes #4613

## Changes

GitHub Issue GH-4613: fix(test): TestResolveMemoryDBPath fails on macOS — /var symlink canonicalization mismatch

## Problem

`TestResolveMemoryDBPath` (`cmd/pilot/startup_banner_test.go:19,48`) fails on macOS on every run, breaking the local pre-push gate (`make gate` step 3/6) for all interactive pushes from a Mac. Green on Linux CI — never caught there.

## Root cause

On macOS `/var` is a symlink to `/private/var`, and `t.TempDir()` returns `/var/folders/...`. `resolveMemoryDBPath` canonicalizes the input (EvalSymlinks or equivalent), returning `/private/var/folders/.../pilot.db`, but the test compares against the raw `t.TempDir()` string:

```
resolveMemoryDBPath("/var/folders/.../T/.../001") = "/private/var/folders/.../T/.../001/pilot.db", want "/var/folders/.../T/.../001/pilot.db"
```

Both subtests fail the same way (`plain_directory_resolves_to_itself`, `symlinked_directory_resolves_to_its_target`).

## Task

In `startup_banner_test.go`, canonicalize the expectation: run the expected dir through `filepath.EvalSymlinks` before joining `pilot.db` (both subtests). Do NOT change `resolveMemoryDBPath` itself — canonicalizing to the symlink target is the desired behavior (it exists to make the startup banner show the real DB path).

## Acceptance criteria

- `go test -short -count=1 ./cmd/pilot/` passes on macOS and Linux.
- No behavior change to `resolveMemoryDBPath`.