### PR TITLE
GH-4668: fix(executor): heartbeat monitor SIGKILLs healthy runs during long local tool executions — make test >5m ⇒ exit 137 infra churn (GH-4648/GH-4649 trigger)

### DIFF
--- a/.agent/sops/executor-heartbeat-kills-live-local-tool.md
+++ b/.agent/sops/executor-heartbeat-kills-live-local-tool.md
@@ -1,0 +1,80 @@
+---
+title: Heartbeat Monitor Killing Healthy Runs During Long Local Tool Calls
+created: 2026-08-03
+status: active
+related: GH-4668, GH-4648, GH-4649, GH-4521, GH-4401, TASK-437
+---
+
+# Heartbeat Monitor Killing Healthy Runs During Long Local Tool Calls
+
+## Problem
+
+`ClaudeCodeBackend`'s heartbeat monitor (`internal/executor/backend_claudecode.go`)
+kills the subprocess whenever `last_event_age > heartbeatTimeout` (default 5m).
+That signal is wrong whenever a *local tool call* (e.g. `make test`, `go
+build`) legitimately runs longer than the timeout: the stream-json protocol
+emits nothing between the `message_stop`/`tool_use` line that starts the tool
+and the tool-result line that ends it — local execution is silent by design,
+not by malfunction.
+
+Two healthy runs (GH-4648, GH-4649, 2026-07-31) were SIGKILLed mid-`make
+test` this way, 22+ minutes and thousands of stream events destroyed each
+time; the retry storm they triggered produced a duplicate-PR race
+(TASK-437). This is a distinct class from GH-4521 (stall watchdog killed by
+silent model *turns*) and GH-4401 (RLIMIT_AS child kills) — same "healthy
+child killed" family, different mechanism.
+
+## Root Cause
+
+`last_event_age` (time since the last stdout byte) was the *only* liveness
+signal. It cannot distinguish "hung" from "busy with a silent local tool,"
+and the pilot repo's own `go test ./...` (3.5–6+ min on the shared
+t3.xlarge box) is squarely in the danger zone of the 5m default.
+
+## Solution
+
+Before killing on `last_event_age > timeout`, check **process-group
+liveness**, not just stdout silence:
+
+1. `internal/executor/heartbeat_monitor.go` — `heartbeatMonitor.evaluate()`
+   is the pure, fake-clock-testable decision function. Given the current
+   silence age, it either does nothing (age within timeout), grants grace
+   (process group has live descendants and/or advancing CPU ticks), or
+   kills (idle group, probe error, or the task-level watchdog deadline was
+   reached — that hard backstop is never extended by grace).
+2. `internal/executor/heartbeat_liveness_linux.go` —
+   `probeProcessLiveness(pgid)` scans `/proc/*/stat` for every process
+   sharing the tracked subprocess's process group id (== its own PID, since
+   `configureProcessGroup`/GH-4503 makes it its own group leader via
+   `Setpgid`), returning descendant count and summed `utime+stime`.
+3. `internal/executor/heartbeat_liveness_other.go` — non-Linux platforms
+   (no `/proc`) always report zero descendants/ticks with a nil error, which
+   reproduces exactly today's kill-on-silence behavior — a deliberate
+   degrade, not a gap.
+4. The **watchdog goroutine's own absolute deadline (`opts.WatchdogTimeout`,
+   typically 30m/1h) still exists unchanged** as the true backstop; the
+   heartbeat monitor additionally checks that same deadline itself before
+   granting grace, so the two mechanisms can never disagree even though
+   they run as separate goroutines.
+5. Probe failure (e.g. `/proc` unreadable) fails **toward** killing — an
+   unreadable process tree is not evidence of liveness.
+
+## Prevention / Next Time
+
+If a new "healthy session killed by the heartbeat monitor" incident
+surfaces:
+
+1. Check the kill log line — post-GH-4668 it always includes `reason=`
+   (`no_activity` / `probe_error` / `watchdog_deadline`) and
+   `descendants=N cpu_delta_ticks=X`. `probe_error` points at `/proc`
+   access, not at the child being hung.
+2. If the tool call in question backgrounds work *outside* the tracked
+   process group (e.g. `nohup`/`setsid` inside the child, or a tool that
+   reparents its own children away from the group), `probeProcessLiveness`
+   will see zero descendants even though real work is happening — the pgid
+   assumption (descendant pgid == leader pid) is the load-bearing
+   invariant; verify it still holds for the new tool.
+3. Do not "fix" a new instance by raising `DefaultHeartbeatTimeout` alone —
+   any fixed timeout eventually loses to a long-enough suite. Liveness is
+   the correct signal; a modest timeout bump is fine as a complement, not a
+   substitute.

--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -669,6 +669,13 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 	lastEventAt.Store(time.Now().UnixNano())
 
 	// Heartbeat monitor goroutine
