### PR TITLE
GH-4609: fix(executor): zombie active-task from stalled-retry blocks self-upgrade drain forever — reconcile registry against live processes + alert on drain timeout

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -3114,6 +3114,13 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 
 		// Set up hot upgrade goroutine - listens for upgrade requests from 'u' key press
 		// The channel is created above and passed to the dashboard model
+		//
+		// GH-4609: drainAlertGate tracks consecutive drain-timeout failures
+		// across retries of this loop (versionChecker re-fires OnUpdate every
+		// DefaultCheckInterval while an update stays available) so the alert
+		// below only pages an operator starting on the second consecutive
+		// drain timeout instead of every 5-minute retry.
+		drainAlertGate := &drainTimeoutAlertGate{}
 		go func() {
 			for {
 				select {
@@ -3153,8 +3160,17 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 					if err := hotUpgrader.PerformHotUpgrade(ctx, info.LatestRelease, upgradeCfg); err != nil {
 						program.Send(dashboard.NotifyUpgradeComplete(false, err.Error())())
 						program.Send(dashboard.AddLog(fmt.Sprintf("✗ upgrade failed: %v", err))())
-						reportUpgradeFailure(alertsEngine, version, info.Latest, err)
+						if drainAlertGate.observe(err) {
+							reportUpgradeFailure(alertsEngine, version, info.Latest, err)
+						} else {
+							slog.Warn("self-upgrade drain timeout — retrying next check, not alerting yet (1st consecutive occurrence)",
+								slog.String("current_version", version),
+								slog.String("target_version", info.Latest),
+								slog.Any("error", err),
+							)
+						}
 					} else {
+						drainAlertGate.observe(nil)
 						// On Unix, process is replaced and this line is never reached.
 						// On Windows, hot restart is not supported — binary is installed
 						// but process continues. Notify user to restart manually.

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -2466,6 +2466,20 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		}
 	}
 
+	// GH-4609: wire the Dispatcher's live-worker liveness signal (and the
+	// store, for its execution_event heartbeat fallback) into the monitor so
+	// ReconcileDeadOwners can finalize a dead-owner active-registry entry —
+	// no live worker holding it, execution row not progressing — before it
+	// blocks self-upgrade drain forever (see monitor.GetRunningTaskIDs,
+	// consumed as upgrade.TaskChecker below via NewHotUpgrader). monitor is
+	// only non-nil in --dashboard mode (see above).
+	if monitor != nil && dispatcher != nil {
+		monitor.SetLiveWorkerChecker(dispatcher)
+		if store != nil {
+			monitor.SetExecutionStore(store)
+		}
+	}
+
 	// GH-4412: wire the always-on Dispatcher liveness signal into every
 	// autopilot controller, unconditionally (unlike SetMonitor above, which
 	// only runs in --dashboard mode). Without this, the orphan-running sweep's

--- a/cmd/pilot/upgrade.go
+++ b/cmd/pilot/upgrade.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"golang.org/x/term"
 
 	"github.com/qf-studio/pilot/internal/alerts"
+	"github.com/qf-studio/pilot/internal/executor"
 	"github.com/qf-studio/pilot/internal/upgrade"
 )
 
@@ -50,6 +52,38 @@ func reportUpgradeFailure(alertsEngine *alerts.Engine, currentVersion, targetVer
 		},
 		Timestamp: time.Now(),
 	})
+}
+
+// drainTimeoutAlertGate gates self-upgrade alerting so a drain-timeout
+// failure (executor.ErrDrainTimeout) only pages an operator starting on the
+// second consecutive occurrence (GH-4609): a single drain timeout can be a
+// legitimately long-running task crossing the wait window, which usually
+// clears on the next automatic retry a few minutes later — alerting on that
+// first occurrence would just be noise. Two in a row means the drain is
+// genuinely stuck, the pattern behind the GH-72 incident this closes: a
+// zombie active-registry entry looped "drain timeout" every 5 minutes for
+// ~55 minutes with no alert ever firing. Any other upgrade failure (bad
+// download, unwritable binary dir, restart failure, ...) is not naturally
+// transient the same way, so it keeps alerting immediately and resets the
+// streak — unchanged from GH-4468.
+type drainTimeoutAlertGate struct {
+	mu     sync.Mutex
+	streak int
+}
+
+// observe records the outcome of one self-upgrade attempt (nil err on
+// success) and reports whether reportUpgradeFailure should fire for it.
+func (g *drainTimeoutAlertGate) observe(err error) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if err == nil || !errors.Is(err, executor.ErrDrainTimeout) {
+		g.streak = 0
+		return err != nil
+	}
+
+	g.streak++
+	return g.streak >= 2
 }
 
 // confirmPromptTimeout bounds how long the upgrade confirmation prompt waits

--- a/cmd/pilot/upgrade_failure_test.go
+++ b/cmd/pilot/upgrade_failure_test.go
@@ -3,12 +3,14 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/qf-studio/pilot/internal/alerts"
+	"github.com/qf-studio/pilot/internal/executor"
 )
 
 // mockAlertChannel is a minimal alerts.Channel implementation for asserting
