### PR TITLE
GH-4390: feat: metrics truthfulness: pilot_prs_merged_total misses autopilot merges;...

### DIFF
--- a/.agent/tasks/gh-4390.md
+++ b/.agent/tasks/gh-4390.md
@@ -1,0 +1,37 @@
+# GH-4390
+
+**Created:** 2026-07-30
+
+## Problem
+
+GitHub Issue GH-4390: Metrics truthfulness: pilot_prs_merged_total misses autopilot merges; store-hydration re-basing inflates increase()
+
+## Context
+
+Two truthfulness defects in daemon metrics, observed 2026-07-16 wiring the Grom drift-watch dashboard against live Prometheus (:9093 scraping :9091):
+
+1. **`pilot_prs_merged_total` misses autopilot merges.** 21:29:06–21:29:26Z: PRs #4379/#4382/#4385/#4386 merged (first three by autopilot within 20s). `sum(pilot_prs_merged_total)` stayed flat at 1143 from 20:52Z through 21:52Z. Every `increase()` throughput panel reads 0 during active shipping. Daemon was on `v2.240.1-12-gccd2af92` (post-#4134 hydration).
+2. **`increase()` over store-hydrated counters is reset-inflated.** `pilot_circuit_breaker_trips_total` lifetime value 190, yet `sum(increase(...[24h]))` = 456 — a monotonic counter cannot increase by more than its lifetime total. Hydration re-basing (counter re-served lower after restart, then climbing) reads as repeated resets to Prometheus, each adding the full post-reset value. Same monotonicity class as #4134's follow-up notes.
+
+## Implementation
+
+Code-side work (all determinable from the codebase — no production-DB access needed):
+
+1. **Merge-counter coverage**: enumerate every path that marks a PR merged (autopilot controller merge, external-merge adoption/scan, SDK-poller path, manual-merge self-heal) and ensure each increments `pilot_prs_merged_total` exactly once through a single chokepoint. The gap is findable by code inspection: at least one of these paths bypasses the increment today.
+2. **Monotonic hydration clamp**: on store-hydration/restart, serve `max(recount, last_served)` so a counter never goes backwards across restarts.
+
+Operator verification against the production ledger (which path the 4 PRs of 07-16 took) happens post-merge and is NOT part of this issue's executable scope.
+
+## Acceptance
+
+- [ ] Every merge-marking path increments `pilot_prs_merged_total` via one shared chokepoint (table-driven test per path: controller merge, external-merge adoption, poller-detected merge)
+- [ ] Double-increment impossible for the same PR (test: same PR observed merged via two paths → counter +1)
+- [ ] Hydrated counters never serve a value lower than the last-served value across a simulated restart (test)
+- [ ] No change to counter semantics otherwise (lifetime totals still accurate)
+
+## Refs
+
+- #4134 (hydration origin), grot `examples/pilot.yaml` (consumer that pinned its PR window around this class), mem-159 (ground-truth-first RCA rule — satisfied by the evidence above)
+
+## Acceptance Criteria
+

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -996,6 +996,11 @@ Examples:
 				// GH-2855: wire token/cost/execution counters into executor
 				if gwRunner != nil {
 					gwRunner.SetMetricsRecorder(gwAutopilotController.Metrics())
+					// GH-4390: wire self-heal/pre-execute short-circuit merges into
+					// pilot_prs_merged_total via the same controller the scan/
+					// handleMerging paths use, so all merge-marking paths share one
+					// counted-exactly-once chokepoint.
+					gwRunner.SetMergeMetricsRecorder(gwAutopilotController)
 				}
 				// GH-4041: restore Prometheus counter baselines from the store's
 				// lifetime execution history before p.Start() below brings up the
@@ -2065,6 +2070,18 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			gwServer.SetAutopilotProvider(&autopilotProviderAdapter{controller: autopilotController})
 			// GH-2855: wire token/cost/execution counters into executor
 			runner.SetMetricsRecorder(autopilotController.Metrics())
+			// GH-4390: wire self-heal/pre-execute short-circuit merges into
+			// pilot_prs_merged_total. Fans out to every controller (not just
+			// the default) since self-heal can fire for any project's tasks
+			// — each controller's own projectPath scoping
+			// (Controller.RecordExternalMerge) ensures exactly one actually
+			// records, matching the approval-routing shape used for
+			// MultiControllerStateWriter above.
+			var mergeRecorderControllers []*autopilot.Controller
+			for _, c := range autopilotControllers {
+				mergeRecorderControllers = append(mergeRecorderControllers, c)
+			}
+			runner.SetMergeMetricsRecorder(autopilot.NewMultiControllerMergeRecorder(mergeRecorderControllers...))
 			// GH-4041: restore Prometheus counter baselines from the store's
 			// lifetime execution history before the /metrics handler starts
 			// serving scrapes below, so external dashboards don't observe a

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -5029,6 +5029,31 @@ func (c *Controller) recordMergeSuccess(prState *PRState) {
 	}
 }
 
