### PR TITLE
GH-4643: fix(autopilot): scope-release carrier loops forever on post-merge CI timeout in workflow-less repos — holds train scopes indefinitely

### DIFF
--- a/internal/autopilot/ci_monitor.go
+++ b/internal/autopilot/ci_monitor.go
@@ -526,6 +526,34 @@ func (m *CIMonitor) CheckCI(ctx context.Context, sha string) (CIStatus, error) {
 	return status, nil
 }
 
+// HasAnyCIConfigured reports whether sha carries any CI signal at all —
+// GitHub Actions check-runs or legacy commit statuses — regardless of the
+// required-checks allowlist or discovery Mode. GH-4643: a post-merge scope-
+// release carrier waiting in StagePostMergeCI needs to distinguish "no CI is
+// configured for this repo at all" (the wait can never resolve) from "CI is
+// configured but the specific required check hasn't reported yet" (a normal
+// wait that must still time out as usual). checkAutoDiscoveredRuns already
+// has a grace-period-then-combined-status fallback for auto mode with no
+// Required allowlist, but checkRequiredChecks (a non-empty Required
+// allowlist) has no such fallback — a required check name a workflow-less
+// repo will never post left checkStatus reporting CIPending forever, which is
+// what let scope-release carriers (auth-service #476/#446/#443/#439,
+// studio-sdk #104) retry every ~30m and hold their scope indefinitely.
+func (m *CIMonitor) HasAnyCIConfigured(ctx context.Context, sha string) (bool, error) {
+	checkRuns, err := m.ghClient.ListCheckRuns(ctx, m.owner, m.repo, sha)
+	if err != nil {
+		return false, err
+	}
+	if checkRuns.TotalCount > 0 {
+		return true, nil
+	}
+	combined, err := m.ghClient.GetCombinedStatus(ctx, m.owner, m.repo, sha)
+	if err != nil {
+		return false, err
+	}
+	return combined.TotalCount > 0, nil
+}
+
 // GetCIStatus returns the current overall CI status for a SHA.
 // This is useful for point-in-time status checks without waiting.
 // Its sole production caller (verifyCIBeforeMerge) only runs after the PR

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -478,6 +478,15 @@ type Controller struct {
 	// alertedMissingReleases (GH-3991).
 	alertedStaleScopes map[string]bool
 
+	// scopeDeferLogAt records, per scope key, the last time
+	// tryStartScopeRelease logged one of its "deferring scope release" INFO
+	// lines, guarded by mu. A scope stuck deferring (member PR mid-pipeline,
+	// anchor PR already tracked, fresh persisted releasing row) logs on every
+	// epicParentTicker tick — for a scope parked mid-flight for an extended
+	// period that floods the log with an identical line every ~30s. Throttled
+	// to at most once per scopeDeferLogThrottle per scope (GH-4643).
+	scopeDeferLogAt map[string]time.Time
+
 	// pilotLabel is the trigger label reconcileLaneStarvation searches open
 	// issues for (default github.LabelPilot = "pilot", overridable via
 	// WithPilotLabel to match a non-default adapters.github.pilot_label).
@@ -636,6 +645,7 @@ func NewController(cfg *Config, ghClient *github.Client, approvalMgr *approval.M
 		log:                     slog.Default().With("component", "autopilot"),
 		alertedMissingReleases:  make(map[string]bool),
 		alertedStaleScopes:      make(map[string]bool),
+		scopeDeferLogAt:         make(map[string]time.Time),
 		alertedPersistFailures:  make(map[int]bool),
 		persistFailedPRs:        make(map[int]time.Time),
 		alertedApprovalFailures: make(map[int]bool),
@@ -3431,6 +3441,15 @@ func (c *Controller) Start(ctx context.Context) {
 	c.startScheduleRelease(ctx)
 }
 
+// postMergeCINoWorkflowGrace bounds how long handlePostMergeCI waits before
+// probing (via CIMonitor.HasAnyCIConfigured) whether a carrier's SHA carries
+// any CI signal at all (GH-4643). Long enough for GitHub's check-runs/
+// commit-status APIs to settle for a commit that just landed (mirrors the 60s
+// default CIChecksConfig.DiscoveryGracePeriod auto mode already uses for the
+// same purpose); short enough that a genuinely workflow-less repo's carrier
+// is never meaningfully held up waiting for a check that will never appear.
+const postMergeCINoWorkflowGrace = 90 * time.Second
+
 // handlePostMergeCI monitors deployment/post-merge checks (non-blocking).
 // Each tick calls CheckCI once and either advances the stage or returns to wait
 // for the next tick, mirroring the pattern used by handleWaitingCI.
@@ -3451,33 +3470,58 @@ func (c *Controller) handlePostMergeCI(ctx context.Context, prState *PRState) er
 		prState.PostMergeCIStartedAt = time.Now()
 	}
 
-	// Enforce timeout using same logic as handleWaitingCI.
-	ciTimeout := c.config.CIWaitTimeout
-	envCITimeout := c.config.ResolvedEnvOrDefault().CITimeout
-	if envCITimeout > 0 && (ciTimeout == 0 || envCITimeout < ciTimeout) {
-		ciTimeout = envCITimeout
-	}
-	if time.Since(prState.PostMergeCIStartedAt) > ciTimeout {
-		c.log.Warn("post-merge CI timeout", "pr", prState.PRNumber, "waited", time.Since(prState.PostMergeCIStartedAt))
-		if prState.ScopeKey != "" {
-			// GH-3990: re-queue the scope for a fresh carrier attempt instead of
-			// leaving this one wedged at StageFailed forever — drain it now so the
-			// anchor PR slot frees for the retry.
-			c.handleScopeReleaseFailure(ctx, prState, fmt.Sprintf("post-merge CI timeout after %v", ciTimeout))
-			c.removePR(prState.PRNumber)
-			return nil
+	mainSHA := prState.PostMergeSHA
+
+	// GH-4643: before ever risking the 30m timeout below, probe once (after a
+	// short grace period) whether this SHA has any CI signal at all. A repo
+	// with no push-main workflow — and a required-checks allowlist naming a
+	// check it will never post — otherwise polls CIPending until the timeout
+	// fires, every single carrier attempt, forever. Detecting the absence up
+	// front and treating post-merge CI as satisfied (status = CISuccess, same
+	// as a real green check) sidesteps the timeout entirely.
+	var status CIStatus
+	if !prState.PostMergeCINoWorkflowChecked && time.Since(prState.PostMergeCIStartedAt) >= postMergeCINoWorkflowGrace {
+		prState.PostMergeCINoWorkflowChecked = true
+		hasCI, probeErr := c.ciMonitor.HasAnyCIConfigured(ctx, mainSHA)
+		if probeErr != nil {
+			c.log.Warn("post-merge CI no-workflow probe failed, falling back to normal polling",
+				"pr", prState.PRNumber, "sha", ShortSHA(mainSHA), "error", probeErr)
+		} else if !hasCI {
+			c.log.Info("no post-merge CI configured for repo, treating post-merge CI as satisfied",
+				"pr", prState.PRNumber, "sha", ShortSHA(mainSHA))
+			status = CISuccess
 		}
-		prState.Stage = StageFailed
-		prState.Error = fmt.Sprintf("post-merge CI timeout after %v", ciTimeout)
-		return nil
 	}
 
-	mainSHA := prState.PostMergeSHA
-	status, err := c.ciMonitor.CheckCI(ctx, mainSHA)
-	if err != nil {
-		// Transient API error — log and retry next tick without failing the PR.
-		c.log.Warn("post-merge CI status check failed", "pr", prState.PRNumber, "sha", ShortSHA(mainSHA), "error", err)
-		return nil
+	if status == "" {
+		// Enforce timeout using same logic as handleWaitingCI.
+		ciTimeout := c.config.CIWaitTimeout
+		envCITimeout := c.config.ResolvedEnvOrDefault().CITimeout
+		if envCITimeout > 0 && (ciTimeout == 0 || envCITimeout < ciTimeout) {
+			ciTimeout = envCITimeout
+		}
+		if time.Since(prState.PostMergeCIStartedAt) > ciTimeout {
+			c.log.Warn("post-merge CI timeout", "pr", prState.PRNumber, "waited", time.Since(prState.PostMergeCIStartedAt))
+			if prState.ScopeKey != "" {
+				// GH-3990: re-queue the scope for a fresh carrier attempt instead of
+				// leaving this one wedged at StageFailed forever — drain it now so the
+				// anchor PR slot frees for the retry.
+				c.handleScopeReleaseFailure(ctx, prState, fmt.Sprintf("post-merge CI timeout after %v", ciTimeout))
+				c.removePR(prState.PRNumber)
+				return nil
+			}
+			prState.Stage = StageFailed
+			prState.Error = fmt.Sprintf("post-merge CI timeout after %v", ciTimeout)
+			return nil
+		}
+
+		var err error
+		status, err = c.ciMonitor.CheckCI(ctx, mainSHA)
+		if err != nil {
+			// Transient API error — log and retry next tick without failing the PR.
+			c.log.Warn("post-merge CI status check failed", "pr", prState.PRNumber, "sha", ShortSHA(mainSHA), "error", err)
+			return nil
+		}
 	}
 
 	prState.CIStatus = status

--- a/internal/autopilot/gh4643_test.go
+++ b/internal/autopilot/gh4643_test.go
@@ -1,0 +1,301 @@
+package autopilot
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/alerts"
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestHandlePostMergeCI_NoWorkflowConfigured_ReleasesWithoutTimeout is the
+// GH-4643 regression guard: a scope-release carrier in a repo with a
+// required-checks allowlist but no push-main workflow at all must not poll
+// CIPending for the full 30m timeout on every single carrier attempt. Once
+// the no-workflow grace period elapses, HasAnyCIConfigured finds zero
+// check-runs and zero legacy commit statuses on the merge SHA, so
+// handlePostMergeCI treats post-merge CI as satisfied and proceeds straight
+// to StageReleasing — sidestepping the timeout (and handleScopeReleaseFailure)
+// entirely. Before the fix, this exact fixture would have hit the timeout
+// branch (PostMergeCIStartedAt is set far enough in the past to prove it).
+func TestHandlePostMergeCI_NoWorkflowConfigured_ReleasesWithoutTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/commits/mainsha42/check-runs":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.CheckRunsResponse{TotalCount: 0})
+		case "/repos/owner/repo/commits/mainsha42/status":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.CombinedStatus{TotalCount: 0})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+	cfg.CIPollInterval = 10 * time.Millisecond
+	// Deliberately short: without the GH-4643 fix, this window would already
+	// have elapsed by the time the probe fires below, forcing the timeout
+	// branch. The fix must bypass that branch entirely.
+	cfg.CIWaitTimeout = 5 * time.Second
+	// A required-checks allowlist naming a check this workflow-less repo will
+	// never post — the exact configuration that made checkRequiredChecks
+	// return CIPending forever (auth-service/studio-sdk's RCA).
+	cfg.RequiredChecks = []string{"required-check-that-never-runs"}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:     9,
+		ScopeKey:     "epic:1",
+		IssueNumber:  1,
+		Stage:        StagePostMergeCI,
+		PostMergeSHA: "mainsha42",
+		// Past both the 90s no-workflow grace period and the 5s CIWaitTimeout —
+		// proves the probe path, not luck, is what avoids the timeout branch.
+		PostMergeCIStartedAt: time.Now().Add(-2 * time.Minute),
+	}
+	c.mu.Lock()
+	c.activePRs[9] = prState
+	c.mu.Unlock()
+
+	if err := c.handlePostMergeCI(context.Background(), prState); err != nil {
+		t.Fatalf("handlePostMergeCI() error = %v", err)
+	}
+
+	if prState.Stage != StageReleasing {
+		t.Errorf("Stage = %v, want StageReleasing (post-merge CI should be treated as satisfied)", prState.Stage)
+	}
+	if prState.Error != "" {
+		t.Errorf("Error = %q, want empty (must not time out)", prState.Error)
+	}
+	if !prState.PostMergeCINoWorkflowChecked {
+		t.Error("PostMergeCINoWorkflowChecked = false, want true (probe should have run)")
+	}
+}
+
+// TestHandlePostMergeCI_WithPostMergeChecks_UnaffectedByNoWorkflowProbe is the
+// GH-4643 regression guard in the opposite direction: a repo that DOES post
+// check-runs on the merge SHA must keep using the real CheckCI verdict — the
+// no-workflow probe must never fire (elapsed time is well under the grace
+// period) and must never override a real, still-pending or real check result.
+func TestHandlePostMergeCI_WithPostMergeChecks_UnaffectedByNoWorkflowProbe(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/commits/mainsha42/check-runs":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns:  []github.CheckRun{{Name: "ci", Status: "completed", Conclusion: "success"}},
+			})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+	cfg.CIPollInterval = 10 * time.Millisecond
+	cfg.CIWaitTimeout = 5 * time.Second
+	cfg.RequiredChecks = []string{"ci"}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:     10,
+		ScopeKey:     "epic:2",
+		IssueNumber:  2,
+		Stage:        StagePostMergeCI,
+		PostMergeSHA: "mainsha42",
+		// Fresh — well within the 90s no-workflow grace period, so the probe
+		// must never run; the real check-runs response drives the verdict.
+		PostMergeCIStartedAt: time.Now(),
+	}
+	c.mu.Lock()
+	c.activePRs[10] = prState
+	c.mu.Unlock()
+
+	if err := c.handlePostMergeCI(context.Background(), prState); err != nil {
+		t.Fatalf("handlePostMergeCI() error = %v", err)
+	}
+
+	if prState.Stage != StageReleasing {
+		t.Errorf("Stage = %v, want StageReleasing (real green check should release same as before)", prState.Stage)
+	}
+	if prState.PostMergeCINoWorkflowChecked {
+		t.Error("PostMergeCINoWorkflowChecked = true, want false (probe must not fire before the grace period elapses)")
+	}
+}
+
+// TestHandleScopeReleaseFailure_ParksAfterRepeatedTimeouts is the GH-4643
+// regression guard for the carrier-retry cap: a scope that fails
+// maxScopeReleaseTimeoutAttempts consecutive times with a "post-merge CI
+// timeout" reason must be parked — a terminal state distinct from 'failed'
+// that recoverFailedScopeReleases (which only lists state='failed' rows)
+// never resurrects — with exactly one scope_release_parked alert, and must
+// not be re-queued by further failures against the same (already parked) row.
+func TestHandleScopeReleaseFailure_ParksAfterRepeatedTimeouts(t *testing.T) {
+	stateStore := newTestStateStore(t)
+	if err := stateStore.EnqueueScopeRelease("owner/repo", "epic:1", "epic", []int{9}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_scope_close"}
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, "http://127.0.0.1:0")
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.SetStateStore(stateStore)
+
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	prState := &PRState{PRNumber: 9, ScopeKey: "epic:1", IssueNumber: 1, PostMergeSHA: "sha-red"}
+
+	for i := 0; i < maxScopeReleaseTimeoutAttempts; i++ {
+		c.handleScopeReleaseFailure(context.Background(), prState, "post-merge CI timeout after 30m0s")
+	}
+
+	row, err := stateStore.GetScopeRelease("owner/repo", "epic:1")
+	if err != nil || row == nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+	if row.State != "parked" {
+		t.Errorf("state = %q, want parked after %d consecutive timeouts", row.State, maxScopeReleaseTimeoutAttempts)
+	}
+	if row.TimeoutAttempts != maxScopeReleaseTimeoutAttempts {
+		t.Errorf("timeout_attempts = %d, want %d", row.TimeoutAttempts, maxScopeReleaseTimeoutAttempts)
+	}
+
+	parkedAlerts := countAlerts(sink.events, "scope_release_parked")
+	if parkedAlerts != 1 {
+		t.Errorf("scope_release_parked alerts = %d, want exactly 1", parkedAlerts)
+	}
+
+	// A further zombie-carrier failure against the now-parked scope must not
+	// re-queue it, bump the counter further, or fire a second alert.
+	c.handleScopeReleaseFailure(context.Background(), prState, "post-merge CI timeout after 30m0s")
+
+	row2, err := stateStore.GetScopeRelease("owner/repo", "epic:1")
+	if err != nil || row2 == nil {
+		t.Fatalf("GetScopeRelease (2nd) failed: %v", err)
+	}
+	if row2.State != "parked" {
+		t.Errorf("state = %q, want still parked", row2.State)
+	}
+	if row2.TimeoutAttempts != maxScopeReleaseTimeoutAttempts {
+		t.Errorf("timeout_attempts = %d, want unchanged at %d", row2.TimeoutAttempts, maxScopeReleaseTimeoutAttempts)
+	}
+	if got := countAlerts(sink.events, "scope_release_parked"); got != 1 {
+		t.Errorf("scope_release_parked alerts after repeat failure = %d, want still 1 (no duplicate alert)", got)
+	}
+}
+
+// TestHandleScopeReleaseFailure_NonTimeoutReasonResetsTimeoutStreak verifies
+// that TimeoutAttempts only accumulates across consecutive timeout failures —
+// a genuine CI-red failure in between resets the streak, so a scope alternating
+// between real (fixable) failures and the occasional timeout is never parked
+// (GH-4643).
+func TestHandleScopeReleaseFailure_NonTimeoutReasonResetsTimeoutStreak(t *testing.T) {
+	stateStore := newTestStateStore(t)
+	if err := stateStore.EnqueueScopeRelease("owner/repo", "epic:1", "epic", []int{9}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_scope_close"}
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, "http://127.0.0.1:0")
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.SetStateStore(stateStore)
+	c.SetAlertsEngine(&fakeAlertSink{})
+
+	prState := &PRState{PRNumber: 9, ScopeKey: "epic:1", IssueNumber: 1, PostMergeSHA: "sha-red"}
+
+	c.handleScopeReleaseFailure(context.Background(), prState, "post-merge CI timeout after 30m0s")
+	c.handleScopeReleaseFailure(context.Background(), prState, "post-merge CI timeout after 30m0s")
+	c.handleScopeReleaseFailure(context.Background(), prState, "post-merge CI failed")
+
+	row, err := stateStore.GetScopeRelease("owner/repo", "epic:1")
+	if err != nil || row == nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+	if row.State != "pending" {
+		t.Errorf("state = %q, want pending (must not be parked — streak was reset)", row.State)
+	}
+	if row.TimeoutAttempts != 0 {
+		t.Errorf("timeout_attempts = %d, want 0 (reset by the non-timeout failure)", row.TimeoutAttempts)
+	}
+}
+
+func countAlerts(events []alerts.Event, eventType string) int {
+	n := 0
+	for _, e := range events {
+		if e.Type == alerts.EventType(eventType) {
+			n++
+		}
+	}
+	return n
+}
+
+// TestTryStartScopeRelease_DeferLogThrottled is the GH-4643 regression guard
+// for the "deferring scope release" log throttle: a scope stuck deferring
+// (here: its member PR still tracked in activePRs) logs its INFO line at
+// most once per scopeDeferLogThrottle, not on every call.
+func TestTryStartScopeRelease_DeferLogThrottled(t *testing.T) {
+	stateStore := newTestStateStore(t)
+	if err := stateStore.EnqueueScopeRelease("owner/repo", "epic:1", "epic", []int{9}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, "http://127.0.0.1:0")
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+	c.SetStateStore(stateStore)
+
+	var logBuf bytes.Buffer
+	c.log = slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	// Member PR 9 still mid-pipeline — every call defers for the same reason.
+	c.mu.Lock()
+	c.activePRs[9] = &PRState{PRNumber: 9}
+	c.mu.Unlock()
+
+	row, err := stateStore.GetScopeRelease("owner/repo", "epic:1")
+	if err != nil || row == nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+
+	for i := 0; i < 5; i++ {
+		c.tryStartScopeRelease(row)
+	}
+
+	got := strings.Count(logBuf.String(), "deferring scope release: a member PR is still mid-pipeline")
+	if got != 1 {
+		t.Errorf("deferral log line count = %d, want exactly 1 across 5 calls within the throttle window\n--- logs ---\n%s", got, logBuf.String())
+	}
+
+	// Simulate the throttle window having elapsed: the next call should log again.
+	c.mu.Lock()
+	c.scopeDeferLogAt["epic:1"] = time.Now().Add(-(scopeDeferLogThrottle + time.Minute))
+	c.mu.Unlock()
+
+	c.tryStartScopeRelease(row)
+
+	got = strings.Count(logBuf.String(), "deferring scope release: a member PR is still mid-pipeline")
+	if got != 2 {
+		t.Errorf("deferral log line count after throttle window elapsed = %d, want 2", got)
+	}
+}