@@ -143,4 +145,149 @@ func TestReportUpgradeFailure_NoMatchingRule(t *testing.T) {
 // reportUpgradeFailure must still log and simply skip alerting.
 func TestReportUpgradeFailure_NilEngineDoesNotPanic(t *testing.T) {
 	reportUpgradeFailure(nil, "v2.242.0", "v2.243.0", errors.New("boom"))
+}
+
+// wrappedDrainTimeoutErr mirrors the real error chain a drain-timeout
+// produces in production: executor.Monitor.WaitForTasks wraps
+// executor.ErrDrainTimeout, and upgrade.HotUpgrader.PerformHotUpgrade wraps
+// that again ("timeout waiting for tasks: %w").
+func wrappedDrainTimeoutErr() error {
+	inner := fmt.Errorf("%w: 1 tasks still active: [GH-72]", executor.ErrDrainTimeout)
+	return fmt.Errorf("timeout waiting for tasks: %w", inner)
+}
+
+// TestDrainTimeoutAlertGate_SuppressesFirstDrainTimeout is the GH-4609
+// acceptance contract: a single drain-timeout failure — which can be a
+// legitimately long-running task crossing the wait window and often clears
+// on the next retry — must not page an operator.
+func TestDrainTimeoutAlertGate_SuppressesFirstDrainTimeout(t *testing.T) {
+	gate := &drainTimeoutAlertGate{}
+
+	if gate.observe(wrappedDrainTimeoutErr()) {
+		t.Fatal("first consecutive drain-timeout should not alert")
+	}
+}
+
+// TestDrainTimeoutAlertGate_AlertsOnSecondConsecutiveDrainTimeout is the
+// GH-4609 acceptance contract: the second consecutive drain-timeout failure
+// must fire an alert — this closes the GH-72 incident where the drain
+// looped "drain timeout" every 5 minutes for ~55 minutes with no alert ever
+// firing.
+func TestDrainTimeoutAlertGate_AlertsOnSecondConsecutiveDrainTimeout(t *testing.T) {
+	gate := &drainTimeoutAlertGate{}
+
+	if gate.observe(wrappedDrainTimeoutErr()) {
+		t.Fatal("first consecutive drain-timeout should not alert")
+	}
+	if !gate.observe(wrappedDrainTimeoutErr()) {
+		t.Fatal("second consecutive drain-timeout should alert")
+	}
+	// A third (and any further) consecutive occurrence should keep alerting.
+	if !gate.observe(wrappedDrainTimeoutErr()) {
+		t.Fatal("third consecutive drain-timeout should also alert")
+	}
+}
+
+// TestDrainTimeoutAlertGate_NonDrainTimeoutAlertsImmediately preserves the
+// GH-4468 contract for every other upgrade failure (bad download, unwritable
+// binary dir, restart failure, ...): those are not naturally transient the
+// way a drain timeout is, so they must keep alerting on the very first
+// occurrence, unchanged.
+func TestDrainTimeoutAlertGate_NonDrainTimeoutAlertsImmediately(t *testing.T) {
+	gate := &drainTimeoutAlertGate{}
+
+	if !gate.observe(errors.New("binary directory /usr/local/bin is not writable")) {
+		t.Fatal("a non-drain-timeout failure should alert immediately")
+	}
+}
+
+// TestDrainTimeoutAlertGate_StreakResetsAfterNonDrainTimeoutFailure verifies
+// an unrelated failure breaks the drain-timeout streak, so a subsequent
+// drain-timeout is again treated as a fresh "first occurrence".
+func TestDrainTimeoutAlertGate_StreakResetsAfterNonDrainTimeoutFailure(t *testing.T) {
+	gate := &drainTimeoutAlertGate{}
+
+	if gate.observe(wrappedDrainTimeoutErr()) {
+		t.Fatal("first consecutive drain-timeout should not alert")
+	}
+	if !gate.observe(errors.New("checksum mismatch")) {
+		t.Fatal("unrelated failure should alert immediately and reset the streak")
+	}
+	if gate.observe(wrappedDrainTimeoutErr()) {
+		t.Fatal("drain-timeout streak should have reset after the unrelated failure")
+	}
+}
+
+// TestDrainTimeoutAlertGate_SuccessResetsStreak verifies a successful
+// upgrade attempt (nil err) clears any accumulated drain-timeout streak.
+func TestDrainTimeoutAlertGate_SuccessResetsStreak(t *testing.T) {
+	gate := &drainTimeoutAlertGate{}
+
+	if gate.observe(wrappedDrainTimeoutErr()) {
+		t.Fatal("first consecutive drain-timeout should not alert")
+	}
+	if gate.observe(nil) {
+		t.Fatal("a successful attempt should not itself alert")
+	}
+	if gate.observe(wrappedDrainTimeoutErr()) {
+		t.Fatal("drain-timeout streak should have reset after a successful attempt")
+	}
+}
+
+// TestDrainTimeoutAlertGate_EndToEndAlertDelivery wires the gate together
+// with reportUpgradeFailure and a real alerts.Engine/Dispatcher, mirroring
+// how cmd/pilot's hot-upgrade goroutine uses both: exactly one alert should
+// reach the channel, on the second consecutive drain-timeout, not the first.
+func TestDrainTimeoutAlertGate_EndToEndAlertDelivery(t *testing.T) {
+	config := &alerts.AlertConfig{
+		Enabled: true,
+		Channels: []alerts.ChannelConfig{
+			{Name: "test-channel", Type: "webhook", Enabled: true},
+		},
+		Rules: []alerts.AlertRule{
+			{
+				Name:     "service-unhealthy",
+				Type:     alerts.AlertTypeServiceUnhealthy,
+				Enabled:  true,
+				Severity: alerts.SeverityWarning,
+				Channels: []string{"test-channel"},
+				Cooldown: 0,
+			},
+		},
+	}
+
+	mockCh := newMockAlertChannel("test-channel")
+	dispatcher := alerts.NewDispatcher(config)
+	dispatcher.RegisterChannel(mockCh)
+
+	engine := alerts.NewEngine(config, alerts.WithDispatcher(dispatcher))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := engine.Start(ctx); err != nil {
+		t.Fatalf("engine.Start() error = %v", err)
+	}
+
+	gate := &drainTimeoutAlertGate{}
+
+	// 1st consecutive drain-timeout: must not alert.
+	if gate.observe(wrappedDrainTimeoutErr()) {
+		reportUpgradeFailure(engine, "v2.248.0", "v2.249.0", wrappedDrainTimeoutErr())
+	}
+	time.Sleep(100 * time.Millisecond)
+	if got := len(mockCh.getAlerts()); got != 0 {
+		t.Fatalf("expected no alert after 1st consecutive drain-timeout, got %d", got)
+	}
+
+	// 2nd consecutive drain-timeout: must alert.
+	if gate.observe(wrappedDrainTimeoutErr()) {
+		reportUpgradeFailure(engine, "v2.248.0", "v2.249.0", wrappedDrainTimeoutErr())
+	}
+	waitForMockAlerts(t, mockCh, 1, 2*time.Second)
+	got := mockCh.getAlerts()
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 alert after 2nd consecutive drain-timeout, got %d", len(got))
+	}
+	if got[0].Type != alerts.AlertTypeServiceUnhealthy {
+		t.Errorf("alert type = %s, want %s", got[0].Type, alerts.AlertTypeServiceUnhealthy)
+	}
 }

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -1603,6 +1603,20 @@ func (d *Dispatcher) beginWithGenerationRetry(task *Task, initial Status) (strin
 					slog.String("project", task.ProjectPath),
 					slog.Any("error", setErr))
 			}
