### PR TITLE
GH-4614: fix(gate): check-integration.sh orphan-command check — BRE \(\) matches any func new*Cmd, false-positives on parameterized test helpers

### DIFF
--- a/scripts/check-integration.sh
+++ b/scripts/check-integration.sh
@@ -29,17 +29,23 @@ echo ""
 # 1. Check for orphan command functions (newXxxCmd not in AddCommand)
 echo "Checking command wiring..."
 
-# Find all newXxxCmd function declarations
-CMD_FUNCS=$(grep -rh 'func new[A-Z][a-zA-Z]*Cmd\(\)' cmd/pilot/*.go 2>/dev/null | grep -oE 'new[A-Z][a-zA-Z]*Cmd' | sort -u || true)
+# Find all newXxxCmd function declarations (zero-arg constructors only —
+# literal parens, not a BRE empty-capture-group `\(\)` which would match
+# any parameter list). Test helpers (e.g. newTestStartCmd(t, ...)) are
+# never CLI commands, so exclude *_test.go from the declaration scan.
+CMD_FUNCS=$(grep -rh --include='*.go' --exclude='*_test.go' 'func new[A-Z][a-zA-Z]*Cmd()' cmd/pilot/ 2>/dev/null | grep -oE 'new[A-Z][a-zA-Z]*Cmd' | sort -u || true)
 
 if [ -n "$CMD_FUNCS" ]; then
     for func in $CMD_FUNCS; do
-        # Check if it's used in AddCommand or called somewhere
-        USED_IN_ADDCMD=$(grep -rh "AddCommand.*${func}()" cmd/pilot/*.go 2>/dev/null || true)
-        CALLED=$(grep -rh "${func}()" cmd/pilot/*.go 2>/dev/null | grep -v "^func " || true)
+        # Check if it's used in AddCommand or called somewhere. Match on
+        # "${func}(" (not "${func}()") so calls with arguments still count
+        # as wired/called, in case a zero-arg constructor is later refactored
+        # to take parameters.
+        USED_IN_ADDCMD=$(grep -rh "AddCommand.*${func}(" cmd/pilot/*.go 2>/dev/null || true)
+        CALLED=$(grep -rh "${func}(" cmd/pilot/*.go 2>/dev/null | grep -v "^func " || true)
 
         # For subcommands, check if they're added to a parent
-        SUBCOMMAND_USAGE=$(grep -rh "\.AddCommand(${func}()" cmd/pilot/*.go 2>/dev/null || true)
+        SUBCOMMAND_USAGE=$(grep -rh "\.AddCommand(${func}(" cmd/pilot/*.go 2>/dev/null || true)
 
         if [ -z "$USED_IN_ADDCMD" ] && [ -z "$CALLED" ] && [ -z "$SUBCOMMAND_USAGE" ]; then
             echo -e "  ${RED}✗${NC} Orphan command: $func() - not wired to AddCommand()"


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4614.

Closes #4614

## Changes

GitHub Issue GH-4614: fix(gate): check-integration.sh orphan-command check — BRE \(\) matches any func new*Cmd, false-positives on parameterized test helpers

## Problem

`scripts/check-integration.sh` (step 6/6 of the pre-push gate) reports:

```
✗ Orphan command: newTestStartCmd() - not wired to AddCommand()
```

`newTestStartCmd` is a parameterized **test helper** (`cmd/pilot/validate_flags_test.go:16`, signature `func newTestStartCmd(t *testing.T, setFlags ...string)`), not a CLI command. Combined with the macOS test issue this blocks every local push from a Mac.

## Root cause

Line ~33: `grep -rh 'func new[A-Z][a-zA-Z]*Cmd\(\)' cmd/pilot/*.go` — in grep's default BRE dialect, `\(\)` is an **empty capture group**, not literal parens. The pattern therefore matches ANY `func new*Cmd` declaration regardless of parameters. The call-site checks (`${func}()` in double quotes, lines ~39-43) DO require literal empty parens, so a helper that is only ever called with arguments (`newTestStartCmd(t, "github")`) can never register as called → flagged orphan.

## Task

In `scripts/check-integration.sh` command-wiring section:
1. Fix the declaration grep to match only zero-arg constructors with literal parens (e.g. `grep -rh 'func new[A-Z][a-zA-Z]*Cmd()' ` — no backslashes — or use `grep -E\` with escaped literals).
2. Exclude `*_test.go` from the declaration scan (test helpers are never CLI commands): change the glob or add `--exclude='*_test.go'`.
3. Relax the call-site grep to match calls with arguments (`${func}(` prefix) so future zero-arg-but-arg-called refactors don't regress.

## Acceptance criteria

- `bash scripts/check-integration.sh` passes on current main (0 orphans).
- Deliberately unwiring a real command (e.g. comment out an `AddCommand(newAllowCmd())`) still fails the check — the check must keep catching true orphans.