+	// GH-4668: a silent stdout stream alone is not evidence of a hang — the
+	// stream-json protocol emits nothing while a local tool (e.g. `make
+	// test`) runs, which routinely exceeds the 5m heartbeat window on this
+	// repo. hbMonitor checks process-group liveness (descendant PIDs and/or
+	// advancing CPU time) before killing; a genuinely idle, silent group is
+	// still killed exactly as before.
+	hbMonitor := newHeartbeatMonitor(b.heartbeatTimeout, opts.WatchdogTimeout, probeProcessLiveness)
 	heartbeatCtx, cancelHeartbeat := context.WithCancel(context.Background())
 	defer cancelHeartbeat()
 	logging.SafeGo("executor-backend-claudecode", func() {
@@ -683,39 +690,66 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 			case <-ticker.C:
 				lastNano := lastEventAt.Load()
 				lastTime := time.Unix(0, lastNano)
-				age := time.Since(lastTime)
-				if age > b.heartbeatTimeout {
-					b.log.Warn("Heartbeat timeout detected, killing hung process",
-						slog.Int("pid", cmd.Process.Pid),
-						slog.Duration("last_event_age", age),
-						slog.Duration("timeout", b.heartbeatTimeout),
-					)
+				now := time.Now()
+				decision, descendants, cpuDelta, logGrace, reason, probeErr := hbMonitor.evaluate(now, startTime, lastTime, cmd.Process.Pid)
 
-					// Invoke callback if provided
-					if opts.HeartbeatCallback != nil {
-						opts.HeartbeatCallback(cmd.Process.Pid, age)
+				switch decision {
+				case heartbeatNoAction:
+					continue
+				case heartbeatGrace:
+					if logGrace {
+						b.log.Info("heartbeat grace: local tool execution in flight",
+							slog.Int("pid", cmd.Process.Pid),
+							slog.Duration("last_event_age", now.Sub(lastTime)),
+							slog.Int("descendants", descendants),
+							slog.Uint64("cpu_delta_ticks", cpuDelta),
+						)
 					}
-
-					// Kill the hung process
-					// GH-4503: signal the whole process group, not just the
-					// tracked PID, so backgrounded grandchildren die too.
-					if cmd.Process != nil {
-						if err := killProcessGroup(cmd, syscall.SIGKILL); err != nil {
-							b.log.Error("Failed to kill hung process",
-								slog.Int("pid", cmd.Process.Pid),
-								slog.Any("error", err),
-							)
-						} else {
-							// GH-4412: mark self-inflicted so classification
-							// doesn't mislabel the resulting 137 as OOM.
-							heartbeatKilled.Store(true)
-							b.log.Info("Hung process killed successfully",
-								slog.Int("pid", cmd.Process.Pid),
-							)
-						}
-					}
-					return
+					continue
+				case heartbeatKill:
+					// fall through below
 				}
+
+				age := now.Sub(lastTime)
+				if probeErr != nil {
+					b.log.Warn("Heartbeat: process-liveness probe failed, killing toward safe default",
+						slog.Int("pid", cmd.Process.Pid),
+						slog.Any("error", probeErr),
+					)
+				}
+				b.log.Warn("Heartbeat timeout detected, killing hung process",
+					slog.Int("pid", cmd.Process.Pid),
+					slog.Duration("last_event_age", age),
+					slog.Duration("timeout", b.heartbeatTimeout),
+					slog.String("reason", string(reason)),
+					slog.Int("descendants", descendants),
+					slog.Uint64("cpu_delta_ticks", cpuDelta),
+				)
+
+				// Invoke callback if provided
+				if opts.HeartbeatCallback != nil {
+					opts.HeartbeatCallback(cmd.Process.Pid, age)
+				}
+
+				// Kill the hung process
+				// GH-4503: signal the whole process group, not just the
+				// tracked PID, so backgrounded grandchildren die too.
+				if cmd.Process != nil {
+					if err := killProcessGroup(cmd, syscall.SIGKILL); err != nil {
+						b.log.Error("Failed to kill hung process",
+							slog.Int("pid", cmd.Process.Pid),
+							slog.Any("error", err),
+						)
+					} else {
+						// GH-4412: mark self-inflicted so classification
+						// doesn't mislabel the resulting 137 as OOM.
+						heartbeatKilled.Store(true)
+						b.log.Info("Hung process killed successfully",
+							slog.Int("pid", cmd.Process.Pid),
+						)
+					}
+				}
+				return
 			}
 		}
 	})

--- a/internal/executor/heartbeat_liveness_linux.go
+++ b/internal/executor/heartbeat_liveness_linux.go
@@ -1,0 +1,101 @@
+//go:build linux
+
+package executor
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// probeProcessLiveness scans /proc for every process whose process group id
+// (pgid) matches pgid — which, thanks to configureProcessGroup's Setpgid, is
+// the same value as the tracked subprocess's own PID — and returns how many
+// such processes exist besides the leader itself, plus their combined
+// utime+stime CPU ticks (jiffies).
+//
+// GH-4668: a claude-code child running a long local tool (e.g. `make test`)
+// forks that tool inside the same process group. The leader's own stdout
+// goes silent for the tool's duration, but the group as a whole keeps
+// accumulating CPU time and gains live descendant PIDs — both distinguish
+// "silent because busy" from "silent because hung".
+func probeProcessLiveness(pgid int) (processLivenessSnapshot, error) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return processLivenessSnapshot{}, fmt.Errorf("read /proc: %w", err)
+	}
+
+	var snap processLivenessSnapshot
+	found := false
+	for _, e := range entries {
+		pid, convErr := strconv.Atoi(e.Name())
+		if convErr != nil {
+			continue // not a pid directory (self, cpuinfo, etc.)
+		}
+
+		statPGID, utime, stime, statErr := readProcStat(pid)
+		if statErr != nil {
+			continue // process exited between ReadDir and stat read — not fatal
+		}
+		if statPGID != pgid {
+			continue
+		}
+		found = true
+		snap.cpuTicks += utime + stime
+		if pid != pgid {
+			snap.descendants++
+		}
+	}
+
+	if !found {
+		// The leader itself should always be found while it's alive. If the
+		// scan found nothing at all for this pgid, that's evidence the scan
+		// itself is broken (e.g. /proc unreadable in this context) rather
+		// than evidence the group is empty — surface it so the caller fails
+		// toward the safe kill-on-silence path instead of reporting a false
+		// "no descendants, no CPU".
+		return processLivenessSnapshot{}, fmt.Errorf("no /proc entries found for pgid %d", pgid)
+	}
+
+	return snap, nil
+}
+
+// readProcStat parses /proc/<pid>/stat and returns its pgrp (process group
+// id) and utime/stime CPU ticks. The comm field (2nd field) is delimited by
+// parentheses and may itself contain spaces or parentheses, so the parse
+// skips to the last ')' before splitting the remaining whitespace-separated
+// fields (see `man 5 proc`): state(1) ppid(2) pgrp(3) session(4) tty_nr(5)
+// tpgid(6) flags(7) minflt(8) cminflt(9) majflt(10) cmajflt(11) utime(12)
+// stime(13) ...
+func readProcStat(pid int) (pgrp int, utime, stime uint64, err error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	line := string(data)
+	idx := strings.LastIndex(line, ")")
+	if idx < 0 || idx+2 > len(line) {
+		return 0, 0, 0, fmt.Errorf("malformed /proc/%d/stat", pid)
+	}
+	fields := strings.Fields(line[idx+2:])
+	// After skipping "pid (comm) ", fields[0]=state fields[1]=ppid
+	// fields[2]=pgrp ... fields[11]=utime fields[12]=stime.
+	const minFields = 13
+	if len(fields) < minFields {
+		return 0, 0, 0, fmt.Errorf("short /proc/%d/stat: %d fields", pid, len(fields))
+	}
+	pgrp, err = strconv.Atoi(fields[2])
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	utime, err = strconv.ParseUint(fields[11], 10, 64)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	stime, err = strconv.ParseUint(fields[12], 10, 64)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	return pgrp, utime, stime, nil
+}