+			// GH-4609 subtask 2: a fresh generation was just granted for this
+			// stalled claim — finalize the PRIOR attempt's active-registry
+			// (Monitor) entry right here instead of leaving it to age into
+			// ReconcileDeadOwners' drain-time backstop. Normally runner.go's
+			// own Stall() call already did this when the watchdog fired; this
+			// is a no-op in that case (ReleasePriorAttempt only touches a
+			// still-non-terminal entry) and only matters when that call
+			// hasn't landed (or never will — e.g. the worker process died
+			// before reaching it), so the retried task is counted exactly
+			// once, under the new generation, not still under the superseded
+			// one.
+			if d.runner != nil && d.runner.monitor != nil {
+				d.runner.monitor.ReleasePriorAttempt(task.ID, fmt.Sprintf("stall-retry: superseded by generation %d", gen))
+			}
 			d.log.Info("dispatch re-pick: prior claim was stall-killed — claiming next generation without counting toward repick hard cap",
 				slog.String("task_id", task.ID),
 				slog.String("project", task.ProjectPath),

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -3837,6 +3837,65 @@ func TestDispatcher_BeginWithGenerationRetry_StallDropsDoNotCountTowardHardCap(t
 	}
 }
 
+// TestDispatcher_BeginWithGenerationRetry_StallRetryReleasesPriorMonitorEntry
+// is the GH-4609 subtask 2 acceptance test: granting a retry for a stalled
+// claim must release/finish the prior attempt's in-memory active-registry
+// (Monitor) entry itself, rather than depending solely on runner.go's own
+// Stall() call having already landed. Simulates the GH-72 incident shape —
+// the executions row reads "stalled" (the watchdog's own detection ran) but
+// the Monitor entry was never transitioned off StatusRunning (e.g. the
+// worker process died before reaching monitor.Stall()) — and asserts the
+// stalled->retry path finalizes it anyway, so the retried task is counted
+// once under its fresh generation instead of leaving a zombie Running entry
+// that would otherwise block drain until the periodic ReconcileDeadOwners
+// backstop (subtask 1) eventually catches up.
+func TestDispatcher_BeginWithGenerationRetry_StallRetryReleasesPriorMonitorEntry(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GH-72", ProjectPath: "/pilot-console"}
+	runner := NewRunner()
+	monitor := NewMonitor()
+	runner.SetMonitor(monitor)
+	dispatcher := NewDispatcher(store, runner, nil)
+	freshTask := &Task{ID: task.ID, ProjectPath: task.ProjectPath}
+
+	if _, err := NewExecutionLifecycle(store).Begin(task, ExecStatusRunning); err != nil {
+		t.Fatalf("setup Begin: %v", err)
+	}
+
+	// The executions row reflects the genuine stall the watchdog detected...
+	markLatestClaimedExecution(t, store, task.ID, task.ProjectPath, "stalled")
+
+	// ...but the Monitor entry never got moved off Running — the exact GH-72
+	// zombie shape (worker process gone before its own monitor.Stall() call).
+	monitor.Register(task.ID, "Zombie task", "")
+	monitor.Start(task.ID)
+
+	execID, err := dispatcher.beginWithGenerationRetry(freshTask, ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("beginWithGenerationRetry: %v", err)
+	}
+	if execID == "" {
+		t.Fatal("expected the stalled claim to be granted a retry")
+	}
+
+	state, ok := monitor.Get(task.ID)
+	if !ok {
+		t.Fatal("GH-72 missing from monitor after stall-retry")
+	}
+	if state.Status == StatusRunning || state.Status == StatusQueued {
+		t.Errorf("expected prior attempt's monitor entry released (not Running/Queued), got %s", state.Status)
+	}
+
+	ids := monitor.GetRunningTaskIDs()
+	for _, id := range ids {
+		if id == task.ID {
+			t.Fatalf("expected GH-72's prior entry excluded from drain-blocking set, got %v", ids)
+		}
+	}
+}
+
 // TestDispatcher_BeginWithGenerationRetry_StallCapEscalatesWithDistinctReason
 // is the GH-4502 stall-cap acceptance test: unlike the operator-cancel carve
 // out, stall-kills must NOT bypass accounting entirely — until the

