### PR TITLE
GH-4661: feat(executor): route gated tasks into recoverExistingSubIssues coordinator flow

### DIFF
--- a/.agent/tasks/gh-4661.md
+++ b/.agent/tasks/gh-4661.md
@@ -1,0 +1,10 @@
+# GH-4661
+
+**Created:** 2026-08-03
+
+## Problem
+
+When the gate triggers, route execution into the existing recoverExistingSubIssues flow (runner.go:2384-2477) so the run resumes as coordinator: re-dispatch failed children at generation+1 using the existing claim machinery (beginWithGenerationRetry/nextRetryGeneration) and wait on any in-flight children.
+
+## Acceptance Criteria
+

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -149,6 +149,10 @@ func NewDispatcher(store *memory.Store, runner *Runner, config *DispatcherConfig
 	// used by tests exercising Dispatcher in isolation.
 	if runner != nil {
 		runner.setReclaimSelfOwnedQueuedChildFn(d.reclaimSelfOwnedQueuedChild)
+		// GH-4655/GH-4661: wire the generation+1 retry mechanism so a
+		// decomposed parent resuming as coordinator can re-dispatch a failed
+		// child instead of losing its claim forever at generation 0.
+		runner.setChildGenerationRetryFn(d.childGenerationRetry)
 	}
 
 	return d
@@ -905,6 +909,33 @@ func (d *Dispatcher) reclaimSelfOwnedQueuedChild(subTask *Task) (execID string, 
 	newExecID, beginErr := d.beginWithGenerationRetry(subTask, ExecStatusRunning)
 	if beginErr != nil {
 		return "", false, fmt.Errorf("reclaimSelfOwnedQueuedChild: beginWithGenerationRetry failed: %w", beginErr)
+	}
+	if newExecID == "" {
+		return "", false, nil
+	}
+	return newExecID, true, nil
+}
+
+// childGenerationRetry wraps beginWithGenerationRetry for
+// executeSubIssuesTracked's coordinator-resume path (GH-4655/GH-4661): a
+// decomposed parent's retry pickup re-discovering its own recorded children
+// must re-dispatch a FAILED one at generation+1 rather than losing the
+// Begin() race against its own dead generation-0 claim forever (the gap
+// epic.go's sub-issue loop has documented since GH-4394 subtask 4).
+//
+// Unlike reclaimSelfOwnedQueuedChild above, this performs no force-stall
+// step: that mechanism exists for a structurally-deadlocked queued child
+// (this Runner's own worker is the only goroutine that could ever run it),
+// where forcing termination is safe because nothing else is actually
+// executing it. Here the prior claim may be genuinely live (another
+// dispatch channel is mid-execution) — beginWithGenerationRetry's own
+// nextRetryGeneration check already declines the retry in that case
+// (returns "", nil), which this method surfaces as ok=false so the caller
+// waits on/polls the live owner instead of dispatching a duplicate run.
+func (d *Dispatcher) childGenerationRetry(subTask *Task) (execID string, ok bool, err error) {
+	newExecID, beginErr := d.beginWithGenerationRetry(subTask, ExecStatusRunning)
+	if beginErr != nil {
+		return "", false, fmt.Errorf("childGenerationRetry: beginWithGenerationRetry failed: %w", beginErr)
 	}
 	if newExecID == "" {
 		return "", false, nil

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -2497,7 +2497,7 @@ func (r *Runner) resolveChildTerminalOutcome(row *memory.Execution, result *Exec
 // as their ProjectPath so they can create their own branches from the real repo.
 // executionPath is still used for gh CLI commands (issue comments) that need worktree context.
 func (r *Runner) ExecuteSubIssues(ctx context.Context, parent *Task, issues []CreatedIssue, executionPath string, repoPath string) error {
-	_, _, err := r.executeSubIssuesTracked(ctx, parent, issues, executionPath, repoPath)
+	_, _, err := r.executeSubIssuesTracked(ctx, parent, issues, executionPath, repoPath, false)
 	return err
 }
 
@@ -2723,7 +2723,19 @@ func (r *Runner) sweepEpicChildrenOnAbort(task *Task, failureReason string) {
 // mirrors the TASK-320 B2 tolerance already applied to the in-process decomposer
 // (runner_decompose.go isNoOpResult). Any other child failure still aborts the
 // whole epic, unchanged from ExecuteSubIssues' prior behavior.
-func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issues []CreatedIssue, executionPath string, repoPath string) ([]string, *ExecutionResult, error) {
+//
+// generationRetry (GH-4655/GH-4661): when true, each child's execution claim
+// is attempted through r.childGenerationRetryFn (wired to
+// Dispatcher.beginWithGenerationRetry) instead of a plain generation-0
+// Begin. This is what lets a decomposed parent's coordinator-resume path
+// re-dispatch a FAILED child at generation+1 rather than losing the Begin()
+// race against its own dead generation-0 claim forever (documented gap
+// below). A live/in-flight child still routes into the existing
+// ErrClaimLost branch, which polls via reconcileChildOutcome until the
+// owner's outcome is known — the "wait on any in-flight children" half of
+// the coordinator-resume contract. Every other caller passes false,
+// preserving today's plain-Begin behavior unchanged.
+func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issues []CreatedIssue, executionPath string, repoPath string, generationRetry bool) ([]string, *ExecutionResult, error) {
 	metrics := &ExecutionResult{}
 	if len(issues) == 0 {
 		return nil, metrics, fmt.Errorf("no sub-issues to execute")
@@ -2885,10 +2897,30 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 		// loses (ErrClaimLost) — the backend is never invoked a second time
 		// for an already-failed child, so there is no unthrottled retry here
 		// to throttle. See TestExecuteSubIssues_RepickDoesNotBypassBackoff.
-		// If this loop ever grows its own generation+1 retry, it must route
-		// through the same shared repick_backoff store beginWithGenerationRetry
-		// uses instead of re-implementing a second, driftable copy.
-		subExecID, err := NewExecutionLifecycle(r.logStore).Begin(subTask, ExecStatusRunning)
+		// GH-4655/GH-4661: this loop DID grow its own generation+1 retry —
+		// the coordinator-resume path passes generationRetry=true and routes
+		// the claim through r.childGenerationRetryFn, the shared wrapper
+		// around beginWithGenerationRetry/repick_backoff, exactly as this
+		// comment previously required rather than re-implementing a second,
+		// driftable copy here. Every other caller still passes
+		// generationRetry=false and keeps claiming generation 0 only.
+		var subExecID string
+		var err error
+		if generationRetry && r.childGenerationRetryFn != nil {
+			var ok bool
+			subExecID, ok, err = r.childGenerationRetryFn(subTask)
+			if err == nil && !ok {
+				// No fresh generation warranted — either another channel
+				// still owns a LIVE claim (wait for it) or the task is
+				// already terminally done (nothing to retry). Both funnel
+				// into the same ErrClaimLost branch below, which polls
+				// reconcileChildOutcome for the real outcome instead of
+				// re-invoking the backend.
+				err = ErrClaimLost
+			}
+		} else {
+			subExecID, err = NewExecutionLifecycle(r.logStore).Begin(subTask, ExecStatusRunning)
+		}
 
 		var result *ExecutionResult
 		if errors.Is(err, ErrClaimLost) {
@@ -3156,4 +3188,147 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 	)
 
 	return childStates, metrics, nil
+}
+
+// resumeDecomposedCoordinator is the routing target for the decomposed
+// child-ledger gate (GH-4655/GH-4660, decomposedChildLedgerNonTerminal in
+// runner.go): once the gate has determined task is a decomposed parent with
+// at least one non-terminal or failed recorded child, this resumes the run
+// as coordinator instead of falling through to complexity classification and
+// epic re-planning — the GH-4648/GH-4649 duplicate-PR race this gate exists
+// to prevent.
+//
+// It reuses the exact recovery flow CreateSubIssues' ErrSubIssuesAlreadyExist
+// branch already relies on (runner.go's "Sub-issues already exist, attempting
+// recovery" block): recoverExistingSubIssues reconstructs every GitHub issue
+// whose body names task as parent, allChildrenDone decides whether the epic
+// is already finished, and executeSubIssuesTracked drives whatever remains
+// open. The one difference from that block is generationRetry=true: a FAILED
+// child gets re-dispatched at generation+1 via r.childGenerationRetryFn
+// (Dispatcher.beginWithGenerationRetry) instead of losing the Begin() race
+// against its own dead generation-0 claim forever, and a genuinely in-flight
+// child is waited on via the existing ErrClaimLost→reconcileChildOutcome poll
+// — never re-invoked, never raced.
+func (r *Runner) resumeDecomposedCoordinator(ctx context.Context, task *Task, executionPath string, start time.Time) (*ExecutionResult, error) {
+	recover := r.recoverSubIssuesFn
+	if recover == nil {
+		recover = recoverExistingSubIssues
+	}
+	recovered, _ := recover(ctx, executionPath, task.ID)
+	if len(recovered) == 0 {
+		// The ledger says children exist, but gh can't find any matching
+		// sub-issue (deleted, cross-repo drift, transient gh CLI failure).
+		// Resuming coordination requires knowing what to re-dispatch or wait
+		// on — fail loud rather than silently falling through to direct
+		// re-implementation, which is exactly the race this gate exists to
+		// prevent.
+		failMsg := fmt.Sprintf("child-ledger gate triggered for %s but recoverExistingSubIssues found no matching sub-issues — cannot resume coordination", task.ID)
+		r.log.Error("Coordinator resume: no recovered sub-issues", slog.String("task_id", task.ID))
+		r.recordExecutionEvent(task.LogExecutionID(), memory.StageFailed, failMsg)
+		return &ExecutionResult{
+			TaskID:   task.ID,
+			Success:  false,
+			Error:    failMsg,
+			Duration: time.Since(start),
+			IsEpic:   true,
+		}, nil
+	}
+
+	if allChildrenDone(recovered) {
+		r.log.Info("Coordinator resume: all recovered sub-issues are done, treating epic as complete",
+			slog.String("task_id", task.ID),
+			slog.Int("recovered_count", len(recovered)),
+		)
+		r.reportProgress(task.ID, "Complete", 100, "All sub-issues already completed")
+		recoveredSummary := formatDecomposedChildrenSummary(recovered)
+		r.recordExecutionEvent(task.LogExecutionID(), memory.StageDecomposed, recoveredSummary)
+		r.recordExecutionEvent(task.LogExecutionID(), memory.StageCompleted, recoveredSummary)
+		return &ExecutionResult{
+			TaskID:    task.ID,
+			Success:   true,
+			Output:    fmt.Sprintf("Epic already completed: %s", recoveredSummary),
+			Duration:  time.Since(start),
+			IsEpic:    true,
+			ModelName: r.fallbackModelName(),
+		}, nil
+	}
+
+	// Filter to open children — mirrors the CreateSubIssues recovery block's
+	// own filter. A closed-but-not-ledger-complete child (rare: manually
+	// closed without a matching completion signal) has nothing left to
+	// redispatch or wait on, so fall back to the full recovered set rather
+	// than dropping it silently.
+	var pending []CreatedIssue
+	for _, iss := range recovered {
+		if strings.ToLower(iss.State) == "open" {
+			pending = append(pending, iss)
+		}
+	}
+	if len(pending) == 0 {
+		pending = recovered
+	}
+
+	r.log.Info("Coordinator resume: re-dispatching/waiting on recovered sub-issues",
+		slog.String("task_id", task.ID),
+		slog.Int("pending_count", len(pending)),
+	)
+	r.reportProgress(task.ID, "Executing", 50, fmt.Sprintf("Resuming coordinator: %d sub-issue(s)...", len(pending)))
+
+	// Scale the timeout to the actual pending count, same rationale as the
+	// multi-package epic branch above (GH-4536/TASK-419): each child gets a
+	// full complex-task budget, derived fresh from ctx rather than any
+	// already-expired parent deadline.
+	perSubIssueTimeout := r.modelRouter.GetTimeoutForComplexity(ComplexityComplex)
+	coordinatorTimeout := perSubIssueTimeout * time.Duration(len(pending))
+	if coordinatorTimeout < perSubIssueTimeout {
+		coordinatorTimeout = perSubIssueTimeout // overflow/empty guard
+	}
+	coordCtx, coordCancel := context.WithTimeout(ctx, coordinatorTimeout)
+	defer coordCancel()
+
+	childStates, childMetrics, err := r.executeSubIssuesTracked(coordCtx, task, pending, executionPath, task.ProjectPath, true)
+	if err != nil {
+		execErr := fmt.Sprintf("coordinator-resume sub-issue execution failed: %v", err)
+		r.recordExecutionEvent(task.LogExecutionID(), memory.StageFailed, truncateForLog(execErr, 200))
+		return &ExecutionResult{
+			TaskID:   task.ID,
+			Success:  false,
+			Error:    execErr,
+			Duration: time.Since(start),
+			IsEpic:   true,
+		}, nil
+	}
+
+	epicResult := &ExecutionResult{
+		TaskID:    task.ID,
+		Success:   true,
+		Output:    fmt.Sprintf("Epic completed: %s", formatDecomposedChildrenSummary(pending)),
+		Duration:  time.Since(start),
+		IsEpic:    true,
+		ModelName: r.fallbackModelName(),
+	}
+	if childMetrics != nil {
+		epicResult.TokensInput = childMetrics.TokensInput
+		epicResult.TokensOutput = childMetrics.TokensOutput
+		epicResult.TokensTotal = childMetrics.TokensTotal
+		epicResult.CacheCreationInputTokens = childMetrics.CacheCreationInputTokens
+		epicResult.CacheReadInputTokens = childMetrics.CacheReadInputTokens
+		epicResult.ResearchTokens = childMetrics.ResearchTokens
+		epicResult.FilesChanged = childMetrics.FilesChanged
+		epicResult.LinesAdded = childMetrics.LinesAdded
+		epicResult.LinesRemoved = childMetrics.LinesRemoved
+		epicResult.EstimatedCostUSD = childMetrics.EstimatedCostUSD
+		if childMetrics.ModelName != "" {
+			epicResult.ModelName = childMetrics.ModelName
+		}
+	}
+
+	if task.CreatePR && task.Branch != "" {
+		r.finalizeEpicBranchPR(coordCtx, task, NewGitOperations(executionPath), epicResult, childStates)
+	} else {
+		r.reportProgress(task.ID, "Complete", 100, "Epic completed successfully")
+	}
+	classifyZeroDeliveryEpicCompletion(epicResult)
+	r.recordEpicTerminalEvent(task.LogExecutionID(), epicResult)
+	return epicResult, nil
 }

--- a/internal/executor/epic_ledger_test.go
+++ b/internal/executor/epic_ledger_test.go
@@ -43,7 +43,7 @@ func TestExecuteSubIssues_LedgerRowPerChild(t *testing.T) {
 	runner := newTestRunnerWithExecFunc(execFn)
 	runner.logStore = store
 
-	childStates, _, err := runner.executeSubIssuesTracked(context.Background(), parent, issues, parent.ProjectPath, "")
+	childStates, _, err := runner.executeSubIssuesTracked(context.Background(), parent, issues, parent.ProjectPath, "", false)
 	if err != nil {
 		t.Fatalf("executeSubIssuesTracked returned error: %v", err)
 	}

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -2598,7 +2598,7 @@ func TestExecuteSubIssuesTracked_TouchesParentProgressPerChild(t *testing.T) {
 			Subtask: PlannedSubtask{Title: "part 2", Description: "do part 2"}},
 	}
 
-	_, _, err := r.executeSubIssuesTracked(context.Background(), parent, issues, "/test/project", "/test/project")
+	_, _, err := r.executeSubIssuesTracked(context.Background(), parent, issues, "/test/project", "/test/project", false)
 	if err != nil {
 		t.Fatalf("executeSubIssuesTracked returned unexpected error: %v", err)
 	}

--- a/internal/executor/gh3938_test.go
+++ b/internal/executor/gh3938_test.go
@@ -343,7 +343,7 @@ func TestExecuteSubIssuesTracked_PostsDecomposedChildrenComment(t *testing.T) {
 	}
 	parent := &Task{ID: "GH-3938PARENT", ProjectPath: t.TempDir()}
 
-	_, metrics, err := runner.executeSubIssuesTracked(context.Background(), parent, issues, "", "")
+	_, metrics, err := runner.executeSubIssuesTracked(context.Background(), parent, issues, "", "", false)
 	if err != nil {
 		t.Fatalf("executeSubIssuesTracked failed: %v", err)
 	}
@@ -414,7 +414,7 @@ func TestGH3938_ExistingCloseGuardsUnchanged(t *testing.T) {
 		}
 		parent := &Task{ID: "GH-8888", ProjectPath: t.TempDir()}
 
-		_, metrics, err := runner.executeSubIssuesTracked(context.Background(), parent, issues, "", t.TempDir())
+		_, metrics, err := runner.executeSubIssuesTracked(context.Background(), parent, issues, "", t.TempDir(), false)
 		if err == nil {
 			t.Fatal("expected the work-loss guard to return an error, got nil")
 		}

--- a/internal/executor/gh4405_test.go
+++ b/internal/executor/gh4405_test.go
@@ -140,7 +140,7 @@ exit 0
 			Subtask: PlannedSubtask{Title: "part 1", Description: "do part 1"}},
 	}
 
-	if _, _, err := r.executeSubIssuesTracked(context.Background(), parent, issues, projectPath, projectPath); err != nil {
+	if _, _, err := r.executeSubIssuesTracked(context.Background(), parent, issues, projectPath, projectPath, false); err != nil {
 		t.Fatalf("executeSubIssuesTracked returned unexpected error: %v", err)
 	}
 

--- a/internal/executor/gh4661_test.go
+++ b/internal/executor/gh4661_test.go
@@ -1,0 +1,183 @@
+package executor
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// TestExecuteSubIssuesTracked_GenerationRetry_RedispatchesFailedChild is the
+// core GH-4661 unit test for the "re-dispatch failed children at
+// generation+1" half of the coordinator-resume contract.
+//
+// TestExecuteSubIssues_RepickDoesNotBypassBackoff (epic_repick_backoff_test.go)
+// already proves that with generationRetry=false (every caller before
+// GH-4661), a repicked epic re-discovering an already-failed child collides
+// with its own terminal generation-0 claim and never re-invokes the backend.
+// This test proves the deliberate exception GH-4661 adds: when
+// executeSubIssuesTracked is driven with generationRetry=true (the
+// coordinator-resume path, resumeDecomposedCoordinator) and
+// r.childGenerationRetryFn grants a fresh generation for the failed child
+// (as Dispatcher.beginWithGenerationRetry's childGenerationRetry wrapper
+// would for a genuinely dead, terminal-but-not-done claim), the backend IS
+// invoked again — the failed child gets a real second attempt instead of
+// being silently dropped.
+func TestExecuteSubIssuesTracked_GenerationRetry_RedispatchesFailedChild(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	var mu sync.Mutex
+	execCalls := 0
+	execFn := func(_ context.Context, task *Task) (*ExecutionResult, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		execCalls++
+		if execCalls == 1 {
+			return &ExecutionResult{TaskID: task.ID, Success: false, Error: "boom: first attempt fails"}, nil
+		}
+		return &ExecutionResult{TaskID: task.ID, Success: true, TokensOutput: 100, FilesChanged: 1}, nil
+	}
+
+	runner := newTestRunnerWithExecFunc(execFn)
+	runner.logStore = store
+	runner.childOutcomeReconcilePollInterval = 20 * time.Millisecond
+	runner.childOutcomeReconcileTimeout = 2 * time.Second
+
+	issues := makeSubIssues(1, 9601)
+	parent := &Task{ID: "GH-9600", Title: "[epic] GH-4661 generation-retry redispatch test"}
+
+	// First attempt: plain generation-0 claim (every pre-GH-4661 caller).
+	// Claims the child, invokes the backend once, and fails.
+	_, _, err1 := runner.executeSubIssuesTracked(context.Background(), parent, issues, "", "", false)
+	if err1 == nil {
+		t.Fatal("expected the first attempt to report the child as failed")
+	}
+
+	mu.Lock()
+	firstCount := execCalls
+	mu.Unlock()
+	if firstCount != 1 {
+		t.Fatalf("backend invocations after first attempt = %d, want 1", firstCount)
+	}
+
+	// Second attempt: the coordinator-resume path (resumeDecomposedCoordinator,
+	// GH-4661) re-discovers the same failed child and grants it a fresh
+	// generation via childGenerationRetryFn — simulating what
+	// Dispatcher.childGenerationRetry would do once nextRetryGeneration
+	// confirms the prior claim is genuinely dead (terminal-but-not-done).
+	runner.childGenerationRetryFn = func(subTask *Task) (string, bool, error) {
+		execID := "exec-retry-gen1-" + subTask.ID
+		// Mirrors what Dispatcher.beginWithGenerationRetry's real Begin call
+		// does: write a fresh execution row for the new generation so the
+		// caller's later finalize step has a real row to update.
+		if saveErr := store.SaveExecution(&memory.Execution{ID: execID, TaskID: subTask.ID, Status: "running"}); saveErr != nil {
+			return "", false, saveErr
+		}
+		return execID, true, nil
+	}
+
+	_, _, err2 := runner.executeSubIssuesTracked(context.Background(), parent, issues, "", "", true)
+	if err2 != nil {
+		t.Fatalf("expected the retried attempt to succeed, got error: %v", err2)
+	}
+
+	mu.Lock()
+	secondCount := execCalls
+	mu.Unlock()
+	if secondCount != 2 {
+		t.Errorf("total backend invocations = %d, want 2 (generation+1 retry must re-invoke the backend for the failed child)", secondCount)
+	}
+}
+
+// TestExecuteSubIssuesTracked_GenerationRetry_WaitsOnLiveChild is the GH-4661
+// unit test for the other half of the coordinator-resume contract: "wait on
+// any in-flight children" instead of racing them with a duplicate dispatch.
+//
+// When r.childGenerationRetryFn reports ok=false (the signal
+// Dispatcher.childGenerationRetry/beginWithGenerationRetry/nextRetryGeneration
+// produce for a still-LIVE owner — a claim that is not actually dead), this
+// must never fall through to invoking the backend a second time. Instead it
+// routes into the same ErrClaimLost -> reconcileChildOutcome(externallyOwned)
+// poll every other externally-owned child already uses, adopting the live
+// owner's real terminal outcome once it lands.
+func TestExecuteSubIssuesTracked_GenerationRetry_WaitsOnLiveChild(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const taskID = "GH-9701"
+	if err := store.SaveExecution(&memory.Execution{
+		ID:     "exec-live-owner",
+		TaskID: taskID,
+		Status: "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	var mu sync.Mutex
+	execCalls := 0
+	execFn := func(_ context.Context, task *Task) (*ExecutionResult, error) {
+		mu.Lock()
+		execCalls++
+		mu.Unlock()
+		return &ExecutionResult{TaskID: task.ID, Success: true}, nil
+	}
+
+	runner := newTestRunnerWithExecFunc(execFn)
+	runner.logStore = store
+	runner.childOutcomeReconcilePollInterval = 20 * time.Millisecond
+	runner.childOutcomeReconcileTimeout = 2 * time.Second
+	// Reports "no fresh generation warranted" — the live owner above is still
+	// genuinely in flight, so nextRetryGeneration (dispatcher.go) would decline
+	// the retry rather than grant a colliding generation+1 claim.
+	runner.childGenerationRetryFn = func(subTask *Task) (string, bool, error) {
+		return "", false, nil
+	}
+
+	issues := makeSubIssues(1, 9701)
+	parent := &Task{ID: "GH-9700", Title: "[epic] GH-4661 generation-retry wait test"}
+
+	var prCalls []subIssuePRCall
+	runner.SetOnSubIssuePRCreated(func(prNumber int, prURL string, issueNumber int, commitSHA, branchName, issueNodeID string) {
+		prCalls = append(prCalls, subIssuePRCall{PRNumber: prNumber, PRURL: prURL, IssueNumber: issueNumber, CommitSHA: commitSHA, BranchName: branchName})
+	})
+
+	// The live owner finishes shortly after the coordinator-resume call starts
+	// waiting on it.
+	go func() {
+		time.Sleep(60 * time.Millisecond)
+		if mcErr := store.MarkExecutionCompleted("exec-live-owner", "https://github.com/owner/repo/pull/9701", "sha-live", 1000); mcErr != nil {
+			t.Errorf("MarkExecutionCompleted: %v", mcErr)
+		}
+	}()
+
+	_, _, err = runner.executeSubIssuesTracked(context.Background(), parent, issues, "", "", true)
+	if err != nil {
+		t.Fatalf("expected the coordinator-resume wait to adopt the live owner's eventual success, got error: %v", err)
+	}
+
+	mu.Lock()
+	calls := execCalls
+	mu.Unlock()
+	if calls != 0 {
+		t.Errorf("backend invocations = %d, want 0 — a genuinely live child must be waited on, never re-dispatched", calls)
+	}
+	if len(prCalls) != 1 {
+		t.Fatalf("PR callback count = %d, want 1 (from the live owner's real completion)", len(prCalls))
+	}
+	if prCalls[0].PRNumber != 9701 {
+		t.Errorf("PR callback PRNumber = %d, want 9701", prCalls[0].PRNumber)
+	}
+	if !strings.Contains(prCalls[0].CommitSHA, "sha-live") {
+		t.Errorf("PR callback CommitSHA = %q, want it to reflect the live owner's row", prCalls[0].CommitSHA)
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2034,6 +2034,52 @@ func (r *Runner) recordEpicTerminalEvent(executionID string, result *ExecutionRe
 	}
 }
 
+// decomposedChildLedgerNonTerminal reports whether taskID has a recorded
+// StageDecomposed ledger event (Store.GetDecomposedChildTaskIDs) AND at
+// least one parsed child is non-terminal (still in flight) or failed —
+// anything childCompletionEvidence (dispatcher.go:2842-2858) would NOT tag
+// "completed", "no_op", or "merged_pr". It reuses that same terminal-status
+// vocabulary rather than defining a new one, so a child counts as terminal
+// here exactly when decomposedChildrenAllComplete's per-child loop would
+// treat it as done.
+//
+// GH-4655/GH-4659: this is the check half of the GH-4648/GH-4649
+// duplicate-execution race fix (TASK-437) — a decomposed parent's retry
+// must resume coordination rather than re-implement once ANY child is
+// recorded, not only when every child has already shipped
+// (decomposedChildrenAllComplete is all-or-nothing and silently falls
+// through when a child failed). Deliberately scoped to the check alone:
+// wiring this into the epic-mode decision ahead of DetectComplexity
+// (~runner.go:2224) and routing into the recoverExistingSubIssues
+// coordinator flow are separate sibling issues (GH-4660/GH-4661); this
+// function adds no new tables, config, or helper abstractions beyond
+// itself.
+//
+// Returns false with no children if taskID never decomposed, or if the
+// StageDecomposed detail string didn't parse into any child refs
+// (malformed/legacy format) — fail safe, matching
+// decomposedChildrenAllComplete's own fallback rather than guessing.
+func decomposedChildLedgerNonTerminal(store *memory.Store, taskID, projectPath string) (hasNonTerminal bool, childIDs []string, err error) {
+	childIDs, found, err := store.GetDecomposedChildTaskIDs(taskID, projectPath)
+	if err != nil {
+		return false, nil, err
+	}
+	if !found || len(childIDs) == 0 {
+		return false, childIDs, nil
+	}
+
+	for _, childID := range childIDs {
+		_, complete, cErr := childCompletionEvidence(store, childID, projectPath)
+		if cErr != nil {
+			return false, childIDs, cErr
+		}
+		if !complete {
+			return true, childIDs, nil
+		}
+	}
+	return false, childIDs, nil
+}
+
 // executeWithOptions is the internal implementation that allows controlling worktree creation.
 // When allowWorktree is false, it skips worktree creation even if configured.
 // This prevents recursive worktree creation in sub-issues and decomposed tasks.

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -813,6 +813,20 @@ type Runner struct {
 	// which case a detected self-owned deadlock fails the sub-issue instead
 	// of hanging.
 	reclaimSelfOwnedQueuedChildFn func(subTask *Task) (execID string, ok bool, err error)
+	// childGenerationRetryFn lets executeSubIssuesTracked (epic.go, GH-4661)
+	// claim a fresh generation for a decomposed child whose prior claim is
+	// dead due to failure, instead of losing the claim at generation 0
+	// forever (the gap documented at epic.go's GH-4394 subtask 4 comment).
+	// Wired by NewDispatcher to a thin wrapper around
+	// Dispatcher.beginWithGenerationRetry. Deliberately does NOT reuse
+	// reclaimSelfOwnedQueuedChildFn's force-stall step above: a coordinator
+	// resuming a decomposed parent (GH-4655/GH-4661) must WAIT for a
+	// genuinely live child, never force-stall it — only a truly dead
+	// (terminal-but-not-done) claim should be granted a new generation.
+	// Only consulted when executeSubIssuesTracked's generationRetry
+	// parameter is true; nil falls back to the plain generation-0 Begin
+	// (today's behavior), same nil-guard shape as reclaimSelfOwnedQueuedChildFn.
+	childGenerationRetryFn func(subTask *Task) (execID string, ok bool, err error)
 }
 
 // SetRepoAllowlist injects the allowlist used by the sub-issue creation
@@ -832,6 +846,15 @@ func (r *Runner) SetRepoAllowlist(allow RepoAllowlist) {
 // implementation detail.
 func (r *Runner) setReclaimSelfOwnedQueuedChildFn(fn func(subTask *Task) (execID string, ok bool, err error)) {
 	r.reclaimSelfOwnedQueuedChildFn = fn
+}
+
+// setChildGenerationRetryFn wires the generation+1 retry mechanism used by
+// executeSubIssuesTracked's coordinator-resume path (GH-4655/GH-4661) to
+// re-dispatch a failed decomposed child instead of losing its claim
+// forever at generation 0. Called by NewDispatcher; unexported since only
+// the Dispatcher constructor should set it.
+func (r *Runner) setChildGenerationRetryFn(fn func(subTask *Task) (execID string, ok bool, err error)) {
+	r.childGenerationRetryFn = fn
 }
 
 // NewRunner creates a new Runner instance with Claude Code backend by default.
@@ -2277,12 +2300,11 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 	// decomposedChildLedgerNonTerminal (GH-4659) is the missing per-child
 	// signal that fires as soon as ANY recorded child isn't terminal.
 	//
-	// Routing a gated run into the recoverExistingSubIssues coordinator
-	// flow (re-dispatching failed children generation+1, waiting on
-	// in-flight ones) is wired in the sibling issue GH-4661 — deliberately
-	// scoped separately so this gate lands as one reviewable seam. Until
-	// GH-4661 lands, a gated run fails loudly here instead of silently
-	// falling through to direct re-implementation.
+	// GH-4661: a gated run routes into resumeDecomposedCoordinator, which
+	// resumes the recoverExistingSubIssues coordinator flow (re-dispatching
+	// failed children at generation+1 via r.childGenerationRetryFn, waiting
+	// on in-flight ones) instead of falling through to direct
+	// re-implementation.
 	var childLedgerNonTerminal bool
 	var childLedgerChildIDs []string
 	if r.logStore != nil {
@@ -2297,18 +2319,11 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		}
 	}
 	if childLedgerNonTerminal {
-		r.log.Info("Decomposed child-ledger gate triggered: skipping complexity detection and epic planning",
+		r.log.Info("Decomposed child-ledger gate triggered: resuming as coordinator instead of re-planning",
 			slog.String("task_id", task.ID),
 			slog.Any("child_ids", childLedgerChildIDs),
 		)
-		r.recordExecutionEvent(task.LogExecutionID(), memory.StageFailed,
-			fmt.Sprintf("child-ledger gate: task_id=%s has non-terminal decomposed children %v — coordinator-resume routing pending (GH-4661)", task.ID, childLedgerChildIDs))
-		return &ExecutionResult{
-			TaskID:   task.ID,
-			Success:  false,
-			Error:    fmt.Sprintf("decomposed parent has non-terminal children %v; coordinator-resume routing not yet wired (GH-4661)", childLedgerChildIDs),
-			Duration: time.Since(start),
-		}, nil
+		return r.resumeDecomposedCoordinator(ctx, task, executionPath, start)
 	}
 
 	// Detect complexity for routing decisions
@@ -2614,7 +2629,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 				// one whose deliverables shipped entirely via child sub-issue PRs.
 				// GH-3938: childMetrics carries the real tokens/files/cost every child
 				// actually burned, rolled up onto the epic-parent's own result below.
-				childStates, childMetrics, err := r.executeSubIssuesTracked(epicCtx, task, issues, executionPath, task.ProjectPath)
+				childStates, childMetrics, err := r.executeSubIssuesTracked(epicCtx, task, issues, executionPath, task.ProjectPath, false)
 				if err != nil {
 					execErr := fmt.Sprintf("sub-issue execution failed: %v", err)
 					r.recordExecutionEvent(task.LogExecutionID(), memory.StageFailed, truncateForLog(execErr, 200))

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2266,6 +2266,51 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		}
 	}
 
+	// GH-4655/GH-4660 (TASK-437): consult the decomposed child-ledger gate
+	// before any complexity classification or epic planning. A retry of an
+	// already-decomposed parent must resume coordination — not re-derive
+	// epic-ness and potentially re-plan/re-implement the whole spec
+	// directly, racing its own still-running or already-failed child (the
+	// GH-4648/GH-4649 duplicate-PR incident). The pickup-time guard
+	// (decomposedChildrenAllComplete, dispatcher.go:2803) is all-or-nothing
+	// and silently falls through here when a child hasn't shipped yet;
+	// decomposedChildLedgerNonTerminal (GH-4659) is the missing per-child
+	// signal that fires as soon as ANY recorded child isn't terminal.
+	//
+	// Routing a gated run into the recoverExistingSubIssues coordinator
+	// flow (re-dispatching failed children generation+1, waiting on
+	// in-flight ones) is wired in the sibling issue GH-4661 — deliberately
+	// scoped separately so this gate lands as one reviewable seam. Until
+	// GH-4661 lands, a gated run fails loudly here instead of silently
+	// falling through to direct re-implementation.
+	var childLedgerNonTerminal bool
+	var childLedgerChildIDs []string
+	if r.logStore != nil {
+		var gateErr error
+		childLedgerNonTerminal, childLedgerChildIDs, gateErr = decomposedChildLedgerNonTerminal(r.logStore, task.ID, task.ProjectPath)
+		if gateErr != nil {
+			r.log.Warn("Decomposed child-ledger gate check failed, proceeding with normal classification",
+				slog.String("task_id", task.ID),
+				slog.Any("error", gateErr),
+			)
+			childLedgerNonTerminal = false
+		}
+	}
+	if childLedgerNonTerminal {
+		r.log.Info("Decomposed child-ledger gate triggered: skipping complexity detection and epic planning",
+			slog.String("task_id", task.ID),
+			slog.Any("child_ids", childLedgerChildIDs),
+		)
+		r.recordExecutionEvent(task.LogExecutionID(), memory.StageFailed,
+			fmt.Sprintf("child-ledger gate: task_id=%s has non-terminal decomposed children %v — coordinator-resume routing pending (GH-4661)", task.ID, childLedgerChildIDs))
+		return &ExecutionResult{
+			TaskID:   task.ID,
+			Success:  false,
+			Error:    fmt.Sprintf("decomposed parent has non-terminal children %v; coordinator-resume routing not yet wired (GH-4661)", childLedgerChildIDs),
+			Duration: time.Since(start),
+		}, nil
+	}
+
 	// Detect complexity for routing decisions
 	complexity := DetectComplexity(task)
 

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -4550,6 +4551,141 @@ func TestGhostSHAGuard(t *testing.T) {
 		}
 		if result.Error != "no new commit produced — worktree HEAD matches base branch parent" {
 			t.Errorf("non-LocalMode task: unexpected error %q", result.Error)
+		}
+	})
+}
+
+// TestDecomposedChildLedgerNonTerminal covers the GH-4659 check function:
+// given a decomposed parent's recorded children, does ANY child fall
+// outside childCompletionEvidence's terminal vocabulary (completed, no_op,
+// merged_pr)? This is the detection half of the GH-4655/TASK-437
+// duplicate-execution race fix — decomposedChildrenAllComplete only acts
+// when EVERY child is terminal, so a single failed/in-flight child needs
+// its own signal for the (separate) coordinator-resume routing to consume.
+func TestDecomposedChildLedgerNonTerminal(t *testing.T) {
+	const projectPath = "/project-child-ledger-gate"
+
+	t.Run("one child failed reports non-terminal", func(t *testing.T) {
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+
+		parentExec := &memory.Execution{ID: "exec-gate-parent-a", TaskID: "GH-6001", ProjectPath: projectPath, Status: "failed"}
+		if err := store.SaveExecution(parentExec); err != nil {
+			t.Fatalf("SaveExecution(parent): %v", err)
+		}
+		if err := store.InsertExecutionEvent(parentExec.ID, memory.StageDecomposed, "decomposed into 2 children: #6002, #6003"); err != nil {
+			t.Fatalf("InsertExecutionEvent: %v", err)
+		}
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-GH-6002", TaskID: "GH-6002", ProjectPath: projectPath,
+			Status: "completed", PRUrl: "https://github.com/qf-studio/pilot/pull/6002",
+		}); err != nil {
+			t.Fatalf("SaveExecution(child1): %v", err)
+		}
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-GH-6003", TaskID: "GH-6003", ProjectPath: projectPath, Status: "failed", Error: "boom",
+		}); err != nil {
+			t.Fatalf("SaveExecution(child2): %v", err)
+		}
+
+		hasNonTerminal, childIDs, err := decomposedChildLedgerNonTerminal(store, "GH-6001", projectPath)
+		if err != nil {
+			t.Fatalf("decomposedChildLedgerNonTerminal: %v", err)
+		}
+		if !hasNonTerminal {
+			t.Error("expected hasNonTerminal=true when a decomposed child recorded a failed row")
+		}
+		if !reflect.DeepEqual(childIDs, []string{"GH-6002", "GH-6003"}) {
+			t.Errorf("childIDs = %v, want [GH-6002 GH-6003]", childIDs)
+		}
+	})
+
+	t.Run("one child still running reports non-terminal", func(t *testing.T) {
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+
+		parentExec := &memory.Execution{ID: "exec-gate-parent-b", TaskID: "GH-6011", ProjectPath: projectPath, Status: "failed"}
+		if err := store.SaveExecution(parentExec); err != nil {
+			t.Fatalf("SaveExecution(parent): %v", err)
+		}
+		if err := store.InsertExecutionEvent(parentExec.ID, memory.StageDecomposed, "decomposed into 1 children: #6012"); err != nil {
+			t.Fatalf("InsertExecutionEvent: %v", err)
+		}
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-GH-6012", TaskID: "GH-6012", ProjectPath: projectPath, Status: "running",
+		}); err != nil {
+			t.Fatalf("SaveExecution(child): %v", err)
+		}
+
+		hasNonTerminal, _, err := decomposedChildLedgerNonTerminal(store, "GH-6011", projectPath)
+		if err != nil {
+			t.Fatalf("decomposedChildLedgerNonTerminal: %v", err)
+		}
+		if !hasNonTerminal {
+			t.Error("expected hasNonTerminal=true when a decomposed child is still in flight (no terminal row)")
+		}
+	})
+
+	t.Run("all children terminal (completed/no_op/merged_pr) reports false", func(t *testing.T) {
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+
+		parentExec := &memory.Execution{ID: "exec-gate-parent-c", TaskID: "GH-6021", ProjectPath: projectPath, Status: "failed"}
+		if err := store.SaveExecution(parentExec); err != nil {
+			t.Fatalf("SaveExecution(parent): %v", err)
+		}
+		if err := store.InsertExecutionEvent(parentExec.ID, memory.StageDecomposed, "decomposed into 3 children: #6022, #6023, #6024"); err != nil {
+			t.Fatalf("InsertExecutionEvent: %v", err)
+		}
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-GH-6022", TaskID: "GH-6022", ProjectPath: projectPath,
+			Status: "completed", PRUrl: "https://github.com/qf-studio/pilot/pull/6022",
+		}); err != nil {
+			t.Fatalf("SaveExecution(child1): %v", err)
+		}
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-GH-6023", TaskID: "GH-6023", ProjectPath: projectPath, Status: "no_op",
+		}); err != nil {
+			t.Fatalf("SaveExecution(child2): %v", err)
+		}
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-GH-6024", TaskID: "GH-6024", ProjectPath: projectPath,
+			Status: "failed", PRUrl: "https://github.com/qf-studio/pilot/pull/6024",
+		}); err != nil {
+			t.Fatalf("SaveExecution(child3): %v", err)
+		}
+
+		hasNonTerminal, childIDs, err := decomposedChildLedgerNonTerminal(store, "GH-6021", projectPath)
+		if err != nil {
+			t.Fatalf("decomposedChildLedgerNonTerminal: %v", err)
+		}
+		if hasNonTerminal {
+			t.Error("expected hasNonTerminal=false when every child matches completed/no_op/merged_pr")
+		}
+		if len(childIDs) != 3 {
+			t.Errorf("expected 3 child IDs, got %v", childIDs)
+		}
+	})
+
+	t.Run("no decomposed event reports false with no children", func(t *testing.T) {
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-gate-direct", TaskID: "GH-6031", ProjectPath: projectPath, Status: "running",
+		}); err != nil {
+			t.Fatalf("SaveExecution: %v", err)
+		}
+
+		hasNonTerminal, childIDs, err := decomposedChildLedgerNonTerminal(store, "GH-6031", projectPath)
+		if err != nil {
+			t.Fatalf("decomposedChildLedgerNonTerminal: %v", err)
+		}
+		if hasNonTerminal {
+			t.Error("expected hasNonTerminal=false for a task that never decomposed")
+		}
+		if len(childIDs) != 0 {
+			t.Errorf("expected no child IDs, got %v", childIDs)
 		}
 	})
 }

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -4693,10 +4693,14 @@ func TestDecomposedChildLedgerNonTerminal(t *testing.T) {
 // TestRunner_Execute_ChildLedgerGate_SkipsPlanning covers the GH-4660 wiring:
 // when decomposedChildLedgerNonTerminal (GH-4659) reports a non-terminal
 // decomposed child for this exact task_id, Execute must short-circuit
-// before DetectComplexity/epic planning ever runs — the backend must never
-// be invoked and the result must be a clear, non-successful terminal state
-// rather than a silent fall-through into direct re-implementation (the
-// GH-4648/GH-4649 duplicate-PR race).
+// before DetectComplexity/epic planning ever runs and route into
+// resumeDecomposedCoordinator (GH-4661) instead. This case exercises the
+// coordinator's own fail-fast branch (recoverExistingSubIssues finds no
+// matching sub-issue for the parent) — recoverSubIssuesFn is injected so the
+// test never shells out to the real gh CLI. The parent's own backend must
+// never be invoked either way: coordinator-resume never re-implements the
+// parent's spec directly (the GH-4648/GH-4649 duplicate-PR race this gate
+// exists to prevent).
 func TestRunner_Execute_ChildLedgerGate_SkipsPlanning(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
@@ -4721,6 +4725,12 @@ func TestRunner_Execute_ChildLedgerGate_SkipsPlanning(t *testing.T) {
 	runner.SetRecordingEnabled(false)
 	runner.skipPreflightChecks = true
 	runner.SetLogStore(store)
+	// No real sub-issues exist for this synthetic parent — inject the
+	// recovery function so resumeDecomposedCoordinator's fail-fast branch
+	// fires deterministically instead of shelling out to gh.
+	runner.recoverSubIssuesFn = func(_ context.Context, _ string, _ string) ([]CreatedIssue, error) {
+		return nil, nil
+	}
 
 	task := &Task{
 		ID:          "GH-7001",
@@ -4741,14 +4751,14 @@ func TestRunner_Execute_ChildLedgerGate_SkipsPlanning(t *testing.T) {
 	if result.Success {
 		t.Fatalf("Execute() succeeded, want a gated failure (Error=%q)", result.Error)
 	}
-	if !strings.Contains(result.Error, "GH-7002") {
-		t.Errorf("result.Error = %q, want it to mention the non-terminal child GH-7002", result.Error)
+	if !strings.Contains(result.Error, "GH-7001") || !strings.Contains(result.Error, "cannot resume coordination") {
+		t.Errorf("result.Error = %q, want it to report the coordinator-resume failure for GH-7001", result.Error)
 	}
 
 	backend.mu.Lock()
 	execCount := backend.execCount
 	backend.mu.Unlock()
 	if execCount != 0 {
-		t.Errorf("backend.execCount = %d, want 0 — complexity detection/epic planning should have short-circuited before any backend call", execCount)
+		t.Errorf("backend.execCount = %d, want 0 — the parent must never re-implement directly, coordinator-resume found nothing to redispatch", execCount)
 	}
 }

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -4689,3 +4689,66 @@ func TestDecomposedChildLedgerNonTerminal(t *testing.T) {
 		}
 	})
 }
+
+// TestRunner_Execute_ChildLedgerGate_SkipsPlanning covers the GH-4660 wiring:
+// when decomposedChildLedgerNonTerminal (GH-4659) reports a non-terminal
+// decomposed child for this exact task_id, Execute must short-circuit
+// before DetectComplexity/epic planning ever runs — the backend must never
+// be invoked and the result must be a clear, non-successful terminal state
+// rather than a silent fall-through into direct re-implementation (the
+// GH-4648/GH-4649 duplicate-PR race).
+func TestRunner_Execute_ChildLedgerGate_SkipsPlanning(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	projectDir := t.TempDir()
+
+	parentExec := &memory.Execution{ID: "exec-gate-wire-parent", TaskID: "GH-7001", ProjectPath: projectDir, Status: "failed"}
+	if err := store.SaveExecution(parentExec); err != nil {
+		t.Fatalf("SaveExecution(parent): %v", err)
+	}
+	if err := store.InsertExecutionEvent(parentExec.ID, memory.StageDecomposed, "decomposed into 1 children: #7002"); err != nil {
+		t.Fatalf("InsertExecutionEvent: %v", err)
+	}
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "exec-GH-7002", TaskID: "GH-7002", ProjectPath: projectDir, Status: "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution(child): %v", err)
+	}
+
+	backend := &mockFixedBackend{result: &BackendResult{Success: true, Output: "should never run"}}
+	runner := NewRunnerWithBackend(backend)
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+	runner.SetLogStore(store)
+
+	task := &Task{
+		ID:          "GH-7001",
+		ExecutionID: parentExec.ID,
+		Title:       "Retry of a decomposed parent",
+		Description: "Should be gated before complexity detection and epic planning",
+		ProjectPath: projectDir,
+		LocalMode:   true,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := runner.Execute(ctx, task)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if result.Success {
+		t.Fatalf("Execute() succeeded, want a gated failure (Error=%q)", result.Error)
+	}
+	if !strings.Contains(result.Error, "GH-7002") {
+		t.Errorf("result.Error = %q, want it to mention the non-terminal child GH-7002", result.Error)
+	}
+
+	backend.mu.Lock()
+	execCount := backend.execCount
+	backend.mu.Unlock()
+	if execCount != 0 {
+		t.Errorf("backend.execCount = %d, want 0 — complexity detection/epic planning should have short-circuited before any backend call", execCount)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4661.

Closes #4661

## Changes

When the gate triggers, route execution into the existing recoverExistingSubIssues flow (runner.go:2384-2477) so the run resumes as coordinator: re-dispatch failed children at generation+1 using the existing claim machinery (beginWithGenerationRetry/nextRetryGeneration) and wait on any in-flight children.