--- a/internal/executor/heartbeat_liveness_linux_test.go
+++ b/internal/executor/heartbeat_liveness_linux_test.go
@@ -1,0 +1,100 @@
+//go:build linux
+
+package executor
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestReadProcStatSelf sanity-checks the /proc/<pid>/stat parser against the
+// current test process, whose pgrp is known independently via
+// syscall.Getpgid.
+func TestReadProcStatSelf(t *testing.T) {
+	pid := os.Getpid()
+	pgrp, _, _, err := readProcStat(pid)
+	if err != nil {
+		t.Fatalf("readProcStat(self) error: %v", err)
+	}
+	wantPgrp, err := syscall.Getpgid(pid)
+	if err != nil {
+		t.Fatalf("syscall.Getpgid: %v", err)
+	}
+	if pgrp != wantPgrp {
+		t.Errorf("pgrp = %d, want %d", pgrp, wantPgrp)
+	}
+}
+
+// TestReadProcStatNonexistentPID verifies a nonexistent pid produces an
+// error rather than a zero-valued success — probeProcessLiveness's "fail
+// toward kill" contract (GH-4668 acceptance d) depends on read errors
+// propagating rather than being silently swallowed as zero.
+func TestReadProcStatNonexistentPID(t *testing.T) {
+	const bogusPID = 2123456789 // far beyond any real pid_max
+	if _, _, _, err := readProcStat(bogusPID); err == nil {
+		t.Fatal("expected error reading /proc/<bogus>/stat, got nil")
+	}
+}
+
+// TestProbeProcessLivenessWithChild spawns a real process group leader that
+// forks a background child, mirroring how Claude Code's Bash tool backgrounds
+// `make test` inside the group configureProcessGroup creates (GH-4503). It
+// asserts probeProcessLiveness finds the descendant and accumulates CPU
+// ticks — the exact signal GH-4668's heartbeat monitor relies on to avoid
+// killing a healthy long-running local tool call.
+func TestProbeProcessLivenessWithChild(t *testing.T) {
+	// Busy-loop child so utime/stime reliably advance within the polling
+	// window, instead of a `sleep` which accrues ~0 CPU time.
+	cmd := exec.Command("sh", "-c", "(i=0; while [ $i -lt 100000000 ]; do i=$((i+1)); done) & wait")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	pgid := cmd.Process.Pid
+	defer func() {
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		_ = cmd.Wait()
+	}()
+
+	deadline := time.Now().Add(5 * time.Second)
+	var snap processLivenessSnapshot
+	var err error
+	for time.Now().Before(deadline) {
+		snap, err = probeProcessLiveness(pgid)
+		if err == nil && snap.descendants > 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("probeProcessLiveness error: %v", err)
+	}
+	if snap.descendants == 0 {
+		t.Fatal("expected at least 1 descendant (backgrounded busy-loop child), got 0")
+	}
+
+	// CPU ticks should advance across two probes while the busy loop spins.
+	first := snap
+	time.Sleep(200 * time.Millisecond)
+	second, err := probeProcessLiveness(pgid)
+	if err != nil {
+		t.Fatalf("second probeProcessLiveness error: %v", err)
+	}
+	if second.cpuTicks <= first.cpuTicks {
+		t.Errorf("cpuTicks did not advance: first=%d second=%d", first.cpuTicks, second.cpuTicks)
+	}
+}
+
+// TestProbeProcessLivenessUnknownPGID verifies that a pgid with no matching
+// /proc entries at all is reported as an error, not as a zero-activity
+// snapshot — an empty scan means "couldn't observe this group", which must
+// fail toward killing (acceptance d), not toward granting grace.
+func TestProbeProcessLivenessUnknownPGID(t *testing.T) {
+	const bogusPGID = 2123456789
+	if _, err := probeProcessLiveness(bogusPGID); err == nil {
+		t.Fatal("expected error for pgid with no /proc entries, got nil")
+	}
+}

