### PR TITLE
GH-4659: feat(executor): add child-ledger gate check function

### DIFF
--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2034,6 +2034,52 @@ func (r *Runner) recordEpicTerminalEvent(executionID string, result *ExecutionRe
 	}
 }
 
+// decomposedChildLedgerNonTerminal reports whether taskID has a recorded
+// StageDecomposed ledger event (Store.GetDecomposedChildTaskIDs) AND at
+// least one parsed child is non-terminal (still in flight) or failed —
+// anything childCompletionEvidence (dispatcher.go:2842-2858) would NOT tag
+// "completed", "no_op", or "merged_pr". It reuses that same terminal-status
+// vocabulary rather than defining a new one, so a child counts as terminal
+// here exactly when decomposedChildrenAllComplete's per-child loop would
+// treat it as done.
+//
+// GH-4655/GH-4659: this is the check half of the GH-4648/GH-4649
+// duplicate-execution race fix (TASK-437) — a decomposed parent's retry
+// must resume coordination rather than re-implement once ANY child is
+// recorded, not only when every child has already shipped
+// (decomposedChildrenAllComplete is all-or-nothing and silently falls
+// through when a child failed). Deliberately scoped to the check alone:
+// wiring this into the epic-mode decision ahead of DetectComplexity
+// (~runner.go:2224) and routing into the recoverExistingSubIssues
+// coordinator flow are separate sibling issues (GH-4660/GH-4661); this
+// function adds no new tables, config, or helper abstractions beyond
+// itself.
+//
+// Returns false with no children if taskID never decomposed, or if the
+// StageDecomposed detail string didn't parse into any child refs
+// (malformed/legacy format) — fail safe, matching
+// decomposedChildrenAllComplete's own fallback rather than guessing.
+func decomposedChildLedgerNonTerminal(store *memory.Store, taskID, projectPath string) (hasNonTerminal bool, childIDs []string, err error) {
+	childIDs, found, err := store.GetDecomposedChildTaskIDs(taskID, projectPath)
+	if err != nil {
+		return false, nil, err
+	}
+	if !found || len(childIDs) == 0 {
+		return false, childIDs, nil
+	}
+
+	for _, childID := range childIDs {
+		_, complete, cErr := childCompletionEvidence(store, childID, projectPath)
+		if cErr != nil {
+			return false, childIDs, cErr
+		}
+		if !complete {
+			return true, childIDs, nil
+		}
+	}
+	return false, childIDs, nil
+}
+
 // executeWithOptions is the internal implementation that allows controlling worktree creation.
 // When allowWorktree is false, it skips worktree creation even if configured.
 // This prevents recursive worktree creation in sub-issues and decomposed tasks.

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -4550,6 +4551,141 @@ func TestGhostSHAGuard(t *testing.T) {
 		}
 		if result.Error != "no new commit produced — worktree HEAD matches base branch parent" {
 			t.Errorf("non-LocalMode task: unexpected error %q", result.Error)
+		}
+	})
+}
+
+// TestDecomposedChildLedgerNonTerminal covers the GH-4659 check function:
+// given a decomposed parent's recorded children, does ANY child fall
+// outside childCompletionEvidence's terminal vocabulary (completed, no_op,
+// merged_pr)? This is the detection half of the GH-4655/TASK-437
+// duplicate-execution race fix — decomposedChildrenAllComplete only acts
+// when EVERY child is terminal, so a single failed/in-flight child needs
+// its own signal for the (separate) coordinator-resume routing to consume.
+func TestDecomposedChildLedgerNonTerminal(t *testing.T) {
+	const projectPath = "/project-child-ledger-gate"
+
+	t.Run("one child failed reports non-terminal", func(t *testing.T) {
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+
+		parentExec := &memory.Execution{ID: "exec-gate-parent-a", TaskID: "GH-6001", ProjectPath: projectPath, Status: "failed"}
+		if err := store.SaveExecution(parentExec); err != nil {
+			t.Fatalf("SaveExecution(parent): %v", err)
+		}
+		if err := store.InsertExecutionEvent(parentExec.ID, memory.StageDecomposed, "decomposed into 2 children: #6002, #6003"); err != nil {
+			t.Fatalf("InsertExecutionEvent: %v", err)
+		}
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-GH-6002", TaskID: "GH-6002", ProjectPath: projectPath,
+			Status: "completed", PRUrl: "https://github.com/qf-studio/pilot/pull/6002",
+		}); err != nil {
+			t.Fatalf("SaveExecution(child1): %v", err)
+		}
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-GH-6003", TaskID: "GH-6003", ProjectPath: projectPath, Status: "failed", Error: "boom",
+		}); err != nil {
+			t.Fatalf("SaveExecution(child2): %v", err)
+		}
+
+		hasNonTerminal, childIDs, err := decomposedChildLedgerNonTerminal(store, "GH-6001", projectPath)
+		if err != nil {
+			t.Fatalf("decomposedChildLedgerNonTerminal: %v", err)
+		}
+		if !hasNonTerminal {
+			t.Error("expected hasNonTerminal=true when a decomposed child recorded a failed row")
+		}
+		if !reflect.DeepEqual(childIDs, []string{"GH-6002", "GH-6003"}) {
+			t.Errorf("childIDs = %v, want [GH-6002 GH-6003]", childIDs)
+		}
+	})
+
+	t.Run("one child still running reports non-terminal", func(t *testing.T) {
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+
+		parentExec := &memory.Execution{ID: "exec-gate-parent-b", TaskID: "GH-6011", ProjectPath: projectPath, Status: "failed"}
+		if err := store.SaveExecution(parentExec); err != nil {
+			t.Fatalf("SaveExecution(parent): %v", err)
+		}
+		if err := store.InsertExecutionEvent(parentExec.ID, memory.StageDecomposed, "decomposed into 1 children: #6012"); err != nil {
+			t.Fatalf("InsertExecutionEvent: %v", err)
+		}
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-GH-6012", TaskID: "GH-6012", ProjectPath: projectPath, Status: "running",
+		}); err != nil {
+			t.Fatalf("SaveExecution(child): %v", err)
+		}
+
+		hasNonTerminal, _, err := decomposedChildLedgerNonTerminal(store, "GH-6011", projectPath)
+		if err != nil {
+			t.Fatalf("decomposedChildLedgerNonTerminal: %v", err)
+		}
+		if !hasNonTerminal {
+			t.Error("expected hasNonTerminal=true when a decomposed child is still in flight (no terminal row)")
+		}
+	})
+
+	t.Run("all children terminal (completed/no_op/merged_pr) reports false", func(t *testing.T) {
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+
+		parentExec := &memory.Execution{ID: "exec-gate-parent-c", TaskID: "GH-6021", ProjectPath: projectPath, Status: "failed"}
+		if err := store.SaveExecution(parentExec); err != nil {
+			t.Fatalf("SaveExecution(parent): %v", err)
+		}
+		if err := store.InsertExecutionEvent(parentExec.ID, memory.StageDecomposed, "decomposed into 3 children: #6022, #6023, #6024"); err != nil {
+			t.Fatalf("InsertExecutionEvent: %v", err)
+		}
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-GH-6022", TaskID: "GH-6022", ProjectPath: projectPath,
+			Status: "completed", PRUrl: "https://github.com/qf-studio/pilot/pull/6022",
+		}); err != nil {
+			t.Fatalf("SaveExecution(child1): %v", err)
+		}
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-GH-6023", TaskID: "GH-6023", ProjectPath: projectPath, Status: "no_op",
+		}); err != nil {
+			t.Fatalf("SaveExecution(child2): %v", err)
+		}
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-GH-6024", TaskID: "GH-6024", ProjectPath: projectPath,
+			Status: "failed", PRUrl: "https://github.com/qf-studio/pilot/pull/6024",
+		}); err != nil {
+			t.Fatalf("SaveExecution(child3): %v", err)
+		}
+
+		hasNonTerminal, childIDs, err := decomposedChildLedgerNonTerminal(store, "GH-6021", projectPath)
+		if err != nil {
+			t.Fatalf("decomposedChildLedgerNonTerminal: %v", err)
+		}
+		if hasNonTerminal {
+			t.Error("expected hasNonTerminal=false when every child matches completed/no_op/merged_pr")
+		}
+		if len(childIDs) != 3 {
+			t.Errorf("expected 3 child IDs, got %v", childIDs)
+		}
+	})
+
+	t.Run("no decomposed event reports false with no children", func(t *testing.T) {
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-gate-direct", TaskID: "GH-6031", ProjectPath: projectPath, Status: "running",
+		}); err != nil {
+			t.Fatalf("SaveExecution: %v", err)
+		}
+
+		hasNonTerminal, childIDs, err := decomposedChildLedgerNonTerminal(store, "GH-6031", projectPath)
+		if err != nil {
+			t.Fatalf("decomposedChildLedgerNonTerminal: %v", err)
+		}
+		if hasNonTerminal {
+			t.Error("expected hasNonTerminal=false for a task that never decomposed")
+		}
+		if len(childIDs) != 0 {
+			t.Errorf("expected no child IDs, got %v", childIDs)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4659.

Closes #4659

## Changes

In internal/executor/runner.go, implement a check (using Store.GetDecomposedChildTaskIDs(task.ID, task.ProjectPath)) that determines whether any recorded child is non-terminal or failed, reusing the terminal-status vocabulary from childCompletionEvidence (dispatcher.go:2842-2858: completed, no_op, merged_pr) without adding new tables, config, or helper abstractions beyond this single check.