### PR TITLE
fix(autopilot): close conflicting PR whose source issue is closed instead of escalating (GH-4657)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -4557,6 +4557,26 @@ func (c *Controller) handleMergeConflict(ctx context.Context, prState *PRState) 
 		prState.ConflictRecorded = true
 	}
 
+	// GH-4657/TASK-437: a conflicting PR whose source issue is already closed
+	// means a sibling/parent run delivered the same scope first (the
+	// PR#4653/#4649 duplicate-execution race is the motivating incident) —
+	// rebasing would just re-resolve a conflict against work already on
+	// main. Check this BEFORE any rebase attempt so the closed-issue case
+	// never reaches escalateAndHold's needs-manual-rebase/pilot-needs-human
+	// ask for a rebase nobody should perform.
+	if prState.IssueNumber > 0 {
+		issue, err := c.ghClient.GetIssue(ctx, c.owner, c.repo, prState.IssueNumber)
+		if err != nil {
+			// Fail-open: an unknown issue state must never block the existing
+			// rebase/escalate ladder — escalation is the safe default when
+			// GitHub state can't be confirmed.
+			c.log.Warn("handleMergeConflict: failed to fetch issue state, falling through to rebase ladder",
+				"pr", prState.PRNumber, "issue", prState.IssueNumber, "error", err)
+		} else if strings.EqualFold(issue.State, github.StateClosed) {
+			return c.closeConflictSourceIssueClosed(ctx, prState, issue)
+		}
+	}
+
 	// Try GitHub auto-update first (merge-from-base, not true rebase)
 	err := c.ghClient.UpdatePullRequestBranch(ctx, c.owner, c.repo, prState.PRNumber)
 	if err == nil {
@@ -4710,6 +4730,48 @@ func (c *Controller) attemptMechanicalConflictResolution(ctx context.Context, pr
 	prState.Stage = StageWaitingCI // mechanical resolution triggers new CI
 	prState.HeadSHA = ""           // force refresh on next tick
 	return true, nil
+}
+
+// closeConflictSourceIssueClosed handles the GH-4657 case where
+// handleMergeConflict discovers the PR's source issue is already closed —
+// almost always because a sibling/parent execution delivered the same scope
+// first (TASK-437's PR#4653/#4649 duplicate-execution race is the
+// motivating incident: #4649 was closed pilot-superseded while a sibling
+// run's PR#4652 for the same scope had already merged, so #4649's own PR
+// (#4653) was born conflicting against work already on main). Resolving
+// that conflict would just recreate merged work, so the honest action is
+// closing the PR with a terminal stage — not escalateAndHold's
+// needs-manual-rebase/pilot-needs-human ask for a rebase nobody should
+// perform. Unlike closeAndReexecute, this never re-adds the pilot label or
+// removes pilot-in-progress: the issue is already closed, so there is
+// nothing to re-dispatch.
+func (c *Controller) closeConflictSourceIssueClosed(ctx context.Context, prState *PRState, issue *github.Issue) error {
+	reason := fmt.Sprintf("source issue #%d is closed", prState.IssueNumber)
+	comment := fmt.Sprintf(
+		"Source issue #%d is closed — closing this PR instead of attempting a rebase. Resolving this merge conflict would duplicate work already merged to main.",
+		prState.IssueNumber,
+	)
+	if github.HasLabel(issue, github.LabelSuperseded) {
+		comment += fmt.Sprintf("\n\nThe issue carries `%s`: it was closed because another run already delivered this scope.", github.LabelSuperseded)
+	}
+
+	c.log.Info("handleMergeConflict: source issue closed, closing PR instead of escalating",
+		"pr", prState.PRNumber, "issue", prState.IssueNumber, "issue_state", issue.State)
+
+	if _, err := c.ghClient.AddPRComment(ctx, c.owner, c.repo, prState.PRNumber, comment); err != nil {
+		c.log.Warn("failed to comment on conflicting PR before close", "pr", prState.PRNumber, "error", err)
+	}
+	if err := c.ghClient.ClosePullRequest(ctx, c.owner, c.repo, prState.PRNumber); err != nil {
+		c.log.Warn("failed to close conflicting PR", "pr", prState.PRNumber, "error", err)
+	}
+
+	prState.Stage = StageFailed
+	prState.Error = reason
+	// GH-3806: tell notifyExternalClose (which runs once this close is
+	// observed on GitHub) not to mark the already-closed issue
+	// pilot-retry-ready — there is nothing to retry.
+	prState.TerminalLabel = github.LabelSuperseded
+	return nil
 }
 
 // closeAndReexecute is the fallback rung of handleMergeConflict: comment on

--- a/internal/autopilot/gh4657_test.go
+++ b/internal/autopilot/gh4657_test.go
@@ -1,0 +1,182 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestController_HandleMergeConflict_SourceIssueClosed covers GH-4657/TASK-437:
+// a conflicting PR whose source issue is already closed — because a
+// sibling/parent run delivered the same scope first (PR#4653 was born
+// conflicting against already-closed issue #4649, whose scope had already
+// merged via PR#4652) — must be closed with an honest terminal state
+// instead of escalated for a rebase nobody should perform.
+//
+// Table-driven across the three branches of the new issue-state check added
+// to handleMergeConflict: a closed source issue (new short-circuit), an open
+// source issue (today's rebase/escalate ladder, unchanged), and a GetIssue
+// API error (fail-open to today's ladder, since escalation is the safe
+// default when issue state can't be confirmed).
+//
+// Every case uses the same source-file (non-go.mod/go.sum) conflict fixture
+// as TestController_HandleMergeConflict_SourceFileConflictEscalatesInsteadOfClosing
+// so that, absent the GH-4657 short-circuit, the path always falls through
+// to escalateAndHold — making "open issue" and "GetIssue error" genuine
+// regression checks that today's escalation behavior is untouched.
+func TestController_HandleMergeConflict_SourceIssueClosed(t *testing.T) {
+	tests := []struct {
+		name           string
+		issueHandler   func(w http.ResponseWriter, r *http.Request)
+		wantPRClosed   bool
+		wantEscalation bool
+	}{
+		{
+			name: "closed issue: PR closed honestly, no escalation",
+			issueHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(github.Issue{
+					Number: 4649,
+					State:  "closed",
+					Labels: []github.Label{{Name: github.LabelSuperseded}},
+				})
+			},
+			wantPRClosed:   true,
+			wantEscalation: false,
+		},
+		{
+			name: "open issue: today's escalation unchanged",
+			issueHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(github.Issue{Number: 4649, State: "open"})
+			},
+			wantPRClosed:   false,
+			wantEscalation: true,
+		},
+		{
+			name: "GetIssue error: fail-open to today's escalation",
+			issueHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			wantPRClosed:   false,
+			wantEscalation: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			local := newFixtureRepo(t)
+			ctx := context.Background()
+
+			// Source-file conflict (not go.mod/go.sum-only): absent the
+			// GH-4657 short-circuit, auto-rebase fails and mechanical
+			// resolution determines the conflict surface isn't
+			// go.mod/go.sum-only, so the ladder escalates instead of
+			// closing (GH-4459).
+			runFixtureGit(t, local, "checkout", "-b", "feature/x")
+			writeFixtureFile(t, local, "main.go", "package fixture\n\nfunc X() int { return 1 }\n")
+			runFixtureGit(t, local, "add", ".")
+			runFixtureGit(t, local, "commit", "-m", "add X returning 1")
+			runFixtureGit(t, local, "push", "origin", "feature/x")
+
+			runFixtureGit(t, local, "checkout", "main")
+			writeFixtureFile(t, local, "main.go", "package fixture\n\nfunc X() int { return 2 }\n")
+			runFixtureGit(t, local, "add", ".")
+			runFixtureGit(t, local, "commit", "-m", "change X to return 2")
+			runFixtureGit(t, local, "push", "origin", "main")
+
+			var (
+				prClosed    bool
+				prComment   string
+				labelsAdded []string
+			)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.URL.Path == "/repos/owner/repo/issues/4649" && r.Method == http.MethodGet:
+					tt.issueHandler(w, r)
+				case r.URL.Path == "/repos/owner/repo/pulls/60/update-branch" && r.Method == http.MethodPut:
+					w.WriteHeader(http.StatusUnprocessableEntity)
+					_, _ = w.Write([]byte(`{"message":"merge conflict between base and head"}`))
+				case r.URL.Path == "/repos/owner/repo/pulls/60" && r.Method == http.MethodPatch:
+					prClosed = true
+					w.WriteHeader(http.StatusOK)
+				case r.URL.Path == "/repos/owner/repo/issues/60/comments" && r.Method == http.MethodPost:
+					var body map[string]string
+					_ = json.NewDecoder(r.Body).Decode(&body)
+					prComment = body["body"]
+					w.WriteHeader(http.StatusCreated)
+					_ = json.NewEncoder(w).Encode(github.PRComment{ID: 1})
+				case r.URL.Path == "/repos/owner/repo/issues/4649/labels" && r.Method == http.MethodPost:
+					var body map[string][]string
+					_ = json.NewDecoder(r.Body).Decode(&body)
+					labelsAdded = append(labelsAdded, body["labels"]...)
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode([]github.Label{})
+				default:
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("{}"))
+				}
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			cfg.Environment = EnvDev
+
+			c := NewController(cfg, ghClient, nil, "owner", "repo", WithProjectPath(local))
+			prState := &PRState{
+				PRNumber:    60,
+				PRURL:       "https://github.com/owner/repo/pull/60",
+				IssueNumber: 4649,
+				BranchName:  "feature/x",
+				HeadSHA:     "deadbeef",
+				Stage:       StageMerging,
+				CreatedAt:   time.Now(),
+			}
+			c.mu.Lock()
+			c.activePRs[60] = prState
+			c.mu.Unlock()
+
+			if err := c.handleMergeConflict(ctx, prState); err != nil {
+				t.Fatalf("handleMergeConflict: %v", err)
+			}
+
+			if prClosed != tt.wantPRClosed {
+				t.Errorf("prClosed = %v, want %v", prClosed, tt.wantPRClosed)
+			}
+			if prState.Stage != StageFailed {
+				t.Errorf("Stage = %s, want %s", prState.Stage, StageFailed)
+			}
+
+			gotEscalationLabel := false
+			for _, l := range labelsAdded {
+				if l == "needs-manual-rebase" || l == labelNeedsHuman {
+					gotEscalationLabel = true
+				}
+			}
+			if gotEscalationLabel != tt.wantEscalation {
+				t.Errorf("escalation labels present = %v (labels=%v), want %v", gotEscalationLabel, labelsAdded, tt.wantEscalation)
+			}
+
+			if tt.wantPRClosed {
+				if prComment == "" || !strings.Contains(prComment, "closed") {
+					t.Errorf("expected an honest close comment naming the closed source issue, got %q", prComment)
+				}
+				if prState.TerminalLabel != github.LabelSuperseded {
+					t.Errorf("TerminalLabel = %q, want %q", prState.TerminalLabel, github.LabelSuperseded)
+				}
+			} else {
+				if prState.TerminalLabel == github.LabelSuperseded {
+					t.Errorf("TerminalLabel must not be set to %q when the PR wasn't closed via the GH-4657 path", github.LabelSuperseded)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `handleMergeConflict` now checks the source issue's live state before any rebase attempt. If the issue is closed, the PR is closed with an honest terminal state instead of being escalated with `needs-manual-rebase`/`pilot-needs-human` for a rebase nobody should perform.
- Fails open to today's rebase/escalate ladder on a `GetIssue` error or when the issue is open — existing behavior is unchanged.

## Context
Same 2026-07-31 incident, autopilot leg (`.agent/tasks/TASK-437-duplicate-execution-race-prevention.md`): PR#4653 was born merge-conflicting because its scope had already merged via PR#4652, and its source issue #4649 was already closed. The conflict machinery worked as designed but produced a semantically wrong outcome — asking a human to rebase a PR that should simply be closed.

## Test plan
- [x] New table-driven test `TestController_HandleMergeConflict_SourceIssueClosed` covers: closed issue → PR closed honestly, zero escalation labels; open issue → today's escalation unchanged; `GetIssue` error → fail-open to today's path
- [x] `go build ./...`
- [x] `make test` (full suite) green
- [x] `gofmt` / `go vet` clean