### PR TITLE
GH-4648: fix(executor): wire ProjectConfig.Canary → Task.IsCanary at intake — GH-4240's canary exclusion is a no-op (is_canary=0 on every row)

### DIFF
--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -724,6 +724,16 @@ Examples:
 			// Apply team flag overrides (GH-635)
 			applyTeamOverrides(cfg, cmd, teamID, teamMember)
 
+			// GH-4648: mirror handler_common.go's handleIssueGeneric — stamp
+			// the canary marker from the registered project config, now that
+			// cfg is loaded, so this direct-execute CLI path doesn't leak a
+			// canary-sandbox run into live metrics. cfg.GetProject returns nil
+			// for an unregistered path (e.g. the cwd fallback above), which
+			// correctly resolves to non-canary.
+			if proj := cfg.GetProject(projectPath); proj != nil {
+				task.IsCanary = proj.Canary
+			}
+
 			// Create the executor runner with config (GH-956: enables worktree isolation, decomposer, model routing)
 			runner, runnerErr := executor.NewRunnerWithConfig(cfg.Executor)
 			if runnerErr != nil {
@@ -1304,6 +1314,15 @@ Examples:
 				Verbose:     verbose,
 				CreatePR:    true,
 				Labels:      extractGitHubLabelNames(issue), // GH-727: flow labels for complexity classifier
+			}
+			// GH-4648: mirror handler_common.go's handleIssueGeneric — stamp
+			// the canary marker from the registered project config so this
+			// direct-execute CLI path doesn't leak a canary-sandbox run into
+			// live metrics. cfg.GetProject returns nil for an unregistered
+			// path (e.g. the cwd fallback above), which correctly resolves to
+			// non-canary.
+			if proj := cfg.GetProject(projectPath); proj != nil {
+				task.IsCanary = proj.Canary
 			}
 
 			// Dry run mode

--- a/cmd/pilot/interactive.go
+++ b/cmd/pilot/interactive.go
@@ -163,6 +163,14 @@ func interactiveNewTask(cfg *config.Config) error {
 		ProjectPath: projectPath,
 		Branch:      branchName,
 	}
+	// GH-4648: mirror handler_common.go's handleIssueGeneric — stamp the
+	// canary marker from the registered project config so this direct-execute
+	// CLI path doesn't leak a canary-sandbox run into live metrics.
+	// cfg.GetProject returns nil for an unregistered path (e.g. a bare cwd
+	// fallback), which correctly resolves to non-canary.
+	if proj := cfg.GetProject(projectPath); proj != nil {
+		task.IsCanary = proj.Canary
+	}
 
 	// GH-2286: use executor config from config.yaml instead of hardcoded defaults
 	backendCfg := cfg.Executor

--- a/internal/comms/handler.go
+++ b/internal/comms/handler.go
@@ -408,14 +408,16 @@ IMPORTANT: Be concise. Limit your exploration to 5-10 files max. Provide a brief
 If the question is too broad, ask for clarification instead of exploring everything.`, question)
 
 	taskID := fmt.Sprintf("Q-%d", time.Now().Unix())
+	questionProjectPath := h.getActiveProjectPath(contextID)
 	task := &executor.Task{
 		ID:          taskID,
 		Title:       "Question: " + TruncateText(question, 40),
 		Description: prompt,
-		ProjectPath: h.getActiveProjectPath(contextID),
+		ProjectPath: questionProjectPath,
 		LocalMode:   true,
 		CreatePR:    false,
 		Verbose:     false,
+		IsCanary:    h.isCanaryProject(questionProjectPath),
 	}
 
 	h.log.Debug("Answering question", slog.String("task_id", taskID), slog.String("context_id", contextID))
@@ -442,6 +444,7 @@ func (h *Handler) handleResearch(ctx context.Context, contextID, threadID, query
 	_ = h.messenger.SendText(ctx, contextID, "🔬 Researching...")
 
 	taskID := fmt.Sprintf("RES-%d", time.Now().Unix())
+	researchProjectPath := h.getActiveProjectPath(contextID)
 	task := &executor.Task{
 		ID:    taskID,
 		Title: "Research: " + TruncateText(query, 40),
@@ -454,9 +457,10 @@ Provide findings in a structured format with:
 - Recommendations
 
 DO NOT make any code changes. This is a read-only research task.`, query),
-		ProjectPath: h.getActiveProjectPath(contextID),
+		ProjectPath: researchProjectPath,
 		LocalMode:   true,
 		CreatePR:    false,
