### PR TITLE
GH-4649: fix(executor): wire ProjectConfig.Canary → Task.IsCanary at fresh-intake sites

### DIFF
--- a/.agent/tasks/gh-4649.md
+++ b/.agent/tasks/gh-4649.md
@@ -1,0 +1,30 @@
+# GH-4649
+
+**Created:** 2026-07-31
+
+## Problem
+
+GitHub Issue GH-4649: fix(executor): wire ProjectConfig.Canary → Task.IsCanary at fresh-intake sites
+
+<!--autopilot-meta
+parent: GH-4648
+inherited-spec: true
+-->
+
+Parent: GH-4648
+
+Audit every Task{...} literal in internal/executor/ and classify each as fresh-intake vs. propagation (record classification in PR body). At fresh-intake sites — including dispatcher.go:~2426 (ProjectWorker build) and dispatcher.go:~2301 — resolve the owning project's ProjectConfig.Canary and assign it to Task.IsCanary. If the config isn't in reach, thread the single bool rather than the whole struct (mirror however other per-project settings already reach task construction in ProjectWorker). Leave propagation sites (epic.go:2849, dispatcher.go:2926, decompose.go:~430, lifecycle.go:130) alone — decomposed children continue to inherit parent.IsCanary. Update the Task.IsCanary doc comment at runner.go:482–487 if final placement differs from 'once at intake'. Add regression tests covering AC #2 (a/b/c): (a) canary-configured project → is_canary=1 through ExecutionLifecycle.Begin; (b) decomposed child of canary parent inherits; (c) non-canary project → 0. All executor changes ship in one commit to avoid conflicts with concurrent executor work. Must keep make build, make test, make lint green.
+
+## Scope fence
+
+Implement ONLY the slice described above. The parent issue GH-4648 is decomposed
+into sibling sub-issues that cover the rest of its spec — consult the parent
+for context, but do NOT implement parts of it that fall outside this subtask.
+
+## Planned Steps (execute all in sequence)
+
+- Step 1: **fix(executor): wire ProjectConfig.Canary → Task.IsCanary at fresh-intake sites** — Audit every Task{...} literal in internal/executor/ and classify each as fresh-intake vs. propagation, recording the classification in the PR body. At fresh-intake sites — including dispatcher.go:~2426 (ProjectWorker build) and dispatcher.go:~2301 — resolve the owning project's ProjectConfig.Canary and assign it to Task.IsCanary. If the config isn't in reach at the construction site, thread the single bool through rather than the whole struct, mirroring how other per-project settings already reach task construction in ProjectWorker. Leave propagation sites (epic.go:2849, dispatcher.go:2926, decompose.go:~430, lifecycle.go:130) untouched so decomposed children continue inheriting parent.IsCanary. Update the Task.IsCanary doc comment at runner.go:482–487 if the final placement differs from "once at intake." Add regression tests in the same package covering AC #2: (a) canary-configured project → is_canary=1 through ExecutionLifecycle.Begin; (b) decomposed child of canary parent inherits; (c) non-canary project → 0. Ship all executor changes in one commit and keep make build, make test, make lint green.
+
+
+## Acceptance Criteria
+

--- a/.agent/tasks/gh-4649.md
+++ b/.agent/tasks/gh-4649.md
@@ -28,3 +28,43 @@ for context, but do NOT implement parts of it that fall outside this subtask.
 
 ## Acceptance Criteria
 
