### PR TITLE
fix(dashboard): startup banner reads resolved env, not stale legacy field

### DIFF
--- a/cmd/pilot/banner_meta_test.go
+++ b/cmd/pilot/banner_meta_test.go
@@ -105,6 +105,27 @@ func TestApplyDashboardBannerMeta(t *testing.T) {
 			notBanner:  []string{"daemon"},
 			notLegend:  []string{"gh", "tg", "slack"},
 		},
+		{
+			// GH-4611: default_environment set in config with no --env
+			// override must resolve through EnvironmentName() (same path as
+			// the "autopilot enabled" structured log), not the stale legacy
+			// Environment field. Before the fix, the banner rendered the
+			// legacy field's zero value ("") instead of "hosted".
+			name: "default_environment with no --env override — banner shows resolved env",
+			cfg: &config.Config{
+				Orchestrator: &config.OrchestratorConfig{
+					Autopilot: &autopilot.Config{
+						DefaultEnvironment: "hosted",
+						Environments: map[string]*autopilot.EnvironmentConfig{
+							"hosted": {Branch: "main"},
+						},
+					},
+				},
+				Adapters: &config.AdaptersConfig{},
+			},
+			wantBanner: []string{"hosted"},
+			notBanner:  []string{"stage"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -136,5 +157,48 @@ func TestApplyDashboardBannerMeta(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestApplyDashboardBannerMeta_ExplicitEnvOverride verifies GH-4611's
+// single-source-of-truth requirement: with an explicit --env override
+// (SetActiveEnvironment, as the CLI flag handler calls at main.go:430) and a
+// conflicting default_environment in config, both the dashboard banner
+// (applyDashboardBannerMeta, via EnvironmentName()) and the structured
+// "autopilot enabled" log line (which also calls EnvironmentName() directly
+// at main.go:2369) must report the overridden environment, not the config
+// default.
+func TestApplyDashboardBannerMeta_ExplicitEnvOverride(t *testing.T) {
+	autopilotCfg := &autopilot.Config{
+		DefaultEnvironment: "hosted",
+		Environments: map[string]*autopilot.EnvironmentConfig{
+			"hosted": {Branch: "main"},
+		},
+	}
+	if err := autopilotCfg.SetActiveEnvironment("stage"); err != nil {
+		t.Fatalf("SetActiveEnvironment(stage): %v", err)
+	}
+
+	cfg := &config.Config{
+		Orchestrator: &config.OrchestratorConfig{Autopilot: autopilotCfg},
+		Adapters:     &config.AdaptersConfig{},
+	}
+
+	model := dashboard.NewModel("9.9.9")
+	applyDashboardBannerMeta(&model, cfg, nil)
+	banner := model.RenderBannerForTest()
+
+	if !strings.Contains(banner, "stage") {
+		t.Errorf("banner missing %q (--env override)\noutput:\n%s", "stage", banner)
+	}
+	if strings.Contains(banner, "hosted") {
+		t.Errorf("banner unexpectedly contains %q (stale default_environment)\noutput:\n%s", "hosted", banner)
+	}
+
+	// The structured "autopilot enabled" log line at main.go:2369 uses the
+	// same EnvironmentName() call directly — assert it agrees with the
+	// banner so both surfaces stay in sync.
+	if got := cfg.Orchestrator.Autopilot.EnvironmentName(); got != "stage" {
+		t.Errorf("EnvironmentName() = %q, want %q (must match banner)", got, "stage")
 	}
 }

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -2708,7 +2708,12 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				})
 
 				if len(autopilotControllers) > 0 && !dashboardMode {
-					fmt.Printf("● autopilot enabled · %s environment (%d repos)\n", cfg.Orchestrator.Autopilot.Environment, len(autopilotControllers))
+					// GH-4611: use EnvironmentName() (same resolution path as the
+					// "autopilot enabled" structured log above) rather than the
+					// raw legacy Environment field, so the banner never shows a
+					// stale/unresolved value when default_environment is set in
+					// config with no --env flag.
+					fmt.Printf("● autopilot enabled · %s environment (%d repos)\n", cfg.Orchestrator.Autopilot.EnvironmentName(), len(autopilotControllers))
 				}
 
 				// Start metrics alerter for default controller (GH-728). The
@@ -3472,7 +3477,12 @@ func (s storeExecutionSaver) SaveDeclinedExecution(taskID, projectPath, status, 
 func applyDashboardBannerMeta(model *dashboard.Model, cfg *config.Config, cmd *cobra.Command) {
 	envName := ""
 	if cfg.Orchestrator != nil && cfg.Orchestrator.Autopilot != nil {
-		envName = string(cfg.Orchestrator.Autopilot.Environment)
+		// GH-4611: use EnvironmentName() (same resolution path as the
+		// "autopilot enabled" structured log and startup banner) rather than
+		// the raw legacy Environment field, so the dashboard banner never
+		// shows a stale value when default_environment is set in config
+		// with no --env flag.
+		envName = cfg.Orchestrator.Autopilot.EnvironmentName()
 	}
 
 	modelStack := ""


### PR DESCRIPTION
## Summary
- Startup banner (polling mode) and dashboard TUI banner now read `cfg.Orchestrator.Autopilot.EnvironmentName()` instead of the legacy `Environment` field, so they share the same resolution path as the structured `autopilot enabled` log line.
- Fixes the case where `default_environment` is set in config with no `--env` override: the legacy field stayed at its zero value and the banner showed a stale/wrong name (e.g. `stage`) while the structured log correctly reported the resolved environment (e.g. `hosted`).

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/pilot/... ./internal/autopilot/...`
- [x] New test: `default_environment` set, no `--env` override → banner shows `hosted`, not `stage`
- [x] New test: explicit `--env stage` override → banner and `EnvironmentName()` both show `stage`

Closes GH-4611