### PR TITLE
GH-4660: feat(executor): insert child-ledger gate before complexity detection in epic decision block

### DIFF
--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2034,6 +2034,52 @@ func (r *Runner) recordEpicTerminalEvent(executionID string, result *ExecutionRe
 	}
 }
 
+// decomposedChildLedgerNonTerminal reports whether taskID has a recorded
+// StageDecomposed ledger event (Store.GetDecomposedChildTaskIDs) AND at
+// least one parsed child is non-terminal (still in flight) or failed —
+// anything childCompletionEvidence (dispatcher.go:2842-2858) would NOT tag
+// "completed", "no_op", or "merged_pr". It reuses that same terminal-status
+// vocabulary rather than defining a new one, so a child counts as terminal
+// here exactly when decomposedChildrenAllComplete's per-child loop would
+// treat it as done.
+//
+// GH-4655/GH-4659: this is the check half of the GH-4648/GH-4649
+// duplicate-execution race fix (TASK-437) — a decomposed parent's retry
+// must resume coordination rather than re-implement once ANY child is
+// recorded, not only when every child has already shipped
+// (decomposedChildrenAllComplete is all-or-nothing and silently falls
+// through when a child failed). Deliberately scoped to the check alone:
+// wiring this into the epic-mode decision ahead of DetectComplexity
+// (~runner.go:2224) and routing into the recoverExistingSubIssues
+// coordinator flow are separate sibling issues (GH-4660/GH-4661); this
+// function adds no new tables, config, or helper abstractions beyond
+// itself.
+//
+// Returns false with no children if taskID never decomposed, or if the
+// StageDecomposed detail string didn't parse into any child refs
+// (malformed/legacy format) — fail safe, matching
+// decomposedChildrenAllComplete's own fallback rather than guessing.
+func decomposedChildLedgerNonTerminal(store *memory.Store, taskID, projectPath string) (hasNonTerminal bool, childIDs []string, err error) {
+	childIDs, found, err := store.GetDecomposedChildTaskIDs(taskID, projectPath)
+	if err != nil {
+		return false, nil, err
+	}
+	if !found || len(childIDs) == 0 {
+		return false, childIDs, nil
+	}
+
+	for _, childID := range childIDs {
+		_, complete, cErr := childCompletionEvidence(store, childID, projectPath)
+		if cErr != nil {
+			return false, childIDs, cErr
+		}
+		if !complete {
+			return true, childIDs, nil
+		}
+	}
+	return false, childIDs, nil
+}
+
 // executeWithOptions is the internal implementation that allows controlling worktree creation.
 // When allowWorktree is false, it skips worktree creation even if configured.
 // This prevents recursive worktree creation in sub-issues and decomposed tasks.

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2266,6 +2266,51 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		}
 	}
 