--- a/internal/executor/heartbeat_liveness_other.go
+++ b/internal/executor/heartbeat_liveness_other.go
@@ -1,0 +1,16 @@
+//go:build !linux
+
+package executor
+
+// probeProcessLiveness is a no-op on non-Linux platforms: it always reports
+// zero descendants and zero CPU ticks with a nil error. GH-4668's liveness
+// grace depends on /proc, which only exists on Linux — the platform the box
+// runs on (t3.xlarge, shared with the daemon) and where the incident this
+// fixes actually happened. Reporting "no activity" rather than an error
+// means non-Linux dev environments (e.g. darwin) get exactly today's
+// kill-on-silence heartbeat behavior: no grace, no spurious probe-error
+// warnings, identical externally observable behavior to the pre-GH-4668
+// code path.
+func probeProcessLiveness(_ int) (processLivenessSnapshot, error) {
+	return processLivenessSnapshot{}, nil
+}

--- a/internal/executor/heartbeat_monitor.go
+++ b/internal/executor/heartbeat_monitor.go
@@ -1,0 +1,129 @@
+package executor
+
+import "time"
+
+// processLivenessSnapshot captures a point-in-time reading of a subprocess's
+// process group: how many processes share it besides the tracked leader, and
+// their combined utime+stime CPU ticks. GH-4668: comparing two snapshots
+// across a heartbeat tick tells the monitor whether the group is doing real
+// work (descendants exist and/or CPU ticks are advancing) even though the
+// claude-code leader itself has gone silent on stdout — which is expected
+// for the full duration of a long local tool call (e.g. `make test`), not
+// evidence of a hang.
+type processLivenessSnapshot struct {
+	descendants int
+	cpuTicks    uint64
+}
+
+// processLivenessProbe abstracts probing a process group for live descendant
+// PIDs and total CPU ticks. Production code uses probeProcessLiveness
+// (heartbeat_liveness_linux.go: /proc scan; heartbeat_liveness_other.go:
+// always reports zero descendants/ticks with a nil error, degrading
+// non-Linux platforms to the pre-GH-4668 kill-on-silence behavior). Tests
+// inject a fake to drive deterministic scenarios without real subprocesses.
+type processLivenessProbe func(pgid int) (processLivenessSnapshot, error)
+
+// heartbeatGraceLogInterval bounds how often the "heartbeat grace" INFO line
+// repeats while a long local tool keeps the stream silent — without this, a
+// 10-minute `make test` run would log once per HeartbeatCheckInterval tick.
+const heartbeatGraceLogInterval = 2 * time.Minute
+
+// heartbeatDecision is the outcome of one heartbeat tick evaluation.
+type heartbeatDecision int
+
+const (
+	// heartbeatNoAction means last_event_age is still within the timeout —
+	// nothing to check or log this tick.
+	heartbeatNoAction heartbeatDecision = iota
+	// heartbeatGrace means the stream is silent but the process group shows
+	// live descendants and/or advancing CPU time — do not kill.
+	heartbeatGrace
+	// heartbeatKill means the process should be killed: either genuinely
+	// hung (silent + idle process group), the liveness probe itself failed
+	// (fail toward the safe kill-on-silence path), or the task-level
+	// watchdog deadline was reached (grace must never extend past it).
+	heartbeatKill
+)
+
+// heartbeatKillReason explains why heartbeatKill was returned, so the kill
+// log line is diagnosable from a single entry (acceptance criterion 3).
+type heartbeatKillReason string
+
+const (
+	heartbeatKillReasonNone             heartbeatKillReason = ""
+	heartbeatKillReasonNoActivity       heartbeatKillReason = "no_activity"
+	heartbeatKillReasonProbeError       heartbeatKillReason = "probe_error"
+	heartbeatKillReasonWatchdogDeadline heartbeatKillReason = "watchdog_deadline"
+)
+
+// heartbeatMonitor tracks process-liveness probe state across ticks and
+// decides, on each tick, whether a silent stdout stream represents a hang or
+// an in-flight local tool execution (GH-4668). It is a stateful struct
+// rather than a free function because the CPU-tick delta check needs the
+// previous tick's snapshot, and the grace log needs its own rate limit.
+type heartbeatMonitor struct {
+	heartbeatTimeout time.Duration
+	// watchdogTimeout is the task-level hard deadline (opts.WatchdogTimeout).
+	// 0 means no ceiling from this source — grace can be granted for as long
+	// as the process group stays live. When > 0, grace must never push a
+	// kill past this deadline, matching the separate watchdog goroutine's
+	// own hard kill so the two mechanisms agree.
+	watchdogTimeout time.Duration
+	probe           processLivenessProbe
+
+	haveSnapshot bool
+	prevSnapshot processLivenessSnapshot
+	lastGraceLog time.Time
+}
+
+// newHeartbeatMonitor constructs a heartbeatMonitor. probe must not be nil.
+func newHeartbeatMonitor(heartbeatTimeout, watchdogTimeout time.Duration, probe processLivenessProbe) *heartbeatMonitor {
+	return &heartbeatMonitor{
+		heartbeatTimeout: heartbeatTimeout,
+		watchdogTimeout:  watchdogTimeout,
+		probe:            probe,
+	}
+}
+
+// evaluate is called once per heartbeat tick. now/startedAt/lastEventAt
+// drive all timing so tests can use a fake clock instead of real sleeps.
+// pid is the tracked process group leader's PID, which (thanks to
+// configureProcessGroup's Setpgid) is also the process group id (pgid).
+func (m *heartbeatMonitor) evaluate(now, startedAt, lastEventAt time.Time, pid int) (decision heartbeatDecision, descendants int, cpuDelta uint64, logGrace bool, reason heartbeatKillReason, probeErr error) {
+	age := now.Sub(lastEventAt)
+	if age <= m.heartbeatTimeout {
+		return heartbeatNoAction, 0, 0, false, heartbeatKillReasonNone, nil
+	}
+
+	// GH-4668: the hard backstop must remain absolute — grace can never push
+	// a kill past the task-level watchdog deadline, regardless of how live
+	// the descendant tree looks.
+	if m.watchdogTimeout > 0 && now.Sub(startedAt) >= m.watchdogTimeout {
+		return heartbeatKill, 0, 0, false, heartbeatKillReasonWatchdogDeadline, nil
+	}
+
+	snap, err := m.probe(pid)
+	if err != nil {
+		// Fail toward the pre-GH-4668 behavior: an unreadable process tree
+		// is not evidence of liveness.
+		return heartbeatKill, 0, 0, false, heartbeatKillReasonProbeError, err
+	}
+
+	if m.haveSnapshot && snap.cpuTicks > m.prevSnapshot.cpuTicks {
+		cpuDelta = snap.cpuTicks - m.prevSnapshot.cpuTicks
+	}
+	descendants = snap.descendants
+	active := descendants > 0 || cpuDelta > 0
+	m.prevSnapshot = snap
+	m.haveSnapshot = true
+
+	if active {
+		logGrace = m.lastGraceLog.IsZero() || now.Sub(m.lastGraceLog) >= heartbeatGraceLogInterval
+		if logGrace {
+			m.lastGraceLog = now
+		}
+		return heartbeatGrace, descendants, cpuDelta, logGrace, heartbeatKillReasonNone, nil
+	}
+
+	return heartbeatKill, descendants, cpuDelta, false, heartbeatKillReasonNoActivity, nil
+}

