### PR TITLE
GH-4617: fix(dashboard): queue-depth card shows len(m.tasks) — counts terminal tasks retained since daemon start, not queue depth

### DIFF
--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -1948,7 +1948,10 @@ func nonFailureSuffix(c MetricsCardData) string {
 }
 
 // renderTaskCard renders the queue stat card with the given card width.
-// Value shows current queue depth (pending + running), not lifetime totals.
+// Value counts only active m.tasks entries (queued/pending/running), not
+// terminal ones — len(m.tasks) is wrong because Monitor never evicts
+// completed/failed/no-op tasks, so it grows with lifetime totals since
+// daemon start instead of reflecting current queue depth (GH-4617).
 // TASK-358: "failed" counts genuine failures only. Non-failure terminal
 // outcomes (no-op / infra / …) are shown as a muted suffix so the numbers
 // reconcile and a no-op is no longer miscounted as a failure. Only append the
@@ -1957,7 +1960,14 @@ func nonFailureSuffix(c MetricsCardData) string {
 // row seen on v2.166.10).
 func (m Model) renderTaskCard(cw int) string {
 	ciw := cw - 4
-	value := boldLabelStyle.Render(fmt.Sprintf("%d", len(m.tasks)))
+	activeCount := 0
+	for _, t := range m.tasks {
+		switch t.Status {
+		case QueueStatusQueued, QueueStatusPending, QueueStatusRunning:
+			activeCount++
+		}
+	}
+	value := boldLabelStyle.Render(fmt.Sprintf("%d", activeCount))
 	detail := statusCompletedStyle.Render(fmt.Sprintf("✓ %d", m.metricsCard.Succeeded)) +
 		"  " + statusFailedStyle.Render(fmt.Sprintf("✗ %d", m.metricsCard.Failed))
 	if suffix := nonFailureSuffix(m.metricsCard); suffix != "" {

--- a/internal/dashboard/tui_test.go
+++ b/internal/dashboard/tui_test.go
@@ -241,15 +241,22 @@ func TestRenderTaskCard_ShowsQueueDepth(t *testing.T) {
 	m.metricsCard.Succeeded = 8
 	m.metricsCard.Failed = 2
 
-	// Simulate 2 active tasks in queue (pending/running)
+	// Simulate 2 active tasks in queue (pending/running) alongside terminal
+	// tasks retained since daemon start (GH-4617: Monitor never evicts
+	// completed/failed/no-op tasks, so m.tasks accumulates lifetime history).
+	// The card value must count only the active ones (2), not len(m.tasks) (5).
 	m.tasks = []TaskDisplay{
-		{ID: "1", Title: "Task A", Status: "running"},
-		{ID: "2", Title: "Task B", Status: "pending"},
+		{ID: "1", Title: "Task A", Status: QueueStatusRunning},
+		{ID: "2", Title: "Task B", Status: QueueStatusPending},
+		{ID: "3", Title: "Task C", Status: QueueStatusDone},
+		{ID: "4", Title: "Task D", Status: QueueStatusFailed},
+		{ID: "5", Title: "Task E", Status: QueueStatusNoOp},
 	}
 
 	output := m.renderTaskCard(cardWidth)
 
 	// queue card value must show current queue depth (2), not lifetime total (10)
+	// and not len(m.tasks) (5, once terminal tasks are included in the fixture)
 	if !strings.Contains(output, "queue") {
 		t.Error("output missing queue title")
 	}
@@ -260,6 +267,11 @@ func TestRenderTaskCard_ShowsQueueDepth(t *testing.T) {
 	// Lifetime total "10" should NOT appear as the main value
 	if strings.Contains(output, "10") {
 		t.Error("queue card should not show lifetime total (10)")
+	}
+	// len(m.tasks) is 5 (2 active + 3 terminal); the pre-fix implementation
+	// rendered this as the value instead of the active count.
+	if strings.Contains(output, "5") {
+		t.Error("queue card should not show len(m.tasks) (5), only active task count")
 	}
 	// Succeeded/failed detail line should still be present
 	if !strings.Contains(output, "✓ 8") {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4617.

Closes #4617

## Changes

GitHub Issue GH-4617: fix(dashboard): queue-depth card shows len(m.tasks) — counts terminal tasks retained since daemon start, not queue depth

## Problem

The TUI "queue depth" stat card shows the size of the entire in-memory Monitor task list, not the queue. Observed 2026-07-30: card read **18** while the ledger had **0** rows in `queued`/`pending`/`running`/`decomposed` and the `pilot_queue_depth` gauge read **0** (box DB `/home/ec2-user/.pilot/data/pilot.db`, freshness 2026-07-29 21:54:54Z). The 18 were terminal ✓/✗/no-op tasks retained since daemon start (Jul 29 15:16Z).

## Root cause

`renderTaskCard` (internal/dashboard/tui.go, ~line 1958) renders `len(m.tasks)`:

```go
// Value shows current queue depth (pending + running), not lifetime totals.
func (m Model) renderTaskCard(cw int) string {
	...
	value := boldLabelStyle.Render(fmt.Sprintf("%d", len(m.tasks)))
```

The doc comment claims "pending + running" but nothing filters by status. `m.tasks` accumulates every task since daemon start: `Monitor.Complete`/`Fail`/`NoOp`/`Stall` transition status but never evict, and `collectDashboardTasks` (cmd/pilot/commands.go:2630) / `convertTaskStatesToDisplay` (:2668) pass all states through — correctly, because the queue *panel* should render terminal rows. Only the card *value* is wrong.

## Fix

In `renderTaskCard`, count only active entries from `m.tasks`:

- `value` = count of tasks with `Status` in `QueueStatusQueued | QueueStatusPending | QueueStatusRunning`.
- Do NOT change what the queue panel renders (terminal rows stay visible).
- Prefer filtering `m.tasks` over calling `Store.CountQueuedTasks` (internal/memory/store.go:2823) from the render path — keeps the card consistent with the rendered list and adds no DB call to the 2s refresh loop. (`CountQueuedTasks` already backs the `pilot_queue_depth` gauge, GH-4246 — leave it as is.)
- Fix the stale doc comment if wording changes.

## Test

`TestRenderTaskCard_ShowsQueueDepth` (internal/dashboard/tui_test.go:237) passes today only because its fixture puts just 2 active tasks in `m.tasks`. Extend the fixture to include terminal tasks (done, failed, no-op) alongside 2 active ones and assert the card value is still 2, not the list length.

## Out of scope

The card's ✓ 1767 / ✗ 329 detail line is correct — verified as pilot-repo-scoped, non-canary, per-attempt counts from `GetLifetimeTaskCounts`. No change.

## Acceptance criteria

- [ ] Card value counts only queued/pending/running tasks in `m.tasks`
- [ ] Queue panel still renders terminal tasks unchanged
- [ ] `TestRenderTaskCard_ShowsQueueDepth` fixture includes terminal tasks and fails against the old `len(m.tasks)` implementation
- [ ] Doc comment on `renderTaskCard` matches the implementation