### PR TITLE
GH-4619: fix(executor): GH-4536 takeover races epic waiter — superseded force-stalled child row fails the epic; takeover execution rows never finalize

### DIFF
--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -821,6 +821,17 @@ func projectWorkerIdentity(ctx context.Context) (string, bool) {
 	return v, ok
 }
 
+// selfOwnedTakeoverForceStallReason is the exact Error text
+// reclaimSelfOwnedQueuedChild stamps on a queued child's dead-end claim when
+// force-stalling it purely to release the claim generation for a GH-4536
+// takeover (below) — not a genuine execution failure. Exported as a package
+// constant (rather than an inline literal) so epic.go's child-outcome
+// lookups (GH-4619) can recognize this exact administrative marker and
+// exclude it from being treated as a genuine terminal outcome, the same
+// exact-reason-match idiom escalateStalledTask already uses to distinguish
+// "already escalated" from "fresh stall" (GH-4502).
+const selfOwnedTakeoverForceStallReason = "GH-4536 (TASK-419): force-stalled for takeover — this Runner's own ProjectWorker is the only goroutine that could ever run this queued child"
+
 // reclaimSelfOwnedQueuedChild takes over a queued sub-issue execution that
 // only the caller's own ProjectWorker could ever run (GH-4536/TASK-419): the
 // blocked worker IS the sole goroutine serializing subTask.ProjectPath
