### PR TITLE
GH-4636: docs(poller): remove stale comment referencing deleted validator

### DIFF
--- a/internal/ghissue/spec.go
+++ b/internal/ghissue/spec.go
@@ -65,10 +65,6 @@ type SpecValidationResult struct {
 // ValidateSpec checks whether the issue body is sufficiently specified for
 // dispatch. parentResolver, if non-nil, is called to fetch a parent issue by
 // number when evaluating decomposer-generated sub-issues.
-//
-// SDK-typed port of internal/adapters/github.ValidateSpec (M7 4d.3); the
-// in-tree copy serves the legacy handler until the adapter package retires.
-// Rule changes must land in BOTH until then.
 func ValidateSpec(issue *github.Issue, parentResolver func(int) (*github.Issue, error)) SpecValidationResult {
 	// Opt-out: pilot-skip-spec-check label bypasses all rules.
 	for _, l := range issue.Labels {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4636.

Closes #4636

## Changes

GitHub Issue GH-4636: docs(poller): remove stale comment referencing deleted validator

<!--autopilot-meta
parent: GH-4624
inherited-spec: true
-->

Parent: GH-4624

In internal/ghissue/spec.go, remove the stale dual-landing comment at ~line 41-43 that references internal/adapters/github/spec_validator.go, which was deleted in #4178. Bundle this trivial 3-line deletion into the same PR to avoid a separate trivial change.

## Acceptance Criteria (folded)
- [ ] Run make test for the spec_guard and ghissue packages and make lint, confirming that the pure-rule ValidateSpec tests remain unchanged and passing.

## Scope fence

Implement ONLY the slice described above. The parent issue GH-4624 is decomposed
into sibling sub-issues that cover the rest of its spec — consult the parent
for context, but do NOT implement parts of it that fall outside this subtask.