+		IsCanary:    h.isCanaryProject(researchProjectPath),
 	}
 
 	researchCtx, cancel := context.WithTimeout(ctx, 3*time.Minute)
@@ -487,6 +491,7 @@ func (h *Handler) handlePlanning(ctx context.Context, contextID, threadID, reque
 	_ = h.messenger.SendText(ctx, contextID, "📐 Drafting plan...")
 
 	taskID := fmt.Sprintf("PLAN-%d", time.Now().Unix())
+	planProjectPath := h.getActiveProjectPath(contextID)
 	task := &executor.Task{
 		ID:    taskID,
 		Title: "Plan: " + TruncateText(request, 40),
@@ -499,8 +504,9 @@ Explore the codebase and propose a detailed plan. Include:
 4. Potential risks or considerations
 
 DO NOT make any code changes. Only explore and plan.`, request),
-		ProjectPath: h.getActiveProjectPath(contextID),
+		ProjectPath: planProjectPath,
 		CreatePR:    false,
+		IsCanary:    h.isCanaryProject(planProjectPath),
 	}
 
 	planTimeout := 2 * time.Minute
@@ -581,6 +587,7 @@ func (h *Handler) handleChat(ctx context.Context, contextID, threadID, message s
 	_ = h.messenger.SendText(ctx, contextID, "💬 Thinking...")
 
 	taskID := fmt.Sprintf("CHAT-%d", time.Now().Unix())
+	chatProjectPath := h.getActiveProjectPath(contextID)
 	task := &executor.Task{
 		ID:    taskID,
 		Title: "Chat: " + TruncateText(message, 30),
@@ -591,10 +598,11 @@ Respond helpfully and conversationally. You can reference project knowledge but 
 
 Be concise - this is a chat conversation, not a report. Keep response under 500 words.
 
-User message: %s`, h.getActiveProjectPath(contextID), message),
-		ProjectPath: h.getActiveProjectPath(contextID),
+User message: %s`, chatProjectPath, message),
+		ProjectPath: chatProjectPath,
 		LocalMode:   true,
 		CreatePR:    false,
+		IsCanary:    h.isCanaryProject(chatProjectPath),
 	}
 
 	chatCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
@@ -776,17 +784,19 @@ func (h *Handler) executeTaskCore(ctx context.Context, contextID, threadID, task
 
 	memberID := h.resolveMemberID(contextID)
 
+	execTaskProjectPath := h.getActiveProjectPath(contextID)
 	task := &executor.Task{
 		ID:          taskID,
 		Title:       TruncateText(description, 50),
 		Description: description,
-		ProjectPath: h.getActiveProjectPath(contextID),
+		ProjectPath: execTaskProjectPath,
 		Verbose:     false,
 		Branch:      branch,
 		BaseBranch:  baseBranch,
 		CreatePR:    createPR,
 		MemberID:    memberID,
 		ImagePath:   imagePath,
+		IsCanary:    h.isCanaryProject(execTaskProjectPath),
 	}
 
 	// Progress callback with throttling (named callback for parallel-safe execution)
@@ -847,6 +857,19 @@ func (h *Handler) getActiveProjectPath(contextID string) string {
 		return path
 	}
 	return h.projectPath
+}
+
+// isCanaryProject reports whether path belongs to a canary-configured
+// project (GH-4240/GH-4648), so chat-triggered Task construction can stamp
+// IsCanary at intake the same way cmd/pilot's handleIssueGeneric does for
+// the poller-driven adapters. An unregistered path (or a nil project
+// source) correctly resolves to non-canary.
+func (h *Handler) isCanaryProject(path string) bool {
+	if h.projects == nil {
+		return false
+	}
+	proj := h.projects.GetProjectByPath(path)
+	return proj != nil && proj.Canary
 }
 
 // SetActiveProject sets the active project for a context by name.

--- a/internal/comms/project.go
+++ b/internal/comms/project.go
@@ -6,6 +6,11 @@ type ProjectInfo struct {
 	Path          string
 	Navigator     bool
 	DefaultBranch string
+	// Canary mirrors config.ProjectConfig.Canary (GH-4240/GH-4648) so
+	// chat-triggered tasks (comms.Handler) can stamp Task.IsCanary at
+	// construction time the same way the poller handlers do via
+	// cmd/pilot/handler_common.go's handleIssueGeneric.
+	Canary bool
 }
 
 // GetName satisfies duck-typed interface used by CommandHandler.handleProjects.

--- a/internal/config/projects.go
+++ b/internal/config/projects.go
@@ -65,5 +65,6 @@ func (a *ProjectSourceAdapter) toProjectInfo(proj *ProjectConfig) *comms.Project
 		Path:          proj.Path,
 		Navigator:     proj.Navigator,
 		DefaultBranch: proj.DefaultBranch,
+		Canary:        proj.Canary,
 	}
 }

--- a/internal/executor/decompose.go
+++ b/internal/executor/decompose.go
@@ -439,6 +439,13 @@ func (d *TaskDecomposer) createSubtasks(parent *Task, parts []string, partType s
 			// "GH-4021-2"), which has no matching executions row and trips the
 			// execution_events FOREIGN KEY constraint on every stage write.
 			ParentExecutionID: parent.LogExecutionID(),
+			// GH-4648: inherit the canary marker from the parent, mirroring
+			// epic.go's sub-issue construction (GH-4240) — without this, every
+			// decomposed subtask of a canary-configured project's task landed
+			// is_canary=0 (the struct literal's zero value) even though the
+			// parent's own row correctly carried is_canary=1, leaking canary
+			// executions into every unscoped metrics/dashboard aggregate.
+			IsCanary: parent.IsCanary,
 		}
 
 		// Last subtask creates the PR

--- a/internal/executor/decompose_test.go
+++ b/internal/executor/decompose_test.go
@@ -217,6 +217,58 @@ Add comprehensive tests for all changes.`,
 	}
 }
 