--- a/internal/executor/heartbeat_monitor_test.go
+++ b/internal/executor/heartbeat_monitor_test.go
@@ -1,0 +1,331 @@
+package executor
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakeProbe builds a processLivenessProbe for tests that returns a
+// pre-scripted sequence of (snapshot, error) results, one per call, without
+// touching a real process tree. It also records how many times it was
+// invoked so tests can assert the watchdog-deadline short-circuit (scenario
+// c) never even calls the probe.
+type fakeProbe struct {
+	results []struct {
+		snap processLivenessSnapshot
+		err  error
+	}
+	calls int
+}
+
+func (f *fakeProbe) probe(_ int) (processLivenessSnapshot, error) {
+	f.calls++
+	if len(f.results) == 0 {
+		return processLivenessSnapshot{}, nil
+	}
+	idx := f.calls - 1
+	if idx >= len(f.results) {
+		idx = len(f.results) - 1
+	}
+	r := f.results[idx]
+	return r.snap, r.err
+}
+
+func (f *fakeProbe) push(snap processLivenessSnapshot, err error) {
+	f.results = append(f.results, struct {
+		snap processLivenessSnapshot
+		err  error
+	}{snap, err})
+}
+
+// TestHeartbeatMonitor_NoActionWithinTimeout verifies that a stream still
+// within the heartbeat window never consults the liveness probe at all -
+// there is nothing to grace or kill yet.
+func TestHeartbeatMonitor_NoActionWithinTimeout(t *testing.T) {
+	fp := &fakeProbe{}
+	m := newHeartbeatMonitor(5*time.Minute, 30*time.Minute, fp.probe)
+
+	startedAt := time.Unix(0, 0)
+	lastEventAt := startedAt
+	now := startedAt.Add(4 * time.Minute) // age = 4m < 5m timeout
+
+	decision, _, _, _, _, err := m.evaluate(now, startedAt, lastEventAt, 1234)
+	if decision != heartbeatNoAction {
+		t.Fatalf("decision = %v, want heartbeatNoAction", decision)
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fp.calls != 0 {
+		t.Fatalf("probe called %d times, want 0 (age within timeout)", fp.calls)
+	}
+}
+
+// TestHeartbeatMonitor_GraceWithActiveDescendant covers acceptance scenario
+// (a): a silent stream with a live descendant process must not be killed,
+// and the grace INFO log must fire (rate-limited across repeated ticks).
+func TestHeartbeatMonitor_GraceWithActiveDescendant(t *testing.T) {
+	fp := &fakeProbe{}
+	// Every tick reports one live descendant with advancing CPU ticks -
+	// exactly the shape of a `make test` child still running.
+	fp.push(processLivenessSnapshot{descendants: 1, cpuTicks: 100}, nil)
+	fp.push(processLivenessSnapshot{descendants: 1, cpuTicks: 150}, nil)
+	fp.push(processLivenessSnapshot{descendants: 1, cpuTicks: 200}, nil)
+
+	m := newHeartbeatMonitor(5*time.Minute, 30*time.Minute, fp.probe)
+	startedAt := time.Unix(0, 0)
+	lastEventAt := startedAt
+
+	// Tick 1: age = 6m, past timeout. Descendant is live -> grace, and since
+	// this is the first grace tick it must log immediately.
+	now := startedAt.Add(6 * time.Minute)
+	decision, descendants, cpuDelta, logGrace, _, err := m.evaluate(now, startedAt, lastEventAt, 1234)
+	if decision != heartbeatGrace {
+		t.Fatalf("tick1 decision = %v, want heartbeatGrace", decision)
+	}
+	if err != nil {
+		t.Fatalf("tick1 unexpected error: %v", err)
+	}
+	if descendants != 1 {
+		t.Fatalf("tick1 descendants = %d, want 1", descendants)
+	}
+	if cpuDelta != 0 {
+		t.Fatalf("tick1 cpuDelta = %d, want 0 (no prior snapshot yet)", cpuDelta)
+	}
+	if !logGrace {
+		t.Fatalf("tick1 logGrace = false, want true (first grace observation)")
+	}
+
+	// Tick 2: 30s later (well under the 2m grace-log rate limit) -> still
+	// grace, but must NOT re-log.
+	now = now.Add(30 * time.Second)
+	decision, descendants, cpuDelta, logGrace, _, err = m.evaluate(now, startedAt, lastEventAt, 1234)
+	if decision != heartbeatGrace {
+		t.Fatalf("tick2 decision = %v, want heartbeatGrace", decision)
+	}
+	if err != nil {
+		t.Fatalf("tick2 unexpected error: %v", err)
+	}
+	if descendants != 1 {
+		t.Fatalf("tick2 descendants = %d, want 1", descendants)
+	}
+	if cpuDelta != 50 {
+		t.Fatalf("tick2 cpuDelta = %d, want 50 (100 -> 150)", cpuDelta)
+	}
+	if logGrace {
+		t.Fatalf("tick2 logGrace = true, want false (rate-limited)")
+	}
+
+	// Tick 3: past the 2m grace-log interval since tick1's log -> must log
+	// again.
+	now = now.Add(2 * time.Minute)
+	decision, _, cpuDelta, logGrace, _, err = m.evaluate(now, startedAt, lastEventAt, 1234)
+	if decision != heartbeatGrace {
+		t.Fatalf("tick3 decision = %v, want heartbeatGrace", decision)
+	}
+	if err != nil {
+		t.Fatalf("tick3 unexpected error: %v", err)
+	}
+	if cpuDelta != 50 {
+		t.Fatalf("tick3 cpuDelta = %d, want 50 (150 -> 200)", cpuDelta)
+	}
+	if !logGrace {
+		t.Fatalf("tick3 logGrace = false, want true (rate limit elapsed)")
+	}
+}
+
+// TestHeartbeatMonitor_KillWhenIdle covers acceptance scenario (b): a
+// genuinely silent stream with no descendants and no CPU movement must
+// still be killed exactly as before.
+func TestHeartbeatMonitor_KillWhenIdle(t *testing.T) {
+	fp := &fakeProbe{}
+	fp.push(processLivenessSnapshot{descendants: 0, cpuTicks: 0}, nil)
+
+	m := newHeartbeatMonitor(5*time.Minute, 30*time.Minute, fp.probe)
+	startedAt := time.Unix(0, 0)
+	lastEventAt := startedAt
+	now := startedAt.Add(6 * time.Minute)
+
+	decision, descendants, cpuDelta, logGrace, reason, err := m.evaluate(now, startedAt, lastEventAt, 1234)
+	if decision != heartbeatKill {
+		t.Fatalf("decision = %v, want heartbeatKill", decision)
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reason != heartbeatKillReasonNoActivity {
+		t.Fatalf("reason = %q, want %q", reason, heartbeatKillReasonNoActivity)
+	}
+	if descendants != 0 || cpuDelta != 0 {
+		t.Fatalf("descendants=%d cpuDelta=%d, want 0/0", descendants, cpuDelta)
+	}
+	if logGrace {
+		t.Fatalf("logGrace = true, want false on a kill decision")
+	}
+}
+
+// TestHeartbeatMonitor_CPUTicksNotAdvancingIsNotActive guards against a
+// stalled-but-present descendant (e.g. a zombie or a process stuck waiting
+// on I/O with no CPU movement and reported as 0 descendants by the probe)
+// being mistaken for liveness, and against CPU-tick counters that appear to
+// go backwards (process reuse/wrap) producing a spurious positive delta.
+func TestHeartbeatMonitor_CPUTicksNotAdvancingIsNotActive(t *testing.T) {
+	fp := &fakeProbe{}
+	fp.push(processLivenessSnapshot{descendants: 0, cpuTicks: 500}, nil)
+	fp.push(processLivenessSnapshot{descendants: 0, cpuTicks: 500}, nil) // no advance
+	fp.push(processLivenessSnapshot{descendants: 0, cpuTicks: 100}, nil) // "decreased"
+
+	m := newHeartbeatMonitor(5*time.Minute, 30*time.Minute, fp.probe)
+	startedAt := time.Unix(0, 0)
+	lastEventAt := startedAt
+
+	now := startedAt.Add(6 * time.Minute)
+	decision, _, _, _, _, _ := m.evaluate(now, startedAt, lastEventAt, 1234)
+	// First observation: no prior snapshot to diff against, no descendants -> kill.
+	if decision != heartbeatKill {
+		t.Fatalf("tick1 decision = %v, want heartbeatKill", decision)
+	}
+
+	// Re-arm a fresh monitor to exercise the "no advance" and "decreased"
+	// cases against a real prior snapshot (the first monitor already killed
+	// so a fresh instance mirrors what production does after a restart).
+	m2 := newHeartbeatMonitor(5*time.Minute, 30*time.Minute, fp.probe)
+	fp2 := &fakeProbe{}
+	fp2.push(processLivenessSnapshot{descendants: 0, cpuTicks: 500}, nil)
+	fp2.push(processLivenessSnapshot{descendants: 0, cpuTicks: 500}, nil)
+	m2.probe = fp2.probe
+
+	now2 := startedAt.Add(6 * time.Minute)
+	decision, _, cpuDelta, _, _, _ := m2.evaluate(now2, startedAt, lastEventAt, 1234)
+	if decision != heartbeatKill || cpuDelta != 0 {
+		t.Fatalf("tick1: decision=%v cpuDelta=%d, want heartbeatKill/0", decision, cpuDelta)
+	}
+	// Simulate the stream staying silent one more tick with an unchanged
+	// CPU reading - must still be a kill (no advance == no activity).
+	now2 = now2.Add(30 * time.Second)
+	decision, _, cpuDelta, _, reason, _ := m2.evaluate(now2, startedAt, lastEventAt, 1234)
+	if decision != heartbeatKill {
+		t.Fatalf("tick2 decision = %v, want heartbeatKill", decision)
+	}
+	if cpuDelta != 0 {
+		t.Fatalf("tick2 cpuDelta = %d, want 0 (ticks unchanged)", cpuDelta)
+	}
+	if reason != heartbeatKillReasonNoActivity {
+		t.Fatalf("tick2 reason = %q, want %q", reason, heartbeatKillReasonNoActivity)
+	}
+}
+
+// TestHeartbeatMonitor_GraceNeverExtendsPastWatchdogDeadline covers
+// acceptance scenario (c): even with a permanently live descendant tree,
+// grace must stop being granted once the task-level watchdog deadline is
+// reached - the probe must not even be consulted past that point, since the
+// hard backstop is absolute.
+func TestHeartbeatMonitor_GraceNeverExtendsPastWatchdogDeadline(t *testing.T) {
+	fp := &fakeProbe{}
+	// Always report a live descendant - if the deadline check didn't
+	// short-circuit before the probe, this would grant grace forever.
+	for i := 0; i < 10; i++ {
+		fp.push(processLivenessSnapshot{descendants: 1, cpuTicks: uint64(100 * (i + 1))}, nil)
+	}
+
+	watchdogTimeout := 10 * time.Minute
+	m := newHeartbeatMonitor(5*time.Minute, watchdogTimeout, fp.probe)
+	startedAt := time.Unix(0, 0)
+	lastEventAt := startedAt
+
+	// Well past heartbeat timeout but before the watchdog deadline -> grace.
+	now := startedAt.Add(6 * time.Minute)
+	decision, _, _, _, _, _ := m.evaluate(now, startedAt, lastEventAt, 1234)
+	if decision != heartbeatGrace {
+		t.Fatalf("pre-deadline decision = %v, want heartbeatGrace", decision)
+	}
+	callsBeforeDeadline := fp.calls
+
+	// At/after the watchdog deadline -> must kill, and must NOT consult the
+	// probe again (the deadline check happens first).
+	now = startedAt.Add(watchdogTimeout)
+	decision, descendants, cpuDelta, logGrace, reason, err := m.evaluate(now, startedAt, lastEventAt, 1234)
+	if decision != heartbeatKill {
+		t.Fatalf("at-deadline decision = %v, want heartbeatKill", decision)
+	}
+	if reason != heartbeatKillReasonWatchdogDeadline {
+		t.Fatalf("at-deadline reason = %q, want %q", reason, heartbeatKillReasonWatchdogDeadline)
+	}
+	if err != nil {
+		t.Fatalf("at-deadline unexpected error: %v", err)
+	}
+	if descendants != 0 || cpuDelta != 0 || logGrace {
+		t.Fatalf("at-deadline descendants=%d cpuDelta=%d logGrace=%v, want 0/0/false", descendants, cpuDelta, logGrace)
+	}
+	if fp.calls != callsBeforeDeadline {
+		t.Fatalf("probe called again after deadline reached (calls %d -> %d); deadline check must short-circuit before probing", callsBeforeDeadline, fp.calls)
+	}
+
+	// Further past the deadline: still kill, still no probe call.
+	now = now.Add(5 * time.Minute)
+	decision, _, _, _, reason, _ = m.evaluate(now, startedAt, lastEventAt, 1234)
+	if decision != heartbeatKill || reason != heartbeatKillReasonWatchdogDeadline {
+		t.Fatalf("past-deadline decision=%v reason=%q, want heartbeatKill/%q", decision, reason, heartbeatKillReasonWatchdogDeadline)
+	}
+	if fp.calls != callsBeforeDeadline {
+		t.Fatalf("probe called again well past deadline (calls %d -> %d)", callsBeforeDeadline, fp.calls)
+	}
+}
+
+// TestHeartbeatMonitor_ProbeErrorFailsTowardKill covers acceptance scenario
+// (d): if the descendant probe itself errors, the monitor must fail toward
+// today's kill-on-silence behavior rather than grant unearned grace, and
+// must surface the error so the caller can log a warning.
+func TestHeartbeatMonitor_ProbeErrorFailsTowardKill(t *testing.T) {
+	probeErr := errors.New("read /proc: permission denied")
+	fp := &fakeProbe{}
+	fp.push(processLivenessSnapshot{}, probeErr)
+
+	m := newHeartbeatMonitor(5*time.Minute, 30*time.Minute, fp.probe)
+	startedAt := time.Unix(0, 0)
+	lastEventAt := startedAt
+	now := startedAt.Add(6 * time.Minute)
+
+	decision, descendants, cpuDelta, logGrace, reason, err := m.evaluate(now, startedAt, lastEventAt, 1234)
+	if decision != heartbeatKill {
+		t.Fatalf("decision = %v, want heartbeatKill", decision)
+	}
+	if !errors.Is(err, probeErr) {
+		t.Fatalf("err = %v, want %v surfaced to caller", err, probeErr)
+	}
+	if reason != heartbeatKillReasonProbeError {
+		t.Fatalf("reason = %q, want %q", reason, heartbeatKillReasonProbeError)
+	}
+	if descendants != 0 || cpuDelta != 0 || logGrace {
+		t.Fatalf("descendants=%d cpuDelta=%d logGrace=%v, want 0/0/false", descendants, cpuDelta, logGrace)
+	}
+}
+
+// TestHeartbeatMonitor_WatchdogDisabledAllowsIndefiniteGrace documents that
+// when opts.WatchdogTimeout is 0 (disabled - no task-level backstop
+// configured by the caller), the heartbeat monitor imposes no ceiling of its
+// own; the separate absence of a watchdog goroutine in that case is a
+// caller-level decision, not something this monitor should paper over.
+func TestHeartbeatMonitor_WatchdogDisabledAllowsIndefiniteGrace(t *testing.T) {
+	fp := &fakeProbe{}
+	fp.push(processLivenessSnapshot{descendants: 1, cpuTicks: 10}, nil)
+	fp.push(processLivenessSnapshot{descendants: 1, cpuTicks: 20}, nil)
+
+	m := newHeartbeatMonitor(5*time.Minute, 0, fp.probe)
+	startedAt := time.Unix(0, 0)
+	lastEventAt := startedAt
+
+	now := startedAt.Add(6 * time.Minute)
+	decision, _, _, _, _, _ := m.evaluate(now, startedAt, lastEventAt, 1234)
+	if decision != heartbeatGrace {
+		t.Fatalf("decision = %v, want heartbeatGrace", decision)
+	}
+
+	// Even very far past what would otherwise be a typical watchdog window.
+	now = startedAt.Add(2 * time.Hour)
+	decision, _, _, _, _, _ = m.evaluate(now, startedAt, lastEventAt, 1234)
+	if decision != heartbeatGrace {
+		t.Fatalf("decision after 2h = %v, want heartbeatGrace (no watchdog ceiling configured)", decision)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4668.

Closes #4668

## Changes

GitHub Issue GH-4668: fix(executor): heartbeat monitor SIGKILLs healthy runs during long local tool executions — make test >5m ⇒ exit 137 infra churn (GH-4648/GH-4649 trigger)

## Context

Diagnosed 2026-08-03 from the GH-4648/GH-4649 incident (record: `.agent/tasks/TASK-437-duplicate-execution-race-prevention.md` — this defect was its TRIGGER). Two healthy executions were SIGKILLed on 2026-07-31 by the heartbeat monitor while `make test` ran:

- GH-4648 gen-0: recording TG-1785521443743 seq 6350 @ 18:27:29 = `tool_use Bash {"command":"timeout 580 make test 2>&1 | tail -200"}` → `message_stop` → stream silent (tests running) → `"Heartbeat timeout detected, killing hung process ... last_event_age=5m14s timeout=5m0s"` @ 18:32:43 → exit 137, status `infra`. 22m38s and 6353 events of healthy work destroyed. Note the session itself wrapped the command in `timeout 580` — it budgeted ~10 min for tests; the 5m heartbeat killed it first.
- GH-4649 gen-0: recording TG-1785523208156 seq 3346 @ 18:48:57 = `tool_use Bash {"command":"make test 2>&1 | tail -80"}` → killed @ 18:54:08 (5m11s silence). Identical shape.

Mechanism: the claude-code stream-json protocol emits NOTHING between a `message_stop` that ends in `tool_use` and the tool result — local tool execution is silent by design. `last_event_age` is therefore the wrong liveness signal whenever a tool run exceeds the heartbeat window. The pilot repo's full `go test ./...` takes 3.5–6+ min on the box (t3.xlarge, shared with the daemon) — every full-suite run is a coin flip against the 5m timeout. GH-4521 fixed the FALSE-silence variant (stdout reader died); this is TRUE silence from a live, working child.

Blast radius beyond the two kills: the retry storm they triggered produced the duplicate-PR race (#4655/#4656/#4657 prevention cluster). This defect converts long test suites into infra churn on every affected run.

## Acceptance

1. Before killing on `last_event_age > timeout`, the heartbeat monitor checks **process liveness**: if the claude child's process tree has live, active descendants (e.g. `go test` children — check for running descendant PIDs and/or CPU-time advancing across two ticks on Linux /proc), the process is NOT hung — skip the kill, log a single rate-limited INFO (`heartbeat grace: local tool execution in flight, descendants=N`), and keep waiting. The hard backstop remains the task-level timeout (30m/1h) — heartbeat grace must never extend past it.
2. A process that is genuinely silent AND has no active descendants for the full window is killed exactly as today (the true-hang case the heartbeat exists for).
3. The kill log line includes what was checked (`descendants=0 cpu_delta=0`) so the next incident is diagnosable from one line.
4. Regression tests with a fake clock + fake process-tree probe: (a) silent stream + active descendant → no kill, grace logged; (b) silent stream + no descendants → kill at timeout as today; (c) grace never extends beyond the task-level timeout; (d) descendant probe error → fail toward today's behavior (kill at timeout) with a logged warning.
5. `make build`, `make test`, `make lint` green.

## Implementation

Seam: the heartbeat watchdog in `internal/executor` (component `executor.claudecode` — the goroutine that logs "Heartbeat timeout detected, killing hung process"). Platform note: descendant/CPU probing needs Linux (/proc) — the box is Linux; on darwin, degrade gracefully to today's behavior (document why). Do NOT simply raise the 5m timeout as the fix — any suite length eventually beats a constant; liveness is the correct signal (a modest bump to complement it is acceptable).

Out of scope: the retry/duplicate-PR race (dispatched separately: #4655/#4656/#4657), the intent-judge deadline kills (separate issue), test-suite runtime optimization.

## Refs

- Incident record: `.agent/tasks/TASK-437-duplicate-execution-race-prevention.md`
- Prior art: GH-4521 (stdout-reader false-silence variant), GH-4401 (RLIMIT_AS child-kill class — different mechanism, same "healthy child killed" family)
- Evidence: box recordings TG-1785521443743 / TG-1785523208156 (stream.jsonl tails), daemon.log 2026-07-31T18:32:43Z / 18:54:08Z