+// RecordExternalMerge implements executor.MergeMetricsRecorder — it lets the
+// executor package (self-heal / pre-execute short-circuit paths that detect
+// a task's branch was already merged on GitHub, outside handleMerging/
+// ScanRecentlyMergedPRsWithWindow) record the merge on this controller
+// without importing autopilot directly (GH-4390). Routes through the same
+// recordMergeSuccess dedup guard as every other merge-marking path, so a PR
+// already recorded via the controller's own scan/handleMerging is never
+// double-counted.
+//
+// No-ops when this controller doesn't own projectPath (multi-repo
+// deployments route through MultiControllerMergeRecorder, which calls this
+// on every controller and relies on this scoping check to land on exactly
+// one). An unscoped controller (projectPath == "", e.g. single-controller
+// test/dev setups without WithProjectPath) always accepts, matching the
+// single-controller-implies-single-owner assumption elsewhere in this file.
+func (c *Controller) RecordExternalMerge(projectPath string, prNumber int) {
+	if c == nil || prNumber <= 0 {
+		return
+	}
+	if c.projectPath != "" && c.projectPath != projectPath {
+		return
+	}
+	c.recordMergeSuccess(&PRState{PRNumber: prNumber})
+}
+
 // GetLastProgressAt returns the timestamp of the last PR state transition.
 // Used by MetricsAlerter for deadlock detection (GH-849).
 func (c *Controller) GetLastProgressAt() time.Time {
@@ -6499,4 +6524,27 @@ func (w *MultiControllerStateWriter) SetApprovalDecision(ctx context.Context, re
 		}
 	}
 	return nil
+}
+
+// MultiControllerMergeRecorder fans an externally-detected merge (see
+// executor.MergeMetricsRecorder) out to every controller in a multi-repo
+// deployment. Each Controller.RecordExternalMerge call no-ops unless its own
+// projectPath matches, so exactly one controller — the one that owns the
+// executor-supplied projectPath — actually records the merge (GH-4390).
+type MultiControllerMergeRecorder struct {
+	controllers []*Controller
+}
+
+// NewMultiControllerMergeRecorder creates a recorder that delegates
+// RecordExternalMerge to every controller, relying on each controller's own
+// projectPath scoping (RecordExternalMerge) to land on exactly one.
+func NewMultiControllerMergeRecorder(controllers ...*Controller) *MultiControllerMergeRecorder {
+	return &MultiControllerMergeRecorder{controllers: controllers}
+}
+
+// RecordExternalMerge implements executor.MergeMetricsRecorder.
+func (m *MultiControllerMergeRecorder) RecordExternalMerge(projectPath string, prNumber int) {
+	for _, c := range m.controllers {
+		c.RecordExternalMerge(projectPath, prNumber)
+	}
 }

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -10024,6 +10024,85 @@ func TestController_RecordMergeSuccess_Idempotency(t *testing.T) {
 	}
 }
 
+// TestController_RecordExternalMerge_DedupesAcrossPaths pins GH-4390's
+// acceptance criterion "double-increment impossible for the same PR": a PR
+// observed merged via the controller's own flow (handleMerging/scan, which
+// calls recordMergeSuccess directly) and then again via the executor's
+// self-heal path (RecordExternalMerge, GH-4390) must only count once —
+// RecordExternalMerge routes through the same recordedMerges dedup guard.
+func TestController_RecordExternalMerge_DedupesAcrossPaths(t *testing.T) {
+	c := NewController(DefaultConfig(), nil, nil, "owner", "repo")
+
+	c.recordMergeSuccess(&PRState{PRNumber: 42})
+	c.RecordExternalMerge("", 42) // same PR, observed via the executor self-heal path
+
+	snap := c.metrics.Snapshot()
+	if snap.PRsMerged != 1 {
+		t.Errorf("PRsMerged = %d after controller merge + external-merge observation of the same PR, want 1", snap.PRsMerged)
+	}
+
+	// The reverse order — external-merge observed first — must also dedupe.
+	c.RecordExternalMerge("", 43)
+	c.recordMergeSuccess(&PRState{PRNumber: 43})
+	snap2 := c.metrics.Snapshot()
+	if snap2.PRsMerged != 2 {
+		t.Errorf("PRsMerged = %d after external-merge + controller merge of the same PR, want 2 (1 from PR 42 + 1 from PR 43)", snap2.PRsMerged)
+	}
+}
+
+// TestController_RecordExternalMerge_ProjectPathScoping verifies
+// RecordExternalMerge only records when the given projectPath matches this
+// controller's own WithProjectPath scope — the guard MultiControllerMergeRecorder
+// relies on to fan a merge out to every controller without double-counting
+// across repos (GH-4390).
+func TestController_RecordExternalMerge_ProjectPathScoping(t *testing.T) {
+	c := NewController(DefaultConfig(), nil, nil, "owner", "repo", WithProjectPath("/project-a"))
+
+	c.RecordExternalMerge("/project-b", 100)
+	if got := c.metrics.Snapshot().PRsMerged; got != 0 {
+		t.Errorf("PRsMerged = %d after RecordExternalMerge with a non-matching projectPath, want 0", got)
+	}
+
+	c.RecordExternalMerge("/project-a", 100)
+	if got := c.metrics.Snapshot().PRsMerged; got != 1 {
+		t.Errorf("PRsMerged = %d after RecordExternalMerge with the matching projectPath, want 1", got)
+	}
+}
+
+// TestController_RecordExternalMerge_UnscopedAcceptsAny verifies a controller
+// with no WithProjectPath (projectPath == "", e.g. single-controller test/dev
+// setups) records regardless of the given projectPath, matching the
+// single-controller-implies-single-owner assumption used elsewhere in this
+// file (GH-4390).
+func TestController_RecordExternalMerge_UnscopedAcceptsAny(t *testing.T) {
+	c := NewController(DefaultConfig(), nil, nil, "owner", "repo")
+
+	c.RecordExternalMerge("/any/project", 200)
+	if got := c.metrics.Snapshot().PRsMerged; got != 1 {
+		t.Errorf("PRsMerged = %d after RecordExternalMerge on an unscoped controller, want 1", got)
+	}
+}
+
+// TestMultiControllerMergeRecorder_RoutesToOwningController is the GH-4390
+// multi-repo counterpart to TestController_RecordExternalMerge_ProjectPathScoping:
+// fanning a merge out to every controller (as SetMergeMetricsRecorder wires
+// in polling mode) must land on exactly the controller that owns the given
+// projectPath, not every controller.
+func TestMultiControllerMergeRecorder_RoutesToOwningController(t *testing.T) {
+	c1 := NewController(DefaultConfig(), nil, nil, "owner", "repo1", WithProjectPath("/project-1"))
+	c2 := NewController(DefaultConfig(), nil, nil, "owner", "repo2", WithProjectPath("/project-2"))
+
+	recorder := NewMultiControllerMergeRecorder(c1, c2)
+	recorder.RecordExternalMerge("/project-2", 55)
+
+	if got := c1.metrics.Snapshot().PRsMerged; got != 0 {
+		t.Errorf("c1 PRsMerged = %d, want 0 (merge belongs to /project-2)", got)
+	}
+	if got := c2.metrics.Snapshot().PRsMerged; got != 1 {
+		t.Errorf("c2 PRsMerged = %d, want 1 (merge belongs to /project-2)", got)
+	}
+}
+
 // TestGetMainBranchSHA_RespectsResolvedEnv asserts that getMainBranchSHA reads
 // the branch name from c.config.ResolvedEnv().Branch instead of the previously
 // hardcoded "main" literal. TASK-291: prevents the regression where develop /

