### PR TITLE
GH-4620: fix(autopilot): StageFailed transition records audit event but never finalizes the source execution row — orphans it to the 2h sweep

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -47,6 +47,12 @@ type approvalPersister interface {
 	// idempotency check: whether executionID already carries a given stage
 	// (e.g. StageReleased), so a repeat pass never double-stamps the ladder.
 	HasExecutionEventStage(executionID string, stage memory.Stage) (bool, error)
+	// UpdateExecutionStatusIfNotTerminal is the CAS-guarded finalize
+	// (memory.Store.UpdateExecutionStatusIfNotTerminal) used by the
+	// StageFailed transition (GH-4620) to close out a non-terminal source
+	// execution row without racing/overwriting a writer that already moved
+	// it to a terminal status.
+	UpdateExecutionStatusIfNotTerminal(id, status string, errorMsg ...string) (applied bool, err error)
 }
 
 // projectBoardSyncer abstracts GitHub Projects V2 board status updates.
@@ -1456,6 +1462,21 @@ func (c *Controller) recordExecutionEvent(prState *PRState, stage memory.Stage, 
 	if err := c.memoryStore.RecordExecutionEvent(exec.ID, stage, detail); err != nil {
 		c.log.Warn("execution audit trail: failed to insert execution event",
 			"pr", prState.PRNumber, "execution_id", exec.ID, "stage", stage, "error", err)
+	}
+
+	// GH-4620: StageFailed is a terminal PR outcome, but the audit-trail
+	// insert above never finalizes executions.status — that left the source
+	// execution row orphaned as "running" until the 2h stale-running sweep
+	// evicted it (companion incident to #4619's takeover-path finalize).
+	// Merge already self-heals via SelfHealExecutionAfterMerge (selfHealTask);
+	// this is the failed-side counterpart. CAS-guarded so a row that already
+	// reached a terminal status (e.g. "completed" via a race with another
+	// writer) is left untouched.
+	if stage == memory.StageFailed {
+		if _, err := c.memoryStore.UpdateExecutionStatusIfNotTerminal(exec.ID, "failed", detail); err != nil {
+			c.log.Warn("execution audit trail: failed to finalize execution row on StageFailed",
+				"pr", prState.PRNumber, "execution_id", exec.ID, "error", err)
+		}
 	}
 }
 

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -9013,6 +9013,21 @@ type mockApprovalPersister struct {
 
 	execByTask      map[string]string
 	executionEvents []recordedExecutionEvent
+
+	// execStatus tracks each execution row's current status keyed by
+	// execution ID (GH-4620), so UpdateExecutionStatusIfNotTerminal can
+	// mirror the real store's CAS guard: a row already at a terminal status
+	// rejects the write instead of being overwritten.
+	execStatus        map[string]string
+	statusUpdateCalls []struct{ id, status, detail string }
+}
+
+// mockTerminalExecStatuses mirrors memory.terminalExecutionStatuses (private
+// to the memory package) closely enough for mockApprovalPersister's CAS
+// emulation in tests.
+var mockTerminalExecStatuses = map[string]bool{
+	"completed": true, "failed": true, "cancelled": true, "declined": true,
+	"stalled": true, "no_op": true, "rate_limited": true, "infra": true, "skipped": true,
 }
 
 type recordedExecutionEvent struct {
@@ -9036,7 +9051,28 @@ func (m *mockApprovalPersister) GetLatestExecutionByTaskID(taskID, _ string) (*m
 	if !ok {
 		return nil, sql.ErrNoRows
 	}
-	return &memory.Execution{ID: id, TaskID: taskID}, nil
+	return &memory.Execution{ID: id, TaskID: taskID, Status: m.execStatus[id]}, nil
+}
+
+// UpdateExecutionStatusIfNotTerminal emulates memory.Store's CAS-guarded
+// finalize (GH-4620): rejects the write once execStatus[id] is already one
+// of mockTerminalExecStatuses, mirroring the real WHERE status NOT IN (...)
+// guard so tests can assert both the finalize AND the no-clobber behavior.
+func (m *mockApprovalPersister) UpdateExecutionStatusIfNotTerminal(id, status string, errorMsg ...string) (bool, error) {
+	detail := ""
+	if len(errorMsg) > 0 {
+		detail = errorMsg[0]
+	}
+	m.statusUpdateCalls = append(m.statusUpdateCalls, struct{ id, status, detail string }{id, status, detail})
+
+	if m.execStatus == nil {
+		m.execStatus = map[string]string{}
+	}
+	if mockTerminalExecStatuses[m.execStatus[id]] {
+		return false, nil
+	}
+	m.execStatus[id] = status
+	return true, nil
 }
 
 func (m *mockApprovalPersister) RecordExecutionEvent(executionID string, stage memory.Stage, detail string) error {
@@ -9097,6 +9133,96 @@ func TestController_SetApprovalDecision_PersistsToMemoryStore(t *testing.T) {
 	}
 }
 
+// TestController_ProcessPR_StageFailed_FinalizesRunningExecutionRow verifies
+// the GH-4620 fix: a PR transition into StageFailed (here via the dirty-PR
+// merge-conflict path exercised by TestController_ProcessPR_MergeConflict_PRCreated)
+// must finalize a non-terminal source execution row as "failed" instead of
+// leaving it orphaned as "running" for the 2h stale-running sweep to evict.
+func TestController_ProcessPR_StageFailed_FinalizesRunningExecutionRow(t *testing.T) {
+	prClosed := false
+
+	mergeable := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/42" && r.Method == "GET":
+			resp := github.PullRequest{
+				Number:         42,
+				Head:           github.PRRef{SHA: "abc1234"},
+				Mergeable:      &mergeable,
+				MergeableState: "dirty",
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/repos/owner/repo/pulls/42/update-branch" && r.Method == "PUT":
+			w.WriteHeader(http.StatusUnprocessableEntity)
+		case r.URL.Path == "/repos/owner/repo/pulls/42" && r.Method == "PATCH":
+			prClosed = true
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.CIPollInterval = 10 * time.Millisecond
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	mock := &mockApprovalPersister{
+		execByTask: map[string]string{"GH-10": "exec-1"},
+		execStatus: map[string]string{"exec-1": "running"},
+	}
+	c.memoryStore = mock
+
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc1234", "pilot/GH-10", "")
+
+	ctx := context.Background()
+	if err := c.ProcessPR(ctx, 42, nil); err != nil {
+		t.Fatalf("ProcessPR error: %v", err)
+	}
+
+	pr, _ := c.GetPRState(42)
+	if pr.Stage != StageFailed {
+		t.Fatalf("Stage = %s, want %s (dirty PR should fail immediately)", pr.Stage, StageFailed)
+	}
+	if !prClosed {
+		t.Error("conflicting PR should have been closed")
+	}
+
+	if got := mock.execStatus["exec-1"]; got != "failed" {
+		t.Errorf("execution row status = %q, want %q (StageFailed must finalize a running row)", got, "failed")
+	}
+}
+
+// TestController_RecordExecutionEvent_StageFailed_RespectsTerminalRow verifies
+// the GH-4620 finalize is CAS-guarded: an execution row already at a terminal
+// status (e.g. "completed" from another writer) must not be clobbered by the
+// StageFailed transition's finalize.
+func TestController_RecordExecutionEvent_StageFailed_RespectsTerminalRow(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	mock := &mockApprovalPersister{
+		execByTask: map[string]string{"GH-11": "exec-2"},
+		execStatus: map[string]string{"exec-2": "completed"},
+	}
+	c.memoryStore = mock
+
+	prState := &PRState{PRNumber: 43, IssueNumber: 11}
+	c.recordExecutionEvent(prState, memory.StageFailed, "pr #43: pr_created -> failed")
+
+	if got := mock.execStatus["exec-2"]; got != "completed" {
+		t.Errorf("execution row status = %q, want %q (terminal row must not be overwritten)", got, "completed")
+	}
+	if len(mock.statusUpdateCalls) != 1 {
+		t.Fatalf("expected 1 UpdateExecutionStatusIfNotTerminal call, got %d", len(mock.statusUpdateCalls))
+	}
+}
+
 // errApprovalPersister is a mock that returns a configurable error for both methods.
 type errApprovalPersister struct {
 	requestIDErr error
@@ -9120,6 +9246,10 @@ func (m *errApprovalPersister) RecordExecutionEvent(_ string, _ memory.Stage, _ 
 }
 
 func (m *errApprovalPersister) HasExecutionEventStage(_ string, _ memory.Stage) (bool, error) {
+	return false, nil
+}
+
+func (m *errApprovalPersister) UpdateExecutionStatusIfNotTerminal(_, _ string, _ ...string) (bool, error) {
 	return false, nil
 }
 

--- a/internal/autopilot/gh4130_test.go
+++ b/internal/autopilot/gh4130_test.go
@@ -30,6 +30,9 @@ func (m *gh4130ExecPersister) RecordExecutionEvent(_ string, _ memory.Stage, _ s
 func (m *gh4130ExecPersister) HasExecutionEventStage(_ string, _ memory.Stage) (bool, error) {
 	return false, nil
 }
+func (m *gh4130ExecPersister) UpdateExecutionStatusIfNotTerminal(_, _ string, _ ...string) (bool, error) {
+	return true, nil
+}
 func (m *gh4130ExecPersister) GetLatestExecutionByTaskID(taskID, _ string) (*memory.Execution, error) {
 	exec, ok := m.execByTask[taskID]
 	if !ok {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4620.

Closes #4620

## Changes

GitHub Issue GH-4620: fix(autopilot): StageFailed transition records audit event but never finalizes the source execution row — orphans it to the 2h sweep

## Problem

When autopilot moves a PR to `StageFailed`, the source execution row is left non-terminal. Observed 2026-07-29 (pilot-console-ui): PR#28 transitioned `pr_created -> failed` at 20:13:21Z (dirty PR — sibling merge conflict), but GH-25's execution row stayed `running` until the 2h orphan-eviction backstop (`orphan eviction after 2h0m0s stuck`, 22:12:40Z). Companion incident to #4619 (which fixes the takeover-path finalize); this fix makes the autopilot chokepoint self-healing regardless of how the row was orphaned.

## Root cause

`ProcessPR`'s stage-transition dispatch (internal/autopilot/controller.go:1750-1801) calls `recordExecutionEvent` (controller.go:1439-1460) on every transition, including → `StageFailed` (mapped at controller.go:1418-1419). That helper already resolves the execution row (`GetLatestExecutionByTaskID`, line 1449) but only writes an `execution_events` AUDIT row — it never mutates `executions.status`. The merge side has a self-heal (`selfHealTask`/`SelfHealExecutionAfterMerge`, controller.go:800-810); the failed/abandoned side has no counterpart.

## Fix

At the `StageFailed` transition (in `recordExecutionEvent` or immediately after its call site at controller.go:1797-1800): when `stage == memory.StageFailed` and the resolved execution row is non-terminal, call `UpdateExecutionStatusIfNotTerminal(exec.ID, "failed", detail)` (internal/memory/store.go:2083 — public, CAS-guarded). Reuse the `exec` already fetched; no extra query.

Do NOT use `UpdateExecutionStatusByTaskID` (store.go:2156-2165) — dead code, and its WHERE clause cannot move a `running` row.

## Acceptance criteria

- [ ] `StageFailed` transition finalizes a non-terminal source execution row as `failed` with the transition detail as error
- [ ] Rows already terminal are untouched (CAS respected — no overwriting `completed`)
- [ ] Merge-side self-heal behavior unchanged
- [ ] Test: PR state moves `pr_created -> failed` while source execution row is `running` → row becomes `failed`; second run with row already `completed` → row stays `completed` (no test exists for the StageFailed path today)

## Cross-refs

#4619 (takeover finalize, same incident), #4609 (in-memory registry zombies), GH-4536/TASK-419, TASK-404 (ExecutionLifecycle owns finalize semantics).