--- a/internal/autopilot/scope_reconcile.go
+++ b/internal/autopilot/scope_reconcile.go
@@ -52,7 +52,7 @@ func (c *Controller) reconcileLabelScopes(ctx context.Context) {
 	}
 
 	repo := c.repoKey()
-	terminal, err := c.stateStore.ListScopeReleases(repo, "done", "failed")
+	terminal, err := c.stateStore.ListScopeReleases(repo, "done", "failed", "parked")
 	if err != nil {
 		c.log.Warn("reconcileLabelScopes: failed to list terminal scope rows", slog.Any("error", err))
 		terminal = nil

--- a/internal/autopilot/scope_release.go
+++ b/internal/autopilot/scope_release.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/qf-studio/pilot/internal/alerts"
@@ -28,6 +29,24 @@ var closesIssueRegex = regexp.MustCompile(`(?i)\b(?:close[sd]?|fix(?:e[sd])?|res
 // scope as 'pending' so the next startPendingScopeReleases sweep registers a
 // fresh carrier (GH-3990).
 const maxScopeReleaseAttempts = 5
+
+// maxScopeReleaseTimeoutAttempts caps consecutive "post-merge CI timeout"
+// carrier failures for one scope before it is parked instead of re-queued
+// (GH-4643). This is deliberately separate from maxScopeReleaseAttempts:
+// ScopeRelease.TimeoutAttempts is never reset by recoverFailedScopeReleases's
+// SHA-advance resurrection the way Attempts is, so it's what actually breaks
+// the loop for a structurally-unresolvable timeout (a repo with no post-merge
+// CI configured at all, but a required-checks allowlist naming a check that
+// will never post) — every ordinary merge to main was otherwise handing a
+// fresh 5-attempt budget to a wait that can never succeed.
+const maxScopeReleaseTimeoutAttempts = 3
+
+// postMergeCITimeoutReasonSubstr is the substring handleScopeReleaseFailure
+// matches against reason to classify a failure as a post-merge CI timeout
+// (see controller.go's handlePostMergeCI, the sole producer of this reason
+// string) rather than any other carrier failure (CI red, handleReleasing
+// escalation, etc).
+const postMergeCITimeoutReasonSubstr = "post-merge CI timeout"
 
 // enqueueScopeRelease durably records that scopeKey's members (mergedPRs) are
 // ready to release as one carrier once startPendingScopeReleases claims the
@@ -155,7 +174,9 @@ func (c *Controller) tryStartScopeRelease(row *ScopeRelease) {
 		return
 	}
 	if c.memberPRsStillActive(row.MemberPRs) {
-		c.log.Info("deferring scope release: a member PR is still mid-pipeline", "scope", row.ScopeKey)
+		if c.shouldLogScopeDefer(row.ScopeKey) {
+			c.log.Info("deferring scope release: a member PR is still mid-pipeline", "scope", row.ScopeKey)
+		}
 		return
 	}
 
@@ -166,7 +187,9 @@ func (c *Controller) tryStartScopeRelease(row *ScopeRelease) {
 	_, tracked := c.activePRs[anchorPR]
 	c.mu.RUnlock()
 	if tracked {
-		c.log.Info("deferring scope release: anchor PR already tracked", "scope", row.ScopeKey, "anchor_pr", anchorPR)
+		if c.shouldLogScopeDefer(row.ScopeKey) {
+			c.log.Info("deferring scope release: anchor PR already tracked", "scope", row.ScopeKey, "anchor_pr", anchorPR)
+		}
 		return
 	}
 	if age, found, err := c.stateStore.PersistedReleasingAge(repo, anchorPR); err != nil {
@@ -174,8 +197,10 @@ func (c *Controller) tryStartScopeRelease(row *ScopeRelease) {
 			"scope", row.ScopeKey, "anchor_pr", anchorPR, "error", err)
 		return
 	} else if found && age < releasingStaleThreshold {
-		c.log.Info("deferring scope release: anchor PR has a fresh persisted releasing row",
-			"scope", row.ScopeKey, "anchor_pr", anchorPR)
+		if c.shouldLogScopeDefer(row.ScopeKey) {
+			c.log.Info("deferring scope release: anchor PR has a fresh persisted releasing row",
+				"scope", row.ScopeKey, "anchor_pr", anchorPR)
+		}
 		return
 	}
 
@@ -209,6 +234,33 @@ func (c *Controller) tryStartScopeRelease(row *ScopeRelease) {
 	prState.mu.Unlock()
 
 	c.log.Info("registered scope release carrier", "scope", row.ScopeKey, "anchor_pr", anchorPR, "members", row.MemberPRs)
+}
+
+// scopeDeferLogThrottle bounds how often tryStartScopeRelease's "deferring
+// scope release" INFO lines repeat for the same scope key (GH-4643). Every
+// deferral reason it guards (member PR mid-pipeline, anchor PR tracked, fresh
+// persisted releasing row) can legitimately persist across many consecutive
+// epicParentTicker ticks, so without a throttle a single stuck scope floods
+// the log with an identical line roughly every tick interval.
+const scopeDeferLogThrottle = 30 * time.Minute
+
+// shouldLogScopeDefer reports whether tryStartScopeRelease should emit its
+// next "deferring scope release" INFO line for scopeKey, and records the
+// attempt — at most once per scopeDeferLogThrottle per scope (GH-4643).
+// Mirrors the guarded-map-on-Controller pattern used by
+// alertedMissingReleases/alertedStaleScopes, just for log throttling instead
+// of alert dedup.
+func (c *Controller) shouldLogScopeDefer(scopeKey string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.scopeDeferLogAt == nil {
+		c.scopeDeferLogAt = make(map[string]time.Time)
+	}
+	if last, ok := c.scopeDeferLogAt[scopeKey]; ok && time.Since(last) < scopeDeferLogThrottle {
+		return false
+	}
+	c.scopeDeferLogAt[scopeKey] = time.Now()
+	return true
 }
 
 // scopeKeyHasLiveCarrier reports whether any tracked PRState currently carries
@@ -358,9 +410,15 @@ func (c *Controller) markScopeReleaseDone(prState *PRState, tag string) {
 // release row: increments attempts and re-queues it as 'pending' for a fresh
 // carrier, or — once attempts exceeds maxScopeReleaseAttempts — marks the
 // scope 'failed' and fires a scope_release_failed alert so a human can
-// intervene. No-op when prState is not a scope carrier or no state store is
-// wired. Callers remain responsible for draining the carrier PRState itself
-// (removePR) so the anchor PR slot frees for the next attempt (GH-3990).
+// intervene. Separately (GH-4643), consecutive "post-merge CI timeout"
+// failures are tracked via TimeoutAttempts; once that reaches
+// maxScopeReleaseTimeoutAttempts the scope is parked instead — a distinct
+// terminal state that recoverFailedScopeReleases's SHA-advance resurrection
+// never revisits, breaking the loop for a repo with no post-merge CI
+// configured at all. No-op when prState is not a scope carrier or no state
+// store is wired. Callers remain responsible for draining the carrier
+// PRState itself (removePR) so the anchor PR slot frees for the next attempt
+// (GH-3990).
 func (c *Controller) handleScopeReleaseFailure(ctx context.Context, prState *PRState, reason string) {
 	_ = ctx
 	if prState.ScopeKey == "" || c.stateStore == nil {
@@ -371,13 +429,34 @@ func (c *Controller) handleScopeReleaseFailure(ctx context.Context, prState *PRS
 		c.log.Warn("handleScopeReleaseFailure: failed to re-queue scope release", "scope", prState.ScopeKey, "error", err)
 		return
 	}
+
+	isTimeout := strings.Contains(reason, postMergeCITimeoutReasonSubstr)
+	timeoutAttempts, err := c.stateStore.UpdateScopeReleaseTimeoutAttempts(repo, prState.ScopeKey, isTimeout)
+	if err != nil {
+		c.log.Warn("handleScopeReleaseFailure: failed to update timeout attempts", "scope", prState.ScopeKey, "error", err)
+	}
+
 	row, err := c.stateStore.GetScopeRelease(repo, prState.ScopeKey)
 	if err != nil || row == nil {
 		c.log.Warn("handleScopeReleaseFailure: failed to read back scope release row", "scope", prState.ScopeKey, "error", err)
 		return
 	}
+	if row.State == "parked" {
+		// Already parked by a prior call — MarkScopeReleasePending's terminal
+		// guard above already left the row untouched. Without this check a
+		// zombie carrier still ticking against an already-parked scope would
+		// re-fire scope_release_parked on every failure instead of exactly
+		// once (GH-4643).
+		return
+	}
 	c.log.Warn("scope release carrier failed",
-		"scope", prState.ScopeKey, "pr", prState.PRNumber, "attempts", row.Attempts, "reason", reason)
+		"scope", prState.ScopeKey, "pr", prState.PRNumber, "attempts", row.Attempts,
+		"timeout_attempts", timeoutAttempts, "reason", reason)
+
+	if isTimeout && timeoutAttempts >= maxScopeReleaseTimeoutAttempts {
+		c.parkScopeReleaseAfterTimeouts(repo, prState.ScopeKey, timeoutAttempts, reason)
+		return
+	}
 
 	if row.Attempts <= maxScopeReleaseAttempts {
 		return
@@ -390,17 +469,44 @@ func (c *Controller) handleScopeReleaseFailure(ctx context.Context, prState *PRS
 
 	msg := fmt.Sprintf("scope release %s failed after %d attempts: %s — manual intervention required",
 		prState.ScopeKey, row.Attempts, reason)
-	if c.alertsEngine == nil {
-		c.log.Error("scope_release_failed alert not delivered: SetAlertsEngine was never called", "scope", prState.ScopeKey)
-	} else {
-		c.alertsEngine.ProcessEvent(alerts.Event{
-			Type:      alerts.EventType("scope_release_failed"),
-			Error:     msg,
-			Timestamp: time.Now(),
-			Metadata: map[string]string{
-				"repo":  repo,
-				"scope": prState.ScopeKey,
-			},
-		})
+	c.fireScopeReleaseAlert("scope_release_failed", repo, prState.ScopeKey, msg)
+}
+
+// parkScopeReleaseAfterTimeouts marks a scope-release row terminal-parked
+// after maxScopeReleaseTimeoutAttempts consecutive post-merge CI timeouts and
+// fires a scope_release_parked alert (GH-4643). Split out from
+// handleScopeReleaseFailure so the timeout-specific park path and the
+// generic attempts-cap failure path stay readable as two separate branches.
+func (c *Controller) parkScopeReleaseAfterTimeouts(repo, scopeKey string, timeoutAttempts int, reason string) {
+	if err := c.stateStore.MarkScopeReleaseParked(repo, scopeKey); err != nil {
+		c.log.Warn("handleScopeReleaseFailure: failed to mark scope release parked", "scope", scopeKey, "error", err)
+		return
 	}
+	c.log.Warn("scope release carrier parked after repeated post-merge CI timeouts",
+		"scope", scopeKey, "timeout_attempts", timeoutAttempts)
+
+	msg := fmt.Sprintf(
+		"scope release %s parked after %d consecutive post-merge CI timeouts (%s) — this repo likely has no post-merge CI configured; add a push-to-main workflow, or drop the unreachable required check from this repo's CI config, then re-enqueue the scope manually",
+		scopeKey, timeoutAttempts, reason,
+	)
+	c.fireScopeReleaseAlert("scope_release_parked", repo, scopeKey, msg)
+}
+
+// fireScopeReleaseAlert sends a scope-release lifecycle alert, or logs at
+// Error level if no alerts engine is wired — shared by both the terminal-
+// failed and terminal-parked paths in handleScopeReleaseFailure (GH-4643).
+func (c *Controller) fireScopeReleaseAlert(eventType, repo, scopeKey, msg string) {
+	if c.alertsEngine == nil {
+		c.log.Error(eventType+" alert not delivered: SetAlertsEngine was never called", "scope", scopeKey)
+		return
+	}
+	c.alertsEngine.ProcessEvent(alerts.Event{
+		Type:      alerts.EventType(eventType),
+		Error:     msg,
+		Timestamp: time.Now(),
+		Metadata: map[string]string{
+			"repo":  repo,
+			"scope": scopeKey,
+		},
+	})
 }

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -187,6 +187,14 @@ func (s *StateStore) migrate() error {
 		// eligible for re-adoption, or reset an already-spent re-adoption budget.
 		`ALTER TABLE autopilot_pr_state ADD COLUMN rebase_hold_active INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE autopilot_pr_state ADD COLUMN readopt_count INTEGER NOT NULL DEFAULT 0`,
+		// GH-4643: a distinct, non-resettable-by-SHA-advance counter for
+		// consecutive "post-merge CI timeout" carrier failures. Unlike
+		// attempts (reset to 0 by recoverFailedScopeReleases whenever main
+		// advances), this counter is what lets a structurally-unresolvable
+		// timeout (a workflow-less repo with a required-checks allowlist
+		// naming a check that will never post) get parked instead of
+		// retrying forever.
+		`ALTER TABLE autopilot_scope_release ADD COLUMN timeout_attempts INTEGER NOT NULL DEFAULT 0`,
 	}
 
 	for _, m := range migrations {
@@ -1029,8 +1037,15 @@ type ScopeRelease struct {
 	// LastFailedSHA is the main-HEAD SHA this scope last failed a carrier
 	// against (GH-4331). Empty until the first genuine carrier failure.
 	LastFailedSHA string
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
+	// TimeoutAttempts counts consecutive "post-merge CI timeout" carrier
+	// failures (GH-4643). Unlike Attempts, this is never reset by
+	// recoverFailedScopeReleases's SHA-advance resurrection — it resets only
+	// when a non-timeout failure reason is recorded, so a structurally-
+	// unresolvable timeout accumulates toward the park threshold across
+	// resurrections instead of getting a fresh budget on every main advance.
+	TimeoutAttempts int
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
 }
 
 // encodeIntCSV renders a sorted []int as a comma-separated string for storage
@@ -1155,7 +1170,7 @@ func (s *StateStore) GetSpawnedFixIssue(repo, dedupKey string) (int, error) {
 // if not found.
 func (s *StateStore) GetScopeRelease(repo, scopeKey string) (*ScopeRelease, error) {
 	row := s.db.QueryRow(`
-		SELECT repo, scope_key, scope_title, member_prs, anchor_pr, state, final_sha, tag, attempts, last_failed_sha, created_at, updated_at
+		SELECT repo, scope_key, scope_title, member_prs, anchor_pr, state, final_sha, tag, attempts, last_failed_sha, timeout_attempts, created_at, updated_at
 		FROM autopilot_scope_release WHERE repo = ? AND scope_key = ?
 	`, repo, scopeKey)
 	sr, err := scanScopeRelease(row.Scan)
@@ -1182,7 +1197,7 @@ func (s *StateStore) ListScopeReleases(repo string, states ...string) ([]*ScopeR
 		args = append(args, st)
 	}
 	query := fmt.Sprintf(`
-		SELECT repo, scope_key, scope_title, member_prs, anchor_pr, state, final_sha, tag, attempts, last_failed_sha, created_at, updated_at
+		SELECT repo, scope_key, scope_title, member_prs, anchor_pr, state, final_sha, tag, attempts, last_failed_sha, timeout_attempts, created_at, updated_at
 		FROM autopilot_scope_release WHERE repo = ? AND state IN (%s)
 	`, strings.Join(placeholders, ", "))
 	rows, err := s.db.Query(query, args...)
@@ -1231,12 +1246,15 @@ func (s *StateStore) MarkScopeReleaseDone(repo, scopeKey, tag, finalSHA string) 
 // failed->pending->failed forever every tick, inflating attempts far past
 // maxScopeReleaseAttempts. Recovery for a genuinely stuck 'failed' row is
 // ResetScopeReleaseForRetry, called only once main has moved past
-// LastFailedSHA.
+// LastFailedSHA. GH-4643: 'parked' rows are excluded on the same terms — a
+// parked scope is never resurrected by SHA-advance recovery, only by manual
+// intervention, so an in-flight zombie carrier for it must not bounce it back
+// to pending either.
 func (s *StateStore) MarkScopeReleasePending(repo, scopeKey string, incrementAttempts bool, failedSHA string) error {
-	q := `UPDATE autopilot_scope_release SET state = 'pending', updated_at = CURRENT_TIMESTAMP WHERE repo = ? AND scope_key = ? AND state NOT IN ('failed', 'done')`
+	q := `UPDATE autopilot_scope_release SET state = 'pending', updated_at = CURRENT_TIMESTAMP WHERE repo = ? AND scope_key = ? AND state NOT IN ('failed', 'done', 'parked')`
 	args := []interface{}{repo, scopeKey}
 	if incrementAttempts {
-		q = `UPDATE autopilot_scope_release SET state = 'pending', attempts = attempts + 1, last_failed_sha = CASE WHEN ? = '' THEN last_failed_sha ELSE ? END, updated_at = CURRENT_TIMESTAMP WHERE repo = ? AND scope_key = ? AND state NOT IN ('failed', 'done')`
+		q = `UPDATE autopilot_scope_release SET state = 'pending', attempts = attempts + 1, last_failed_sha = CASE WHEN ? = '' THEN last_failed_sha ELSE ? END, updated_at = CURRENT_TIMESTAMP WHERE repo = ? AND scope_key = ? AND state NOT IN ('failed', 'done', 'parked')`
 		args = []interface{}{failedSHA, failedSHA, repo, scopeKey}
 	}
 	_, err := s.db.Exec(q, args...)
@@ -1251,6 +1269,52 @@ func (s *StateStore) MarkScopeReleaseFailed(repo, scopeKey string) error {
 		WHERE repo = ? AND scope_key = ?
 	`, repo, scopeKey)
 	return err
+}
+
+// MarkScopeReleaseParked marks a scope-release row terminal-parked (GH-4643):
+// distinct from 'failed' specifically so recoverFailedScopeReleases — which
+// only ever lists state='failed' rows — never resurrects it. Reached after
+// maxScopeReleaseTimeoutAttempts consecutive "post-merge CI timeout"
+// failures, the signature of a repo with no post-merge CI configured at all
+// (a required-checks allowlist naming a check that will never post), where
+// resurrecting on every main-branch advance just re-times-out forever.
+func (s *StateStore) MarkScopeReleaseParked(repo, scopeKey string) error {
+	_, err := s.db.Exec(`
+		UPDATE autopilot_scope_release SET state = 'parked', updated_at = CURRENT_TIMESTAMP
+		WHERE repo = ? AND scope_key = ?
+	`, repo, scopeKey)
+	return err
+}
+
+// UpdateScopeReleaseTimeoutAttempts bumps (isTimeout=true) or resets to zero
+// (isTimeout=false) a scope-release row's timeout_attempts counter and
+// returns the resulting value (GH-4643). Guarded by the same terminal-state
+// exclusion as MarkScopeReleasePending so a row already resolved terminal
+// between the caller's MarkScopeReleasePending call and this one is left
+// untouched. Returns 0, nil if the row doesn't exist or is terminal (no
+// change made) rather than erroring — callers treat that as "nothing to cap
+// against yet".
+func (s *StateStore) UpdateScopeReleaseTimeoutAttempts(repo, scopeKey string, isTimeout bool) (int, error) {
+	set := "timeout_attempts = 0"
+	if isTimeout {
+		set = "timeout_attempts = timeout_attempts + 1"
+	}
+	q := fmt.Sprintf(`
+		UPDATE autopilot_scope_release SET %s, updated_at = CURRENT_TIMESTAMP
+		WHERE repo = ? AND scope_key = ? AND state NOT IN ('failed', 'done', 'parked')
+	`, set)
+	if _, err := s.db.Exec(q, repo, scopeKey); err != nil {
+		return 0, err
+	}
+
+	var count int
+	err := s.db.QueryRow(`
+		SELECT timeout_attempts FROM autopilot_scope_release WHERE repo = ? AND scope_key = ?
+	`, repo, scopeKey).Scan(&count)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	return count, err
 }
 
 // ResetScopeReleaseForRetry resurrects a terminal 'failed' scope-release row