--- a/internal/autopilot/metrics.go
+++ b/internal/autopilot/metrics.go
@@ -414,6 +414,27 @@ func (m *Metrics) HydratePRsFailedLifetime(n int64) {
 	m.PRsFailedLifetime += n
 }
 
+// HydrateCircuitBreakerTrips sets a monotonic floor — max(recount,
+// last_served) — on the circuit-breaker trip counter from the last periodic
+// autopilot_metrics snapshot persisted before this restart (GH-4390).
+// pilot_circuit_breaker_trips_total has no append-only per-event ledger to
+// recount from (RecordCircuitBreakerTrip only ever increments an in-memory
+// value), so "recount" here is always 0 and the floor reduces to
+// last_served: a fresh Metrics starts at 0, and this raises it to the last
+// value Prometheus actually scraped pre-restart, so a restart can only hold
+// the exposed counter steady or grow it — never re-serve Prometheus a value
+// below what it already observed. That's the exact shape of counter-reset
+// misbehavior this closes: increase()/rate() treat any nonzero-but-lower
+// value as a reset and replay the whole new value as fabricated growth
+// (GH-4511 hit this same failure mode for pilot_prs_merged_total).
+func (m *Metrics) HydrateCircuitBreakerTrips(lastServed int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if lastServed > m.CircuitBreakerTrips {
+		m.CircuitBreakerTrips = lastServed
+	}
+}
+
 // --- Gauge updates ---
 
 // UpdateActivePRs recalculates active PR counts by stage from a snapshot.

--- a/internal/autopilot/metrics_hydrator.go
+++ b/internal/autopilot/metrics_hydrator.go
@@ -162,24 +162,43 @@ func HydrateFromStore(ctx context.Context, store *memory.Store, metrics *Metrics
 		metrics.RecordApprovalWaitDuration(d)
 	}
 
+	// GH-4390: pilot_circuit_breaker_trips_total has no append-only per-event
+	// ledger (RecordCircuitBreakerTrip only ever increments an in-memory
+	// value), so unlike the ledger-backed counters above it can't be fully
+	// recounted from scratch. The periodic autopilot_metrics snapshot
+	// (SaveAutopilotMetrics) is the only durable record of it, and its
+	// "latest row" only covers up to the last snapshot write, not all the way
+	// to the actual restart — using it as the sole baseline would silently
+	// under-report the gap between that write and the restart. So this does
+	// NOT set the counter from the snapshot directly; it only floors it
+	// (max(0, last_served) since there's no recount to take the max with),
+	// which can never regress the exposed value below what Prometheus already
+	// scraped pre-restart. See HydrateCircuitBreakerTrips's doc comment for
+	// why a floor is safe here where a full baseline assignment (GH-4511's
+	// pre-fix approach) was not.
+	if latestSnapshot, err := store.LatestAutopilotMetrics(); err != nil {
+		return fmt.Errorf("hydrate metrics from store: latest autopilot metrics snapshot: %w", err)
+	} else if latestSnapshot != nil {
+		metrics.HydrateCircuitBreakerTrips(int64(latestSnapshot.CircuitBreakerTrips))
+	}
+
 	// The remaining counters are intentionally NOT hydrated here — they have no
 	// durable per-event source to hydrate from (unlike execution_events, which