--- a/internal/executor/monitor.go
+++ b/internal/executor/monitor.go
@@ -669,6 +669,15 @@ func executionRecentlyProgressed(store *memory.Store, taskID, projectPath string
 	return time.Since(events[len(events)-1].OccurredAt) < deadOwnerHeartbeatWindow
 }
 
+// ErrDrainTimeout is the sentinel wrapped into WaitForTasks' timeout error so
+// callers (e.g. cmd/pilot's self-upgrade loop) can distinguish "still-active
+// tasks blocked the drain" from other TaskChecker failures via errors.Is,
+// without parsing the message. GH-4609: the self-upgrade alert path needs
+// this to gate on consecutive drain-timeout occurrences specifically,
+// leaving other upgrade failures (bad download, unwritable binary dir, ...)
+// alerting immediately as before.
+var ErrDrainTimeout = errors.New("drain timeout")
+
 // WaitForTasks polls until all running/queued tasks complete or context expires.
 // Implements upgrade.TaskChecker interface for graceful drain during hot upgrade.
 func (m *Monitor) WaitForTasks(ctx context.Context, timeout time.Duration) error {
@@ -686,7 +695,7 @@ func (m *Monitor) WaitForTasks(ctx context.Context, timeout time.Duration) error
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-deadline:
-			return fmt.Errorf("drain timeout: %d tasks still active: %v", len(ids), ids)
+			return fmt.Errorf("%w: %d tasks still active: %v", ErrDrainTimeout, len(ids), ids)
 		case <-ticker.C:
 			// continue polling
 		}

--- a/internal/executor/monitor.go
+++ b/internal/executor/monitor.go
@@ -414,6 +414,47 @@ func (m *Monitor) Stall(taskID, reason string) {
 	}
 }
 
+// ReleasePriorAttempt finalizes taskID's active-registry entry as stalled if
+// it is still showing a non-terminal status (Running/Queued/Pending) — the
+// stalled->retry seam GH-4609 subtask 2 requires: the moment a fresh
+// generation is granted for a task whose prior claim stalled
+// (Dispatcher.beginWithGenerationRetry's priorClaimWasStalled branch), the
+// prior attempt's entry must be released/finished right there, rather than
+// leaving it to eventually age past deadOwnerGracePeriod/
+// deadOwnerHeartbeatWindow and get swept up by the next drain-time
+// ReconcileDeadOwners call (subtask 1's backstop, which exists for the
+// general dead-owner case but can take up to deadOwnerHeartbeatWindow to
+// fire). Without this, a retry granted while the prior attempt's own Stall()
+// call hasn't landed yet (or never lands, e.g. an externally killed worker
+// process) leaves the SAME map entry straddling two generations — the
+// dashboard/drain count would keep reading the superseded attempt's stale
+// Running/Queued status until the backstop eventually catches up, instead of
+// the retried task being counted exactly once, under its fresh generation.
+//
+// A no-op when the entry is missing or already terminal (including the
+// common case where the prior attempt's own Stall() already ran) — this only
+// forces the transition when it hasn't happened yet.
+func (m *Monitor) ReleasePriorAttempt(taskID, reason string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	state, ok := m.tasks[taskID]
+	if !ok {
+		return
+	}
+	switch state.Status {
+	case StatusRunning, StatusQueued, StatusPending:
+	default:
+		return
+	}
+
+	now := time.Now()
+	state.Status = StatusStalled
+	state.CompletedAt = &now
+	state.Phase = "Stalled"
+	state.Error = reason
+}
+
 // Cancel marks a task as cancelled
 func (m *Monitor) Cancel(taskID string) {
 	m.mu.Lock()

--- a/internal/executor/monitor.go
+++ b/internal/executor/monitor.go
@@ -47,10 +47,29 @@ type TaskState struct {
 	ProjectName string // Short project name for display (GH-2167)
 }
 
+// LiveWorkerChecker reports which task IDs a live executor worker is
+// currently processing right now — the same "is a live worker actually
+// holding this task" signal *Dispatcher.GetRunningTaskIDs already exposes to
+// the autopilot orphan-running sweep (GH-4412). ReconcileDeadOwners (GH-4609)
+// uses it to tell a genuinely in-flight task apart from a Monitor entry whose
+// owning executor process is gone.
+type LiveWorkerChecker interface {
+	GetRunningTaskIDs() []string
+}
+
 // Monitor tracks task execution progress
 type Monitor struct {
 	tasks map[string]*TaskState
 	mu    sync.RWMutex
+
+	// liveWorkers and execStore back ReconcileDeadOwners (GH-4609): the
+	// live-worker liveness signal and the execution-row heartbeat fallback
+	// used to detect an active-registry entry whose owning executor process
+	// is gone. Both nil by default — ReconcileDeadOwners is then a no-op,
+	// preserving today's behavior for any caller that never wires one (e.g.
+	// tests) — until SetLiveWorkerChecker/SetExecutionStore are called.
+	liveWorkers LiveWorkerChecker
+	execStore   *memory.Store
 }
 
 // NewMonitor creates a new task monitor
@@ -248,6 +267,29 @@ func terminalMonitorStatus(dbStatus string) (TaskStatus, bool) {
 	default:
 		return StatusFailed, true
 	}
+}
+
+// SetLiveWorkerChecker wires the live-worker liveness signal ReconcileDeadOwners
+// (GH-4609) uses to detect a Monitor entry whose owning executor process is
+// gone. In production this is *executor.Dispatcher, wired once the Dispatcher
+// exists (see cmd/pilot/main.go). Optional — nil keeps ReconcileDeadOwners a
+// no-op, matching today's behavior for any caller that never wires one.
+func (m *Monitor) SetLiveWorkerChecker(c LiveWorkerChecker) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.liveWorkers = c
+}
+
+// SetExecutionStore wires the store ReconcileDeadOwners (GH-4609) queries for
+// a dead-owner candidate's execution_event heartbeat before finalizing it —
+// the "or its execution row has progressed within N minutes" fallback that
+// protects a task caught in the narrow race between Monitor.Start and the
+// live-worker checker registering it. Optional — nil skips the fallback
+// check (a dead-owner candidate is finalized on the liveness signal alone).
+func (m *Monitor) SetExecutionStore(store *memory.Store) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.execStore = store
 }
 
 // SetProjectInfo sets the project path and name for a task (GH-2167).
