### PR TITLE
GH-4594: fix(executor): hosted direct-mode execution corrupts the daemon clone — branches cut from stale HEAD, quality-retry double-applies changes, leftover dirt wedges git_clean

### DIFF
--- a/.agent/tasks/archive/gh-4594-3.md
+++ b/.agent/tasks/archive/gh-4594-3.md
@@ -1,0 +1,23 @@
+# GH-4594-3
+
+**Created:** 2026-07-30
+
+## Problem
+
+## Subtask 3 of 4
+
+**Parent Task:** GH-4594 - fix(executor): hosted direct-mode execution corrupts the daemon clone — branches cut from stale HEAD, quality-retry double-applies changes, leftover dirt wedges git_clean
+
+## Objective
+
+After a failed direct-mode execution the clone is clean; a subsequent dispatch on the same project does not hit `git_clean` failure (test)
+
+## Context
+
+This is part of a larger task that has been decomposed for better execution.
+Focus on this specific objective. Other subtasks will handle the remaining work.
+
+
+
+## Acceptance Criteria
+

--- a/.agent/tasks/archive/gh-4594-4.md
+++ b/.agent/tasks/archive/gh-4594-4.md
@@ -1,0 +1,24 @@
+# GH-4594-4
+
+**Created:** 2026-07-30
+
+## Problem
+
+## Subtask 4 of 4
+
+**Parent Task:** GH-4594 - fix(executor): hosted direct-mode execution corrupts the daemon clone — branches cut from stale HEAD, quality-retry double-applies changes, leftover dirt wedges git_clean
+
+## Objective
+
+No behavior change for the worktree path
+
+## Context
+
+This is part of a larger task that has been decomposed for better execution.
+Focus on this specific objective. Other subtasks will handle the remaining work.
+
+**Note:** This is the final subtask. Ensure all previous subtasks are complete before finishing.
+
+
+## Acceptance Criteria
+

--- a/internal/executor/git.go
+++ b/internal/executor/git.go
@@ -91,6 +91,127 @@ func (g *GitOperations) CreateOrResetBranch(ctx context.Context, branchName stri
 	return nil
 }
 
+// CreateOrResetBranchFromOrigin fetches origin/<baseBranch> (best-effort,
+// via resolveGuardBaseRef) and force-creates/resets branchName directly from
+// the resolved ref via `git checkout -B <branchName> <baseRef>`. Falls back
+// to the local <baseBranch> ref when origin isn't reachable (offline, no
+// "origin" remote configured — some test fixtures), preserving behavior in
+// that environment.
+//
+// This unconditionally discards any commits an existing branchName already
+// carried, so it is only safe to use where a pre-existing branch cannot yet
+// hold real work — e.g. the decomposed-parent branch step, which runs before
+// any subtask executes. Callers where a task branch may already carry
+// legitimate in-progress commits from an earlier attempt (the common
+// single-task execution path) must use EnsureBranchFromOrigin instead, which
+// only recreates the branch when it is actually stale.
+func (g *GitOperations) CreateOrResetBranchFromOrigin(ctx context.Context, branchName, baseBranch string) (string, error) {
+	baseRef := g.resolveGuardBaseRef(ctx, baseBranch)
+
+	cmd := exec.CommandContext(ctx, "git", "checkout", "-B", branchName, baseRef)
+	cmd.Dir = g.projectPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to create/reset branch %s from %s: %w: %s", branchName, baseRef, err, output)
+	}
+	return baseRef, nil
+}
+
+// EnsureBranchFromOrigin fetches origin/<baseBranch> (best-effort, via
+// resolveGuardBaseRef) and ensures branchName exists, cut from that resolved
+// ref:
+//
+//   - branchName doesn't exist locally yet: created directly from baseRef.
+//   - branchName exists but is behind baseRef (stale — e.g. left over from a
+//     prior, now-superseded run, GH-912): deleted and recreated from baseRef.
+//   - branchName exists and is NOT behind baseRef (it may carry legitimate
+//     work-in-progress commits from an earlier attempt on this same clone):
+//     switched to as-is, preserving those commits.
+//
+// GH-4594: direct-mode (non-worktree) task branches used to be cut via
+// SwitchToDefaultBranchAndPull/SwitchToBranchAndPull (checkout the LOCAL base
+// branch, then `git pull` — a merge) followed by CreateBranch (checkout -b
+// with no explicit start point, i.e. from whatever HEAD the pull left
+// behind) — and, on the stale-branch path, CommitsBehindMain's own fresh
+// `git fetch` was discarded immediately afterward because the recreate step
+// (CreateBranch) still branched off that same ambient HEAD instead of the
+// ref CommitsBehindMain had just resolved. Pull failure is also silently
+// swallowed (non-fatal, to support offline use), so any fetch hiccup left
+// the branch-doesn't-exist-yet path cutting from stale local state too. This
+// method fixes both: baseRef is resolved once up front from a real fetch,
+// and every branch-creating code path below is given that ref explicitly —
+// never ambient HEAD.
+//
+// Returns the base ref actually used, and whether the branch was freshly
+// (re)created from it (false when an existing non-stale branch was merely
+// switched to).
+func (g *GitOperations) EnsureBranchFromOrigin(ctx context.Context, branchName, baseBranch string) (baseRef string, created bool, err error) {
+	baseRef = g.resolveGuardBaseRef(ctx, baseBranch)
+
+	if !g.branchExists(ctx, branchName) {
+		if createErr := g.checkoutNewBranchFrom(ctx, branchName, baseRef); createErr != nil {
+			return baseRef, false, fmt.Errorf("failed to create branch %s from %s: %w", branchName, baseRef, createErr)
+		}
+		return baseRef, true, nil
+	}
+
+	stale, staleErr := g.branchIsBehind(ctx, branchName, baseRef)
+	if staleErr != nil {
+		// Fail open on the staleness check itself (mirrors CommitsBehindMain's
+		// prior non-fatal logging): fall through to switching to the existing
+		// branch as-is rather than risking discarding unverified work.
+		stale = false
+	}
+
+	if !stale {
+		if switchErr := g.SwitchBranch(ctx, branchName); switchErr != nil {
+			return baseRef, false, fmt.Errorf("failed to switch to existing branch %s: %w", branchName, switchErr)
+		}
+		return baseRef, false, nil
+	}
+
+	if delErr := g.DeleteBranch(ctx, branchName); delErr != nil {
+		return baseRef, false, fmt.Errorf("failed to delete stale branch %s: %w", branchName, delErr)
+	}
+	if createErr := g.checkoutNewBranchFrom(ctx, branchName, baseRef); createErr != nil {
+		return baseRef, false, fmt.Errorf("failed to recreate stale branch %s from %s: %w", branchName, baseRef, createErr)
+	}
+	return baseRef, true, nil
+}
+
+// checkoutNewBranchFrom runs `git checkout -b <branchName> <startPoint>`.
+// Assumes branchName does not already exist locally (callers are
+// responsible for that precondition — EnsureBranchFromOrigin only calls this
+// after confirming absence or deleting a stale branch).
+func (g *GitOperations) checkoutNewBranchFrom(ctx context.Context, branchName, startPoint string) error {
+	cmd := exec.CommandContext(ctx, "git", "checkout", "-b", branchName, startPoint)
+	cmd.Dir = g.projectPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, output)
+	}
+	return nil
+}
+
+// branchIsBehind reports whether branchName is missing any commits that
+// baseRef has — i.e. `git rev-list --count <branchName>..<baseRef>` > 0.
+// This only detects "behind"; a branch that has both unique commits AND is
+// missing baseRef commits (diverged) is also reported stale here, matching
+// CommitsBehindMain's prior GH-912 semantics.
+func (g *GitOperations) branchIsBehind(ctx context.Context, branchName, baseRef string) (bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "rev-list", "--count", branchName+".."+baseRef)
+	cmd.Dir = g.projectPath
+	output, err := cmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("failed to count commits behind: %w", err)
+	}
+	var count int
+	if _, scanErr := fmt.Sscanf(strings.TrimSpace(string(output)), "%d", &count); scanErr != nil {
+		return false, fmt.Errorf("failed to parse behind count %q: %w", strings.TrimSpace(string(output)), scanErr)
+	}
+	return count > 0, nil
+}
+
 // SwitchBranch switches to an existing branch
 func (g *GitOperations) SwitchBranch(ctx context.Context, branchName string) error {
 	cmd := exec.CommandContext(ctx, "git", "checkout", branchName)

--- a/internal/executor/git.go
+++ b/internal/executor/git.go
@@ -1097,6 +1097,46 @@ func (g *GitOperations) GetCurrentCommitSHA(ctx context.Context) (string, error)
 	return strings.TrimSpace(string(output)), nil
 }
 