@@ -1307,7 +1371,7 @@ func scanScopeRelease(scan func(dest ...interface{}) error) (*ScopeRelease, erro
 	var createdAt, updatedAt sql.NullTime
 	err := scan(
 		&sr.Repo, &sr.ScopeKey, &sr.ScopeTitle, &memberCSV, &sr.AnchorPR,
-		&sr.State, &sr.FinalSHA, &sr.Tag, &sr.Attempts, &sr.LastFailedSHA, &createdAt, &updatedAt,
+		&sr.State, &sr.FinalSHA, &sr.Tag, &sr.Attempts, &sr.LastFailedSHA, &sr.TimeoutAttempts, &createdAt, &updatedAt,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -1109,6 +1109,14 @@ type PRState struct {
 	// between held and waiting_ci forever — it eventually stays parked for a
 	// human. Never reset (lifetime counter for the PR). Persisted.
 	ReadoptCount int
+	// PostMergeCINoWorkflowChecked is true once handlePostMergeCI has probed
+	// (via CIMonitor.HasAnyCIConfigured) whether this carrier's SHA has any
+	// CI signal at all (GH-4643). Set exactly once — regardless of the
+	// probe's outcome — so a workflow-less repo isn't re-probed on every
+	// ~30s tick for the entire post-merge CI wait. In-memory only: a restart
+	// simply re-probes once more after another postMergeCINoWorkflowGrace
+	// wait, which is harmless.
+	PostMergeCINoWorkflowChecked bool
 }
 
 // snapshot returns a detached, field-by-field copy of the PRState with a fresh
@@ -1119,48 +1127,49 @@ type PRState struct {
 // trip go vet copylocks.
 func (ps *PRState) snapshot() *PRState {
 	cp := &PRState{
-		PRNumber:                ps.PRNumber,
-		PRURL:                   ps.PRURL,
-		IssueNumber:             ps.IssueNumber,
-		BranchName:              ps.BranchName,
-		HeadSHA:                 ps.HeadSHA,
-		Stage:                   ps.Stage,
-		CIStatus:                ps.CIStatus,
-		LastChecked:             ps.LastChecked,
-		CIWaitStartedAt:         ps.CIWaitStartedAt,
-		MergeAttempts:           ps.MergeAttempts,
-		RebaseAttempts:          ps.RebaseAttempts,
-		Error:                   ps.Error,
-		CreatedAt:               ps.CreatedAt,
-		ReleaseVersion:          ps.ReleaseVersion,
-		ReleaseBumpType:         ps.ReleaseBumpType,
-		ConsecutiveAPIFailures:  ps.ConsecutiveAPIFailures,
-		NotFoundCount:           ps.NotFoundCount,
-		ClosedReadCount:         ps.ClosedReadCount,
-		PersistFailureCount:     ps.PersistFailureCount,
-		EnvironmentName:         ps.EnvironmentName,
-		PRTitle:                 ps.PRTitle,
-		TargetBranch:            ps.TargetBranch,
-		IssueNodeID:             ps.IssueNodeID,
-		MergeNotificationPosted: ps.MergeNotificationPosted,
-		ApprovalRequestID:       ps.ApprovalRequestID,
-		ApprovalDecision:        ps.ApprovalDecision,
-		ApprovalRequestedAt:     ps.ApprovalRequestedAt,
-		PostMergeSHA:            ps.PostMergeSHA,
-		PostMergeCIStartedAt:    ps.PostMergeCIStartedAt,
-		ReleasingAttempts:       ps.ReleasingAttempts,
-		ReleasingFirstAt:        ps.ReleasingFirstAt,
-		EscalationReason:        ps.EscalationReason,
-		Parked:                  ps.Parked,
-		TerminalLabel:           ps.TerminalLabel,
-		ScopeKey:                ps.ScopeKey,
-		ScopeTitle:              ps.ScopeTitle,
-		ConflictRecorded:        ps.ConflictRecorded,
-		MergeFollowupPosted:     ps.MergeFollowupPosted,
-		InfraRerunCount:         ps.InfraRerunCount,
-		InfraRerunSHA:           ps.InfraRerunSHA,
-		RebaseHoldActive:        ps.RebaseHoldActive,
-		ReadoptCount:            ps.ReadoptCount,
+		PRNumber:                     ps.PRNumber,
+		PRURL:                        ps.PRURL,
+		IssueNumber:                  ps.IssueNumber,
+		BranchName:                   ps.BranchName,
+		HeadSHA:                      ps.HeadSHA,
+		Stage:                        ps.Stage,
+		CIStatus:                     ps.CIStatus,
+		LastChecked:                  ps.LastChecked,
+		CIWaitStartedAt:              ps.CIWaitStartedAt,
+		MergeAttempts:                ps.MergeAttempts,
+		RebaseAttempts:               ps.RebaseAttempts,
+		Error:                        ps.Error,
+		CreatedAt:                    ps.CreatedAt,
+		ReleaseVersion:               ps.ReleaseVersion,
+		ReleaseBumpType:              ps.ReleaseBumpType,
+		ConsecutiveAPIFailures:       ps.ConsecutiveAPIFailures,
+		NotFoundCount:                ps.NotFoundCount,
+		ClosedReadCount:              ps.ClosedReadCount,
+		PersistFailureCount:          ps.PersistFailureCount,
+		EnvironmentName:              ps.EnvironmentName,
+		PRTitle:                      ps.PRTitle,
+		TargetBranch:                 ps.TargetBranch,
+		IssueNodeID:                  ps.IssueNodeID,
+		MergeNotificationPosted:      ps.MergeNotificationPosted,
+		ApprovalRequestID:            ps.ApprovalRequestID,
+		ApprovalDecision:             ps.ApprovalDecision,
+		ApprovalRequestedAt:          ps.ApprovalRequestedAt,
+		PostMergeSHA:                 ps.PostMergeSHA,
+		PostMergeCIStartedAt:         ps.PostMergeCIStartedAt,
+		ReleasingAttempts:            ps.ReleasingAttempts,
+		ReleasingFirstAt:             ps.ReleasingFirstAt,
+		EscalationReason:             ps.EscalationReason,
+		Parked:                       ps.Parked,
+		TerminalLabel:                ps.TerminalLabel,
+		ScopeKey:                     ps.ScopeKey,
+		ScopeTitle:                   ps.ScopeTitle,
+		ConflictRecorded:             ps.ConflictRecorded,
+		MergeFollowupPosted:          ps.MergeFollowupPosted,
+		InfraRerunCount:              ps.InfraRerunCount,
+		InfraRerunSHA:                ps.InfraRerunSHA,
+		RebaseHoldActive:             ps.RebaseHoldActive,
+		ReadoptCount:                 ps.ReadoptCount,
+		PostMergeCINoWorkflowChecked: ps.PostMergeCINoWorkflowChecked,
 	}
 	// DiscoveredChecks and ScopeMemberPRs are slices — copy the backing arrays
 	// so consumers can't mutate the live PR's slice through the snapshot.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4643.

Closes #4643

## Changes

GitHub Issue GH-4643: fix(autopilot): scope-release carrier loops forever on post-merge CI timeout in workflow-less repos — holds train scopes indefinitely

## Context

Scope-release carriers wait on `post_merge_ci` that can never complete in repos with no push-main CI workflow, holding train scopes forever and retry-looping every ~30 min:

```
15:39:04 WARN scope release carrier failed scope=train:2026-07-28T14:00:00Z pr=476 attempts=3 reason="post-merge CI timeout after 30m0s"
15:39:11 WARN scope release carrier failed scope=train:2026-07-30T14:00:00Z pr=104 attempts=4 reason="post-merge CI timeout after 30m0s"
```

Affected carriers observed (2026-07-30): auth-service #476/#446/#443/#439 (trains 07-27/07-28) and studio-sdk #104 — now holding **today's** train scope (07-30), not just historical ones. Side effect: `"deferring scope release: a member PR is still mid-pipeline"` logged every 30s per held scope, indefinitely. Known watch item since Jul 19–21 ("carriers 439/443/103/104 need push-main test workflows in auth-service/studio-sdk"); it has graduated from log spam to holding current train scopes.

Related but distinct: GH-4384 (CI watcher polls legacy combined-status API while repos use Actions check-runs — every Actions-only repo times out at `waiting_ci` with green checks). Today it also forced two manual merges of studio-sdk#106 whose 3 checks were all SUCCESS while the watcher timed out twice. If fixing #4384's watcher also serves the post-merge path, fold it in.

## Implementation

Pick whichever subset kills the class:

1. **Detect absence, don't time out**: before waiting on post-merge CI for a carrier, check whether the repo has any push-main workflow (or any check-run/status on the merge commit after a short grace). None → treat post-merge CI as satisfied (log once at INFO), release the scope.
2. **Cap carrier retries**: after N consecutive `post-merge CI timeout` failures for the same carrier, park the scope with a single WARN + operator alert instead of retrying every ~30 min forever.
3. **Throttle the deferral log**: `deferring scope release` per scope at most once per ~30 min, not every 30s.

Repo-side alternative (out of daemon scope, note for operator): add minimal push-main test workflows to auth-service and studio-sdk — but the daemon must still behave sanely for the next workflow-less repo it meets.

## Acceptance

- [ ] A merged carrier PR in a repo with no push-main workflow releases its scope without a 30m timeout (test: repo fixture with zero workflows/check-runs on merge SHA)
- [ ] Repos WITH post-merge CI keep current verify-then-release behavior (regression test)
- [ ] Carrier retry cap: after N timeouts the scope parks with one alert; no infinite ~30-min retry loop (test)
- [ ] `deferring scope release` log volume bounded per scope
- [ ] Held scopes from trains 07-27/07-28/07-30 release after deploy (operator-verified on the box)

## Refs

- GH-4384 (waiting_ci twin of this class, combined-status vs check-runs), #4595/#4602 (park-instead-of-hard-fail precedent for approval misconfig — same "escalate visibly, don't loop" shape)
- Evidence: box daemon.log 2026-07-30 15:39–16:19Z; autopilot panel carriers 476/446/443/439/104

## Planned Steps (execute all in sequence)

- Step 1: **fix(autopilot): stop scope-release carriers from looping on post-merge CI timeout in workflow-less repos** — Single subtask covering all coordinated changes in internal/autopilot/ (controller.go, scope_release.go, and tests), since splitting would cause merge conflicts on shared files per the Avoid Single-Package Splits rule.

(a) Detect absence of post-merge CI before waiting: In internal/autopilot/controller.go around the PostMergeCIStartedAt timeout check (~L3455-3472), before entering the 30-min wait, probe whether the merge commit has any check-runs/statuses and whether the repo has any push-main workflow. If none exist after a short grace period (60-90s), treat post-merge CI as satisfied: log once at INFO ("no post-merge CI configured for repo, releasing scope"), call handleScopeReleaseFailure's success path (or an equivalent scope-release helper) rather than the timeout path, and drain the carrier. Repos WITH check-runs/statuses keep the existing verify-then-release behavior. Consider sharing the detection primitive with GH-4384's fix (check-runs vs combined-status) if applicable.

(b) Cap carrier retries: In internal/autopilot/scope_release.go handleScopeReleaseFailure (~L358-?), introduce a distinct cap (or reuse maxScopeReleaseAttempts) specifically for 'post-merge CI timeout' reasons: after N consecutive timeouts on the same scope, mark the scope parked (or failed with a park-only alert reason), emit one WARN + one operator alert, and stop re-queueing. Precedent shape: #4595 / #4602 park-instead-of-hard-fail on approval misconfig.

(c) Throttle the 'deferring scope release' INFO log in scope_release.go at L158 (and sibling deferral logs at L169, L177 if they show the same 30s spam pattern) to at most once per ~30 min per scope key. Use a simple in-memory map[scopeKey]time.Time guard on the controller struct.

Tests (internal/autopilot/scope_release_test.go, controller_test.go, or a new gh4643_test.go):
- Fixture: merged carrier PR in a repo with zero workflows / zero check-runs on the merge SHA -> scope releases without hitting the 30m timeout.
- Regression fixture: repo WITH post-merge check-runs -> existing verify-then-release path unchanged.
- Carrier-retry-cap: after N 'post-merge CI timeout' failures for one scope, scope enters parked/failed with a single alert and no further re-queue.
- Log throttle: N deferral attempts within 30 min for the same scope produce exactly one log line.

Out of scope for this subtask (note in PR body): adding push-main workflows to auth-service and studio-sdk repos - that's operator/repo work, but the daemon must behave sanely regardless.