@@ -456,7 +498,14 @@ func (m *Monitor) Count() int {
 
 // GetRunningTaskIDs returns IDs of currently running or queued tasks.
 // Implements upgrade.TaskChecker interface for graceful drain during hot upgrade.
+//
+// GH-4609: reconciles dead-owner entries first, so a StatusRunning entry
+// whose owning executor process is gone is finalized as failed and excluded
+// from the result instead of blocking a caller (e.g. self-upgrade drain)
+// forever. See ReconcileDeadOwners.
 func (m *Monitor) GetRunningTaskIDs() []string {
+	m.ReconcileDeadOwners()
+
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -467,6 +516,116 @@ func (m *Monitor) GetRunningTaskIDs() []string {
 		}
 	}
 	return ids
+}
+
+// deadOwnerGracePeriod protects a task Monitor.Start just marked running from
+// being reconciled as a dead owner before its worker has had a chance to
+// register with the wired LiveWorkerChecker — Start() and the Dispatcher's
+// own "processing" flag are not set atomically with each other. GH-4609.
+const deadOwnerGracePeriod = 30 * time.Second
+
+// deadOwnerHeartbeatWindow bounds how recently a dead-owner candidate's
+// execution row must have logged an execution_event to still count as
+// "progressing" despite having no live worker. Mirrors the orphan-running
+// sweep's heartbeat check (autopilot/controller.go's
+// orphanRunningHeartbeatWindow), but deliberately skips that sweep's 120m
+// floor (minOrphanRunningThreshold) — a stuck drain blocks every queued task
+// in the daemon, not just one execution row, so this reconciliation needs to
+// resolve much sooner. GH-4609.
+const deadOwnerHeartbeatWindow = 10 * time.Minute
+
+// ReconcileDeadOwners finalizes any Monitor entry still showing StatusRunning
+// whose owning executor process is gone, so it stops blocking self-upgrade
+// drain forever — the GH-72 stalled-retry incident (GH-4609): the retry
+// produced a PR and left no worker process alive, but the in-memory active
+// registry kept counting the original entry, so drain looped
+// "1 tasks still active" every 5 minutes indefinitely.
+//
+// A "dead owner" is a StatusRunning entry that is (a) absent from the wired
+// LiveWorkerChecker's current set — no live worker holds it right now — and
+// (b) has logged no execution_event heartbeat within deadOwnerHeartbeatWindow.
+// Both conditions must hold before an entry is finalized: (a) alone can
+// misfire in the race between Monitor.Start and the live-worker checker
+// registering the task (deadOwnerGracePeriod also guards this), and (b) alone
+// can't distinguish a dead task from one legitimately mid-tool-call with no
+// heartbeat yet (GH-4412).
+//
+// No-op (fail-open) when no LiveWorkerChecker is wired via
+// SetLiveWorkerChecker — call sites that never wire one (tests, and any
+// Monitor not driven by the polling-mode daemon) keep today's behavior
+// exactly.
+func (m *Monitor) ReconcileDeadOwners() {
+	m.mu.RLock()
+	liveWorkers := m.liveWorkers
+	execStore := m.execStore
+	m.mu.RUnlock()
+
+	if liveWorkers == nil {
+		return
+	}
+
+	live := make(map[string]bool)
+	for _, id := range liveWorkers.GetRunningTaskIDs() {
+		live[id] = true
+	}
+
+	type candidate struct {
+		id          string
+		projectPath string
+	}
+	var candidates []candidate
+	now := time.Now()
+
+	m.mu.RLock()
+	for id, state := range m.tasks {
+		if state.Status != StatusRunning || live[id] {
+			continue
+		}
+		if state.StartedAt != nil && now.Sub(*state.StartedAt) < deadOwnerGracePeriod {
+			continue
+		}
+		candidates = append(candidates, candidate{id: id, projectPath: state.ProjectPath})
+	}
+	m.mu.RUnlock()
+
+	for _, c := range candidates {
+		if execStore != nil && executionRecentlyProgressed(execStore, c.id, c.projectPath) {
+			continue
+		}
+
+		m.mu.Lock()
+		if state, ok := m.tasks[c.id]; ok && state.Status == StatusRunning {
+			completedAt := time.Now()
+			state.Status = StatusFailed
+			state.CompletedAt = &completedAt
+			state.Phase = "Failed"
+			state.Error = "reconciled: dead-owner active-registry entry (no live executor process, execution row not progressing) — GH-4609"
+		}
+		m.mu.Unlock()
+	}
+}
+
+// executionRecentlyProgressed reports whether taskID's most recent execution
+// row has logged an execution_event within deadOwnerHeartbeatWindow — the
+// corroborating "still making progress" signal ReconcileDeadOwners checks
+// before finalizing a candidate with no live worker. Fails open (treats as
+// progressing) on any store error so a store hiccup can never wrongly
+// finalize a possibly-live task; a clean "no execution row at all" is treated
+// as not progressing.
+func executionRecentlyProgressed(store *memory.Store, taskID, projectPath string) bool {
+	exec, err := store.GetLatestExecutionByTaskID(taskID, projectPath)
+	if err != nil {
+		return !errors.Is(err, sql.ErrNoRows)
+	}
+
+	events, err := store.ListExecutionEvents(exec.ID)
+	if err != nil {
+		return true
+	}
+	if len(events) == 0 {
+		return false
+	}
+	return time.Since(events[len(events)-1].OccurredAt) < deadOwnerHeartbeatWindow
 }
 
 // WaitForTasks polls until all running/queued tasks complete or context expires.

