### PR TITLE
GH-4633: feat(poller): post escalation comment on second strike

### DIFF
--- a/cmd/pilot/spec_guard_sdk.go
+++ b/cmd/pilot/spec_guard_sdk.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 	"log/slog"
 	"strings"
 
@@ -46,12 +47,19 @@ func applySpecGuardSDK(ctx context.Context, client *githubSDK.Client, owner, rep
 		slog.Warn("spec-guard(sdk): first strike — issue body too thin, dispatch skipped",
 			slog.Int("issue", issue.Number), slog.Any("reasons", reasons))
 	} else {
-		// Second strike: block the issue.
+		// Second strike: post an escalation comment (marker + fresh
+		// fingerprint + current reasons/body length) before blocking, so the
+		// block/unblock loop is visible on the issue thread — mirrors the
+		// first-strike branch above.
+		comment := buildSpecEscalationComment(reasons, len(issue.Body))
+		if _, err := client.AddComment(ctx, owner, repo, issue.Number, comment); err != nil {
+			logGitHubAPIError("AddComment[blocked,sdk]", owner, repo, issue.Number, err)
+		}
 		if err := client.AddLabels(ctx, owner, repo, issue.Number, []string{githubSDK.LabelBlocked}); err != nil {
 			logGitHubAPIError("AddLabels[blocked,sdk]", owner, repo, issue.Number, err)
 		}
 		slog.Warn("spec-guard(sdk): second strike — escalating to pilot-blocked",
-			slog.Int("issue", issue.Number))
+			slog.Int("issue", issue.Number), slog.Any("reasons", reasons), slog.Int("body_len", len(issue.Body)))
 	}
 
 	return true
@@ -75,4 +83,29 @@ func buildSpecIncompleteComment(reasons []string) string {
 	fmt.Fprintf(&b, "To retry: edit the issue body, then remove the `%s` label.\n", githubSDK.LabelSpecIncomplete)
 	fmt.Fprintf(&b, "If `%s` was also added, remove that too.\n", githubSDK.LabelBlocked)
 	return b.String()
+}
+
+// buildSpecEscalationComment renders the structured second-strike (escalation)
+// comment. It carries the same marker used to detect the first strike, tagged
+// with a fingerprint of the current reasons/body length so repeated
+// block/unblock cycles are distinguishable on the issue thread.
+func buildSpecEscalationComment(reasons []string, bodyLen int) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s fp:%s\n\n", ghissue.SpecCommentMarker, specFingerprint(reasons, bodyLen))
+	fmt.Fprintf(&b, "🚫 Pilot is escalating this issue to `%s`: the spec body is still too thin after an earlier warning.\n\n", githubSDK.LabelBlocked)
+	fmt.Fprintf(&b, "**What still fails (body length: %d chars):**\n", bodyLen)
+	for _, r := range reasons {
+		fmt.Fprintf(&b, "- %s\n", r)
+	}
+	fmt.Fprintf(&b, "\nTo retry: edit the issue body, then remove the `%s` label.\n", githubSDK.LabelBlocked)
+	return b.String()
+}
+
+// specFingerprint hashes the current failure reasons + observed body length
+// so the escalation comment reflects whether the underlying spec problem
+// changed between strikes.
+func specFingerprint(reasons []string, bodyLen int) string {
+	h := fnv.New64a()
+	_, _ = fmt.Fprintf(h, "%d:%s", bodyLen, strings.Join(reasons, "|"))
+	return fmt.Sprintf("%x", h.Sum64())
 }

--- a/cmd/pilot/spec_guard_sdk_test.go
+++ b/cmd/pilot/spec_guard_sdk_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -102,8 +103,19 @@ func TestApplySpecGuardSDK_SecondStrikeEscalates(t *testing.T) {
 	if len(f.labelsAdded) != 1 || f.labelsAdded[0] != githubSDK.LabelBlocked {
 		t.Errorf("labels added = %v, want [%s]", f.labelsAdded, githubSDK.LabelBlocked)
 	}
-	if len(f.commentsAdded) != 0 {
-		t.Errorf("second strike must not post another comment; got %d", len(f.commentsAdded))
+	if len(f.commentsAdded) != 1 {
+		t.Fatalf("second strike must post an escalation comment; got %d", len(f.commentsAdded))
+	}
+	escalation := f.commentsAdded[0]
+	if !strings.Contains(escalation, ghissue.SpecCommentMarker) {
+		t.Error("escalation comment missing marker")
+	}
+	if !strings.Contains(escalation, "body too short") {
+		t.Error("escalation comment missing current FailureReasons")
+	}
+	wantBodyLen := fmt.Sprintf("body length: %d chars", len(issue.Body))
+	if !strings.Contains(escalation, wantBodyLen) {
+		t.Errorf("escalation comment missing observed body length %q; comment = %q", wantBodyLen, escalation)
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4633.

Closes #4633

## Changes

In cmd/pilot/spec_guard_sdk.go, in the second-strike branch (~line 48-55), mirror the first-strike branch by posting an escalation comment carrying the marker (with current fingerprint), the current FailureReasons, and the observed body length, before the AddLabels call, so the block/unblock loop becomes visible on the issue thread.