-	// is an append-only ledger keyed off executions.id) and reset to zero on
-	// every restart by design:
+	// is an append-only ledger keyed off executions.id) and no periodic
+	// snapshot column to floor against either (unlike CircuitBreakerTrips
+	// above), so they reset to zero on every restart by design:
 	//   - pilot_prs_conflicting_total (RecordPRConflicting): no execution_events
 	//     stage exists for "conflicting" — handleMergeConflict does not log to
 	//     the ledger, only to the in-memory counter (GH-4069).
-	//   - pilot_circuit_breaker_trips_total, pilot_api_errors_total,
-	//     pilot_label_cleanups_total, pilot_approval_persist_misses_total,
-	//     pilot_poller_skipped_total, pilot_poller_dispatched_total,
-	//     pilot_poller_deferred_scope_overlap_total, pilot_panics_total: pure
-	//     in-memory operational/diagnostic counters with no matching table or
-	//     ledger row anywhere in the store. The periodic autopilot_metrics
-	//     snapshot table (SaveAutopilotMetrics) records point-in-time values of
-	//     these but is not append-only across restarts — its "latest row"
-	//     reflects the session since the previous restart, not lifetime, so
-	//     using it as a hydration baseline would silently drop everything
-	//     between the last snapshot write and the actual restart. Treated as
-	//     reset-on-restart by design; see FEATURE-MATRIX.md.
+	//   - pilot_api_errors_total, pilot_label_cleanups_total,
+	//     pilot_approval_persist_misses_total, pilot_poller_skipped_total,
+	//     pilot_poller_dispatched_total, pilot_poller_deferred_scope_overlap_total,
+	//     pilot_panics_total: pure in-memory operational/diagnostic counters
+	//     with no matching table or ledger row anywhere in the store, not even
+	//     the periodic autopilot_metrics snapshot (which only persists
+	//     circuit_breaker_trips and api_errors_total's point-in-time count,
+	//     not a per-endpoint breakdown matching APIErrors' map shape — see
+	//     AutopilotMetricsRow). Treated as reset-on-restart by design; see
+	//     FEATURE-MATRIX.md.
 	return nil
 }

--- a/internal/autopilot/metrics_hydrator_test.go
+++ b/internal/autopilot/metrics_hydrator_test.go
@@ -566,6 +566,88 @@ func TestHydrateFromStore_CIRunCounters(t *testing.T) {
 	}
 }
 
+// TestHydrateFromStore_CircuitBreakerTripsNeverRegressesAcrossRestart pins
+// GH-4390's acceptance criterion "hydrated counters never serve a value
+// lower than the last-served value across a simulated restart". Session 1
+// records some trips and persists a periodic snapshot (as the live
+// metrics_persister does); a restart must hydrate the fresh Metrics up to at
+// least that snapshot value instead of leaving it at 0, and live recording
+// on top must add rather than replace.
+func TestHydrateFromStore_CircuitBreakerTripsNeverRegressesAcrossRestart(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// --- Session 1 (pre-restart): 5 trips occur, then a periodic snapshot
+	// persists that value (mirrors metrics_persister.go's periodic save).
+	session1 := NewMetrics()
+	if err := HydrateFromStore(context.Background(), store, session1); err != nil {
+		t.Fatalf("HydrateFromStore (session 1): %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		session1.RecordCircuitBreakerTrip()
+	}
+	preRestart := session1.Snapshot()
+	if preRestart.CircuitBreakerTrips != 5 {
+		t.Fatalf("pre-restart CircuitBreakerTrips = %d, want 5", preRestart.CircuitBreakerTrips)
+	}
+	if err := store.SaveAutopilotMetrics(&memory.AutopilotMetricsRow{
+		SnapshotAt:          time.Now(),
+		CircuitBreakerTrips: int(preRestart.CircuitBreakerTrips),
+	}); err != nil {
+		t.Fatalf("SaveAutopilotMetrics: %v", err)
+	}
+
+	// --- Restart: fresh Metrics, re-hydrated from the same store.
+	session2 := NewMetrics()
+	if err := HydrateFromStore(context.Background(), store, session2); err != nil {
+		t.Fatalf("HydrateFromStore (session 2): %v", err)
+	}
+	postRestart := session2.Snapshot()
+
+	// The core GH-4390 assertion: post-restart must be >= the pre-restart
+	// high-water mark, not reset to 0 — a fresh 0 would make increase()/
+	// rate() replay every subsequent live trip as if the counter had never
+	// seen the pre-restart 5, silently losing them from the lifetime view.
+	if postRestart.CircuitBreakerTrips < preRestart.CircuitBreakerTrips {
+		t.Errorf("post-restart CircuitBreakerTrips = %d, want >= pre-restart %d",
+			postRestart.CircuitBreakerTrips, preRestart.CircuitBreakerTrips)
+	}
+	if postRestart.CircuitBreakerTrips != 5 {
+		t.Errorf("post-restart CircuitBreakerTrips = %d, want 5 (floored to last-served snapshot)", postRestart.CircuitBreakerTrips)
+	}
+
+	// Live recording on top of the hydrated floor adds, does not replace.
+	session2.RecordCircuitBreakerTrip()
+	if got := session2.Snapshot().CircuitBreakerTrips; got != 6 {
+		t.Errorf("CircuitBreakerTrips after live record post-restart = %d, want 6 (floor 5 + live 1)", got)
+	}
+}
+
+// TestHydrateFromStore_CircuitBreakerTripsNoSnapshotStartsAtZero verifies a
+// fresh store (no periodic snapshot ever persisted, e.g. first boot) leaves
+// the counter at 0 rather than erroring or panicking — LatestAutopilotMetrics
+// returns (nil, nil) and HydrateCircuitBreakerTrips must handle that.
+func TestHydrateFromStore_CircuitBreakerTripsNoSnapshotStartsAtZero(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	metrics := NewMetrics()
+	if err := HydrateFromStore(context.Background(), store, metrics); err != nil {
+		t.Fatalf("HydrateFromStore: %v", err)
+	}
+	if got := metrics.Snapshot().CircuitBreakerTrips; got != 0 {
+		t.Errorf("CircuitBreakerTrips with no persisted snapshot = %d, want 0", got)
+	}
+}
+
 // TestHydrateFromStore_NilStoreIsNoop verifies hydration is a no-op (not an
 // error) when no store is configured, matching how other optional
 // store-backed features degrade in this codebase.

--- a/internal/autopilot/metrics_test.go
+++ b/internal/autopilot/metrics_test.go
@@ -472,3 +472,39 @@ func TestUpdateActivePRsReset(t *testing.T) {
 		t.Errorf("waiting_ci should be 0 after reset, got %d", snap.ActivePRsByStage[StageWaitingCI])
 	}
 }