@@ -856,7 +867,7 @@ func (d *Dispatcher) reclaimSelfOwnedQueuedChild(subTask *Task) (execID string, 
 		return "", false, fmt.Errorf("reclaimSelfOwnedQueuedChild: execution lookup failed: %w", lookupErr)
 	}
 	if existing != nil && !isTerminalExecutionStatus(existing.Status) {
-		reason := "GH-4536 (TASK-419): force-stalled for takeover — this Runner's own ProjectWorker is the only goroutine that could ever run this queued child"
+		reason := selfOwnedTakeoverForceStallReason
 		applied, casErr := d.store.UpdateExecutionStatusIfNotTerminal(existing.ID, string(ExecStatusStalled), reason)
 		if casErr != nil {
 			return "", false, fmt.Errorf("reclaimSelfOwnedQueuedChild: force-stall failed: %w", casErr)

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -2310,11 +2310,25 @@ func (r *Runner) reconcileSelfOwnedTakeover(ctx context.Context, taskID, project
 // Returns (nil, nil) when rows exist for the task but none is terminal yet
 // (still worth polling), and (nil, sql.ErrNoRows) when no other row exists
 // at all (nothing to wait for).
+//
+// GH-4619: rows are filtered through filterOutTakeoverBookkeepingStalls
+// before the scan below, so a GH-4536 takeover's force-stalled dead-end
+// claim (reclaimSelfOwnedQueuedChild, dispatcher.go) is invisible here — it
+// is administrative bookkeeping to release a claim generation, not a
+// genuine outcome, and must never be surfaced as the child's terminal
+// status regardless of whether the takeover's own replacement execution row
+// is visible in this particular query (it is excluded via selfExecID when
+// this call is itself reconciling that replacement's own synchronous
+// result). A row that is NOT the exact takeover marker — including any
+// other "stalled" row — is unaffected, preserving GH-4381 semantics
+// (an older genuine terminal row still wins over a newer non-running
+// duplicate).
 func (r *Runner) findTerminalChildExecution(taskID, projectPath, selfExecID string) (*memory.Execution, error) {
 	rows, err := r.logStore.ListExecutionsByTaskIDExcluding(taskID, projectPath, selfExecID)
 	if err != nil {
 		return nil, err
 	}
+	rows = filterOutTakeoverBookkeepingStalls(rows)
 	if len(rows) == 0 {
 		return nil, sql.ErrNoRows
 	}
@@ -2324,6 +2338,38 @@ func (r *Runner) findTerminalChildExecution(taskID, projectPath, selfExecID stri
 		}
 	}
 	return nil, nil
+}
+
+// isSelfOwnedTakeoverBookkeepingStall reports whether row is a "stalled" row
+// written purely as GH-4536/TASK-419 takeover bookkeeping
+// (reclaimSelfOwnedQueuedChild, dispatcher.go force-stalling a dead-end
+// queued claim to release its generation) rather than a genuine execution
+// outcome. Recognized by matching row.Error against the exact reason text
+// reclaimSelfOwnedQueuedChild stamps — the same exact-reason-match idiom
+// escalateStalledTask already uses (dispatcher.go, GH-4502) to distinguish
+// an administrative marker from a real status transition, since Status
+// alone ("stalled") can't tell the two apart.
+func isSelfOwnedTakeoverBookkeepingStall(row *memory.Execution) bool {
+	return row != nil && row.Status == string(ExecStatusStalled) && row.Error == selfOwnedTakeoverForceStallReason
+}
+
+// filterOutTakeoverBookkeepingStalls drops every row
+// isSelfOwnedTakeoverBookkeepingStall flags, preserving the input's
+// created_at DESC order. GH-4619: findTerminalChildExecution and
+// findChildExecutionState must treat a takeover's force-stalled original
+// claim as if it were never written — not merely "not terminal yet", which
+// would still let it block reconcileChildOutcome from falling back to a
+// synchronous result it already has (sql.ErrNoRows) when the takeover's own
+// replacement row is the caller's excluded selfExecID and no other row
+// exists to consult.
+func filterOutTakeoverBookkeepingStalls(rows []*memory.Execution) []*memory.Execution {
+	filtered := rows[:0]
+	for _, row := range rows {
+		if !isSelfOwnedTakeoverBookkeepingStall(row) {
+			filtered = append(filtered, row)
+		}
+	}
+	return filtered
 }
 
 // findChildExecutionState is findTerminalChildExecution's sibling for the
@@ -2347,11 +2393,21 @@ func (r *Runner) findTerminalChildExecution(taskID, projectPath, selfExecID stri
 // sql.ErrNoRows) when no other row exists at all (nothing to wait for);
 // (nil, false, nil, nil) when rows exist but the newest is still "queued";
 // (nil, true, startedAt, nil) when the newest is "running".
+//
+// GH-4619: rows are filtered through filterOutTakeoverBookkeepingStalls
+// before classification, same as findTerminalChildExecution — a queued
+// child force-stalled purely to release its claim generation for a
+// GH-4536 takeover (reclaimSelfOwnedQueuedChild, dispatcher.go) is an
+// administrative marker, not a genuine child state, and must not be
+// reported as "still queued" (or, if scanned before a still-running
+// takeover row, be allowed to hide that the takeover is in fact
+// actively running).
 func (r *Runner) findChildExecutionState(taskID, projectPath, selfExecID string) (terminal *memory.Execution, running bool, startedAt *time.Time, err error) {
 	rows, err := r.logStore.ListExecutionsByTaskIDExcluding(taskID, projectPath, selfExecID)
 	if err != nil {
 		return nil, false, nil, err
 	}
+	rows = filterOutTakeoverBookkeepingStalls(rows)
 	if len(rows) == 0 {
 		return nil, false, nil, sql.ErrNoRows
 	}
@@ -2360,8 +2416,7 @@ func (r *Runner) findChildExecutionState(taskID, projectPath, selfExecID string)
 			return row, false, nil, nil
 		}
 	}
-	newest := rows[0]
-	if newest.Status == string(ExecStatusRunning) {
+	if newest := rows[0]; newest.Status == string(ExecStatusRunning) {
 		return nil, true, newest.StartedAt, nil
 	}
 	return nil, false, nil, nil
@@ -2850,6 +2905,21 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 				fmt.Sprintf("sub-issue %s claim lost to another dispatch channel", issueRef))
 
 			result, err = r.reconcileChildOutcome(ctx, taskID, subTaskRepoPath, "", nil, nil, true, subTask)
+
+			// GH-4619: a GH-4536 takeover (reconcileChildOutcome ->
+			// reconcileSelfOwnedTakeover) stamps its own replacement
+			// execution's ID onto subTask.ExecutionID via
+			// ExecutionLifecycle.Begin (lifecycle.go) — subTask is the same
+			// pointer threaded all the way down, so this call site observes
+			// it once the reconcile above returns. Without re-deriving
+			// subExecID here, it stays "" (its value on the ErrClaimLost
+			// branch above) and every finalizeSubIssueExecution call below
+			// silently no-ops (epic.go's execID=="" guard), leaving the
+			// takeover's execution row to never reach a terminal status
+			// outside the 2h orphan-eviction sweep.
+			if subTask.ExecutionID != "" {
+				subExecID = subTask.ExecutionID
+			}
 		} else {
 			if err != nil {
 				r.log.Warn("Failed to insert sub-issue execution row",

--- a/internal/executor/gh4619_test.go
+++ b/internal/executor/gh4619_test.go
@@ -1,0 +1,440 @@
+package executor
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// gh4619ForceStallReason is an alias for selfOwnedTakeoverForceStallReason
+// (dispatcher.go) — the exact marker text reclaimSelfOwnedQueuedChild stamps
+// on a force-stalled dead-end child claim. Referencing the production
+// constant directly (rather than duplicating the literal) keeps these tests
+// from silently drifting out of sync with the real exact-reason-match
+// filtering findTerminalChildExecution/findChildExecutionState now rely on
+// (GH-4619).
+const gh4619ForceStallReason = selfOwnedTakeoverForceStallReason
+
+// TestFindTerminalChildExecution_TakeoverBookkeepingRowDoesNotShadowRunningChild
+// is the GH-4619 regression for defect A: a GH-4536 takeover force-stalls the
+// dead-end original child row purely to release its claim generation
+// (reclaimSelfOwnedQueuedChild, dispatcher.go), then begins its replacement
+// execution directly in ExecStatusRunning. A caller with no execution row of
+// its own to exclude (selfExecID="") — e.g. a re-entrant epic attempt whose
+// own Begin() also lost the claim — must see "still running" instead of
+// misreading the older force-stalled row as the child's terminal outcome.
+// This is the exact incident shape: ui#21's epic re-entry read GH-26's
+// force-stalled original row and failed the whole epic while GH-26's
+// takeover execution was still live in the ledger.
+func TestFindTerminalChildExecution_TakeoverBookkeepingRowDoesNotShadowRunningChild(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const taskID = "GH-26"
+	const projectPath = "/repo/pilot-console-ui"
+
+	oldRowCreated := time.Now().Add(-time.Hour)
+	newRowCreated := time.Now()
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-original",
+		TaskID:      taskID,
+		ProjectPath: projectPath,
+		Status:      "stalled",
+		Error:       gh4619ForceStallReason,
+		CreatedAt:   oldRowCreated,
+	}); err != nil {
+		t.Fatalf("SaveExecution (force-stalled original): %v", err)
+	}
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-takeover",
+		TaskID:      taskID,
+		ProjectPath: projectPath,
+		Status:      "running",
+		CreatedAt:   newRowCreated,
+	}); err != nil {
+		t.Fatalf("SaveExecution (takeover replacement): %v", err)
+	}
+
+	runner := newTestRunnerWithExecFunc(nil)
+	runner.logStore = store
+
+	row, err := runner.findTerminalChildExecution(taskID, projectPath, "")
+	if err != nil {
+		t.Fatalf("findTerminalChildExecution returned error, want nil (still waiting): %v", err)
+	}
+	if row != nil {
+		t.Fatalf("findTerminalChildExecution returned row %+v, want nil — the force-stalled original must not shadow the actively-running takeover", row)
+	}
+
+	terminal, running, _, err := runner.findChildExecutionState(taskID, projectPath, "")
+	if err != nil {
+		t.Fatalf("findChildExecutionState returned error, want nil: %v", err)
+	}
+	if terminal != nil {
+		t.Fatalf("findChildExecutionState returned terminal row %+v, want nil — the force-stalled original must not shadow the actively-running takeover", terminal)
+	}
+	if !running {
+		t.Error("findChildExecutionState running = false, want true (the takeover's replacement execution is actively running)")
+	}
+}
+
+// TestFindTerminalChildExecution_GenuineTerminalFailureStillReported ensures
+// the GH-4619 guard doesn't overcorrect: when the newest (and only) row for
+// a child is a genuine terminal failure — not takeover bookkeeping — it must
+// still be reported as terminal so the epic actually fails.
+func TestFindTerminalChildExecution_GenuineTerminalFailureStillReported(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const taskID = "GH-27"
+	const projectPath = "/repo/pilot-console-ui"
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-failed",
+		TaskID:      taskID,
+		ProjectPath: projectPath,
+		Status:      "failed",
+		Error:       "panic: nil pointer dereference",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	runner := newTestRunnerWithExecFunc(nil)
+	runner.logStore = store
+
+	row, err := runner.findTerminalChildExecution(taskID, projectPath, "")
+	if err != nil {
+		t.Fatalf("findTerminalChildExecution: %v", err)
+	}
+	if row == nil {
+		t.Fatal("findTerminalChildExecution returned nil, want the genuine terminal-failed row")
+	}
+	if row.ID != "exec-failed" {
+		t.Errorf("returned row ID = %q, want %q", row.ID, "exec-failed")
+	}
+
+	terminal, running, _, err := runner.findChildExecutionState(taskID, projectPath, "")
+	if err != nil {
+		t.Fatalf("findChildExecutionState: %v", err)
+	}
+	if terminal == nil || terminal.ID != "exec-failed" {
+		t.Errorf("findChildExecutionState terminal = %+v, want the genuine terminal-failed row", terminal)
+	}
+	if running {
+		t.Error("findChildExecutionState running = true, want false for a genuinely terminal-failed child")
+	}
+}
+
+// TestFindTerminalChildExecution_GH4381DuplicateQueuedRowRegression is the
+// non-regression guard for GH-4381: a newer "queued" duplicate row (not a
+// GH-4536 takeover — merely queued, not running) must NOT suppress an older
+// genuine terminal outcome. Only an actively "running" newest row triggers
+// the GH-4619 guard.
+func TestFindTerminalChildExecution_GH4381DuplicateQueuedRowRegression(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const taskID = "GH-92"
+	const projectPath = ""
+
+	oldRowCreated := time.Now().Add(-time.Hour)
+	newRowCreated := time.Now()
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-owner",
+		TaskID:      taskID,
+		ProjectPath: projectPath,
+		Status:      "no_op",
+		CreatedAt:   oldRowCreated,
+	}); err != nil {
+		t.Fatalf("SaveExecution (terminal no_op row): %v", err)
+	}
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-duplicate",
+		TaskID:      taskID,
+		ProjectPath: projectPath,
+		Status:      "queued",
+		CreatedAt:   newRowCreated,
+	}); err != nil {
+		t.Fatalf("SaveExecution (fresh queued duplicate): %v", err)
+	}
+
+	runner := newTestRunnerWithExecFunc(nil)
+	runner.logStore = store
+
+	row, err := runner.findTerminalChildExecution(taskID, projectPath, "")
+	if err != nil {
+		t.Fatalf("findTerminalChildExecution: %v", err)
+	}
+	if row == nil || row.ID != "exec-owner" {
+		t.Fatalf("findTerminalChildExecution = %+v, want the older genuine no_op row (GH-4381 semantics preserved)", row)
+	}
+}
+
+// TestExecuteSubIssues_SelfOwnedTakeover_ChildCompletes_FinalizesTakeoverRow
+// is the GH-4619 regression for defect B: reclaimSelfOwnedQueuedChild stamps
+// its replacement execution's ID onto subTask.ExecutionID (via
+// ExecutionLifecycle.Begin, the same *Task pointer threaded through), but
+// executeSubIssuesTracked's finalizeSubIssueExecution calls used the
+// loop-local subExecID captured before the claim was lost — "" on the
+// ErrClaimLost branch — so the takeover row never finalized and relied on
+// the 2h orphan-eviction sweep. This drives a real takeover through
+// ExecuteSubIssues and asserts the takeover's OWN execution row (not the
+// force-stalled original) reaches "completed" via the normal finalize path.
+func TestExecuteSubIssues_SelfOwnedTakeover_ChildCompletes_FinalizesTakeoverRow(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const taskID = "GH-4619"
+	const projectPath = "/repo/gh4619-takeover-completes"
+
+	// Another dispatch channel already won the claim before the epic loop
+	// reaches this sub-issue (mirrors the real incident: the poller
+	// dispatched the same sub-issue independently).
+	claimed, err := store.ClaimExecution(taskID, projectPath, 0, "exec-orphan")
+	if err != nil {
+		t.Fatalf("ClaimExecution: %v", err)
+	}
+	if !claimed {
+		t.Fatal("test setup: expected the seeded orphan claim to win")
+	}
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-orphan",
+		TaskID:      taskID,
+		ProjectPath: projectPath,
+		Status:      "queued",
+	}); err != nil {
+		t.Fatalf("SaveExecution (orphan queued row): %v", err)
+	}
+
+	issues := makeSubIssues(1, 4619)
+	parent := &Task{ID: "GH-9000", Title: "[epic] GH-4619 takeover finalize regression", ProjectPath: projectPath}
+
+	var newExecID string
+	execFn := func(_ context.Context, task *Task) (*ExecutionResult, error) {
+		return &ExecutionResult{TaskID: task.ID, Success: true, PRUrl: "https://github.com/owner/repo/pull/9619", CommitSHA: "sha-4619"}, nil
+	}
+
+	runner := newTestRunnerWithExecFunc(execFn)
+	runner.logStore = store
+	runner.childOutcomeReconcilePollInterval = 20 * time.Millisecond
+	runner.childOutcomeReconcileTimeout = 2 * time.Second
+	runner.childOutcomeQueuedAbsoluteCeiling = 2 * time.Second
+
+	// Fake takeover: mirrors Dispatcher.reclaimSelfOwnedQueuedChild's real
+	// mechanics (force-stall the dead-end claim, then re-claim at a fresh
+	// generation) closely enough to exercise the same subTask.ExecutionID
+	// stamping this fix depends on.
+	runner.setReclaimSelfOwnedQueuedChildFn(func(subTask *Task) (string, bool, error) {
+		existing, lookupErr := store.GetLatestExecutionByTaskID(subTask.ID, subTask.ProjectPath)
+		if lookupErr == nil && existing != nil {
+			if _, casErr := store.UpdateExecutionStatusIfNotTerminal(existing.ID, "stalled", gh4619ForceStallReason); casErr != nil {
+				return "", false, casErr
+			}
+		}
+		execID, beginErr := NewExecutionLifecycle(store).Begin(subTask, ExecStatusRunning, 1)
+		if beginErr != nil {
+			return "", false, beginErr
+		}
+		newExecID = execID
+		return execID, true, nil
+	})
+
+	ctx := withProjectWorkerIdentity(context.Background(), projectPath)
+
+	if err := runner.ExecuteSubIssues(ctx, parent, issues, parent.ProjectPath, ""); err != nil {
+		t.Fatalf("ExecuteSubIssues returned error, want nil (takeover child completed successfully): %v", err)
+	}
+
+	if newExecID == "" {
+		t.Fatal("test setup: takeover never ran (newExecID never set)")
+	}
+
+	takeoverRow, err := store.GetExecution(newExecID)
+	if err != nil {
+		t.Fatalf("GetExecution(takeover row): %v", err)
+	}
+	if takeoverRow.Status != "completed" {
+		t.Errorf("takeover execution row status = %q, want %q — finalizeSubIssueExecution must reach the takeover's own row, not no-op on an empty execID (GH-4619)", takeoverRow.Status, "completed")
+	}
+	if takeoverRow.PRUrl != "https://github.com/owner/repo/pull/9619" {
+		t.Errorf("takeover execution row PRUrl = %q, want the finalized PR URL", takeoverRow.PRUrl)
+	}
+
+	origRow, err := store.GetExecution("exec-orphan")
+	if err != nil {
+		t.Fatalf("GetExecution(original row): %v", err)
+	}
+	if origRow.Status != "stalled" {
+		t.Errorf("original force-stalled row status = %q, want it to remain %q (bookkeeping, untouched by finalize)", origRow.Status, "stalled")
+	}
+}
+
+// TestExecuteSubIssues_SelfOwnedTakeover_ChildFails_FinalizesTakeoverRowAsFailed
+// is TestExecuteSubIssues_SelfOwnedTakeover_ChildCompletes_FinalizesTakeoverRow's
+// failure-path counterpart: when the takeover's own child execution fails,
+// the takeover row must reach "failed" (not stay stuck "running" for the 2h
+// orphan sweep to reap), and the epic must report the real failure.
+func TestExecuteSubIssues_SelfOwnedTakeover_ChildFails_FinalizesTakeoverRowAsFailed(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const taskID = "GH-4620"
+	const projectPath = "/repo/gh4619-takeover-fails"
+
+	claimed, err := store.ClaimExecution(taskID, projectPath, 0, "exec-orphan")
+	if err != nil {
+		t.Fatalf("ClaimExecution: %v", err)
+	}
+	if !claimed {
+		t.Fatal("test setup: expected the seeded orphan claim to win")
+	}
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-orphan",
+		TaskID:      taskID,
+		ProjectPath: projectPath,
+		Status:      "queued",
+	}); err != nil {
+		t.Fatalf("SaveExecution (orphan queued row): %v", err)
+	}
+
+	issues := makeSubIssues(1, 4620)
+	parent := &Task{ID: "GH-9001", Title: "[epic] GH-4619 takeover failure regression", ProjectPath: projectPath}
+
+	execFn := func(_ context.Context, task *Task) (*ExecutionResult, error) {
+		return &ExecutionResult{TaskID: task.ID, Success: false, Error: "compile error in generated code"}, nil
+	}
+
+	runner := newTestRunnerWithExecFunc(execFn)
+	runner.logStore = store
+	runner.childOutcomeReconcilePollInterval = 20 * time.Millisecond
+	runner.childOutcomeReconcileTimeout = 2 * time.Second
+	runner.childOutcomeQueuedAbsoluteCeiling = 2 * time.Second
+
+	var newExecID string
+	runner.setReclaimSelfOwnedQueuedChildFn(func(subTask *Task) (string, bool, error) {
+		existing, lookupErr := store.GetLatestExecutionByTaskID(subTask.ID, subTask.ProjectPath)
+		if lookupErr == nil && existing != nil {
+			if _, casErr := store.UpdateExecutionStatusIfNotTerminal(existing.ID, "stalled", gh4619ForceStallReason); casErr != nil {
+				return "", false, casErr
+			}
+		}
+		execID, beginErr := NewExecutionLifecycle(store).Begin(subTask, ExecStatusRunning, 1)
+		if beginErr != nil {
+			return "", false, beginErr
+		}
+		newExecID = execID
+		return execID, true, nil
+	})
+
+	ctx := withProjectWorkerIdentity(context.Background(), projectPath)
+
+	err = runner.ExecuteSubIssues(ctx, parent, issues, parent.ProjectPath, "")
+	if err == nil {
+		t.Fatal("expected ExecuteSubIssues to report the takeover child's real failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "compile error in generated code") {
+		t.Errorf("error = %q, want it to surface the takeover child's real failure message", err.Error())
+	}
+
+	if newExecID == "" {
+		t.Fatal("test setup: takeover never ran (newExecID never set)")
+	}
+
+	takeoverRow, gerr := store.GetExecution(newExecID)
+	if gerr != nil {
+		t.Fatalf("GetExecution(takeover row): %v", gerr)
+	}
+	if takeoverRow.Status != "failed" {
+		t.Errorf("takeover execution row status = %q, want %q — finalizeSubIssueExecution must reach the takeover's own row (GH-4619)", takeoverRow.Status, "failed")
+	}
+}
+
+// TestExecuteSubIssues_SelfOwnedTakeover_NeverFinalizes_ReproducesPreFixBug
+// documents (and would fail without the GH-4619 fix) the exact pre-fix
+// symptom: without re-deriving subExecID from subTask.ExecutionID after the
+// claim-lost reconcile, the takeover's execution row is left "running"
+// forever — this asserts the fixed behavior explicitly by checking the row
+// is NOT left running once ExecuteSubIssues returns.
+func TestExecuteSubIssues_SelfOwnedTakeover_NeverFinalizes_ReproducesPreFixBug(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const taskID = "GH-4621"
+	const projectPath = "/repo/gh4619-takeover-not-orphaned"
+
+	claimed, err := store.ClaimExecution(taskID, projectPath, 0, "exec-orphan")
+	if err != nil {
+		t.Fatalf("ClaimExecution: %v", err)
+	}
+	if !claimed {
+		t.Fatal("test setup: expected the seeded orphan claim to win")
+	}
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-orphan",
+		TaskID:      taskID,
+		ProjectPath: projectPath,
+		Status:      "queued",
+	}); err != nil {
+		t.Fatalf("SaveExecution (orphan queued row): %v", err)
+	}
+
+	issues := makeSubIssues(1, 4621)
+	parent := &Task{ID: "GH-9002", Title: "[epic] GH-4619 orphan-sweep dependency regression", ProjectPath: projectPath}
+
+	execFn := func(_ context.Context, task *Task) (*ExecutionResult, error) {
+		return &ExecutionResult{TaskID: task.ID, Success: true, PRUrl: "https://github.com/owner/repo/pull/9621", CommitSHA: "sha-4621"}, nil
+	}
+
+	runner := newTestRunnerWithExecFunc(execFn)
+	runner.logStore = store
+	runner.childOutcomeReconcilePollInterval = 20 * time.Millisecond
+	runner.childOutcomeReconcileTimeout = 2 * time.Second
+	runner.childOutcomeQueuedAbsoluteCeiling = 2 * time.Second
+
+	var newExecID string
+	runner.setReclaimSelfOwnedQueuedChildFn(func(subTask *Task) (string, bool, error) {
+		execID, beginErr := NewExecutionLifecycle(store).Begin(subTask, ExecStatusRunning, 1)
+		if beginErr != nil {
+			return "", false, beginErr
+		}
+		newExecID = execID
+		return execID, true, nil
+	})
+
+	ctx := withProjectWorkerIdentity(context.Background(), projectPath)
+
+	if err := runner.ExecuteSubIssues(ctx, parent, issues, parent.ProjectPath, ""); err != nil {
+		t.Fatalf("ExecuteSubIssues returned error, want nil: %v", err)
+	}
+
+	takeoverRow, err := store.GetExecution(newExecID)
+	if err != nil {
+		t.Fatalf("GetExecution(takeover row): %v", err)
+	}
+	if takeoverRow.Status == "running" {
+		t.Errorf("takeover row left status=%q after ExecuteSubIssues returned — this is the pre-GH-4619-fix bug (only the 2h orphan sweep would ever finalize it)", takeoverRow.Status)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4619.

Closes #4619

## Changes

GitHub Issue GH-4619: fix(executor): GH-4536 takeover races epic waiter — superseded force-stalled child row fails the epic; takeover execution rows never finalize

## Context

**Incident (2026-07-29, pilot-console-ui, box ledger evidence).** Epic ui#21 decomposed into #24/#25/#26 and queued child execution rows. The GitHub poller independently dispatched the same sub-issues; the parent lost the dispatch claims (`sub-issue 25/26 claim lost to another dispatch channel`, 20:06:07Z / 20:12:08Z). The GH-4536 (TASK-419) takeover machinery then force-stalled the parent's queued child rows and started replacement executions. Two defects followed:

**(A)** The epic (on re-entry) read the force-stalled ORIGINAL child row and failed the whole epic: `sub-issue execution failed: sub-issue 26 failed: child execution status=stalled: GH-4536 (TASK-419): force-stalled for takeover…` (20:17:12Z) — while #26's takeover execution was actively running claude. The parent then re-picked and re-implemented #26's scope itself in PR#29 (TASK-401 "epic re-implements child work" class, new vector).

**(B)** Both takeover execution rows never reached a terminal status. GH-25's takeover ran to `pr_created` (PR#28, 20:12:03Z) yet stayed `running` until `orphan eviction after 2h0m0s stuck` (22:12:40Z). GH-26's takeover stalled the same way (22:51:40Z). The 2h alerts-engine backstop is the only thing finalizing takeover rows today.

Ledger rows (box DB): executions `d2007683`/`c3272a30` (force-stalled originals), `45adb9d6`/`0695440b` (never-finalized takeovers), `cba62152` (epic failed on the misread), `4bab8634` (epic gen-2 re-implementation, PR#29).

## Background — root causes (researched, file:line against current main)

**A — child-outcome lookup returns first terminal row regardless of recency.** `findTerminalChildExecution` (internal/executor/epic.go:2313-2327) and `findChildExecutionState` (epic.go:2350-2368) scan ALL rows for a task_id (`ListExecutionsByTaskIDExcluding`, internal/memory/store.go:820-841, newest-first) and return the first TERMINAL status found while scanning. This was built for GH-4381 (newer queued duplicate must not hide an older genuine terminal row) but is wrong when the NEWEST row is actively `running` (a GH-4536 takeover) and an older row is `stalled` only as takeover bookkeeping (`reclaimSelfOwnedQueuedChild`, internal/executor/dispatcher.go:824-894, force-stall at :858-877). `resolveChildTerminalOutcome` (epic.go:2389-2434) then converts the superseded row into a hard epic failure. `terminalExecutionStatuses` (dispatcher.go:45-46) has no notion of "administratively retired for takeover".

**B — takeover's new execution ID is dropped; all finalize calls no-op.** `reconcileSelfOwnedTakeover` (epic.go:2267-2292) gets `newExecID` from `reclaimSelfOwnedQueuedChild` → `beginWithGenerationRetry` (dispatcher.go:1421) → `ExecutionLifecycle.Begin` stamps `subTask.ExecutionID = newExecID` (internal/executor/lifecycle.go:114). But `executeSubIssuesTracked`'s five `finalizeSubIssueExecution` call sites (epic.go:2893, 2923, 2929, 2970, 2974) all use the loop-local `subExecID` captured at epic.go:2836 — which is `""` on the ErrClaimLost branch — and `finalizeSubIssueExecution` silently no-ops on empty execID (epic.go:2476). So no takeover row is ever finalized, succeed or fail.

## Implementation

**A (epic.go, both lookup functions).** Newest-row-first guard: if the newest row for the task_id is non-terminal `running` (or `pending`/`queued` with a live claim generation above the terminal row's), report "still running" instead of scanning older rows for a terminal status. Preserve the GH-4381 behavior when the newest row is NOT actively running. Precedent for "don't trust a superseded stalled row": `sweepStalledEpicChildren` (epic.go:2567-2630, GH-4564) checks `HasExecutionEventStage(exec.ID, StagePRCreated)` before stamping stalled.

**B (epic.go, one seam).** After the claim-lost `reconcileChildOutcome` call at epic.go:2852 returns, re-derive `subExecID` from `subTask.ExecutionID` when non-empty before falling through to the finalize calls. No signature changes — the takeover path already stamps the correct ID into the task.

## Acceptance

The takeover mechanism currently has ZERO test coverage — no test references `reconcileSelfOwnedTakeover`, `reclaimSelfOwnedQueuedChild`, or the "force-stalled for takeover" string.

- [ ] A: waiter sees old row `stalled` (takeover marker) + newest row `running` → epic keeps waiting, does NOT fail; still fails when newest row is genuinely terminal-failed
- [ ] B: ErrClaimLost → takeover → child completes: takeover row reaches `completed` via `finalizeSubIssueExecution` (not orphan sweep); same for child failure → `failed`
- [ ] Regression guard for GH-4381 semantics (older genuine terminal row still wins when no newer running row exists)
- [ ] Post-merge verification signal (operator-observed, not a code AC): epic-lifecycle canary `child-count` assertion — failing since 07-28 while `duplicate-pr` passes — plausibly this class (takeover→misread→parent re-pick changes decomposition); watch it after this ships

## Refs

- #4609 — adjacent but distinct: covers in-memory active-registry zombies blocking drain; this issue covers the ledger rows. GH-25/26 here are the "finalize-on-stall-retry evidence" noted there.
- #4265 (closed) — epic-lifecycle canary tracker; its residual `child-count` failures are now watched via this issue.
- TASK-419 / GH-4536 (takeover machinery), TASK-407 (claims), TASK-401 (epic-overlap class), GH-4381 (all-rows scan origin), GH-4564 (fix-shape precedent).
- Poller dispatching sub-issues of an in-flight epic is BY DESIGN post-TASK-407 (claims arbitrate) — not in scope; the takeover mechanism exists for exactly that race.

## Planned Steps (execute all in sequence)

- Step 1: **fix(executor): stop takeover from racing epic waiter and finalize takeover execution rows** — In internal/executor/epic.go, fix both GH-4619 defects together in a single subtask (both touch the same file/package, so splitting would cause merge conflicts). (A) Newest-row-first guard in child-outcome lookup: update findTerminalChildExecution (epic.go:2313-2327) and findChildExecutionState (epic.go:2350-2368) so that when the newest row for the task_id is actively running (or a pending/queued row with a live claim generation above the terminal row's), the function reports 'still running' instead of returning an older stalled row; preserve GH-4381 semantics by continuing to scan older rows for a genuine terminal outcome when the newest row is not actively running; model this on sweepStalledEpicChildren (epic.go:2567-2630), which already inspects execution-event stages to avoid trusting a superseded stalled row; as a result, resolveChildTerminalOutcome (epic.go:2389-2434) no longer converts a takeover-bookkeeping stall into an epic failure. (B) Re-derive subExecID after claim-lost reconciliation: in executeSubIssuesTracked, after the claim-lost reconcileChildOutcome call at epic.go:2852 returns, re-read subTask.ExecutionID and, when non-empty, use it as subExecID for the downstream finalizeSubIssueExecution call sites (epic.go:2893, 2923, 2929, 2970, 2974); the takeover path already stamps the new execution ID onto the task via ExecutionLifecycle.Begin (lifecycle.go:114), so this seam just picks it up so the takeover execution row reaches a terminal status instead of relying on the 2h orphan sweep; no signature changes. Add table-driven tests (new, since the takeover mechanism currently has zero coverage) in internal/executor covering: 1) waiter sees old row stalled (takeover marker 'force-stalled for takeover') plus newest row running -> epic keeps waiting and does not fail; 2) waiter still fails the epic when the newest row is a genuine terminal-failed row; 3) GH-4381 regression where an older genuine terminal row wins when no newer running row exists; 4) ErrClaimLost -> takeover -> child completes, with the takeover row transitioning to completed via finalizeSubIssueExecution (not the orphan sweep); 5) ErrClaimLost -> takeover -> child fails, with the takeover row transitioning to failed.