+// TestTaskDecomposer_SubtasksInheritParentIsCanary is a GH-4648 regression
+// test: createSubtasks previously omitted IsCanary from the subtask literal
+// entirely, so every decomposed subtask of a canary-configured project's
+// task landed is_canary=0 in the ledger (the struct's zero value) even
+// though the parent row correctly carried is_canary=1 — leaking canary
+// executions into every unscoped metrics/dashboard aggregate. epic.go's
+// sibling sub-issue construction already did this correctly (GH-4240); this
+// asserts createSubtasks now matches that posture for both a canary and a
+// non-canary parent (no false positives).
+func TestTaskDecomposer_SubtasksInheritParentIsCanary(t *testing.T) {
+	config := &DecomposeConfig{
+		Enabled:             true,
+		MinComplexity:       "complex",
+		MaxSubtasks:         5,
+		MinDescriptionWords: 10,
+	}
+
+	description := `This task requires refactoring the entire authentication system with multiple changes.
+
+## Task 1: Update the user model
+
+Add new fields for MFA.
+
+## Task 2: Refactor the login endpoint
+
+Support the MFA flow.`
+
+	for _, canary := range []bool{true, false} {
+		decomposer := NewTaskDecomposer(config)
+		task := &Task{
+			ID:          "TEST-CANARY",
+			Title:       "Refactor authentication system",
+			Description: description,
+			ProjectPath: "/test/project",
+			IsCanary:    canary,
+		}
+
+		result := decomposer.Decompose(task)
+		if !result.Decomposed {
+			t.Fatalf("IsCanary=%v: expected task to be decomposed, reason: %s", canary, result.Reason)
+		}
+		if len(result.Subtasks) == 0 {
+			t.Fatalf("IsCanary=%v: expected at least one subtask", canary)
+		}
+		for i, subtask := range result.Subtasks {
+			if subtask.IsCanary != canary {
+				t.Errorf("IsCanary=%v: subtask %d IsCanary = %v, want %v (must inherit from parent)", canary, i, subtask.IsCanary, canary)
+			}
+		}
+	}
+}
+
 // TestTaskDecomposer_PlainBulletsFallBackToNoDecompose is a GH-4395
 // regression test: plain "- " bullets (no checkbox) are narrative structure,
 // not explicit work-item structure — #4390's incident timeline was written

--- a/internal/executor/lifecycle_test.go
+++ b/internal/executor/lifecycle_test.go
@@ -46,6 +46,44 @@ func TestExecutionLifecycle_Begin_CreatesRowAndThreadsID(t *testing.T) {
 	}
 }
 