+
+// TestHydrateCircuitBreakerTrips_MaxClamp pins GH-4390: hydration is a
+// monotonic floor (max(current, lastServed)), never a blind assignment or
+// add — it can raise the counter but never lower it below whatever value it
+// already holds.
+func TestHydrateCircuitBreakerTrips_MaxClamp(t *testing.T) {
+	m := NewMetrics()
+
+	// A lower/equal lastServed than the current value (0) must not change it.
+	m.HydrateCircuitBreakerTrips(0)
+	if got := m.Snapshot().CircuitBreakerTrips; got != 0 {
+		t.Fatalf("CircuitBreakerTrips after hydrating 0 onto 0 = %d, want 0", got)
+	}
+
+	// A higher lastServed raises the counter to that floor.
+	m.HydrateCircuitBreakerTrips(190)
+	if got := m.Snapshot().CircuitBreakerTrips; got != 190 {
+		t.Fatalf("CircuitBreakerTrips after hydrating 190 = %d, want 190", got)
+	}
+
+	// A subsequent hydration call with a LOWER value than what's already
+	// live (e.g. a stale/short-lag snapshot read after live trips already
+	// pushed the counter higher) must not regress it — this is the exact
+	// "counter re-served lower after restart" shape GH-4390 exists to
+	// prevent.
+	m.HydrateCircuitBreakerTrips(100)
+	if got := m.Snapshot().CircuitBreakerTrips; got != 190 {
+		t.Errorf("CircuitBreakerTrips after hydrating a lower value (100) onto 190 = %d, want 190 (never regress)", got)
+	}
+
+	// Live increments on top of the floor still work normally.
+	m.RecordCircuitBreakerTrip()
+	if got := m.Snapshot().CircuitBreakerTrips; got != 191 {
+		t.Errorf("CircuitBreakerTrips after live record on top of hydrated floor = %d, want 191", got)
+	}
+}

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -309,6 +309,10 @@ func (d *Dispatcher) reconcileOrphanedExecutions() int {
 						slog.String("execution_id", exec.ID), slog.String("task_id", exec.TaskID), slog.String("pr_url", mergedURL))
 					d.recordExecutionEvent(exec.ID, memory.StageCompleted,
 						fmt.Sprintf("boot orphan healed to completed after restart (merged PR: %s, GH-4392)", mergedURL))
+					// GH-4390: this heal is a confirmed GitHub merge that never
+					// passed through the controller's own handleMerging/scan —
+					// without this, pilot_prs_merged_total misses it entirely.
+					d.runner.recordExternalMerge(exec.ProjectPath, mergedURL)
 				}
 				continue
 			}
@@ -537,6 +541,10 @@ func (d *Dispatcher) recoverStaleRunningTasks() int {
 			} else {
 				d.recordExecutionEvent(exec.ID, memory.StageCompleted,
 					fmt.Sprintf("stale_running healed to completed after restart (merged PR: %s)", mergedURL))
+				// GH-4390: confirmed GitHub merge that never passed through the
+				// controller's own handleMerging/scan — record it so
+				// pilot_prs_merged_total doesn't miss it.
+				d.runner.recordExternalMerge(exec.ProjectPath, mergedURL)
 			}
 			continue
 		}
@@ -2558,6 +2566,10 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 					w.log.Error("Failed to mark pre-execute merged-PR short-circuit completed", slog.Any("error", err))
 				}
 				w.recordExecutionEvent(exec.ID, memory.StageCompleted, "pre-execute merged-PR short-circuit: "+mergedURL)