+	// GH-4655/GH-4660 (TASK-437): consult the decomposed child-ledger gate
+	// before any complexity classification or epic planning. A retry of an
+	// already-decomposed parent must resume coordination — not re-derive
+	// epic-ness and potentially re-plan/re-implement the whole spec
+	// directly, racing its own still-running or already-failed child (the
+	// GH-4648/GH-4649 duplicate-PR incident). The pickup-time guard
+	// (decomposedChildrenAllComplete, dispatcher.go:2803) is all-or-nothing
+	// and silently falls through here when a child hasn't shipped yet;
+	// decomposedChildLedgerNonTerminal (GH-4659) is the missing per-child
+	// signal that fires as soon as ANY recorded child isn't terminal.
+	//
+	// Routing a gated run into the recoverExistingSubIssues coordinator
+	// flow (re-dispatching failed children generation+1, waiting on
+	// in-flight ones) is wired in the sibling issue GH-4661 — deliberately
+	// scoped separately so this gate lands as one reviewable seam. Until
+	// GH-4661 lands, a gated run fails loudly here instead of silently
+	// falling through to direct re-implementation.
+	var childLedgerNonTerminal bool
+	var childLedgerChildIDs []string
+	if r.logStore != nil {
+		var gateErr error
+		childLedgerNonTerminal, childLedgerChildIDs, gateErr = decomposedChildLedgerNonTerminal(r.logStore, task.ID, task.ProjectPath)
+		if gateErr != nil {
+			r.log.Warn("Decomposed child-ledger gate check failed, proceeding with normal classification",
+				slog.String("task_id", task.ID),
+				slog.Any("error", gateErr),
+			)
+			childLedgerNonTerminal = false
+		}
+	}
+	if childLedgerNonTerminal {
+		r.log.Info("Decomposed child-ledger gate triggered: skipping complexity detection and epic planning",
+			slog.String("task_id", task.ID),
+			slog.Any("child_ids", childLedgerChildIDs),
+		)
+		r.recordExecutionEvent(task.LogExecutionID(), memory.StageFailed,
+			fmt.Sprintf("child-ledger gate: task_id=%s has non-terminal decomposed children %v — coordinator-resume routing pending (GH-4661)", task.ID, childLedgerChildIDs))
+		return &ExecutionResult{
+			TaskID:   task.ID,
+			Success:  false,
+			Error:    fmt.Sprintf("decomposed parent has non-terminal children %v; coordinator-resume routing not yet wired (GH-4661)", childLedgerChildIDs),
+			Duration: time.Since(start),
+		}, nil
+	}
+
 	// Detect complexity for routing decisions
 	complexity := DetectComplexity(task)
 

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -4550,6 +4551,141 @@ func TestGhostSHAGuard(t *testing.T) {
 		}
 		if result.Error != "no new commit produced — worktree HEAD matches base branch parent" {
 			t.Errorf("non-LocalMode task: unexpected error %q", result.Error)
+		}
+	})
+}
+
+// TestDecomposedChildLedgerNonTerminal covers the GH-4659 check function:
+// given a decomposed parent's recorded children, does ANY child fall
+// outside childCompletionEvidence's terminal vocabulary (completed, no_op,
+// merged_pr)? This is the detection half of the GH-4655/TASK-437
+// duplicate-execution race fix — decomposedChildrenAllComplete only acts
+// when EVERY child is terminal, so a single failed/in-flight child needs
+// its own signal for the (separate) coordinator-resume routing to consume.
+func TestDecomposedChildLedgerNonTerminal(t *testing.T) {
+	const projectPath = "/project-child-ledger-gate"
+
+	t.Run("one child failed reports non-terminal", func(t *testing.T) {
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+
+		parentExec := &memory.Execution{ID: "exec-gate-parent-a", TaskID: "GH-6001", ProjectPath: projectPath, Status: "failed"}
+		if err := store.SaveExecution(parentExec); err != nil {
+			t.Fatalf("SaveExecution(parent): %v", err)
+		}
+		if err := store.InsertExecutionEvent(parentExec.ID, memory.StageDecomposed, "decomposed into 2 children: #6002, #6003"); err != nil {
+			t.Fatalf("InsertExecutionEvent: %v", err)
+		}
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-GH-6002", TaskID: "GH-6002", ProjectPath: projectPath,
+			Status: "completed", PRUrl: "https://github.com/qf-studio/pilot/pull/6002",
+		}); err != nil {
+			t.Fatalf("SaveExecution(child1): %v", err)
+		}
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-GH-6003", TaskID: "GH-6003", ProjectPath: projectPath, Status: "failed", Error: "boom",
+		}); err != nil {
+			t.Fatalf("SaveExecution(child2): %v", err)
+		}
+
+		hasNonTerminal, childIDs, err := decomposedChildLedgerNonTerminal(store, "GH-6001", projectPath)
+		if err != nil {
+			t.Fatalf("decomposedChildLedgerNonTerminal: %v", err)
+		}
+		if !hasNonTerminal {
+			t.Error("expected hasNonTerminal=true when a decomposed child recorded a failed row")
+		}
+		if !reflect.DeepEqual(childIDs, []string{"GH-6002", "GH-6003"}) {
+			t.Errorf("childIDs = %v, want [GH-6002 GH-6003]", childIDs)
+		}
+	})
+
+	t.Run("one child still running reports non-terminal", func(t *testing.T) {
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+
+		parentExec := &memory.Execution{ID: "exec-gate-parent-b", TaskID: "GH-6011", ProjectPath: projectPath, Status: "failed"}
+		if err := store.SaveExecution(parentExec); err != nil {
+			t.Fatalf("SaveExecution(parent): %v", err)
+		}
+		if err := store.InsertExecutionEvent(parentExec.ID, memory.StageDecomposed, "decomposed into 1 children: #6012"); err != nil {
+			t.Fatalf("InsertExecutionEvent: %v", err)
+		}
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-GH-6012", TaskID: "GH-6012", ProjectPath: projectPath, Status: "running",
+		}); err != nil {
+			t.Fatalf("SaveExecution(child): %v", err)
+		}
+
+		hasNonTerminal, _, err := decomposedChildLedgerNonTerminal(store, "GH-6011", projectPath)
+		if err != nil {
+			t.Fatalf("decomposedChildLedgerNonTerminal: %v", err)
+		}
+		if !hasNonTerminal {
+			t.Error("expected hasNonTerminal=true when a decomposed child is still in flight (no terminal row)")
+		}
+	})
+
+	t.Run("all children terminal (completed/no_op/merged_pr) reports false", func(t *testing.T) {
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+
+		parentExec := &memory.Execution{ID: "exec-gate-parent-c", TaskID: "GH-6021", ProjectPath: projectPath, Status: "failed"}
+		if err := store.SaveExecution(parentExec); err != nil {
+			t.Fatalf("SaveExecution(parent): %v", err)
+		}
+		if err := store.InsertExecutionEvent(parentExec.ID, memory.StageDecomposed, "decomposed into 3 children: #6022, #6023, #6024"); err != nil {
+			t.Fatalf("InsertExecutionEvent: %v", err)
+		}
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-GH-6022", TaskID: "GH-6022", ProjectPath: projectPath,
+			Status: "completed", PRUrl: "https://github.com/qf-studio/pilot/pull/6022",
+		}); err != nil {
+			t.Fatalf("SaveExecution(child1): %v", err)
+		}
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-GH-6023", TaskID: "GH-6023", ProjectPath: projectPath, Status: "no_op",
+		}); err != nil {
+			t.Fatalf("SaveExecution(child2): %v", err)
+		}
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-GH-6024", TaskID: "GH-6024", ProjectPath: projectPath,
+			Status: "failed", PRUrl: "https://github.com/qf-studio/pilot/pull/6024",
+		}); err != nil {
+			t.Fatalf("SaveExecution(child3): %v", err)
+		}
+
+		hasNonTerminal, childIDs, err := decomposedChildLedgerNonTerminal(store, "GH-6021", projectPath)
+		if err != nil {
+			t.Fatalf("decomposedChildLedgerNonTerminal: %v", err)
+		}
+		if hasNonTerminal {
+			t.Error("expected hasNonTerminal=false when every child matches completed/no_op/merged_pr")
+		}
+		if len(childIDs) != 3 {
+			t.Errorf("expected 3 child IDs, got %v", childIDs)
+		}
+	})
+
+	t.Run("no decomposed event reports false with no children", func(t *testing.T) {
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-gate-direct", TaskID: "GH-6031", ProjectPath: projectPath, Status: "running",
+		}); err != nil {
+			t.Fatalf("SaveExecution: %v", err)
+		}
+
+		hasNonTerminal, childIDs, err := decomposedChildLedgerNonTerminal(store, "GH-6031", projectPath)
+		if err != nil {
+			t.Fatalf("decomposedChildLedgerNonTerminal: %v", err)
+		}
+		if hasNonTerminal {
+			t.Error("expected hasNonTerminal=false for a task that never decomposed")
+		}
+		if len(childIDs) != 0 {
+			t.Errorf("expected no child IDs, got %v", childIDs)
 		}
 	})
 }

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -4689,3 +4689,66 @@ func TestDecomposedChildLedgerNonTerminal(t *testing.T) {
 		}
 	})
 }