+// TestExecutionLifecycle_Begin_PersistsIsCanary is a GH-4648 regression test
+// for the intake-wire fix: a task built for a canary-configured project must
+// produce an execution row with is_canary=1 through the ExecutionLifecycle.Begin
+// chokepoint, and a non-canary project's task must land 0 — no false
+// positives. This is the write-side half of the GH-4240 canary isolation
+// mechanism; the read-side COALESCE(is_canary, 0) = 0 filters were dead code
+// until every fresh-intake Task construction site actually set this field.
+func TestExecutionLifecycle_Begin_PersistsIsCanary(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	canaryTask := &Task{ID: "GH-4648-canary", ProjectPath: "/canary-sandbox", IsCanary: true}
+	canaryExecID, err := NewExecutionLifecycle(store).Begin(canaryTask, ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("Begin (canary) failed: %v", err)
+	}
+	canaryExec, err := store.GetExecution(canaryExecID)
+	if err != nil {
+		t.Fatalf("failed to load canary execution: %v", err)
+	}
+	if !canaryExec.IsCanary {
+		t.Error("expected canary task's execution row to have IsCanary=true, got false")
+	}
+
+	regularTask := &Task{ID: "GH-4648-regular", ProjectPath: "/normal-project", IsCanary: false}
+	regularExecID, err := NewExecutionLifecycle(store).Begin(regularTask, ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("Begin (regular) failed: %v", err)
+	}
+	regularExec, err := store.GetExecution(regularExecID)
+	if err != nil {
+		t.Fatalf("failed to load regular execution: %v", err)
+	}
+	if regularExec.IsCanary {
+		t.Error("expected non-canary task's execution row to have IsCanary=false, got true (false positive)")
+	}
+}
+
 // TestExecutionLifecycle_Begin_NilStore_StillThreadsID mirrors the epic
 // sub-issue path's mem-026 tolerance: a nil store (or a failed save) must
 // never stop task.ExecutionID from being stamped, so downstream event

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -480,10 +480,25 @@ type Task struct {
 	// execution_events FOREIGN KEY constraint on every stage write (GH-4032).
 	ParentExecutionID string
 	// IsCanary marks this task as belonging to a synthetic sandbox project
-	// (ProjectConfig.Canary, GH-4240). Set once at intake from the project
-	// config and threaded through the executions row so metrics/hydrators/
-	// dashboards can exclude it — the ledger (executions/execution_events/
-	// execution_logs) is written exactly the same regardless of this flag.
+	// (ProjectConfig.Canary, GH-4240). Threaded through the executions row so
+	// metrics/hydrators/dashboards can exclude it — the ledger
+	// (executions/execution_events/execution_logs) is written exactly the
+	// same regardless of this flag.
+	//
+	// Set at every fresh-intake construction site (GH-4648) by resolving the
+	// owning project's config — there is no single chokepoint. Each adapter/
+	// entrypoint that builds a brand-new Task from external input (issue,
+	// chat message, CLI flag) is responsible for stamping it:
+	//   - cmd/pilot/handler_common.go's handleIssueGeneric (all 7 SDK-adapter
+	//     poller handlers: GitHub/Linear/Jira/Asana/Plane/GitLab/AzureDevOps)
+	//   - internal/comms/handler.go (chat-triggered tasks: Telegram/Slack)
+	//   - cmd/pilot/interactive.go and cmd/pilot/commands.go (direct CLI
+	//     execution: `pilot task`, `pilot github run`, interactive prompt)
+	// Sites that instead derive a Task from an existing parent/execution
+	// (decomposed subtasks, epic sub-issues, dispatcher requeue/replay) must
+	// propagate the parent's IsCanary rather than re-resolving config, so a
+	// canary parent's descendants stay canary even if project config changes
+	// mid-run.
 	IsCanary bool
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4648.

Closes #4648

## Changes

GitHub Issue GH-4648: fix(executor): wire ProjectConfig.Canary → Task.IsCanary at intake — GH-4240's canary exclusion is a no-op (is_canary=0 on every row)

## Context

GH-4240 shipped canary isolation in two halves that were never connected:

- **Config half**: `ProjectConfig.Canary bool` (`internal/config/config.go:283`) marks a project as a synthetic sandbox.
- **Read half**: ~20 SQL filters `COALESCE(is_canary, 0) = 0` across `internal/memory/store.go` + `internal/memory/metrics.go` (success-rate, cost, model, dashboard, lifetime-counts queries), plus live-path guards `!task.IsCanary` around `metricsRecorder` at `internal/executor/runner.go:2030/3164/3555`.

**The intake wire between them is missing.** `Task.IsCanary`'s own doc comment (`runner.go:482–487`) says "Set once at intake from the project config (ProjectConfig.Canary, GH-4240)" — but the only assignment sites in the tree are propagation, not intake:

- `internal/executor/epic.go:2849` — epic sub-task inherits `parent.IsCanary`
- `internal/executor/dispatcher.go:2926` — task restored from an execution row copies `exec.IsCanary`
- `internal/executor/lifecycle.go:130` — task → execution row (write-through)

No site ever reads `ProjectConfig.Canary`. Consequence, operator-verified on the box ledger: **`is_canary = 0` on every row ever written.** Every read-side filter is dead code; the runner metric guards never fire; canary executions count in every aggregate. Where exclusion appears to work, it's only because the caller happens to scope by `project_path` — unscoped callers include canary rows: the autopilot metrics hydrator (`internal/autopilot/metrics_hydrator.go:52`, `GetLifetimeTaskCounts("")`) and the gateway dashboard aggregates.

Corroborating breadcrumb: `dispatcher.go:1554–1559` (a prior investigation) already records that the daemon "never inspects IsCanary" — the flag was known-inert on the read path there; this issue fixes the write path so the whole mechanism finally works as documented.

## Acceptance

1. **Every fresh-intake `Task` construction sets `IsCanary` from the owning project's config.** Known fresh-build sites: `dispatcher.go:~2426` (ProjectWorker build — the main poller intake) and `dispatcher.go:~2301`. Decomposed children (`decompose.go:~430`) inherit `parent.IsCanary` (same posture as `epic.go:2849` — do not re-resolve config). The AC is the **invariant, not this site list** — audit every `Task{...}` literal in `internal/executor` and classify it fresh-intake (wire it) vs propagation (leave it); note the classification in the PR description. Existing propagation sites stay as-is.
2. **Regression tests**: (a) a task built for a canary-configured project produces an execution row with `is_canary=1` through the `ExecutionLifecycle.Begin` chokepoint; (b) a decomposed child of a canary parent inherits it; (c) a non-canary project row lands `0` (no false positives).
3. **One read-side exclusion test**: a representative query (e.g. `GetLifetimeTaskCounts`) excludes an `is_canary=1` row — converting the dormant filters from dead code into asserted behavior.
4. If the mechanism ends up anywhere other than "once at intake", update `Task.IsCanary`'s doc comment to match reality.
5. `make build`, `make test`, `make lint` green. Conventional-commit PR title.

## Implementation

- The ProjectWorker knows its project path; check whether it already holds (or can cheaply receive) the project's `ProjectConfig` — mirror however other per-project settings reach task construction. If the config isn't in reach at a build site, thread the single bool, not the whole config.
- **Out of scope**: backfilling historical rows on any live ledger (operator action — path-scoped UPDATE per ops SOP, never string time-ranges) · removing or consolidating the read-side filters · per-tenant semantics on hosted instances (a canary-only tenant zeroing its own metrics is a product question, not this bug).

## Refs

- **Status**: 🚀 Dispatched to Pilot 2026-07-31
- GH-4240 (original feature — closed; shipped config + read halves only) · GH-4536/TASK-419 (source of the restore-path propagation site)
- `.agent/.context-markers/2026-07-31_first-self-upgrade-trains-unblocked-4646.md` WATCH item 4 (the unfiled-candidate note this resolves)

## Planned Steps (execute all in sequence)

- Step 1: **fix(executor): wire ProjectConfig.Canary → Task.IsCanary at fresh-intake sites** — Audit every Task{...} literal in internal/executor and classify each as fresh-intake vs propagation; document the classification in the PR body. At fresh-intake sites (known: dispatcher.go:~2426 ProjectWorker build and dispatcher.go:~2301), set IsCanary from the owning project's ProjectConfig.Canary. Determine whether ProjectWorker already holds the ProjectConfig — mirror the pattern used by other per-project settings that already reach task construction; if config isn't in reach, thread the single bool rather than the whole config struct. Leave existing propagation sites untouched (epic.go:2849, dispatcher.go:2926, decompose.go:~430, lifecycle.go:130). Add regression tests: (a) canary-configured project → execution row is_canary=1 through ExecutionLifecycle.Begin; (b) decomposed child of canary parent inherits the flag; (c) non-canary project → 0 (no false positives); (d) one read-side test asserting a representative query like GetLifetimeTaskCounts excludes an is_canary=1 row, converting the dormant COALESCE(is_canary, 0) = 0 filters from dead code into asserted behavior. If the wiring mechanism ends up anywhere other than 'once at intake,' update the Task.IsCanary doc comment at runner.go:482-487 to match reality. Verify make build, make test, make lint all green. Out of scope: backfilling historical rows, consolidating read-side filters, per-tenant hosted-instance semantics.