+				// GH-4390: confirmed GitHub merge that never passed through the
+				// controller's own handleMerging/scan — record it so
+				// pilot_prs_merged_total doesn't miss it.
+				w.runner.recordExternalMerge(exec.ProjectPath, mergedURL)
 				w.runner.EmitProgress(exec.TaskID, "Completed", 100, "work already merged: "+mergedURL)
 				w.currentTaskID.Store("")
 				continue

--- a/internal/executor/merge_metrics.go
+++ b/internal/executor/merge_metrics.go
@@ -1,0 +1,20 @@
+package executor
+
+// MergeMetricsRecorder is an interface for recording PR merges that the
+// executor discovers outside the autopilot controller's own merge flow —
+// e.g. self-heal noticing a task's branch was already merged on GitHub
+// (boot orphan heal, stale-running heal) or the pre-execute short-circuit
+// skipping a queued task whose branch merged while it waited. Without this,
+// pilot_prs_merged_total undercounts every merge that ships via one of
+// these paths instead of the controller's handleMerging (GH-4390).
+//
+// Satisfied by autopilot.Controller and autopilot.MultiControllerMergeRecorder.
+// Kept as a mirrored interface here (rather than importing autopilot
+// directly) to avoid an import cycle — autopilot already imports executor.
+type MergeMetricsRecorder interface {
+	// RecordExternalMerge records a merge for the given project path and PR
+	// number, deduping against any merge already recorded for that PR
+	// (e.g. by the controller's own handleMerging or an external-merge scan)
+	// so the same PR is never double-counted across paths.
+	RecordExternalMerge(projectPath string, prNumber int)
+}