+
+// TestRunner_Execute_ChildLedgerGate_SkipsPlanning covers the GH-4660 wiring:
+// when decomposedChildLedgerNonTerminal (GH-4659) reports a non-terminal
+// decomposed child for this exact task_id, Execute must short-circuit
+// before DetectComplexity/epic planning ever runs — the backend must never
+// be invoked and the result must be a clear, non-successful terminal state
+// rather than a silent fall-through into direct re-implementation (the
+// GH-4648/GH-4649 duplicate-PR race).
+func TestRunner_Execute_ChildLedgerGate_SkipsPlanning(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	projectDir := t.TempDir()
+
+	parentExec := &memory.Execution{ID: "exec-gate-wire-parent", TaskID: "GH-7001", ProjectPath: projectDir, Status: "failed"}
+	if err := store.SaveExecution(parentExec); err != nil {
+		t.Fatalf("SaveExecution(parent): %v", err)
+	}
+	if err := store.InsertExecutionEvent(parentExec.ID, memory.StageDecomposed, "decomposed into 1 children: #7002"); err != nil {
+		t.Fatalf("InsertExecutionEvent: %v", err)
+	}
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "exec-GH-7002", TaskID: "GH-7002", ProjectPath: projectDir, Status: "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution(child): %v", err)
+	}
+
+	backend := &mockFixedBackend{result: &BackendResult{Success: true, Output: "should never run"}}
+	runner := NewRunnerWithBackend(backend)
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+	runner.SetLogStore(store)
+
+	task := &Task{
+		ID:          "GH-7001",
+		ExecutionID: parentExec.ID,
+		Title:       "Retry of a decomposed parent",
+		Description: "Should be gated before complexity detection and epic planning",
+		ProjectPath: projectDir,
+		LocalMode:   true,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := runner.Execute(ctx, task)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if result.Success {
+		t.Fatalf("Execute() succeeded, want a gated failure (Error=%q)", result.Error)
+	}
+	if !strings.Contains(result.Error, "GH-7002") {
+		t.Errorf("result.Error = %q, want it to mention the non-terminal child GH-7002", result.Error)
+	}
+
+	backend.mu.Lock()
+	execCount := backend.execCount
+	backend.mu.Unlock()
+	if execCount != 0 {
+		t.Errorf("backend.execCount = %d, want 0 — complexity detection/epic planning should have short-circuited before any backend call", execCount)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4660.

Closes #4660

## Changes

Wire the new check into runner.go at the top of the epic-mode decision block (~line 2253), positioned before DetectComplexity (:2224) and before the epic gate (:2253), so that if the check finds a non-terminal/failed child, complexity detection and planning are skipped entirely.