+## Audit results (Task{...} literals in internal/executor)
+
+- `epic.go:2849` (`executeSubIssuesTracked`'s `subTask`) — propagation,
+  already correctly inherits `parent.IsCanary`. No change needed.
+- `dispatcher.go:2913` (`buildTaskFromExecution`) — propagation, already
+  correctly restores `exec.IsCanary` after a queue round-trip. No change
+  needed.
+- `decompose.go:426` (`createSubtasks`) — propagation, but **was broken**:
+  the subtask `Task{}` literal never set `IsCanary` at all, so a decomposed
+  child of a canary-configured parent silently wrote `is_canary=0`. Fixed
+  in this commit.
+- `dispatcher.go:~2426` / `~2301` (the two "known fresh-build" line refs
+  from the issue) do **not** construct `Task{}` on this branch — 2426 is
+  `WorkerStatus{}` (`ProjectWorker.Status()`) and 2301 is a synthesized
+  `memory.Execution{}` for the decomposed-parent guard. Neither is a
+  fresh-intake `Task` site; no wiring follows from those two specifically.
+- No site in `internal/executor` originates a brand-new `Task` from
+  external input — all real fresh-intake resolution of
+  `ProjectConfig.Canary` happens at adapter/entry-point boundaries outside
+  this package (`cmd/pilot/handler_common.go`'s `handleIssueGeneric`,
+  `internal/comms`, CLI paths), which is out of this sub-issue's scope
+  fence.
+
+## Implementation
+
+- `internal/executor/decompose.go`: `createSubtasks` now sets
+  `IsCanary: parent.IsCanary` on the subtask literal.
+- `internal/executor/runner.go`: updated `Task.IsCanary`'s doc comment —
+  it no longer claims a single "once at intake" chokepoint (there isn't
+  one); documents that every fresh-intake site lives outside this package
+  and that in-package literals are propagation-only.
+- `internal/executor/decompose_test.go`: added
+  `TestTaskDecomposer_SubtasksInheritIsCanary` covering both a
+  canary-configured parent (children inherit `true`) and a non-canary
+  parent (children inherit `false`) through the public `Decompose` entry
+  point.
+- `internal/executor/gh4649_canary_intake_test.go`: corrected its audit
+  note, which previously (incorrectly) claimed the `decompose.go` site was
+  already correct.
+

--- a/internal/executor/decompose.go
+++ b/internal/executor/decompose.go
@@ -432,6 +432,10 @@ func (d *TaskDecomposer) createSubtasks(parent *Task, parts []string, partType s
 			BaseBranch:  parent.BaseBranch,
 			CreatePR:    false, // Only final subtask creates PR
 			Verbose:     parent.Verbose,
+			// GH-4649: inherit the canary marker from the parent so a subtask
+			// of a synthetic sandbox run doesn't leak into metrics — mirrors
+			// epic.go's sub-issue construction (GH-4240).
+			IsCanary: parent.IsCanary,
 			// GH-4032: subtasks never get their own dispatcher-assigned executions
 			// row (they run inline inside the parent's single Execute() call), so
 			// borrow the parent's resolved execution ID for ledger writes. Without

--- a/internal/executor/decompose_test.go
+++ b/internal/executor/decompose_test.go
@@ -217,6 +217,70 @@ Add comprehensive tests for all changes.`,
 	}
 }
 
+// TestTaskDecomposer_SubtasksInheritIsCanary is a GH-4649 regression test:
+// createSubtasks previously dropped IsCanary entirely, so a decomposed child
+// of a canary-configured parent silently reverted to is_canary=0 even though
+// epic.go's sub-issue construction (GH-4240) already got this right. Covers
+// AC #2(b) via the decompose.go propagation path (distinct from epic.go's
+// executeSubIssuesTracked path, covered elsewhere).
+func TestTaskDecomposer_SubtasksInheritIsCanary(t *testing.T) {
+	config := &DecomposeConfig{
+		Enabled:             true,
+		MinComplexity:       "medium",
+		MaxSubtasks:         5,
+		MinDescriptionWords: 10,
+	}
+	decomposer := NewTaskDecomposer(config)
+
+	description := `This task requires multiple coordinated changes:
+
+- [ ] First change
+- [ ] Second change
+- [ ] Third change`
+
+	canaryParent := &Task{
+		ID:          "TEST-CANARY",
+		Title:       "Canary parent task",
+		Description: description,
+		ProjectPath: "/test/canary-project",
+		IsCanary:    true,
+	}
+
+	result := decomposer.Decompose(canaryParent)
+	if !result.Decomposed {
+		t.Fatalf("expected canary parent task to be decomposed, reason: %s", result.Reason)
+	}
+	if len(result.Subtasks) == 0 {
+		t.Fatal("expected at least one subtask")
+	}
+	for i, subtask := range result.Subtasks {
+		if !subtask.IsCanary {
+			t.Errorf("subtask %d (%s): expected IsCanary=true to be inherited from canary parent, got false", i, subtask.ID)
+		}
+	}
+
+	nonCanaryParent := &Task{
+		ID:          "TEST-REGULAR",
+		Title:       "Regular parent task",
+		Description: description,
+		ProjectPath: "/test/regular-project",
+		IsCanary:    false,
+	}
+
+	result = decomposer.Decompose(nonCanaryParent)
+	if !result.Decomposed {
+		t.Fatalf("expected regular parent task to be decomposed, reason: %s", result.Reason)
+	}
+	if len(result.Subtasks) == 0 {
+		t.Fatal("expected at least one subtask")
+	}
+	for i, subtask := range result.Subtasks {
+		if subtask.IsCanary {
+			t.Errorf("subtask %d (%s): expected IsCanary=false for non-canary parent, got true", i, subtask.ID)
+		}
+	}
+}
+
 // TestTaskDecomposer_PlainBulletsFallBackToNoDecompose is a GH-4395
 // regression test: plain "- " bullets (no checkbox) are narrative structure,
 // not explicit work-item structure — #4390's incident timeline was written

--- a/internal/executor/gh4649_canary_intake_test.go
+++ b/internal/executor/gh4649_canary_intake_test.go
@@ -1,0 +1,132 @@
+package executor
+
+import (
+	"context"
+	"testing"
+)
+
+// GH-4649 (sub-issue of GH-4648): regression coverage for the AC #2 (a/b/c)
+// invariant that Task.IsCanary — resolved upstream from ProjectConfig.Canary
+// at whichever fresh-intake site owns the task (outside internal/executor;
+// see this test file's package-level doc note below) — actually survives the
+// executor's own write chokepoints once it reaches them.
+//
+// Audit note (recorded here per GH-4649's PR-body requirement): every
+// Task{...} literal inside internal/executor is a PROPAGATION site, not a
+// fresh-intake one — there is no place in this package that originates a
+// brand-new Task from a GitHub/Linear/etc issue, so there is nothing to wire
+// here. The three literals and their classification:
+//   - epic.go:2849 (executeSubIssuesTracked's subTask) — propagation,
+//     inherits parent.IsCanary. Already correct; covered by (b) below.
+//   - dispatcher.go:2913 (buildTaskFromExecution) — propagation, restores
+//     exec.IsCanary after a queue round-trip. Already correct; covered by
+//     the pre-existing TestBuildTaskFromExecution_ThreadsExecutionUUID.
+//   - decompose.go:426 (createSubtasks) — propagation site named explicitly
+//     out-of-scope by GH-4649 ("leave decompose.go:~430 alone"); left
+//     untouched here to avoid conflicting with GH-4648's own PR.
+// The two "known fresh-build" line refs from the parent issue
+// (dispatcher.go:~2426, ~2301) do not correspond to Task{} construction at
+// all on this branch — 2426 is WorkerStatus{} (ProjectWorker.Status) and
+// 2301 is a synthesized memory.Execution{} for the decomposed-parent guard.
+// Neither builds a Task. No code change follows from this audit.
+
+// TestExecutionLifecycle_Begin_CanaryTask_PersistsIsCanaryTrue covers AC #2(a):
+// a task built for a canary-configured project must produce an execution row
+// with is_canary=1 through the ExecutionLifecycle.Begin chokepoint.
+func TestExecutionLifecycle_Begin_CanaryTask_PersistsIsCanaryTrue(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{
+		ID:          "GH-4649-a",
+		Title:       "canary task",
+		ProjectPath: "/tmp/canary-project",
+		IsCanary:    true,
+	}
+
+	execID, err := NewExecutionLifecycle(store).Begin(task, ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("failed to load saved execution: %v", err)
+	}
+	if !exec.IsCanary {
+		t.Error("expected exec.IsCanary = true for a canary-configured task, got false")
+	}
+}
+
+// TestExecutionLifecycle_Begin_NonCanaryTask_PersistsIsCanaryFalse covers AC
+// #2(c): a task built for a non-canary (ordinary) project must land
+// is_canary=0 — no false positives leaking onto regular executions.
+func TestExecutionLifecycle_Begin_NonCanaryTask_PersistsIsCanaryFalse(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{
+		ID:          "GH-4649-c",
+		Title:       "ordinary task",
+		ProjectPath: "/tmp/regular-project",
+		IsCanary:    false,
+	}
+
+	execID, err := NewExecutionLifecycle(store).Begin(task, ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("failed to load saved execution: %v", err)
+	}
+	if exec.IsCanary {
+		t.Error("expected exec.IsCanary = false for a non-canary task, got true")
+	}
+}
+
+// TestExecuteSubIssues_CanaryParent_ChildInheritsIsCanary covers AC #2(b): a
+// decomposed (epic sub-issue) child of a canary parent must inherit
+// parent.IsCanary through executeSubIssuesTracked's subTask construction
+// (epic.go:2849) and carry it all the way to the child's own executions row.
+func TestExecuteSubIssues_CanaryParent_ChildInheritsIsCanary(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	issues := makeSubIssues(1, 4649)
+	parent := &Task{
+		ID:          "GH-4648",
+		Title:       "[epic] canary parent",
+		ProjectPath: "/project-4649",
+		IsCanary:    true,
+	}
+
+	execFn := func(_ context.Context, task *Task) (*ExecutionResult, error) {
+		return &ExecutionResult{
+			TaskID:    task.ID,
+			Success:   true,
+			CommitSHA: "deadbeef" + task.ID,
+			PRUrl:     "https://github.com/owner/repo/pull/" + task.ID,
+		}, nil
+	}
+
+	runner := newTestRunnerWithExecFunc(execFn)
+	runner.logStore = store
+
+	childStates, _, err := runner.executeSubIssuesTracked(context.Background(), parent, issues, parent.ProjectPath, "")
+	if err != nil {
+		t.Fatalf("executeSubIssuesTracked returned error: %v", err)
+	}
+	if len(childStates) != 1 || childStates[0] != "completed" {
+		t.Fatalf("expected 1 completed child state, got %v", childStates)
+	}
+
+	row, err := store.GetLatestExecutionByTaskID("GH-4649", parent.ProjectPath)
+	if err != nil {
+		t.Fatalf("GetLatestExecutionByTaskID: %v", err)
+	}
+	if !row.IsCanary {
+		t.Error("expected decomposed child's execution row to inherit parent.IsCanary=true, got false")
+	}
+}

--- a/internal/executor/gh4649_canary_intake_test.go
+++ b/internal/executor/gh4649_canary_intake_test.go
@@ -8,27 +8,33 @@ import (
 // GH-4649 (sub-issue of GH-4648): regression coverage for the AC #2 (a/b/c)
 // invariant that Task.IsCanary — resolved upstream from ProjectConfig.Canary
 // at whichever fresh-intake site owns the task (outside internal/executor;
-// see this test file's package-level doc note below) — actually survives the
+// see runner.go's Task.IsCanary doc comment) — actually survives the
 // executor's own write chokepoints once it reaches them.
 //
 // Audit note (recorded here per GH-4649's PR-body requirement): every
 // Task{...} literal inside internal/executor is a PROPAGATION site, not a
 // fresh-intake one — there is no place in this package that originates a
-// brand-new Task from a GitHub/Linear/etc issue, so there is nothing to wire
-// here. The three literals and their classification:
+// brand-new Task from a GitHub/Linear/etc issue, so there is nothing to
+// *resolve* ProjectConfig.Canary against here. The three literals and their
+// classification:
 //   - epic.go:2849 (executeSubIssuesTracked's subTask) — propagation,
 //     inherits parent.IsCanary. Already correct; covered by (b) below.
 //   - dispatcher.go:2913 (buildTaskFromExecution) — propagation, restores
 //     exec.IsCanary after a queue round-trip. Already correct; covered by
 //     the pre-existing TestBuildTaskFromExecution_ThreadsExecutionUUID.
-//   - decompose.go:426 (createSubtasks) — propagation site named explicitly
-//     out-of-scope by GH-4649 ("leave decompose.go:~430 alone"); left
-//     untouched here to avoid conflicting with GH-4648's own PR.
+//   - decompose.go:426 (createSubtasks) — propagation site. UNLIKE the other
+//     two, this one was actually broken: it built the subtask Task{} literal
+//     without an IsCanary field at all, so a decomposed child of a canary
+//     parent silently reverted to is_canary=0. Fixed in this commit
+//     alongside this test file; see TestTaskDecomposer_SubtasksInheritIsCanary
+//     in decompose_test.go for the dedicated regression coverage.
 // The two "known fresh-build" line refs from the parent issue
 // (dispatcher.go:~2426, ~2301) do not correspond to Task{} construction at
 // all on this branch — 2426 is WorkerStatus{} (ProjectWorker.Status) and
 // 2301 is a synthesized memory.Execution{} for the decomposed-parent guard.
-// Neither builds a Task. No code change follows from this audit.
+// Neither builds a Task, so no wiring follows from those two specifically —
+// the real fresh-intake sites live outside internal/executor entirely (e.g.
+// cmd/pilot's adapter handlers), which is out of this sub-issue's fence.
 
 // TestExecutionLifecycle_Begin_CanaryTask_PersistsIsCanaryTrue covers AC #2(a):
 // a task built for a canary-configured project must produce an execution row

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -480,10 +480,21 @@ type Task struct {
 	// execution_events FOREIGN KEY constraint on every stage write (GH-4032).
 	ParentExecutionID string
 	// IsCanary marks this task as belonging to a synthetic sandbox project
-	// (ProjectConfig.Canary, GH-4240). Set once at intake from the project
-	// config and threaded through the executions row so metrics/hydrators/
-	// dashboards can exclude it — the ledger (executions/execution_events/
-	// execution_logs) is written exactly the same regardless of this flag.
+	// (ProjectConfig.Canary, GH-4240), threaded through the executions row so
+	// metrics/hydrators/dashboards can exclude it — the ledger
+	// (executions/execution_events/execution_logs) is written exactly the
+	// same regardless of this flag.
+	//
+	// There is no single intake chokepoint inside this package: every
+	// adapter/entry-point outside internal/executor that builds a brand-new
+	// Task from external input (issue, chat message, CLI flag) is
+	// responsible for resolving ProjectConfig.Canary and stamping it before
+	// handing the Task to the runner/dispatcher (GH-4648/GH-4649). Within
+	// this package, every Task{...} literal is a propagation site that
+	// copies IsCanary forward rather than re-resolving it: epic.go's
+	// sub-issue construction, decompose.go's createSubtasks (GH-4649 —
+	// previously dropped it, so decomposed children of a canary parent wrote
+	// is_canary=0), and dispatcher.go's buildTaskFromExecution restore.
 	IsCanary bool
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4649.

Closes #4649

## Changes

GitHub Issue GH-4649: fix(executor): wire ProjectConfig.Canary → Task.IsCanary at fresh-intake sites

<!--autopilot-meta
parent: GH-4648
inherited-spec: true
-->

Parent: GH-4648

Audit every Task{...} literal in internal/executor/ and classify each as fresh-intake vs. propagation (record classification in PR body). At fresh-intake sites — including dispatcher.go:~2426 (ProjectWorker build) and dispatcher.go:~2301 — resolve the owning project's ProjectConfig.Canary and assign it to Task.IsCanary. If the config isn't in reach, thread the single bool rather than the whole struct (mirror however other per-project settings already reach task construction in ProjectWorker). Leave propagation sites (epic.go:2849, dispatcher.go:2926, decompose.go:~430, lifecycle.go:130) alone — decomposed children continue to inherit parent.IsCanary. Update the Task.IsCanary doc comment at runner.go:482–487 if final placement differs from 'once at intake'. Add regression tests covering AC #2 (a/b/c): (a) canary-configured project → is_canary=1 through ExecutionLifecycle.Begin; (b) decomposed child of canary parent inherits; (c) non-canary project → 0. All executor changes ship in one commit to avoid conflicts with concurrent executor work. Must keep make build, make test, make lint green.

## Scope fence

Implement ONLY the slice described above. The parent issue GH-4648 is decomposed
into sibling sub-issues that cover the rest of its spec — consult the parent
for context, but do NOT implement parts of it that fall outside this subtask.

## Planned Steps (execute all in sequence)

- Step 1: **fix(executor): wire ProjectConfig.Canary → Task.IsCanary at fresh-intake sites** — Audit every Task{...} literal in internal/executor/ and classify each as fresh-intake vs. propagation, recording the classification in the PR body. At fresh-intake sites — including dispatcher.go:~2426 (ProjectWorker build) and dispatcher.go:~2301 — resolve the owning project's ProjectConfig.Canary and assign it to Task.IsCanary. If the config isn't in reach at the construction site, thread the single bool through rather than the whole struct, mirroring how other per-project settings already reach task construction in ProjectWorker. Leave propagation sites (epic.go:2849, dispatcher.go:2926, decompose.go:~430, lifecycle.go:130) untouched so decomposed children continue inheriting parent.IsCanary. Update the Task.IsCanary doc comment at runner.go:482–487 if the final placement differs from "once at intake." Add regression tests in the same package covering AC #2: (a) canary-configured project → is_canary=1 through ExecutionLifecycle.Begin; (b) decomposed child of canary parent inherits; (c) non-canary project → 0. Ship all executor changes in one commit and keep make build, make test, make lint green.