+// ResetHardToCommit discards every change made since sha — committed or
+// uncommitted, tracked or untracked — restoring the working tree to exactly
+// that commit's state.
+//
+// GH-4594: direct-mode (non-worktree) quality-gate retries re-invoked Claude
+// Code in place, on top of whatever the previous (rejected) attempt left
+// behind. Since that attempt's edits were never undone, the retry's new
+// edits landed on top of the old ones instead of a clean slate — the
+// "leftover ` M version.go` observed x3" symptom from the incident this
+// fixes: three retries, three stacked partial edits to the same file, none
+// of them ever fully applied or cleanly discarded. Worktree mode doesn't
+// need this: each execution already gets an isolated copy created fresh
+// from a commit.
+//
+// Untracked paths matching defaultExcludeDirs/defaultExcludeGlobs (Navigator
+// scaffold, lock files, build artifacts) are preserved via `git clean`'s -e
+// excludes — the same allowlist Commit() and checkGitClean() already use to
+// decide what isn't really a project change.
+func (g *GitOperations) ResetHardToCommit(ctx context.Context, sha string) error {
+	resetCmd := exec.CommandContext(ctx, "git", "reset", "--hard", sha)
+	resetCmd.Dir = g.projectPath
+	if output, err := resetCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to reset to %s: %w: %s", sha, err, output)
+	}
+
+	cleanArgs := []string{"clean", "-fd"}
+	for _, dir := range defaultExcludeDirs {
+		cleanArgs = append(cleanArgs, "-e", dir)
+	}
+	for _, glob := range defaultExcludeGlobs {
+		cleanArgs = append(cleanArgs, "-e", glob)
+	}
+	cleanCmd := exec.CommandContext(ctx, "git", cleanArgs...)
+	cleanCmd.Dir = g.projectPath
+	if output, err := cleanCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to clean untracked files after reset to %s: %w: %s", sha, err, output)
+	}
+	return nil
+}
+
 // GetDiff returns the diff between the base branch and HEAD.
 // Uses three-dot notation (base...HEAD) to show changes on the current branch.
 func (g *GitOperations) GetDiff(ctx context.Context, baseBranch string) (string, error) {

--- a/internal/executor/git_gh4594_test.go
+++ b/internal/executor/git_gh4594_test.go
@@ -1,0 +1,247 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCreateOrResetBranchFromOrigin_StaleLocalHEAD_UsesOriginTip is the
+// GH-4594 repro/regression: direct-mode (non-worktree) execution runs
+// against the daemon's shared clone, whose local base-branch ref can lag
+// origin (or, per GH-4594's "corrupts the daemon clone" framing, even carry
+// stray local-only commits from a prior run). The old flow
+// (SwitchToDefaultBranchAndPull + CreateBranch) checked out that local ref
+// and relied on a best-effort `git pull` to catch it up before cutting the
+// task branch from whatever HEAD was left — silently cutting from stale
+// local state whenever the pull/fetch hiccuped.
+//
+// This test leaves local `main` deliberately stale (one commit behind
+// origin, never fetched) and verifies CreateOrResetBranchFromOrigin still
+// cuts the new task branch from the freshly fetched origin/main tip, not the
+// stale local HEAD.
+func TestCreateOrResetBranchFromOrigin_StaleLocalHEAD_UsesOriginTip(t *testing.T) {
+	local, origin := setupSyncTestRepos(t, "main")
+	ctx := context.Background()
+
+	// A second clone pushes a commit to origin/main. The primary `local`
+	// clone never fetches it — its local `main` ref is now stale.
+	pushExtraCommitFromSecondClone(t, origin, "main", "remote new")
+
+	staleLocalHEAD := headSHA(t, local)
+
+	git := NewGitOperations(local)
+	baseRef, err := git.CreateOrResetBranchFromOrigin(ctx, "pilot/GH-4594", "main")
+	if err != nil {
+		t.Fatalf("CreateOrResetBranchFromOrigin: %v", err)
+	}
+	if baseRef != "origin/main" {
+		t.Errorf("baseRef = %q, want origin/main", baseRef)
+	}
+
+	currentBranch, err := git.GetCurrentBranch(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentBranch: %v", err)
+	}
+	if currentBranch != "pilot/GH-4594" {
+		t.Fatalf("current branch = %q, want pilot/GH-4594", currentBranch)
+	}
+
+	// The new branch's tip must match origin/main's tip (fetched fresh by
+	// CreateOrResetBranchFromOrigin), not the stale local HEAD this clone
+	// had before the call.
+	newBranchHEAD := headSHA(t, local)
+	if newBranchHEAD == staleLocalHEAD {
+		t.Fatalf("REGRESSION: task branch cut from stale local HEAD %s instead of the fetched origin/main tip", staleLocalHEAD[:8])
+	}
+
+	originTip := gitOutput(t, local, "rev-parse", "origin/main")
+	if newBranchHEAD != originTip {
+		t.Errorf("task branch HEAD = %s, want it to match freshly-fetched origin/main tip %s", newBranchHEAD, originTip)
+	}
+}
+
+// TestCreateOrResetBranchFromOrigin_ResetsExistingStaleBranch covers the
+// GH-912 stale-branch-recreation case that CreateOrResetBranchFromOrigin's
+// -B flag now folds into a single atomic step (replacing the old
+// CommitsBehindMain/DeleteBranch dance): a task branch left over from a
+// previous, now-superseded run must be force-reset to the fresh origin tip
+// rather than reused as-is.
+func TestCreateOrResetBranchFromOrigin_ResetsExistingStaleBranch(t *testing.T) {
+	local, origin := setupSyncTestRepos(t, "main")
+	ctx := context.Background()
+
+	git := NewGitOperations(local)
+
+	// Simulate a prior, now-stale run: the task branch already exists,
+	// forked from the old origin/main tip.
+	if err := git.CreateBranch(ctx, "pilot/GH-4594"); err != nil {
+		t.Fatalf("seed stale branch: %v", err)
+	}
+	staleBranchHEAD := headSHA(t, local)
+	runGit(t, local, "checkout", "main")
+
+	// Origin advances after the stale branch was cut.
+	pushExtraCommitFromSecondClone(t, origin, "main", "remote advanced")
+
+	baseRef, err := git.CreateOrResetBranchFromOrigin(ctx, "pilot/GH-4594", "main")
+	if err != nil {
+		t.Fatalf("CreateOrResetBranchFromOrigin: %v", err)
+	}
+	if baseRef != "origin/main" {
+		t.Errorf("baseRef = %q, want origin/main", baseRef)
+	}
+
+	resetHEAD := headSHA(t, local)
+	if resetHEAD == staleBranchHEAD {
+		t.Fatalf("REGRESSION: pre-existing branch was reused instead of force-reset to the fresh origin/main tip")
+	}
+	originTip := gitOutput(t, local, "rev-parse", "origin/main")
+	if resetHEAD != originTip {
+		t.Errorf("reset branch HEAD = %s, want origin/main tip %s", resetHEAD, originTip)
+	}
+}
+
+// TestCreateOrResetBranchFromOrigin_NoOriginRemote_FallsBackToLocal covers
+// repos with no "origin" remote at all (offline / bare local repos used by
+// several existing unit tests), preserving the prior tolerant behavior in
+// that environment rather than hard-failing the branch step.
+func TestCreateOrResetBranchFromOrigin_NoOriginRemote_FallsBackToLocal(t *testing.T) {
+	dir, _ := initTestRepo(t)
+	ctx := context.Background()
+	git := NewGitOperations(dir)
+
+	// initTestRepo doesn't pin a branch name — respect whatever `git init`
+	// picked locally (main or master) rather than assuming "main".
+	localBranch, err := git.GetCurrentBranch(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentBranch: %v", err)
+	}
+
+	baseRef, err := git.CreateOrResetBranchFromOrigin(ctx, "pilot/GH-4594-offline", localBranch)
+	if err != nil {
+		t.Fatalf("CreateOrResetBranchFromOrigin: %v", err)
+	}
+	if baseRef != localBranch {
+		t.Errorf("baseRef = %q, want local %q fallback (no origin remote)", baseRef, localBranch)
+	}
+
+	currentBranch, err := git.GetCurrentBranch(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentBranch: %v", err)
+	}
+	if currentBranch != "pilot/GH-4594-offline" {
+		t.Errorf("current branch = %q, want pilot/GH-4594-offline", currentBranch)
+	}
+}
+
+// TestEnsureBranchFromOrigin_NewBranch_CutFromFreshOriginTip is
+// EnsureBranchFromOrigin's version of the stale-local-HEAD repro: it's the
+// method the direct-mode single-task execution path (runner.go) actually
+// calls, and must cut a brand-new task branch from the freshly fetched
+// origin tip even though local `main` never fetched it.
+func TestEnsureBranchFromOrigin_NewBranch_CutFromFreshOriginTip(t *testing.T) {
+	local, origin := setupSyncTestRepos(t, "main")
+	ctx := context.Background()
+
+	pushExtraCommitFromSecondClone(t, origin, "main", "remote new")
+	staleLocalHEAD := headSHA(t, local)
+
+	git := NewGitOperations(local)
+	baseRef, created, err := git.EnsureBranchFromOrigin(ctx, "pilot/GH-4594", "main")
+	if err != nil {
+		t.Fatalf("EnsureBranchFromOrigin: %v", err)
+	}
+	if baseRef != "origin/main" {
+		t.Errorf("baseRef = %q, want origin/main", baseRef)
+	}
+	if !created {
+		t.Error("created = false, want true (branch did not exist yet)")
+	}
+
+	newBranchHEAD := headSHA(t, local)
+	if newBranchHEAD == staleLocalHEAD {
+		t.Fatalf("REGRESSION: task branch cut from stale local HEAD %s instead of the fetched origin/main tip", staleLocalHEAD[:8])
+	}
+	originTip := gitOutput(t, local, "rev-parse", "origin/main")
+	if newBranchHEAD != originTip {
+		t.Errorf("task branch HEAD = %s, want origin/main tip %s", newBranchHEAD, originTip)
+	}
+}
+
+// TestEnsureBranchFromOrigin_StaleExistingBranch_Recreated covers the GH-912
+// case: a task branch left over from a prior, now-superseded run (behind the
+// freshly fetched base) must be recreated from the fresh tip, not reused.
+func TestEnsureBranchFromOrigin_StaleExistingBranch_Recreated(t *testing.T) {
+	local, origin := setupSyncTestRepos(t, "main")
+	ctx := context.Background()
+
+	git := NewGitOperations(local)
+	if err := git.CreateBranch(ctx, "pilot/GH-4594"); err != nil {
+		t.Fatalf("seed stale branch: %v", err)
+	}
+	staleBranchHEAD := headSHA(t, local)
+	runGit(t, local, "checkout", "main")
+
+	pushExtraCommitFromSecondClone(t, origin, "main", "remote advanced")
+
+	baseRef, created, err := git.EnsureBranchFromOrigin(ctx, "pilot/GH-4594", "main")
+	if err != nil {
+		t.Fatalf("EnsureBranchFromOrigin: %v", err)
+	}
+	if baseRef != "origin/main" {
+		t.Errorf("baseRef = %q, want origin/main", baseRef)
+	}
+	if !created {
+		t.Error("created = false, want true (stale branch should be recreated)")
+	}
+
+	resetHEAD := headSHA(t, local)
+	if resetHEAD == staleBranchHEAD {
+		t.Fatalf("REGRESSION: stale branch was reused instead of recreated from the fresh origin/main tip")
+	}
+	originTip := gitOutput(t, local, "rev-parse", "origin/main")
+	if resetHEAD != originTip {
+		t.Errorf("recreated branch HEAD = %s, want origin/main tip %s", resetHEAD, originTip)
+	}
+}
+
+// TestEnsureBranchFromOrigin_NonStaleExistingBranch_PreservesCommits is the
+// counterpart guarding against over-eager reset: a task branch that already
+// carries legitimate work-in-progress commits from an earlier attempt on
+// this same clone (and is NOT behind the fresh base) must be switched to
+// as-is, not wiped. This is the exact shape TestRunner_PRCreate_HasCommits_
+// ProceedsToCreate depends on at the runner.go level.
+func TestEnsureBranchFromOrigin_NonStaleExistingBranch_PreservesCommits(t *testing.T) {
+	local, _ := setupSyncTestRepos(t, "main")
+	ctx := context.Background()
+
+	git := NewGitOperations(local)
+	if err := git.CreateBranch(ctx, "pilot/GH-4594"); err != nil {
+		t.Fatalf("seed branch: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(local, "work.txt"), []byte("in progress"), 0644); err != nil {
+		t.Fatalf("write work file: %v", err)
+	}
+	if _, err := git.Commit(ctx, "wip: legitimate in-progress work"); err != nil {
+		t.Fatalf("commit wip: %v", err)
+	}
+	wantHEAD := headSHA(t, local)
+
+	baseRef, created, err := git.EnsureBranchFromOrigin(ctx, "pilot/GH-4594", "main")
+	if err != nil {
+		t.Fatalf("EnsureBranchFromOrigin: %v", err)
+	}
+	if baseRef != "origin/main" {
+		t.Errorf("baseRef = %q, want origin/main", baseRef)
+	}
+	if created {
+		t.Error("created = true, want false (existing non-stale branch should be preserved, not recreated)")
+	}
+
+	gotHEAD := headSHA(t, local)
+	if gotHEAD != wantHEAD {
+		t.Fatalf("REGRESSION: in-progress commit was discarded — HEAD = %s, want %s", gotHEAD, wantHEAD)
+	}
+}

--- a/internal/executor/git_reset_gh4594_test.go
+++ b/internal/executor/git_reset_gh4594_test.go
@@ -1,0 +1,110 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestResetHardToCommit_DiscardsCommittedAndUncommittedChanges is the
+// GH-4594 unit-level regression guard for ResetHardToCommit: everything made
+// since the given SHA — a new commit, a dirty edit to a tracked file, and a
+// brand-new untracked file — must be gone afterward, and HEAD must land
+// exactly back on that SHA.
+func TestResetHardToCommit_DiscardsCommittedAndUncommittedChanges(t *testing.T) {
+	dir, cleanup := initTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+	git := NewGitOperations(dir)
+
+	preAttemptSHA, err := git.GetCurrentCommitSHA(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommitSHA: %v", err)
+	}
+
+	// Simulate a rejected attempt: a committed change to a tracked file...
+	readmePath := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(readmePath, []byte("attempt edit"), 0644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "-m", "attempt commit")
+
+	// ...plus leftover uncommitted dirt on top: a dirty tracked file...
+	if err := os.WriteFile(readmePath, []byte("uncommitted dirt"), 0644); err != nil {
+		t.Fatalf("dirty README: %v", err)
+	}
+	// ...and a stray untracked file.
+	strayPath := filepath.Join(dir, "stray.txt")
+	if err := os.WriteFile(strayPath, []byte("stray"), 0644); err != nil {
+		t.Fatalf("write stray file: %v", err)
+	}
+
+	if err := git.ResetHardToCommit(ctx, preAttemptSHA); err != nil {
+		t.Fatalf("ResetHardToCommit: %v", err)
+	}
+
+	afterSHA, err := git.GetCurrentCommitSHA(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommitSHA after reset: %v", err)
+	}
+	if afterSHA != preAttemptSHA {
+		t.Fatalf("HEAD = %s, want pre-attempt SHA %s", afterSHA, preAttemptSHA)
+	}
+
+	got, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read README after reset: %v", err)
+	}
+	if string(got) != "root" {
+		t.Errorf("README.md content = %q, want original %q (attempt commit + dirty edit both discarded)", got, "root")
+	}
+
+	if _, err := os.Stat(strayPath); !os.IsNotExist(err) {
+		t.Errorf("stray.txt should have been removed by the post-reset clean, got err=%v", err)
+	}
+
+	dirty, err := git.HasUncommittedChanges(ctx)
+	if err != nil {
+		t.Fatalf("HasUncommittedChanges: %v", err)
+	}
+	if dirty {
+		out := gitOutput(t, dir, "status", "--porcelain")
+		t.Errorf("working tree should be clean after ResetHardToCommit, got dirty status:\n%s", out)
+	}
+}
+
+// TestResetHardToCommit_PreservesExcludedScaffold verifies the post-reset
+// `git clean` leaves Navigator/build scaffold paths alone (the same
+// defaultExcludeDirs/defaultExcludeGlobs allowlist Commit()/checkGitClean()
+// use), so a quality-gate retry reset can't nuke a hosted tenant's untracked
+// .agent/ bootstrap (GH-4526) as a side effect.
+func TestResetHardToCommit_PreservesExcludedScaffold(t *testing.T) {
+	dir, cleanup := initTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+	git := NewGitOperations(dir)
+
+	preAttemptSHA, err := git.GetCurrentCommitSHA(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommitSHA: %v", err)
+	}
+
+	scaffoldDir := filepath.Join(dir, ".agent", "knowledge")
+	if err := os.MkdirAll(scaffoldDir, 0755); err != nil {
+		t.Fatalf("mkdir scaffold: %v", err)
+	}
+	scaffoldFile := filepath.Join(scaffoldDir, "graph.json")
+	if err := os.WriteFile(scaffoldFile, []byte("{}"), 0644); err != nil {
+		t.Fatalf("write scaffold file: %v", err)
+	}
+
+	if err := git.ResetHardToCommit(ctx, preAttemptSHA); err != nil {
+		t.Fatalf("ResetHardToCommit: %v", err)
+	}
+
+	if _, err := os.Stat(scaffoldFile); err != nil {
+		t.Errorf("untracked .agent/ scaffold should survive the reset's clean step, got err=%v", err)
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2662,64 +2662,40 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 	// When using worktree, CreateWorktreeWithBranch already created the branch
 	useWorktree := r.config != nil && r.config.UseWorktree && task.Branch != "" && !task.DirectCommit
 	if task.Branch != "" && !task.DirectCommit && !useWorktree {
-		r.reportProgress(task.ID, "Branching", 3, "Switching to default branch...")
+		r.reportProgress(task.ID, "Branching", 3, "Fetching base branch...")
 
-		// GH-279: Always switch to default branch and pull latest before creating new branch.
-		// This prevents new branches from forking off previous pilot branches instead of main.
-		// GH-836: Hard fail if we can't switch - continuing from wrong branch causes corrupted PRs.
 		// GH-2290: Honor task.BaseBranch (sourced from project.default_branch / branch_from) so
-		// `main → dev → feature` workflows branch off dev rather than git's HEAD.
-		var defaultBranch string
-		var err error
-		if task.BaseBranch != "" {
-			defaultBranch, err = git.SwitchToBranchAndPull(ctx, task.BaseBranch)
-		} else {
-			defaultBranch, err = git.SwitchToDefaultBranchAndPull(ctx)
+		// `main → dev → feature` workflows branch off dev rather than the repo's configured default.
+		baseBranch := task.BaseBranch
+		if baseBranch == "" {
+			var branchErr error
+			baseBranch, branchErr = git.GetDefaultBranch(ctx)
+			if branchErr != nil || baseBranch == "" {
+				baseBranch = "main"
+			}
 		}
+
+		// GH-4594: cut the task branch directly from a freshly fetched
+		// origin/<baseBranch> (falling back to the local ref only when origin
+		// isn't reachable) instead of checking out the local base branch and
+		// `git pull`-merging it. Pull failure was silently swallowed, so a
+		// fetch hiccup on the shared daemon clone left the branch cut from
+		// stale local HEAD — and even the old stale-branch recreate path
+		// (GH-912) branched off that same stale ambient HEAD instead of the
+		// ref it had just checked freshness against. EnsureBranchFromOrigin
+		// still preserves an existing, non-stale branch's commits (e.g.
+		// legitimate work already committed by an earlier attempt on this
+		// clone) rather than resetting it unconditionally.
+		// GH-836: Hard fail if we can't create the branch - continuing from the wrong branch causes corrupted PRs.
+		baseRef, created, err := git.EnsureBranchFromOrigin(ctx, task.Branch, baseBranch)
 		if err != nil {
-			return nil, fmt.Errorf("branch switch failed, aborting execution: failed to switch to default branch: %w", err)
+			return nil, fmt.Errorf("branch creation failed, aborting execution: %w", err)
 		}
-		r.reportProgress(task.ID, "Branching", 5, fmt.Sprintf("On %s, creating %s...", defaultBranch, task.Branch))
-
-		if err := git.CreateBranch(ctx, task.Branch); err != nil {
-			// Branch already exists - check if it's stale (GH-912)
-			behindCount, behindErr := git.CommitsBehindMain(ctx, task.Branch)
-			if behindErr != nil {
-				log.Warn("Failed to check if branch is behind main",
-					slog.String("branch", task.Branch),
-					slog.Any("error", behindErr),
-				)
-			}
-
-			if behindCount > 0 {
-				// Branch is stale - delete and recreate from main
-				log.Info("Stale branch detected, recreating from main",
-					slog.String("branch", task.Branch),
-					slog.Int("commits_behind", behindCount),
-				)
-				r.reportProgress(task.ID, "Branching", 6, fmt.Sprintf("Stale branch %s (%d behind), recreating...", task.Branch, behindCount))
-
-				if delErr := git.DeleteBranch(ctx, task.Branch); delErr != nil {
-					log.Warn("Failed to delete stale branch",
-						slog.String("branch", task.Branch),
-						slog.Any("error", delErr),
-					)
-				}
-				// Create fresh branch from main
-				if createErr := git.CreateBranch(ctx, task.Branch); createErr != nil {
-					return nil, fmt.Errorf("failed to recreate branch after stale detection: %w", createErr)
-				}
-				r.reportProgress(task.ID, "Branching", 8, fmt.Sprintf("Recreated fresh branch %s", task.Branch))
-			} else {
-				// Branch exists and is not stale - switch to it
-				if switchErr := git.SwitchBranch(ctx, task.Branch); switchErr != nil {
-					return nil, fmt.Errorf("failed to create/switch branch: %w", err)
-				}
-				r.reportProgress(task.ID, "Branching", 8, fmt.Sprintf("Switched to existing branch %s", task.Branch))
-			}
-		} else {
-			r.reportProgress(task.ID, "Branching", 8, fmt.Sprintf("Created branch %s", task.Branch))
+		if created {
+			r.reportProgress(task.ID, "Branching", 8, fmt.Sprintf("Created branch %s from %s", task.Branch, baseRef))
 			r.saveLogEntry(task.LogExecutionID(), "info", "Branch created: "+task.Branch)
+		} else {
+			r.reportProgress(task.ID, "Branching", 8, fmt.Sprintf("Switched to existing branch %s", task.Branch))
 		}
 	}
 

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2699,6 +2699,22 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		}
 	}
 
+	// GH-4594: capture the pre-attempt commit SHA now — before Claude's first
+	// invocation touches the tree — so a later quality-gate retry can hard-reset
+	// the direct-mode clone back to this exact point instead of stacking its
+	// edits on top of a previous (rejected) attempt's leftovers. Worktree mode
+	// already gets an isolated, freshly-created copy per execution, so no reset
+	// baseline is needed there (preAttemptSHA stays empty and the retry loop's
+	// reset is a no-op).
+	var preAttemptSHA string
+	if !useWorktree {
+		if sha, shaErr := git.GetCurrentCommitSHA(ctx); shaErr == nil {
+			preAttemptSHA = sha
+		} else {
+			log.Warn("Failed to capture pre-attempt commit SHA", slog.Any("error", shaErr))
+		}
+	}
+
 	// GH-994: Create task documentation if Navigator is present
 	agentPath := filepath.Join(executionPath, ".agent")
 	if _, err := os.Stat(agentPath); err == nil {
@@ -3959,6 +3975,28 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 						},
 						Timestamp: time.Now(),
 					})
+
+					// GH-4594: hard-reset the direct-mode clone to the pre-attempt
+					// baseline before re-invoking Claude, so this retry starts from a
+					// clean state instead of stacking its edits onto the previous
+					// (rejected) attempt's leftovers. preAttemptSHA is only set for
+					// direct-mode (non-worktree) execution — worktree mode is already
+					// isolated and this is a no-op there.
+					if preAttemptSHA != "" {
+						if resetErr := git.ResetHardToCommit(ctx, preAttemptSHA); resetErr != nil {
+							log.Warn("Failed to reset clone to pre-attempt state before quality-gate retry",
+								slog.String("task_id", task.ID),
+								slog.Int("retry_attempt", retryAttempt+1),
+								slog.Any("error", resetErr),
+							)
+						} else {
+							log.Info("Reset clone to pre-attempt state before quality-gate retry",
+								slog.String("task_id", task.ID),
+								slog.Int("retry_attempt", retryAttempt+1),
+								slog.String("sha", preAttemptSHA),
+							)
+						}
+					}
 
 					// Build retry prompt with feedback
 					retryPrompt := r.buildRetryPrompt(task, outcome.RetryFeedback, retryAttempt+1)

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2012,7 +2012,7 @@ func (r *Runner) recordEpicTerminalEvent(executionID string, result *ExecutionRe
 // executeWithOptions is the internal implementation that allows controlling worktree creation.
 // When allowWorktree is false, it skips worktree creation even if configured.
 // This prevents recursive worktree creation in sub-issues and decomposed tasks.
-func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktree bool) (*ExecutionResult, error) {
+func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktree bool) (outResult *ExecutionResult, outErr error) {
 	start := time.Now()
 	defer func() {
 		// GH-4240: canary executions are still fully logged, just excluded
@@ -2714,6 +2714,44 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 			log.Warn("Failed to capture pre-attempt commit SHA", slog.Any("error", shaErr))
 		}
 	}
+
+	// GH-4594: on a terminal failure (no more quality-gate retries left, or
+	// any other failure path below), discard any uncommitted dirt the failed
+	// attempt left behind in the direct-mode clone so the *next* dispatch on
+	// this same project's shared (non-worktree) clone doesn't wedge on the
+	// git_clean preflight check. Deliberately resets to "HEAD" — not
+	// preAttemptSHA — so it only discards uncommitted changes and never
+	// rewinds commits: both the quality-gate retry loop's kept last-attempt
+	// commit and GH-4517's auto-preserved WIP commit are legitimate committed
+	// work a human may need to review, and must survive this cleanup. Only
+	// genuinely leftover, never-committed dirt (partial fixes, scratch files
+	// Claude wrote before erroring out, etc.) gets discarded here. Worktree
+	// mode doesn't need this: preAttemptSHA stays empty there and the whole
+	// worktree is discarded by cleanupWorktree regardless of outcome. Uses a
+	// fresh context (not ctx, which is frequently already Done() here — this
+	// cleanup runs precisely when the attempt failed via timeout) with its
+	// own short deadline so the cleanup isn't skipped for the most common
+	// failure cause.
+	defer func() {
+		if useWorktree || preAttemptSHA == "" {
+			return
+		}
+		if outResult != nil && outResult.Success {
+			return
+		}
+		resetCtx, resetCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer resetCancel()
+		if resetErr := git.ResetHardToCommit(resetCtx, "HEAD"); resetErr != nil {
+			log.Warn("Failed to discard uncommitted dirt after failed execution",
+				slog.String("task_id", task.ID),
+				slog.Any("error", resetErr),
+			)
+		} else {
+			log.Info("Discarded uncommitted dirt after failed direct-mode execution",
+				slog.String("task_id", task.ID),
+			)
+		}
+	}()
 
 	// GH-994: Create task documentation if Navigator is present
 	agentPath := filepath.Join(executionPath, ".agent")

--- a/internal/executor/runner_decompose.go
+++ b/internal/executor/runner_decompose.go
@@ -59,24 +59,27 @@ func (r *Runner) executeDecomposedTask(ctx context.Context, parentTask *Task, su
 	// to checkout the branch again fails because it's locked by the active worktree.
 	inWorktreeMode := executionPath != parentTask.ProjectPath
 	if parentTask.Branch != "" && !inWorktreeMode {
-		r.reportProgress(parentTask.ID, "Branching", 1, "Switching to default branch...")
+		r.reportProgress(parentTask.ID, "Branching", 1, "Fetching base branch...")
 
-		// GH-279: Always switch to default branch and pull latest before creating new branch.
-		// This prevents new branches from forking off previous pilot branches instead of main.
-		// GH-836: Hard fail if we can't switch - continuing from wrong branch causes corrupted PRs.
-		defaultBranch, err := git.SwitchToDefaultBranchAndPull(ctx)
+		baseBranch := parentTask.BaseBranch
+		if baseBranch == "" {
+			var branchErr error
+			baseBranch, branchErr = git.GetDefaultBranch(ctx)
+			if branchErr != nil || baseBranch == "" {
+				baseBranch = "main"
+			}
+		}
+
+		// GH-4594: cut directly from a freshly fetched origin/<baseBranch>
+		// instead of checking out the local base branch and `git pull`-merging
+		// it — see CreateOrResetBranchFromOrigin's doc comment. -B still
+		// force-resets the branch if worktree mode already created it (GH-1235).
+		// GH-836: Hard fail if we can't create the branch - continuing from the wrong branch causes corrupted PRs.
+		baseRef, err := git.CreateOrResetBranchFromOrigin(ctx, parentTask.Branch, baseBranch)
 		if err != nil {
-			return nil, fmt.Errorf("branch switch failed, aborting execution: failed to switch to default branch: %w", err)
+			return nil, fmt.Errorf("branch creation failed, aborting execution: %w", err)
 		}
-		r.reportProgress(parentTask.ID, "Branching", 2, fmt.Sprintf("On %s, creating %s...", defaultBranch, parentTask.Branch))
-
-		// GH-1235: Use CreateOrResetBranch (-B flag) instead of CreateBranch (-b flag)
-		// because worktree mode may have already created this branch. The -B flag
-		// handles both cases: creates if missing, resets if exists.
-		if err := git.CreateOrResetBranch(ctx, parentTask.Branch); err != nil {
-			return nil, fmt.Errorf("failed to create/reset branch: %w", err)
-		}
-		r.reportProgress(parentTask.ID, "Branching", 5, fmt.Sprintf("Branch %s ready", parentTask.Branch))
+		r.reportProgress(parentTask.ID, "Branching", 5, fmt.Sprintf("Branch %s ready (from %s)", parentTask.Branch, baseRef))
 	} else if parentTask.Branch != "" && inWorktreeMode {
 		r.reportProgress(parentTask.ID, "Branching", 5, fmt.Sprintf("Branch %s already checked out in worktree", parentTask.Branch))
 	}

--- a/internal/executor/runner_quality_retry_reset_gh4594_test.go
+++ b/internal/executor/runner_quality_retry_reset_gh4594_test.go
@@ -1,0 +1,135 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// stackingAttemptBackend simulates a Claude Code invocation that, on every
+// call, writes and commits a brand-new file named after the attempt number.
+// It never touches a previous attempt's file — exactly the shape of a "fresh
+// session with no memory of the last rejected attempt" retry.
+type stackingAttemptBackend struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (b *stackingAttemptBackend) Name() string      { return "stacking-attempt" }
+func (b *stackingAttemptBackend) IsAvailable() bool { return true }
+
+func (b *stackingAttemptBackend) Execute(ctx context.Context, opts ExecuteOptions) (*BackendResult, error) {
+	b.mu.Lock()
+	b.calls++
+	n := b.calls
+	b.mu.Unlock()
+
+	fname := filepath.Join(opts.ProjectPath, fmt.Sprintf("attempt_%d.txt", n))
+	if err := os.WriteFile(fname, []byte(fmt.Sprintf("attempt %d", n)), 0o644); err != nil {
+		return nil, err
+	}
+	for _, args := range [][]string{{"add", "."}, {"commit", "-m", fmt.Sprintf("attempt %d", n)}} {
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = opts.ProjectPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("git %v: %v (%s)", args, err, out)
+		}
+	}
+	return &BackendResult{Success: true, Output: "done"}, nil
+}
+
+func (b *stackingAttemptBackend) callCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.calls
+}
+
+// TestRunner_QualityRetry_DirectMode_ResetsToCleanPreAttemptState is the
+// GH-4594 regression guard for the direct-mode (non-worktree) quality-gate
+// retry loop: the reported incident showed leftover ` M version.go` diffs
+// stacking across three retries because each retry's edits landed on top of
+// the previous (rejected) attempt's leftovers instead of a clean slate.
+//
+// The quality gate here is rigged to always fail, forcing the maximum
+// number of retries. Each simulated attempt commits a distinctly-named file
+// so a stacking bug is unambiguous: without the pre-attempt reset, every
+// attempt's file and commit survives; with it, only the last attempt's file
+// and commit remain, and the working tree ends up clean.
+func TestRunner_QualityRetry_DirectMode_ResetsToCleanPreAttemptState(t *testing.T) {
+	localRepo, remoteRepo := setupTestRepoWithRemote(t)
+	defer func() { _ = os.RemoveAll(localRepo) }()
+	defer func() { _ = os.RemoveAll(remoteRepo) }()
+
+	preAttemptSHA := strings.TrimSpace(headSHA(t, localRepo))
+
+	backend := &stackingAttemptBackend{}
+	runner := NewRunnerWithBackend(backend)
+	runner.config = &BackendConfig{UseWorktree: false} // direct mode: no worktree isolation
+	runner.SetSkipPreflightChecks(true)
+	runner.SetRecordingEnabled(false)
+	runner.SetQualityCheckerFactory(func(taskID, projectPath string) QualityChecker {
+		return &failingQualityChecker{}
+	})
+
+	task := &Task{
+		ID:          "GH-4594-2",
+		Title:       "force repeated quality-gate retries in direct mode",
+		Description: "gates always fail, so every allowed retry fires",
+		ProjectPath: localRepo,
+		Branch:      "pilot/GH-4594-2",
+		CreatePR:    true,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// The task ultimately fails (gates never pass) — we only care about the
+	// git state the retry loop leaves behind in the shared direct-mode clone.
+	result, _ := runner.Execute(ctx, task)
+	if result == nil || result.Success {
+		t.Fatalf("expected task failure (gates never pass), got %+v", result)
+	}
+
+	calls := backend.callCount()
+	if calls < 2 {
+		t.Fatalf("expected >=2 backend calls (initial + at least one quality retry), got %d", calls)
+	}
+
+	// Exactly one commit should separate the pre-attempt baseline from HEAD:
+	// the last attempt's. Every earlier (rejected) attempt's commit must have
+	// been discarded by the reset before the next retry ran.
+	countOut := gitOutput(t, localRepo, "rev-list", "--count", preAttemptSHA+"..HEAD")
+	if got := strings.TrimSpace(countOut); got != "1" {
+		t.Errorf("commits ahead of pre-attempt baseline = %s, want 1 (earlier rejected attempts must not stack)", got)
+	}
+
+	// Only the LAST attempt's file should exist; every earlier attempt's file
+	// is leftover dirt from a rejected try and must have been removed.
+	entries, err := os.ReadDir(localRepo)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var attemptFiles []string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "attempt_") {
+			attemptFiles = append(attemptFiles, e.Name())
+		}
+	}
+	wantFile := fmt.Sprintf("attempt_%d.txt", calls)
+	if len(attemptFiles) != 1 || attemptFiles[0] != wantFile {
+		t.Errorf("attempt files present = %v, want exactly [%s] (earlier attempts' leftovers must be discarded)", attemptFiles, wantFile)
+	}
+
+	// The clone must be clean — no leftover modified/untracked files — so the
+	// next dispatch's git_clean preflight check doesn't wedge (GH-4594).
+	status := gitOutput(t, localRepo, "status", "--porcelain")
+	if strings.TrimSpace(status) != "" {
+		t.Errorf("working tree should be clean after the retry loop, got:\n%s", status)
+	}
+}