--- a/internal/executor/monitor_test.go
+++ b/internal/executor/monitor_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -431,6 +432,12 @@ func TestMonitorWaitForTasksTimeout(t *testing.T) {
 	err := monitor.WaitForTasks(ctx, 100*time.Millisecond)
 	if err == nil {
 		t.Fatal("WaitForTasks should timeout")
+	}
+	// GH-4609: the self-upgrade alert path (cmd/pilot's drainTimeoutAlertGate)
+	// needs to distinguish a drain-timeout from any other TaskChecker
+	// failure via errors.Is, not by parsing the message.
+	if !errors.Is(err, ErrDrainTimeout) {
+		t.Errorf("WaitForTasks timeout error should wrap ErrDrainTimeout, got: %v", err)
 	}
 }
 

--- a/internal/executor/monitor_test.go
+++ b/internal/executor/monitor_test.go
@@ -434,6 +434,171 @@ func TestMonitorWaitForTasksTimeout(t *testing.T) {
 	}
 }
 
+// fakeLiveWorkerChecker is a test double for LiveWorkerChecker (GH-4609).
+type fakeLiveWorkerChecker struct {
+	ids []string
+}
+
+func (f *fakeLiveWorkerChecker) GetRunningTaskIDs() []string {
+	return f.ids
+}
+
+// pastStart backdates taskID's StartedAt beyond deadOwnerGracePeriod so
+// ReconcileDeadOwners tests aren't gated by the just-started grace window.
+// White-box (package executor): reaches into Monitor's internal map directly.
+func pastStart(t *testing.T, m *Monitor, taskID string) {
+	t.Helper()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	past := time.Now().Add(-time.Hour)
+	if state, ok := m.tasks[taskID]; ok {
+		state.StartedAt = &past
+	}
+}
+
+// GH-4609 acceptance: a dead-owner active-registry entry (no live executor
+// process, execution row not progressing) does not block self-upgrade drain
+// forever — it is finalized as failed and excluded from the drain-blocking
+// set. Reproduces the GH-72 stalled-retry incident: the in-memory registry
+// kept counting a task whose worker process was long gone.
+func TestMonitorReconcileDeadOwners_ExcludedFromDrain(t *testing.T) {
+	m := NewMonitor()
+	m.Register("GH-72", "Zombie task", "")
+	m.Start("GH-72")
+	m.SetLiveWorkerChecker(&fakeLiveWorkerChecker{}) // no live worker holds anything
+	pastStart(t, m, "GH-72")
+
+	ids := m.GetRunningTaskIDs()
+	if len(ids) != 0 {
+		t.Fatalf("Expected dead-owner entry excluded from drain-blocking set, got %v", ids)
+	}
+
+	state, ok := m.Get("GH-72")
+	if !ok {
+		t.Fatal("GH-72 missing after reconciliation")
+	}
+	if state.Status != StatusFailed {
+		t.Errorf("Status = %s, want %s (dead-owner entry must be finalized as failed)", state.Status, StatusFailed)
+	}
+}
+
+// A task a live worker is currently holding must never be reconciled away,
+// regardless of how long ago it started.
+func TestMonitorReconcileDeadOwners_LiveWorkerNotFinalized(t *testing.T) {
+	m := NewMonitor()
+	m.Register("GH-73", "Live task", "")
+	m.Start("GH-73")
+	m.SetLiveWorkerChecker(&fakeLiveWorkerChecker{ids: []string{"GH-73"}})
+	pastStart(t, m, "GH-73")
+
+	ids := m.GetRunningTaskIDs()
+	if len(ids) != 1 || ids[0] != "GH-73" {
+		t.Fatalf("Expected live-worker task to remain drain-blocking, got %v", ids)
+	}
+	state, _ := m.Get("GH-73")
+	if state.Status != StatusRunning {
+		t.Errorf("Status = %s, want %s (live worker must not be reconciled away)", state.Status, StatusRunning)
+	}
+}
+
+// deadOwnerGracePeriod protects a task Monitor.Start just marked running from
+// being reconciled before its worker has had a chance to register with the
+// live-worker checker.
+func TestMonitorReconcileDeadOwners_GracePeriodProtectsRecentStart(t *testing.T) {
+	m := NewMonitor()
+	m.Register("GH-74", "Freshly started task", "")
+	m.Start("GH-74") // StartedAt = now, well inside deadOwnerGracePeriod
+	m.SetLiveWorkerChecker(&fakeLiveWorkerChecker{})
+
+	ids := m.GetRunningTaskIDs()
+	if len(ids) != 1 || ids[0] != "GH-74" {
+		t.Fatalf("Expected freshly started task protected by grace period, got %v", ids)
+	}
+}
+
+// A recent execution_event heartbeat protects a no-live-worker candidate from
+// finalization — the fallback signal for the narrow race between
+// Monitor.Start and the live-worker checker registering the task.
+func TestMonitorReconcileDeadOwners_RecentHeartbeatProtectsCandidate(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "e1", TaskID: "GH-75", ProjectPath: "/p", Status: "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+	if err := store.RecordExecutionEvent("e1", memory.StageRunning, "heartbeat"); err != nil {
+		t.Fatalf("RecordExecutionEvent: %v", err)
+	}
+
+	m := NewMonitor()
+	m.Register("GH-75", "Task 75", "")
+	m.SetProjectInfo("GH-75", "/p", "proj")
+	m.Start("GH-75")
+	m.SetLiveWorkerChecker(&fakeLiveWorkerChecker{}) // no live worker
+	m.SetExecutionStore(store)
+	pastStart(t, m, "GH-75")
+
+	ids := m.GetRunningTaskIDs()
+	if len(ids) != 1 || ids[0] != "GH-75" {
+		t.Fatalf("Expected recent heartbeat to protect candidate from finalization, got %v", ids)
+	}
+	state, _ := m.Get("GH-75")
+	if state.Status != StatusRunning {
+		t.Errorf("Status = %s, want %s (recent heartbeat must protect from dead-owner finalization)", state.Status, StatusRunning)
+	}
+}
+
+// No heartbeat at all (and no live worker) is exactly the GH-72 zombie
+// shape — the candidate must be finalized as failed.
+func TestMonitorReconcileDeadOwners_NoHeartbeatFinalizes(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "e1", TaskID: "GH-76", ProjectPath: "/p", Status: "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+	// No execution_events recorded -- "not progressing".
+
+	m := NewMonitor()
+	m.Register("GH-76", "Task 76", "")
+	m.SetProjectInfo("GH-76", "/p", "proj")
+	m.Start("GH-76")
+	m.SetLiveWorkerChecker(&fakeLiveWorkerChecker{})
+	m.SetExecutionStore(store)
+	pastStart(t, m, "GH-76")
+
+	ids := m.GetRunningTaskIDs()
+	if len(ids) != 0 {
+		t.Fatalf("Expected dead-owner with no heartbeat excluded from drain, got %v", ids)
+	}
+	state, _ := m.Get("GH-76")
+	if state.Status != StatusFailed {
+		t.Errorf("Status = %s, want %s", state.Status, StatusFailed)
+	}
+}
+
+// End-to-end acceptance: WaitForTasks is the method upgrade.TaskChecker calls
+// to block self-upgrade drain (GracefulUpgrader.PerformUpgrade /
+// HotUpgrader.PerformHotUpgrade). A dead-owner entry must let it resolve
+// promptly instead of timing out — the literal GH-72 incident symptom
+// ("drain timeout: 1 tasks still active: [GH-72]" looping every 5 minutes).
+func TestMonitorWaitForTasks_DeadOwnerDoesNotBlockDrain(t *testing.T) {
+	m := NewMonitor()
+	m.Register("GH-72", "Zombie task", "")
+	m.Start("GH-72")
+	m.SetLiveWorkerChecker(&fakeLiveWorkerChecker{})
+	pastStart(t, m, "GH-72")
+
+	ctx := context.Background()
+	if err := m.WaitForTasks(ctx, 5*time.Second); err != nil {
+		t.Fatalf("WaitForTasks should resolve promptly once the dead-owner entry is reconciled, got: %v", err)
+	}
+}
+
 func TestTaskStatusConstants(t *testing.T) {
 	tests := []struct {
 		status   TaskStatus

--- a/internal/executor/monitor_test.go
+++ b/internal/executor/monitor_test.go
@@ -599,6 +599,76 @@ func TestMonitorWaitForTasks_DeadOwnerDoesNotBlockDrain(t *testing.T) {
 	}
 }
 
+// TestMonitorReleasePriorAttempt_FinalizesNonTerminalEntry is the GH-4609
+// subtask 2 Monitor-level acceptance test: a still-Running (or Queued/
+// Pending) entry must be finalized to Stalled so a granted stall-retry never
+// leaves the prior attempt's active-registry entry looking like it's still
+// in flight.
+func TestMonitorReleasePriorAttempt_FinalizesNonTerminalEntry(t *testing.T) {
+	m := NewMonitor()
+	m.Register("GH-72", "Zombie task", "")
+	m.Start("GH-72")
+
+	m.ReleasePriorAttempt("GH-72", "stall-retry: superseded by generation 1")
+
+	state, ok := m.Get("GH-72")
+	if !ok {
+		t.Fatal("GH-72 missing after ReleasePriorAttempt")
+	}
+	if state.Status != StatusStalled {
+		t.Errorf("Status = %s, want %s", state.Status, StatusStalled)
+	}
+	if state.Error != "stall-retry: superseded by generation 1" {
+		t.Errorf("Error = %q, want the release reason recorded", state.Error)
+	}
+	if state.CompletedAt == nil {
+		t.Error("expected CompletedAt to be set once the entry is finalized")
+	}
+}
+
+// A terminal entry (the common case: runner.go's own Stall() already ran)
+// must be left untouched — ReleasePriorAttempt only forces the transition
+// when it hasn't already happened.
+func TestMonitorReleasePriorAttempt_TerminalEntryUntouched(t *testing.T) {
+	m := NewMonitor()
+	m.Register("GH-73", "Already stalled task", "")
+	m.Start("GH-73")
+	m.Stall("GH-73", "session stalled: no agent event for >10m")
+
+	m.ReleasePriorAttempt("GH-73", "stall-retry: superseded by generation 1")
+
+	state, _ := m.Get("GH-73")
+	if state.Error != "session stalled: no agent event for >10m" {
+		t.Errorf("expected the original Stall() reason preserved, got %q", state.Error)
+	}
+}
+
+// A completed entry must never be reclassified as stalled by a later
+// stall-retry decision for a different, unrelated generation.
+func TestMonitorReleasePriorAttempt_CompletedEntryUntouched(t *testing.T) {
+	m := NewMonitor()
+	m.Register("GH-74", "Completed task", "")
+	m.Start("GH-74")
+	m.Complete("GH-74", "https://github.com/org/repo/pull/1")
+
+	m.ReleasePriorAttempt("GH-74", "stall-retry: superseded by generation 1")
+
+	state, _ := m.Get("GH-74")
+	if state.Status != StatusCompleted {
+		t.Errorf("Status = %s, want %s (completed entry must not be overwritten)", state.Status, StatusCompleted)
+	}
+}
+
+// An unregistered task ID is a no-op — nothing to release.
+func TestMonitorReleasePriorAttempt_UnknownTaskIsNoOp(t *testing.T) {
+	m := NewMonitor()
+	m.ReleasePriorAttempt("GH-does-not-exist", "reason")
+
+	if _, ok := m.Get("GH-does-not-exist"); ok {
+		t.Fatal("expected no entry to be created for an unknown task ID")
+	}
+}
+
 func TestTaskStatusConstants(t *testing.T) {
 	tests := []struct {
 		status   TaskStatus


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4609.

Closes #4609

## Changes

GitHub Issue GH-4609: fix(executor): zombie active-task from stalled-retry blocks self-upgrade drain forever — reconcile registry against live processes + alert on drain timeout

## Context

**Incident (2026-07-29, founder box).** v2.249.0 released 14:20Z; the box could not self-upgrade for ~55 minutes and required an operator restart. Chain:

1. GH-72 (pilot-console) execution stalled 13:31Z, retried 13:38Z; the retry produced PR #75 at 13:58Z but **never finalized** — two execution rows exist for it with no `started_at` (`e7140304…`, `bafae02a…`), and no worker process remained alive (verified: `pgrep` showed only the daemon).
2. The in-memory active-task registry still counted GH-72. Self-upgrade began 14:24:39Z → drain → `self-upgrade failed … drain timeout: 1 tasks still active: [GH-72]` at 14:54:39Z → immediately re-armed → looped every 5 min indefinitely.
3. During each drain the pollers pause, so the daemon sat effectively idle while showing "Waiting for 1 task(s) to complete…".
4. `stale recovery complete, reset N tasks count=0` ran repeatedly during this window without touching the zombie — the sweep does not reconcile the active registry against live worker processes (the GH-4311/#4392 class covered ledger rows, not the in-memory registry).
5. No alert fired for either the drain-timeout failure or the retry loop.

Operator recovery: SIGTERM + tmux relaunch 15:16Z → registry cleared → self-upgrade completed autonomously 15:17:40Z (`upgrade verified complete via hot restart`).

## Implementation

Fix directions (any subset):

- **Drain-time reconciliation**: before counting a task as drain-blocking, verify its executor process is alive (or its execution row has progressed within N minutes); dead-owner actives get finalized as failed and excluded.
- **Finalize on stall-retry**: the stalled→retry path must Finish/release the prior active-registry entry (ExecutionLifecycle owns this seam — TASK-404).
- **Alert**: `self-upgrade failed` with reason drain-timeout should fire an operator alert on the second consecutive failure, not log-and-loop silently.

## Acceptance

- [ ] A dead-owner active-registry entry (no live executor process, execution row not progressing) does not block self-upgrade drain; it is finalized as failed and excluded from the drain count
- [ ] The stalled→retry path releases/finishes the prior active-registry entry so the retried task is counted once
- [ ] Second consecutive drain-timeout self-upgrade failure fires an operator alert (not silent log-and-loop)
- [ ] Tests cover: zombie entry excluded from drain; retry path releases prior entry; alert fires on 2nd consecutive drain timeout

## Refs

- Evidence: `/home/ec2-user/.pilot/logs/daemon.log` 14:24–15:17Z; board showed `GH-72 running` from 13:38Z with procs=1.
- #4619 — ledger-side companion (takeover executions never finalized); this issue is the in-memory-registry/drain side.
- GH-4311 / #4392 (ledger-row reconciliation class), TASK-404 (ExecutionLifecycle).