--- a/internal/executor/merge_metrics_test.go
+++ b/internal/executor/merge_metrics_test.go
@@ -1,0 +1,202 @@
+package executor
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// fakeMergeMetricsRecorder is a test double for MergeMetricsRecorder that
+// captures every recorded merge so tests can assert exactly what (and how
+// many times) was recorded, without pulling in the autopilot package.
+type fakeMergeMetricsRecorder struct {
+	mu    sync.Mutex
+	calls []fakeMergeCall
+}
+
+type fakeMergeCall struct {
+	ProjectPath string
+	PRNumber    int
+}
+
+func (f *fakeMergeMetricsRecorder) RecordExternalMerge(projectPath string, prNumber int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, fakeMergeCall{ProjectPath: projectPath, PRNumber: prNumber})
+}
+
+func (f *fakeMergeMetricsRecorder) snapshot() []fakeMergeCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]fakeMergeCall, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+// TestRunner_RecordExternalMerge covers Runner.recordExternalMerge's own
+// contract in isolation: forwards a well-formed PR URL as (projectPath,
+// prNumber) to the configured recorder, skips URLs that don't parse to a PR
+// number, and never panics on a nil Runner or an unconfigured recorder
+// (GH-4390).
+func TestRunner_RecordExternalMerge(t *testing.T) {
+	t.Run("forwards parsed PR number to configured recorder", func(t *testing.T) {
+		runner := NewRunner()
+		recorder := &fakeMergeMetricsRecorder{}
+		runner.SetMergeMetricsRecorder(recorder)
+
+		runner.recordExternalMerge("/project-a", "https://github.com/qf-studio/pilot/pull/4390")
+
+		got := recorder.snapshot()
+		if len(got) != 1 {
+			t.Fatalf("expected 1 recorded call, got %d: %+v", len(got), got)
+		}
+		if got[0].ProjectPath != "/project-a" || got[0].PRNumber != 4390 {
+			t.Errorf("expected {/project-a 4390}, got %+v", got[0])
+		}
+	})
+
+	t.Run("unparseable PR URL is skipped, not recorded as PR 0", func(t *testing.T) {
+		runner := NewRunner()
+		recorder := &fakeMergeMetricsRecorder{}
+		runner.SetMergeMetricsRecorder(recorder)
+
+		runner.recordExternalMerge("/project-a", "not-a-valid-pr-url")
+
+		if got := recorder.snapshot(); len(got) != 0 {
+			t.Errorf("expected no recorded calls for an unparseable URL, got %+v", got)
+		}
+	})
+
+	t.Run("no recorder configured does not panic", func(t *testing.T) {
+		runner := NewRunner()
+		runner.recordExternalMerge("/project-a", "https://github.com/qf-studio/pilot/pull/1")
+	})
+
+	t.Run("nil Runner does not panic", func(t *testing.T) {
+		var runner *Runner
+		runner.recordExternalMerge("/project-a", "https://github.com/qf-studio/pilot/pull/1")
+	})
+}
+
+// TestMergeMetricsRecorded_AcrossSelfHealPaths is the GH-4390 table-driven
+// acceptance test: every path that discovers a task's branch was already
+// merged on GitHub outside the autopilot controller's own merge flow must
+// route through Runner.recordExternalMerge exactly once. Covers the three
+// executor-side call sites — boot orphan heal (GH-4392), stale-running heal
+// (GH-4092), and the pre-execute merged-PR short-circuit (GH-4141 Phase 3) —
+// each exercised through its real production code path (not the bare
+// recordExternalMerge unit above), so the wiring at each call site is what's
+// actually under test.
+func TestMergeMetricsRecorded_AcrossSelfHealPaths(t *testing.T) {
+	const mergedPRURL = "https://github.com/qf-studio/pilot/pull/9500"
+	const wantPRNumber = 9500
+
+	tests := []struct {
+		name        string
+		projectPath string
+		run         func(t *testing.T, store *memory.Store, recorder *fakeMergeMetricsRecorder, projectPath string)
+	}{
+		{
+			name:        "boot orphan heal",
+			projectPath: "/project-merge-metrics-orphan",
+			run: func(t *testing.T, store *memory.Store, recorder *fakeMergeMetricsRecorder, projectPath string) {
+				task := &Task{ID: "GH-9500", ProjectPath: projectPath}
+				if _, err := NewExecutionLifecycle(store).Begin(task, ExecStatusRunning); err != nil {
+					t.Fatalf("setup Begin: %v", err)
+				}
+
+				origCheck := staleRunningMergedPRCheck
+				staleRunningMergedPRCheck = func(_ context.Context, gotProjectPath, _ string) (string, error) {
+					if gotProjectPath == projectPath {
+						return mergedPRURL, nil
+					}
+					return "", nil
+				}
+				defer func() { staleRunningMergedPRCheck = origCheck }()
+
+				runner := NewRunner()
+				runner.SetMergeMetricsRecorder(recorder)
+				dispatcher := NewDispatcher(store, runner, nil)
+				dispatcher.reconcileOrphanedExecutions()
+			},
+		},
+		{
+			name:        "stale-running heal",
+			projectPath: "/project-merge-metrics-stale",
+			run: func(t *testing.T, store *memory.Store, recorder *fakeMergeMetricsRecorder, projectPath string) {
+				exec := &memory.Execution{ID: "exec-merge-metrics-stale", TaskID: "GH-9500", ProjectPath: projectPath, Status: "running"}
+				if err := store.SaveExecution(exec); err != nil {
+					t.Fatalf("SaveExecution: %v", err)
+				}
+
+				origCheck := staleRunningMergedPRCheck
+				staleRunningMergedPRCheck = func(_ context.Context, gotProjectPath, _ string) (string, error) {
+					if gotProjectPath == projectPath {
+						return mergedPRURL, nil
+					}
+					return "", nil
+				}
+				defer func() { staleRunningMergedPRCheck = origCheck }()
+
+				runner := NewRunner()
+				runner.SetMergeMetricsRecorder(recorder)
+				dispatcher := NewDispatcher(store, runner, &DispatcherConfig{
+					StaleRunningThreshold: 0,
+					StaleQueuedThreshold:  0,
+					StaleRecoveryInterval: time.Hour,
+				})
+				dispatcher.recoverStaleRunningTasks()
+			},
+		},
+		{
+			name:        "pre-execute merged-PR short-circuit",
+			projectPath: "/project-merge-metrics-preflight",
+			run: func(t *testing.T, store *memory.Store, recorder *fakeMergeMetricsRecorder, projectPath string) {
+				exec := &memory.Execution{
+					ID: "exec-merge-metrics-preflight", TaskID: "GH-9500", ProjectPath: projectPath,
+					Status: "queued", TaskBranch: "pilot/GH-9500", TaskCreatePR: true,
+				}
+				if err := store.SaveExecution(exec); err != nil {
+					t.Fatalf("SaveExecution: %v", err)
+				}
+
+				origCheck := mergedPRPreflightCheck
+				mergedPRPreflightCheck = func(_ context.Context, gotProjectPath, _ string) (string, error) {
+					if gotProjectPath == projectPath {
+						return mergedPRURL, nil
+					}
+					return "", nil
+				}
+				defer func() { mergedPRPreflightCheck = origCheck }()
+
+				backend := &mockFixedBackend{result: &BackendResult{Success: true, Output: "should never run"}}
+				runner := NewRunnerWithBackend(backend)
+				runner.SetMergeMetricsRecorder(recorder)
+				worker := NewProjectWorker(projectPath, store, runner, slog.Default())
+				worker.processQueue(context.Background())
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store, cleanup := setupTestStore(t)
+			defer cleanup()
+
+			recorder := &fakeMergeMetricsRecorder{}
+			tc.run(t, store, recorder, tc.projectPath)
+
+			got := recorder.snapshot()
+			if len(got) != 1 {
+				t.Fatalf("expected exactly 1 recorded merge, got %d: %+v", len(got), got)
+			}
+			if got[0].ProjectPath != tc.projectPath || got[0].PRNumber != wantPRNumber {
+				t.Errorf("expected {%s %d}, got %+v", tc.projectPath, wantPRNumber, got[0])
+			}
+		})
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -701,6 +701,8 @@ type Runner struct {
 	enableRecording        bool                                                            // Whether to record executions
 	alertProcessor         AlertEventProcessor                                             // Optional alert processor for event emission
 	alertProcessorWarnOnce sync.Once                                                       // GH-3734: log the first dropped alert event only, not every one
+	mergeMetrics           MergeMetricsRecorder                                            // Optional recorder for externally-detected PR merges (GH-4390)
+	mergeMetricsWarnOnce   sync.Once                                                       // Log the first dropped merge-metric event only, not every one
 	webhooks               *webhooks.Manager                                               // Optional webhook manager for event delivery
 	qualityCheckerFactory  QualityCheckerFactory                                           // Optional factory for creating quality checkers
 	modelRouter            *ModelRouter                                                    // Model and timeout routing based on complexity
@@ -1102,6 +1104,14 @@ func (r *Runner) CloseWorktreePool() {
 // The processor interface is satisfied by alerts.Engine.
 func (r *Runner) SetAlertProcessor(processor AlertEventProcessor) {
 	r.alertProcessor = processor
+}
+
+// SetMergeMetricsRecorder sets the recorder for externally-detected PR merges
+// (self-heal / pre-execute short-circuit paths — see MergeMetricsRecorder
+// doc comment). The recorder interface is satisfied by autopilot.Controller
+// and autopilot.MultiControllerMergeRecorder (GH-4390).
+func (r *Runner) SetMergeMetricsRecorder(recorder MergeMetricsRecorder) {
+	r.mergeMetrics = recorder
 }
 
 // SetWebhookManager sets the webhook manager for delivering task lifecycle events.
@@ -5968,6 +5978,32 @@ func (r *Runner) emitAlertEvent(event AlertEvent) {
 // once logic that already lives here.
 func (r *Runner) EmitAlertEvent(event AlertEvent) {
 	r.emitAlertEvent(event)
+}
+
+// recordExternalMerge records a merge discovered outside the autopilot
+// controller's own merge flow (self-heal / pre-execute short-circuit paths —
+// see MergeMetricsRecorder). Nil-safe on both the Runner and its recorder so
+// callers (Dispatcher, ProjectWorker) don't need their own guards; a PR URL
+// that doesn't parse to a number is silently skipped rather than recording a
+// bogus PR 0 (GH-4390).
+func (r *Runner) recordExternalMerge(projectPath, prURL string) {
+	if r == nil {
+		return
+	}
+	if r.mergeMetrics == nil {
+		r.mergeMetricsWarnOnce.Do(func() {
+			r.log.Warn("Merge metrics recorder not configured, pilot_prs_merged_total will undercount self-heal/short-circuit merges",
+				slog.String("pr_url", prURL))
+		})
+		return
+	}
+	prNumber := parsePRNumberFromURL(prURL)
+	if prNumber <= 0 {
+		r.log.Warn("Could not parse PR number from merged URL, skipping merge-metric record",
+			slog.String("pr_url", prURL))
+		return
+	}
+	r.mergeMetrics.RecordExternalMerge(projectPath, prNumber)
 }
 
 // dispatchWebhook sends a webhook event if webhook manager is configured


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4390.

Closes #4390

## Changes

GitHub Issue GH-4390: Metrics truthfulness: pilot_prs_merged_total misses autopilot merges; store-hydration re-basing inflates increase()

## Context

Two truthfulness defects in daemon metrics, observed 2026-07-16 wiring the Grom drift-watch dashboard against live Prometheus (:9093 scraping :9091):

1. **`pilot_prs_merged_total` misses autopilot merges.** 21:29:06–21:29:26Z: PRs #4379/#4382/#4385/#4386 merged (first three by autopilot within 20s). `sum(pilot_prs_merged_total)` stayed flat at 1143 from 20:52Z through 21:52Z. Every `increase()` throughput panel reads 0 during active shipping. Daemon was on `v2.240.1-12-gccd2af92` (post-#4134 hydration).
2. **`increase()` over store-hydrated counters is reset-inflated.** `pilot_circuit_breaker_trips_total` lifetime value 190, yet `sum(increase(...[24h]))` = 456 — a monotonic counter cannot increase by more than its lifetime total. Hydration re-basing (counter re-served lower after restart, then climbing) reads as repeated resets to Prometheus, each adding the full post-reset value. Same monotonicity class as #4134's follow-up notes.

## Implementation

Code-side work (all determinable from the codebase — no production-DB access needed):

1. **Merge-counter coverage**: enumerate every path that marks a PR merged (autopilot controller merge, external-merge adoption/scan, SDK-poller path, manual-merge self-heal) and ensure each increments `pilot_prs_merged_total` exactly once through a single chokepoint. The gap is findable by code inspection: at least one of these paths bypasses the increment today.
2. **Monotonic hydration clamp**: on store-hydration/restart, serve `max(recount, last_served)` so a counter never goes backwards across restarts.

Operator verification against the production ledger (which path the 4 PRs of 07-16 took) happens post-merge and is NOT part of this issue's executable scope.

## Acceptance

- [ ] Every merge-marking path increments `pilot_prs_merged_total` via one shared chokepoint (table-driven test per path: controller merge, external-merge adoption, poller-detected merge)
- [ ] Double-increment impossible for the same PR (test: same PR observed merged via two paths → counter +1)
- [ ] Hydrated counters never serve a value lower than the last-served value across a simulated restart (test)
- [ ] No change to counter semantics otherwise (lifetime totals still accurate)

## Refs

- #4134 (hydration origin), grot `examples/pilot.yaml` (consumer that pinned its PR window around this class), mem-159 (ground-truth-first RCA rule — satisfied by the evidence above)