--- a/internal/executor/runner_terminal_failure_clean_gh4594_test.go
+++ b/internal/executor/runner_terminal_failure_clean_gh4594_test.go
@@ -1,0 +1,139 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// commitPlusStrayDirtBackend simulates the exact GH-4594 incident shape: the
+// attempt does real, legitimate work (a committed file — so the "no commits
+// at all" auto-preserve safety net, GH-4517, never fires) but also leaves an
+// extra file it never staged or committed — the "leftover ` M version.go`
+// observed x3" symptom from the incident report, here surviving all the way
+// to a terminal (non-retryable) quality-gate failure.
+type commitPlusStrayDirtBackend struct{}
+
+func (b *commitPlusStrayDirtBackend) Name() string      { return "commit-plus-stray-dirt" }
+func (b *commitPlusStrayDirtBackend) IsAvailable() bool { return true }
+
+func (b *commitPlusStrayDirtBackend) Execute(ctx context.Context, opts ExecuteOptions) (*BackendResult, error) {
+	committedFile := filepath.Join(opts.ProjectPath, "change.txt")
+	if err := os.WriteFile(committedFile, []byte("real committed change"), 0o644); err != nil {
+		return nil, err
+	}
+	for _, args := range [][]string{{"add", "change.txt"}, {"commit", "-m", "real change"}} {
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = opts.ProjectPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("git %v: %v (%s)", args, err, out)
+		}
+	}
+
+	// Leftover dirt: never staged, never committed.
+	strayFile := filepath.Join(opts.ProjectPath, "version.go")
+	if err := os.WriteFile(strayFile, []byte("partial stray edit"), 0o644); err != nil {
+		return nil, err
+	}
+
+	return &BackendResult{Success: true, Output: "done"}, nil
+}
+
+// terminallyFailingQualityChecker fails without requesting a retry, so the
+// quality-gate loop exits on its very first pass via the "no more retries
+// allowed" path (runner.go's finalOutcome branch) rather than the
+// quality-gate retry-reset loop already covered by
+// TestRunner_QualityRetry_DirectMode_ResetsToCleanPreAttemptState.
+type terminallyFailingQualityChecker struct{}
+
+func (c *terminallyFailingQualityChecker) Check(_ context.Context) (*QualityOutcome, error) {
+	return &QualityOutcome{
+		Passed:        false,
+		ShouldRetry:   false,
+		RetryFeedback: "synthetic terminal gate failure",
+		Attempt:       1,
+	}, nil
+}
+
+// TestRunner_DirectMode_TerminalFailure_LeavesCloneClean is the GH-4594
+// regression guard for the final leg of the incident: after a direct-mode
+// (non-worktree) execution fails for good — no quality-gate retries left —
+// the shared clone must be left clean, with no leftover uncommitted dirt.
+// Before this fix, only the quality-gate *retry* loop reset the tree
+// (GH-4594 subtask 2); the terminal-failure return path left whatever
+// uncommitted dirt the failed attempt wrote behind, so the *next* dispatch
+// on this same project's shared clone tripped the git_clean preflight check.
+//
+// The legitimate commit the attempt made must survive the cleanup —
+// discarding a human-reviewable commit just to satisfy git_clean would be
+// its own regression (it's exactly what the quality-gate retry loop's
+// "keep the last attempt's commit" behavior and GH-4517's auto-preserved WIP
+// commit both depend on).
+func TestRunner_DirectMode_TerminalFailure_LeavesCloneClean(t *testing.T) {
+	localRepo, remoteRepo := setupTestRepoWithRemote(t)
+	defer func() { _ = os.RemoveAll(localRepo) }()
+	defer func() { _ = os.RemoveAll(remoteRepo) }()
+
+	preAttemptSHA := strings.TrimSpace(headSHA(t, localRepo))
+
+	runner := NewRunnerWithBackend(&commitPlusStrayDirtBackend{})
+	runner.config = &BackendConfig{UseWorktree: false} // direct mode: no worktree isolation
+	runner.SetSkipPreflightChecks(true)
+	runner.SetRecordingEnabled(false)
+	runner.SetQualityCheckerFactory(func(taskID, projectPath string) QualityChecker {
+		return &terminallyFailingQualityChecker{}
+	})
+
+	task := &Task{
+		ID:          "GH-4594-3",
+		Title:       "terminal quality-gate failure leaves uncommitted dirt",
+		Description: "gate fails with ShouldRetry=false; no retry-loop reset ever fires",
+		ProjectPath: localRepo,
+		Branch:      "pilot/GH-4594-3",
+		CreatePR:    true,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	result, _ := runner.Execute(ctx, task)
+	if result == nil || result.Success {
+		t.Fatalf("expected terminal task failure, got %+v", result)
+	}
+
+	// The never-committed stray file must be gone.
+	if _, err := os.Stat(filepath.Join(localRepo, "version.go")); !os.IsNotExist(err) {
+		t.Errorf("version.go stray dirt should have been discarded after terminal failure, stat err=%v", err)
+	}
+
+	// The legitimate commit must survive: HEAD is ahead of the pre-attempt
+	// baseline by exactly one commit, and its file is still present.
+	if got := strings.TrimSpace(headSHA(t, localRepo)); got == preAttemptSHA {
+		t.Errorf("HEAD unchanged at pre-attempt SHA %s — the attempt's legitimate commit must not be discarded", preAttemptSHA)
+	}
+	if _, err := os.Stat(filepath.Join(localRepo, "change.txt")); err != nil {
+		t.Errorf("change.txt from the legitimate commit should survive cleanup, stat err=%v", err)
+	}
+	countOut := gitOutput(t, localRepo, "rev-list", "--count", preAttemptSHA+"..HEAD")
+	if got := strings.TrimSpace(countOut); got != "1" {
+		t.Errorf("commits ahead of pre-attempt baseline = %s, want 1 (the legitimate commit)", got)
+	}
+
+	// The clone must be fully clean.
+	status := gitOutput(t, localRepo, "status", "--porcelain")
+	if strings.TrimSpace(status) != "" {
+		t.Fatalf("working tree should be clean after terminal failure, got:\n%s", status)
+	}
+
+	// GH-4594: the actual regression this guards against — a subsequent
+	// dispatch's git_clean preflight check on the same (shared, non-worktree)
+	// clone must not fail because of this attempt's leftovers.
+	if err := checkGitClean(ctx, localRepo); err != nil {
+		t.Errorf("next dispatch's git_clean preflight check failed: %v", err)
+	}
+}

--- a/internal/executor/runner_worktree_parity_gh4594_test.go
+++ b/internal/executor/runner_worktree_parity_gh4594_test.go
@@ -1,0 +1,205 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// stackingAttemptRecorderBackend simulates a Claude Code invocation that, on
+// every call, first records how many earlier attempts' files are still
+// present in the working tree, then writes and commits a brand-new file
+// named after the attempt number. It never removes an earlier attempt's
+// file itself, so the recorded counts reveal whether something reset the
+// tree between calls — the same "stacking" shape as stackingAttemptBackend
+// (git_reset_gh4594_test.go's sibling), but instrumented so a worktree-mode
+// test can assert the tree was NOT reset (unlike the direct-mode guard).
+type stackingAttemptRecorderBackend struct {
+	mu         sync.Mutex
+	calls      int
+	seenCounts []int
+}
+
+func (b *stackingAttemptRecorderBackend) Name() string      { return "stacking-attempt-recorder" }
+func (b *stackingAttemptRecorderBackend) IsAvailable() bool { return true }
+
+func (b *stackingAttemptRecorderBackend) Execute(ctx context.Context, opts ExecuteOptions) (*BackendResult, error) {
+	b.mu.Lock()
+	b.calls++
+	n := b.calls
+	b.mu.Unlock()
+
+	entries, err := os.ReadDir(opts.ProjectPath)
+	if err != nil {
+		return nil, err
+	}
+	existing := 0
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "attempt_") {
+			existing++
+		}
+	}
+	b.mu.Lock()
+	b.seenCounts = append(b.seenCounts, existing)
+	b.mu.Unlock()
+
+	fname := filepath.Join(opts.ProjectPath, fmt.Sprintf("attempt_%d.txt", n))
+	if err := os.WriteFile(fname, []byte(fmt.Sprintf("attempt %d", n)), 0o644); err != nil {
+		return nil, err
+	}
+	for _, args := range [][]string{{"add", "."}, {"commit", "-m", fmt.Sprintf("attempt %d", n)}} {
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = opts.ProjectPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("git %v: %v (%s)", args, err, out)
+		}
+	}
+	return &BackendResult{Success: true, Output: "done"}, nil
+}
+
+func (b *stackingAttemptRecorderBackend) counts() []int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]int, len(b.seenCounts))
+	copy(out, b.seenCounts)
+	return out
+}
+
+// TestRunner_QualityRetry_WorktreeMode_AttemptsStackAcrossRetries is the
+// worktree-mode counterpart to
+// TestRunner_QualityRetry_DirectMode_ResetsToCleanPreAttemptState
+// (runner_quality_retry_reset_gh4594_test.go). GH-4594 subtask 2 added a
+// pre-attempt hard-reset before every quality-gate retry, but ONLY for
+// direct (non-worktree) mode — worktree mode was never part of the
+// incident (every execution already gets its own throwaway worktree) and
+// must keep its pre-existing "no reset between retries" behavior. This test
+// fails if that gating is ever accidentally widened to worktree mode.
+func TestRunner_QualityRetry_WorktreeMode_AttemptsStackAcrossRetries(t *testing.T) {
+	localRepo, remoteRepo := setupTestRepoWithRemote(t)
+	defer func() { _ = os.RemoveAll(localRepo) }()
+	defer func() { _ = os.RemoveAll(remoteRepo) }()
+
+	backend := &stackingAttemptRecorderBackend{}
+	runner := NewRunnerWithBackend(backend)
+	runner.config = &BackendConfig{UseWorktree: true} // worktree mode: must behave exactly as before GH-4594
+	runner.SetSkipPreflightChecks(true)
+	runner.SetRecordingEnabled(false)
+	runner.SetQualityCheckerFactory(func(taskID, projectPath string) QualityChecker {
+		return &failingQualityChecker{}
+	})
+
+	task := &Task{
+		ID:          "GH-4594-4-worktree-retry",
+		Title:       "force repeated quality-gate retries in worktree mode",
+		Description: "gates always fail, so every allowed retry fires",
+		ProjectPath: localRepo,
+		Branch:      "pilot/GH-4594-4-worktree-retry",
+		CreatePR:    true,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// The task ultimately fails (gates never pass) — we only care about what
+	// each retry saw in the isolated worktree.
+	result, _ := runner.Execute(ctx, task)
+	if result == nil || result.Success {
+		t.Fatalf("expected task failure (gates never pass), got %+v", result)
+	}
+
+	counts := backend.counts()
+	if len(counts) < 2 {
+		t.Fatalf("expected >=2 backend calls (initial + at least one quality retry), got %d", len(counts))
+	}
+
+	// counts[i] is how many earlier attempts' files were still present when
+	// call i started: 0 before the first call, 1 before the second, etc. Any
+	// value less than that index means something reset the worktree between
+	// retries — the direct-mode-only behavior added by GH-4594 subtask 2 must
+	// not have leaked into worktree mode.
+	for i, c := range counts {
+		if c != i {
+			t.Errorf("REGRESSION: retry %d saw %d prior attempt files still present, want %d — worktree-mode retries must not be reset (that's direct-mode-only behavior)", i, c, i)
+		}
+	}
+}
+
+// TestRunner_WorktreeMode_TerminalFailure_LeavesProjectRepoUntouched is the
+// worktree-mode counterpart to
+// TestRunner_DirectMode_TerminalFailure_LeavesCloneClean
+// (runner_terminal_failure_clean_gh4594_test.go). GH-4594 subtask 3 added a
+// deferred hard-reset-to-HEAD cleanup for direct-mode terminal failures, but
+// it's gated off entirely for worktree mode (preAttemptSHA stays empty
+// there) because worktree isolation already handles this: every execution
+// gets its own throwaway worktree, discarded by cleanupWorktree regardless
+// of outcome. This test guards that the new direct-mode cleanup logic (and
+// the branch-creation changes from subtasks 1 and its runner_decompose.go
+// counterpart) never touch the real project repo in worktree mode — after a
+// terminal quality-gate failure, the real repo must be exactly as it was
+// before Execute ran.
+func TestRunner_WorktreeMode_TerminalFailure_LeavesProjectRepoUntouched(t *testing.T) {
+	localRepo, remoteRepo := setupTestRepoWithRemote(t)
+	defer func() { _ = os.RemoveAll(localRepo) }()
+	defer func() { _ = os.RemoveAll(remoteRepo) }()
+
+	ctx := context.Background()
+	git := NewGitOperations(localRepo)
+
+	preAttemptSHA := strings.TrimSpace(headSHA(t, localRepo))
+	preAttemptBranch, err := git.GetCurrentBranch(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentBranch: %v", err)
+	}
+
+	runner := NewRunnerWithBackend(&commitPlusStrayDirtBackend{})
+	runner.config = &BackendConfig{UseWorktree: true} // worktree mode: no direct-mode cleanup should apply
+	runner.SetSkipPreflightChecks(true)
+	runner.SetRecordingEnabled(false)
+	runner.SetQualityCheckerFactory(func(taskID, projectPath string) QualityChecker {
+		return &terminallyFailingQualityChecker{}
+	})
+
+	task := &Task{
+		ID:          "GH-4594-4-worktree-terminal",
+		Title:       "terminal quality-gate failure in worktree mode",
+		Description: "gate fails with ShouldRetry=false; the failed attempt's commit+dirt live only in the throwaway worktree",
+		ProjectPath: localRepo,
+		Branch:      "pilot/GH-4594-4-worktree-terminal",
+		CreatePR:    true,
+	}
+
+	execCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	result, _ := runner.Execute(execCtx, task)
+	if result == nil || result.Success {
+		t.Fatalf("expected terminal task failure, got %+v", result)
+	}
+
+	// The real project repo must be entirely untouched: still on its original
+	// branch, at its original commit, with no trace of the failed attempt's
+	// files — they only ever existed in the now-deleted worktree.
+	if gotBranch, err := git.GetCurrentBranch(ctx); err != nil {
+		t.Fatalf("GetCurrentBranch: %v", err)
+	} else if gotBranch != preAttemptBranch {
+		t.Errorf("REGRESSION: project repo branch = %q, want unchanged %q (worktree mode must never check out the task branch in the real repo)", gotBranch, preAttemptBranch)
+	}
+	if got := strings.TrimSpace(headSHA(t, localRepo)); got != preAttemptSHA {
+		t.Errorf("REGRESSION: project repo HEAD = %s, want unchanged %s — a failed worktree-mode attempt must never touch the real repo's history", got, preAttemptSHA)
+	}
+	for _, f := range []string{"change.txt", "version.go"} {
+		if _, err := os.Stat(filepath.Join(localRepo, f)); !os.IsNotExist(err) {
+			t.Errorf("REGRESSION: %s leaked into the real project repo (should only ever exist in the discarded worktree), stat err=%v", f, err)
+		}
+	}
+	status := gitOutput(t, localRepo, "status", "--porcelain")
+	if strings.TrimSpace(status) != "" {
+		t.Errorf("REGRESSION: real project repo has uncommitted changes after worktree-mode terminal failure:\n%s", status)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4594.

Closes #4594

## Changes

GitHub Issue GH-4594: fix(executor): hosted direct-mode execution corrupts the daemon clone — branches cut from stale HEAD, quality-retry double-applies changes, leftover dirt wedges git_clean

## Context

Hosted direct-mode execution (`useWorktree=false`, internal/executor/runner.go:2083) runs tasks directly in the daemon's clone instead of an isolated worktree, and corrupts that clone across executions. Observed on the hosted tenant during S2 canary work (2026-07-25 and 07-28 storms; filed from the 07-28 session — see `.agent/.context-markers/2026-07-28_s2-exit-met-billing-fixed.md`):

1. **Branches cut from stale HEAD** — the clone's HEAD lags origin/main, so new task branches start behind (canary PR #108 showed a version diff `0.0.18→0.0.23` — five releases of drift folded into one PR).
2. **Quality-retry double-applies changes** — retry runs re-apply edits on top of the previous attempt's leftovers (leftover ` M version.go` observed ×3), producing dirty diffs and phantom modifications.
3. **git_clean self-wedge** — leftover dirt makes the pre-execution `git_clean` step fail or loop, wedging every subsequent dispatch on that project (the repick-storm signature: repeated claim-lost drops on a dirty clone).

The three symptoms share one root: direct mode has no per-execution isolation or reset discipline, so any residue from attempt N poisons attempt N+1 and branch-cut points drift.

## Implementation

Investigate and fix the direct-mode path in `internal/executor/runner.go` (the `useWorktree=false` branch, ~:2083):

- Before cutting a task branch: fetch + reset the clone to fresh `origin/<base>` (same freshness guarantee the worktree path gets by construction).
- Between quality-gate retries: hard-reset to the branch's pre-attempt state so retries never stack onto leftovers.
- After execution (success or failure): leave the clone clean (`git status --porcelain` empty) so `git_clean` never wedges the next dispatch.
- Consider whether hosted direct-mode should simply use worktrees; if that is the cleaner fix, say so in the PR rather than patching all three symptoms individually.

## Acceptance

- [ ] Direct-mode task branches are cut from freshly-fetched `origin/<base>` (test: stale local HEAD, branch must match remote tip)
- [ ] A quality-gate retry starts from a clean pre-attempt state — no double-applied hunks, no leftover modified files (test)
- [ ] After a failed direct-mode execution the clone is clean; a subsequent dispatch on the same project does not hit `git_clean` failure (test)
- [ ] No behavior change for the worktree path

## Refs

- Marker: `.agent/.context-markers/2026-07-28_s2-exit-met-billing-fixed.md` (defect summary + PR #108 evidence)
- Siblings filed same session: #4591 (CI classifier vs never-started jobs), #4595 (merge-gate escalation, shipped via #4602–#4607)
- Re-arms the version-bump canary leg (operator-closed #99/#107/#109 — record in #99's close comment)