### PR TITLE
fix(executor): revalidate issue state at pickup and before PR creation (GH-4656)

### DIFF
--- a/cmd/pilot/poller_github.go
+++ b/cmd/pilot/poller_github.go
@@ -452,6 +452,10 @@ func startGithubSDKPollerForRepo(ctx context.Context, deps *PollerDeps, log *slo
 	// back to gh CLI for any github task without a registered creator.
 	if deps.Runner != nil {
 		deps.Runner.RegisterPRCreator("github:"+target.repoFullName, sdkshim.NewGitHubPRCreator(sdkClient, repoOwner, repoName))
+		// GH-4656: register the same repo's issue-state checker alongside its
+		// PR creator, on the same sdkClient — in-process, ghbudget-visible
+		// reads for the pickup-time and PR-creation preflight guards.
+		deps.Runner.RegisterIssueStateChecker("github:"+target.repoFullName, sdkshim.NewGitHubIssueStateChecker(sdkClient))
 	}
 
 	githubPoller := githubSDK.New(sdkCfg).NewPoller(pollerDeps)

--- a/internal/adapters/sdkshim/github_issue_state_checker.go
+++ b/internal/adapters/sdkshim/github_issue_state_checker.go
@@ -1,0 +1,45 @@
+package sdkshim
+
+import (
+	"context"
+	"strings"
+
+	"github.com/qf-studio/pilot/internal/executor"
+	githubSDK "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GitHubIssueStateChecker adapts the studio-sdk github client to
+// executor.IssueStateChecker (GH-4656). Registered per-repo alongside
+// GitHubPRCreator so the pickup-time and PR-creation preflight guards read
+// issue state through the same in-process, ghbudget-visible client used for
+// PR creation instead of an untracked `gh` CLI subprocess. Unlike
+// GitHubPRCreator, this shim is not bound to a fixed owner/repo — the
+// executor.IssueStateChecker interface takes owner/repo per call (mirroring
+// the gh-CLI fallback, which is genuinely repo-agnostic) — but a fresh
+// checker is still registered per repo (RegisterIssueStateChecker key
+// "github:owner/repo"), one per registered PR-creator client.
+type GitHubIssueStateChecker struct {
+	client *githubSDK.Client
+}
+
+// NewGitHubIssueStateChecker returns an issue-state checker over client.
+func NewGitHubIssueStateChecker(client *githubSDK.Client) *GitHubIssueStateChecker {
+	return &GitHubIssueStateChecker{client: client}
+}
+
+// GetIssueState fetches the live state of issue number via a single GetIssue
+// call.
+func (g *GitHubIssueStateChecker) GetIssueState(ctx context.Context, owner, repo string, number int) (executor.IssueState, error) {
+	issue, err := g.client.GetIssue(ctx, owner, repo, number)
+	if err != nil {
+		return executor.IssueState{}, err
+	}
+	labels := make([]string, 0, len(issue.Labels))
+	for _, l := range issue.Labels {
+		labels = append(labels, l.Name)
+	}
+	return executor.IssueState{
+		Closed: strings.EqualFold(strings.TrimSpace(issue.State), "closed"),
+		Labels: labels,
+	}, nil
+}

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -44,6 +44,7 @@ var ErrDispatchGated = errors.New("dispatch gated: pre-dispatch admission check 
 var terminalExecutionStatuses = map[string]bool{
 	"completed": true, "failed": true, "cancelled": true, "declined": true,
 	"no_op": true, "rate_limited": true, "skipped": true, "stalled": true, "infra": true,
+	"superseded": true,
 }
 
 // isTerminalExecutionStatus reports whether status is one of
@@ -2550,6 +2551,43 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 		// gates see the same labels the dispatch-time Decompose() saw.
 		task := buildTaskFromExecution(exec)
 
+		// GH-4656: revalidate the issue's live GitHub state at pickup time.
+		// Closes the 2026-07-31 GH-4649 incident window: a retry's claim was
+		// admitted legitimately at 18:57, sat queued behind this serial
+		// worker, and physically reached this line at ~19:33 — by which time
+		// its scope had merged via a sibling's PR and its issue had been
+		// closed as superseded at 19:43. Every pickup-time guard above this
+		// point is task_id-local (this task's own ledger rows); this is the
+		// first one that asks GitHub itself. Fails open on any lookup error
+		// (adapter mismatch, unparseable issue number, unresolved repo,
+		// transient GitHub error) — pipeline availability outranks the guard
+		// (acceptance #4).
+		if task.SourceAdapter == "" || task.SourceAdapter == "github" {
+			if state, ghErr := fetchIssueState(ctx, w.runner, task, exec.ProjectPath); ghErr != nil {
+				w.log.Warn("Failed to revalidate issue state before pickup; proceeding (fail-open)",
+					slog.String("execution_id", exec.ID),
+					slog.String("task_id", exec.TaskID),
+					slog.Any("error", ghErr))
+			} else if state.Closed {
+				detail := fmt.Sprintf("issue closed before pickup (superseded_label=%t, labels=%v)", state.HasLabel(labelPilotSuperseded), state.Labels)
+				w.log.Info("Task's issue closed before pickup; superseding without execution",
+					slog.String("execution_id", exec.ID),
+					slog.String("task_id", exec.TaskID),
+					slog.Any("labels", state.Labels),
+				)
+				// GH-4259: record the event before Finish persists the terminal
+				// status, so a poller can never observe the terminal row before
+				// the matching event exists.
+				w.recordExecutionEvent(exec.ID, memory.StageSuperseded, detail)
+				if _, finErr := w.lifecycle.Finish(exec.ID, nil, nil, 0, ExecStatusSuperseded); finErr != nil {
+					w.log.Error("Failed to finalize superseded execution", slog.String("execution_id", exec.ID), slog.Any("error", finErr))
+				}
+				w.runner.EmitProgress(exec.TaskID, "Superseded", 100, detail)
+				w.currentTaskID.Store("")
+				continue
+			}
+		}
+
 		// GH-4141 Phase 3: pre-execute merged-PR short-circuit. A queued task
 		// whose branch already has a merged PR (e.g. a poller-retry duplicate of
 		// a sub-issue the epic already shipped) must not re-invoke the backend
@@ -2899,6 +2937,8 @@ func dispatchTerminalStage(status string) (memory.Stage, bool) {
 		return memory.StageSkipped, true
 	case "infra":
 		return memory.StageFailed, true
+	case "superseded":
+		return memory.StageSuperseded, true
 	default:
 		return "", false
 	}
@@ -2948,6 +2988,8 @@ func terminalPhaseLabel(status string) string {
 		return "Stalled"
 	case "declined":
 		return "Declined"
+	case "superseded":
+		return "Superseded"
 	default:
 		return "Failed"
 	}

--- a/internal/executor/gh4656_issue_state_test.go
+++ b/internal/executor/gh4656_issue_state_test.go
@@ -1,0 +1,310 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// GH-4656 regression suite: the 2026-07-31 incident window where a queued or
+// in-flight run's GitHub issue was closed out from under it (delivered by a
+// sibling/parent run) went unnoticed because every existing pickup-time
+// re-check was task_id-local and the PR-creation preflight was branch-local.
+// These tests exercise the two new GitHub-state guards this issue adds:
+//
+//   - the dispatcher's pickup-time revalidation (dispatcher.go, before
+//     Execute()), driven end-to-end via ProjectWorker.processQueue — mirrors
+//     TestProcessQueue_MergedPRPreflight_SkipsBackend's shape.
+//   - the runner's PR-creation preflight, exercised directly against the
+//     extracted checkIssueSupersededBeforePR method — mirrors
+//     TestDirectPathExistingBranchPR's use of adoptOpenBranchPR as a unit
+//     boundary instead of driving a full Execute() through git push.
+//
+// Both guards share the same swappable fetchIssueState var (issue_state.go),
+// stubbed here exactly like the existing mergedPRPreflightCheck idiom —
+// no real git remote or GitHub call is exercised.
+
+// stubFetchIssueState overrides the package-level fetchIssueState var for the
+// duration of the test and restores the original on cleanup.
+func stubFetchIssueState(t *testing.T, fn func(ctx context.Context, runner *Runner, task *Task, projectPath string) (IssueState, error)) {
+	t.Helper()
+	orig := fetchIssueState
+	fetchIssueState = fn
+	t.Cleanup(func() { fetchIssueState = orig })
+}
+
+// (a) claim admitted -> issue closed before pickup -> no Execute, row
+// finalized with the typed "superseded" status.
+func TestProcessQueue_IssueClosedBeforePickup_SupersedesWithoutExecute(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	const projectPath = "/project-gh4656-pickup-closed"
+	const taskID = "GH-8101"
+
+	exec := &memory.Execution{
+		ID:           "exec-gh4656-pickup-closed",
+		TaskID:       taskID,
+		ProjectPath:  projectPath,
+		Status:       "queued",
+		TaskBranch:   "pilot/GH-8101",
+		TaskCreatePR: true,
+	}
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	stubFetchIssueState(t, func(_ context.Context, _ *Runner, task *Task, _ string) (IssueState, error) {
+		if task.ID != taskID {
+			t.Fatalf("fetchIssueState called with unexpected task ID %q", task.ID)
+		}
+		return IssueState{Closed: true, Labels: []string{"pilot-superseded", "pilot"}}, nil
+	})
+
+	backend := &mockFixedBackend{result: &BackendResult{Success: true, Output: "should never run"}}
+	runner := NewRunnerWithBackend(backend)
+	worker := NewProjectWorker(projectPath, store, runner, slog.Default())
+
+	worker.processQueue(context.Background())
+
+	backend.mu.Lock()
+	count := backend.execCount
+	backend.mu.Unlock()
+	if count != 0 {
+		t.Errorf("expected zero backend invocations (issue already closed at pickup), got %d", count)
+	}
+
+	got, err := store.GetExecution(exec.ID)
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if got.Status != string(ExecStatusSuperseded) {
+		t.Errorf("expected status %q, got %q", ExecStatusSuperseded, got.Status)
+	}
+
+	events, err := store.ListExecutionEvents(exec.ID)
+	if err != nil {
+		t.Fatalf("ListExecutionEvents: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("expected at least one execution event")
+	}
+	last := events[len(events)-1]
+	if last.Stage != memory.StageSuperseded {
+		t.Errorf("expected last event stage %q, got %q", memory.StageSuperseded, last.Stage)
+	}
+	if !strings.Contains(last.Detail, "closed before pickup") || !strings.Contains(last.Detail, "superseded_label=true") {
+		t.Errorf("expected event detail to name the closed state and superseded label, got %q", last.Detail)
+	}
+}
+
+// (b) run finishes -> issue closed mid-run -> PR refused, finalized
+// superseded. Exercises checkIssueSupersededBeforePR directly, mirroring how
+// TestDirectPathExistingBranchPR exercises adoptOpenBranchPR without driving
+// a full Execute() through git push/PR creation.
+func TestCheckIssueSupersededBeforePR(t *testing.T) {
+	tests := []struct {
+		name          string
+		fetchResult   IssueState
+		fetchErr      error
+		wantHandled   bool
+		wantOutcome   string
+		wantLogWarn   bool
+		wantEventKind bool
+	}{
+		{
+			name:          "issue closed mid-run: PR refused, superseded",
+			fetchResult:   IssueState{Closed: true, Labels: []string{"pilot-superseded"}},
+			wantHandled:   true,
+			wantOutcome:   "superseded",
+			wantEventKind: true,
+		},
+		{
+			name:        "issue still open: proceeds to create PR as today",
+			fetchResult: IssueState{Closed: false},
+			wantHandled: false,
+		},
+		{
+			name:        "GitHub 5xx on state fetch: fails open, proceeds",
+			fetchErr:    errors.New("GitHub API: 503 Service Unavailable"),
+			wantHandled: false,
+			wantLogWarn: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, cleanup := setupTestStore(t)
+			defer cleanup()
+
+			stubFetchIssueState(t, func(_ context.Context, _ *Runner, _ *Task, _ string) (IssueState, error) {
+				return tt.fetchResult, tt.fetchErr
+			})
+
+			var logBuf bytes.Buffer
+			r := &Runner{log: slog.New(slog.NewTextHandler(&logBuf, nil))}
+			r.SetLogStore(store)
+
+			task := &Task{ID: "GH-8102", Title: "fix: mid-run supersede test", Branch: "pilot/GH-8102"}
+			if err := store.SaveExecution(&memory.Execution{ID: task.ID, TaskID: task.ID, Status: "running"}); err != nil {
+				t.Fatalf("SaveExecution: %v", err)
+			}
+			result := &ExecutionResult{TaskID: task.ID, Success: true}
+
+			handled := r.checkIssueSupersededBeforePR(context.Background(), task, result)
+			if handled != tt.wantHandled {
+				t.Fatalf("checkIssueSupersededBeforePR handled = %v, want %v", handled, tt.wantHandled)
+			}
+
+			if tt.wantHandled {
+				if result.Success {
+					t.Error("expected result.Success = false when PR is refused")
+				}
+				if result.Outcome != tt.wantOutcome {
+					t.Errorf("result.Outcome = %q, want %q", result.Outcome, tt.wantOutcome)
+				}
+			} else {
+				if !result.Success {
+					t.Errorf("expected result.Success to remain true when not handled, got false (error=%q)", result.Error)
+				}
+			}
+
+			events, err := store.ListExecutionEvents(task.LogExecutionID())
+			if err != nil {
+				t.Fatalf("ListExecutionEvents: %v", err)
+			}
+			if tt.wantEventKind {
+				if len(events) == 0 {
+					t.Fatal("expected a superseded execution event to be recorded")
+				}
+				if events[len(events)-1].Stage != memory.StageSuperseded {
+					t.Errorf("expected last event stage %q, got %q", memory.StageSuperseded, events[len(events)-1].Stage)
+				}
+			} else if len(events) != 0 {
+				t.Errorf("expected no execution events, got %d", len(events))
+			}
+
+			if tt.wantLogWarn && !strings.Contains(logBuf.String(), "Failed to revalidate issue state before PR creation") {
+				t.Errorf("expected a fail-open warning to be logged, got log: %q", logBuf.String())
+			}
+		})
+	}
+}
+
+// (c) open issue at pickup: identical behavior to today — the backend still
+// runs, and no "superseded" status is spuriously written.
+func TestProcessQueue_IssueOpenAtPickup_ProceedsNormally(t *testing.T) {
+	const branch = "pilot/GH-8103"
+	dir := setupPRGuardRepo(t, branch, false) // no additional commits
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	exec := &memory.Execution{
+		ID:           "exec-gh4656-pickup-open",
+		TaskID:       "GH-8103",
+		ProjectPath:  dir,
+		Status:       "queued",
+		TaskBranch:   branch,
+		TaskCreatePR: true,
+	}
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	stubFetchIssueState(t, func(_ context.Context, _ *Runner, _ *Task, _ string) (IssueState, error) {
+		return IssueState{Closed: false}, nil
+	})
+	origCheck := mergedPRPreflightCheck
+	mergedPRPreflightCheck = func(_ context.Context, _, _ string) (string, error) { return "", nil }
+	t.Cleanup(func() { mergedPRPreflightCheck = origCheck })
+
+	backend := &mockFixedBackend{result: &BackendResult{Success: true, Output: "analysis complete"}}
+	runner := NewRunnerWithBackend(backend)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+	worker := NewProjectWorker(dir, store, runner, slog.Default())
+
+	worker.processQueue(context.Background())
+
+	backend.mu.Lock()
+	count := backend.execCount
+	backend.mu.Unlock()
+	if count == 0 {
+		t.Error("expected the backend to be invoked (issue open) — pickup guard must not have short-circuited")
+	}
+
+	got, err := store.GetExecution(exec.ID)
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if got.Status == string(ExecStatusSuperseded) {
+		t.Errorf("did not expect status %q for an open issue", ExecStatusSuperseded)
+	}
+}
+
+// (d) GitHub 5xx on the pickup-time state fetch: fails open — the backend
+// still runs, with a logged warning naming the failure.
+func TestProcessQueue_IssueStateFetchError_FailsOpenAtPickup(t *testing.T) {
+	const branch = "pilot/GH-8104"
+	dir := setupPRGuardRepo(t, branch, false) // no additional commits
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	exec := &memory.Execution{
+		ID:           "exec-gh4656-pickup-error",
+		TaskID:       "GH-8104",
+		ProjectPath:  dir,
+		Status:       "queued",
+		TaskBranch:   branch,
+		TaskCreatePR: true,
+	}
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	fetchErr := fmt.Errorf("GitHub API: 503 Service Unavailable")
+	stubFetchIssueState(t, func(_ context.Context, _ *Runner, _ *Task, _ string) (IssueState, error) {
+		return IssueState{}, fetchErr
+	})
+	origCheck := mergedPRPreflightCheck
+	mergedPRPreflightCheck = func(_ context.Context, _, _ string) (string, error) { return "", nil }
+	t.Cleanup(func() { mergedPRPreflightCheck = origCheck })
+
+	backend := &mockFixedBackend{result: &BackendResult{Success: true, Output: "analysis complete"}}
+	runner := NewRunnerWithBackend(backend)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+
+	var logBuf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&logBuf, nil))
+	worker := NewProjectWorker(dir, store, runner, log)
+
+	worker.processQueue(context.Background())
+
+	backend.mu.Lock()
+	count := backend.execCount
+	backend.mu.Unlock()
+	if count == 0 {
+		t.Error("expected the backend to still be invoked despite the GitHub lookup error (fail-open)")
+	}
+
+	got, err := store.GetExecution(exec.ID)
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if got.Status == string(ExecStatusSuperseded) {
+		t.Errorf("did not expect status %q when the state fetch merely errored", ExecStatusSuperseded)
+	}
+
+	if !strings.Contains(logBuf.String(), "Failed to revalidate issue state before pickup") {
+		t.Errorf("expected a fail-open warning naming the pickup-time lookup failure, got log: %q", logBuf.String())
+	}
+}

--- a/internal/executor/issue_state.go
+++ b/internal/executor/issue_state.go
@@ -1,0 +1,192 @@
+// Package executor — GH-4656
+//
+// Live GitHub issue-state revalidation used by two boundaries: the
+// dispatcher's pickup-time guard (dispatcher.go, before Execute()) and the
+// runner's PR-creation preflight (runner.go, immediately before opening a
+// PR). Both close the same class of incident (2026-07-31, GH-4648/GH-4649):
+// a queued or in-flight run whose scope was already delivered by a
+// sibling/parent run on a different branch has no way to notice its own
+// issue was closed out from under it — every existing pickup-time re-check
+// is task_id-local (this task's own ledger rows) and mergedPRPreflightCheck
+// is keyed to this task's own branch. This file adds the one check neither
+// covers: ask GitHub itself.
+package executor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// labelPilotSuperseded mirrors github.LabelSuperseded's value
+// (internal/adapters/github/types.go) without importing that package —
+// adapters/github imports internal/comms, which imports internal/executor,
+// so importing adapters/github here would be a cycle (same constraint
+// documented on GithubSideEffectSearcher, sideeffect_audit.go).
+const labelPilotSuperseded = "pilot-superseded"
+
+// IssueState is the live GitHub issue state fetched by IssueStateChecker —
+// just enough to decide whether a queued or in-flight execution's issue has
+// been closed/superseded out from under it.
+type IssueState struct {
+	Closed bool
+	Labels []string
+}
+
+// HasLabel reports whether name is present in Labels (case-insensitive).
+func (s IssueState) HasLabel(name string) bool {
+	for _, l := range s.Labels {
+		if strings.EqualFold(l, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// IssueStateChecker is the narrow read surface the pickup-time and
+// PR-creation preflight guards need: one GET for one issue's live
+// state+labels. Mirrors the GithubSideEffectSearcher/RepoAllowlist pattern
+// (sideeffect_audit.go, repo_guardrail.go) — a small consumer-side
+// interface, faked directly in tests. Two implementations exist:
+//
+//   - sdkshim.GitHubIssueStateChecker (internal/adapters/sdkshim): wraps the
+//     studio-sdk client already registered per-repo for PR creation
+//     (RegisterPRCreator) — in-process, so its traffic is visible to
+//     ghbudget's shared-user-pool accounting (GH-4391). Registered per-repo
+//     via RegisterIssueStateChecker at daemon startup.
+//   - ghCLIIssueStateChecker (this file): gh-CLI fallback used when no SDK
+//     checker is registered for a repo, mirroring queryParentDoneViaGitHub's
+//     shellout idiom (epic.go) — keeps the guard functional for projects
+//     that aren't SDK-managed.
+type IssueStateChecker interface {
+	// GetIssueState fetches the live state of issue `number` in owner/repo.
+	// Implementations must make at most one GitHub API call.
+	GetIssueState(ctx context.Context, owner, repo string, number int) (IssueState, error)
+}
+
+// ghCLIIssueStateChecker is the default fallback IssueStateChecker: shells
+// out to `gh issue view`, the same idiom already used throughout this
+// package (epic.go's queryParentDoneViaGitHub, sideeffect_audit.go) to read
+// GitHub state without importing adapters/github.
+type ghCLIIssueStateChecker struct{}
+
+// GetIssueState implements IssueStateChecker via `gh issue view --repo
+// owner/repo <number> --json state,labels`, one process invocation (one
+// GitHub API call). Never shells out during `go test` — tests override
+// fetchIssueState (or inject a fake IssueStateChecker via
+// RegisterIssueStateChecker) instead of exercising this path.
+func (ghCLIIssueStateChecker) GetIssueState(ctx context.Context, owner, repo string, number int) (IssueState, error) {
+	if testing.Testing() {
+		return IssueState{}, fmt.Errorf("ghCLIIssueStateChecker: shellout disabled under go test")
+	}
+	args := []string{
+		"issue", "view", strconv.Itoa(number),
+		"--repo", owner + "/" + repo,
+		"--json", "state,labels",
+	}
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return IssueState{}, fmt.Errorf("gh issue view: %w (stderr: %s)", err, stderr.String())
+	}
+
+	var resp struct {
+		State  string `json:"state"`
+		Labels []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		return IssueState{}, fmt.Errorf("parse gh issue view output: %w", err)
+	}
+
+	labels := make([]string, 0, len(resp.Labels))
+	for _, l := range resp.Labels {
+		labels = append(labels, l.Name)
+	}
+	return IssueState{
+		Closed: strings.EqualFold(strings.TrimSpace(resp.State), "closed"),
+		Labels: labels,
+	}, nil
+}
+
+// RegisterIssueStateChecker registers an IssueStateChecker under an explicit
+// key ("adapter:owner/repo"), mirroring RegisterPRCreator (runner.go) —
+// registrations happen once at startup (cmd/pilot's SDK poller wiring,
+// alongside RegisterPRCreator for the same repo/client), so concurrent tasks
+// from different repos can never observe another repo's checker.
+func (r *Runner) RegisterIssueStateChecker(key string, checker IssueStateChecker) {
+	r.issueStateCheckersMu.Lock()
+	defer r.issueStateCheckersMu.Unlock()
+	if r.issueStateCheckers == nil {
+		r.issueStateCheckers = make(map[string]IssueStateChecker)
+	}
+	r.issueStateCheckers[key] = checker
+}
+
+// issueStateCheckerFor returns the registered checker for key, or nil.
+func (r *Runner) issueStateCheckerFor(key string) IssueStateChecker {
+	r.issueStateCheckersMu.RLock()
+	defer r.issueStateCheckersMu.RUnlock()
+	return r.issueStateCheckers[key]
+}
+
+// fetchIssueState resolves task's GitHub issue (owner/repo/number) and
+// fetches its live state. Both GH-4656 call sites (dispatcher.go's
+// pickup-time guard, runner.go's PR-creation preflight) call this exact var
+// so tests can override it wholesale — mirrors mergedPRPreflightCheck's
+// swappable-var idiom (dispatcher.go) — instead of wiring a real git remote
+// plus a registered checker per test case.
+//
+// Owner/repo resolution: task.SourceRepo when populated (set on tasks built
+// from a fresh GitHub event), else the `origin` remote at projectPath —
+// buildTaskFromExecution never populates SourceRepo (the executions table
+// has no matching column), so the dispatcher pickup site always falls
+// through to the git-remote path.
+//
+// Checker resolution: the per-repo SDK-backed checker registered via
+// RegisterIssueStateChecker when one exists for "github:owner/repo", else
+// the gh-CLI fallback (ghCLIIssueStateChecker) so the guard still functions
+// for repos with no registered SDK client.
+//
+// Returns an error (never IssueState.Closed=true) for anything that isn't a
+// clean live read — callers must fail open and proceed rather than block
+// (GH-4656 acceptance #4: pipeline availability outranks the guard).
+var fetchIssueState = func(ctx context.Context, runner *Runner, task *Task, projectPath string) (IssueState, error) {
+	if task == nil {
+		return IssueState{}, fmt.Errorf("fetchIssueState: nil task")
+	}
+
+	numStr := strings.TrimSpace(task.GHIssueRef())
+	num, err := strconv.Atoi(numStr)
+	if err != nil {
+		return IssueState{}, fmt.Errorf("fetchIssueState: parse issue number %q: %w", numStr, err)
+	}
+
+	owner, repo := "", ""
+	if task.SourceRepo != "" {
+		owner, repo, _ = strings.Cut(task.SourceRepo, "/")
+	}
+	if owner == "" || repo == "" {
+		owner, repo, err = resolveGitRemote(ctx, projectPath)
+		if err != nil {
+			return IssueState{}, fmt.Errorf("fetchIssueState: resolve repo: %w", err)
+		}
+	}
+
+	var checker IssueStateChecker
+	if runner != nil {
+		checker = runner.issueStateCheckerFor("github:" + owner + "/" + repo)
+	}
+	if checker == nil {
+		checker = ghCLIIssueStateChecker{}
+	}
+	return checker.GetIssueState(ctx, owner, repo, num)
+}

--- a/internal/executor/lifecycle.go
+++ b/internal/executor/lifecycle.go
@@ -41,6 +41,14 @@ const (
 	ExecStatusSkipped     Status = "skipped"
 	ExecStatusDeclined    Status = "declined"
 	ExecStatusDecomposed  Status = "decomposed"
+	// ExecStatusSuperseded marks an execution finalized without running (or
+	// without opening a PR) because its GitHub issue was found closed by the
+	// GH-4656 pickup-time / PR-creation preflight guards — the issue's scope
+	// was already delivered by another run (sibling/parent) before this one
+	// reached the gate. Distinct from ExecStatusSkipped (which covers other
+	// pre-dispatch admission declines): superseded specifically means "another
+	// run already shipped this."
+	ExecStatusSuperseded Status = "superseded"
 )
 
 // ExecutionLifecycle is the single chokepoint for creating and transitioning

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -285,6 +285,8 @@ func TerminalStatus(result *ExecutionResult) string {
 		return "infra"
 	case "skipped":
 		return "skipped"
+	case "superseded":
+		return "superseded"
 	}
 	for _, c := range outcomeClassifiers {
 		if containsAny(result.Error, c.signatures) {
@@ -628,9 +630,12 @@ type ExecutionResult struct {
 	// DeclinedReason is the human-readable reason Claude provided for the decline.
 	DeclinedReason string
 	// Outcome is a fine-grained terminal classification ("declined", "no_op",
-	// "no_commits", "stalled", "budget_exceeded") used by the dispatcher to pick
-	// the persisted execution status instead of collapsing every !Success result
-	// into "failed". Empty means "classify from Success/Declined/Error". TASK-358.
+	// "no_commits", "stalled", "budget_exceeded", "superseded") used by the
+	// dispatcher to pick the persisted execution status instead of collapsing
+	// every !Success result into "failed". Empty means "classify from
+	// Success/Declined/Error". TASK-358. "superseded" (GH-4656): the
+	// PR-creation preflight found the task's GitHub issue already closed —
+	// another run delivered this scope first.
 	Outcome string
 	// PeakRSSMB is the peak subprocess RSS in MiB collected by the RSS sampler. GH-3028.
 	// Zero on non-Linux/darwin platforms or when the sampler had no data.
@@ -755,6 +760,13 @@ type Runner struct {
 	// which legacy handlers still mutate per-event.
 	prCreators   map[string]PRCreator
 	prCreatorsMu sync.RWMutex
+	// GH-4656: issueStateCheckers holds startup-registered per-repo GitHub
+	// issue-state checkers keyed "adapter:owner/repo" — same key shape and
+	// registration timing as prCreators, populated alongside RegisterPRCreator
+	// (see issue_state.go). Used by fetchIssueState for the pickup-time and
+	// PR-creation preflight guards.
+	issueStateCheckers   map[string]IssueStateChecker
+	issueStateCheckersMu sync.RWMutex
 	// GH-2211: SubIssueLinker for native GitHub sub-issue API linking
 	subIssueLinker SubIssueLinker // Optional linker for native GitHub parent→child wiring
 	// GH-1599: Execution log store for milestone entries
@@ -1995,6 +2007,47 @@ func (r *Runner) adoptOpenBranchPR(ctx context.Context, git *GitOperations, task
 	if recorder != nil {
 		recorder.SetPRUrl(openURL)
 	}
+	return true
+}
+
+// checkIssueSupersededBeforePR is the GH-4656 PR-creation preflight: it
+// refetches the task's live GitHub issue state immediately before opening a
+// PR and, if the issue is already closed, refuses to create the PR. Runs
+// AFTER push/adoptOpenBranchPR (mirroring adoptOpenBranchPR's own ordering
+// note) so it sits directly on the critical path the 2026-07-31 incident
+// exploited: PR#4653 was opened at 19:58 against an issue that had already
+// been closed as superseded by a sibling/parent's PR at 19:43. Fails open on
+// any lookup error — pipeline availability outranks the guard (acceptance
+// #4) — and is a no-op for non-GitHub-sourced tasks (SourceAdapter set to
+// anything other than "" or "github").
+//
+// Returns true when the PR must not be opened (result has already been
+// populated with the superseded outcome); false when the caller should
+// proceed to normal PR creation.
+func (r *Runner) checkIssueSupersededBeforePR(ctx context.Context, task *Task, result *ExecutionResult) bool {
+	if task.SourceAdapter != "" && task.SourceAdapter != "github" {
+		return false
+	}
+	state, ghErr := fetchIssueState(ctx, r, task, task.ProjectPath)
+	if ghErr != nil {
+		r.log.Warn("Failed to revalidate issue state before PR creation; proceeding (fail-open)",
+			slog.String("task_id", task.ID),
+			slog.Any("error", ghErr))
+		return false
+	}
+	if !state.Closed {
+		return false
+	}
+	detail := fmt.Sprintf("issue closed before PR creation (superseded_label=%t, labels=%v)", state.HasLabel(labelPilotSuperseded), state.Labels)
+	r.log.Info("Task's issue closed before PR creation; refusing to open PR",
+		slog.String("task_id", task.ID),
+		slog.Any("labels", state.Labels),
+	)
+	r.recordExecutionEvent(task.LogExecutionID(), memory.StageSuperseded, detail)
+	result.Success = false
+	result.Outcome = "superseded"
+	result.Error = detail
+	r.reportProgress(task.ID, "Superseded", 100, detail)
 	return true
 }
 
@@ -4675,6 +4728,14 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 			// duplicate PR. Runs after push so the branch is guaranteed to exist on
 			// the remote for the gh CLI lookup.
 			if r.adoptOpenBranchPR(ctx, git, task, result, recorder) {
+				return result, nil
+			}
+
+			// GH-4656: PR-creation preflight — refuses to open a PR if the
+			// task's GitHub issue has already been closed (see
+			// checkIssueSupersededBeforePR doc for the incident this closes).
+			// The branch remains pushed; only PR creation is refused.
+			if r.checkIssueSupersededBeforePR(ctx, task, result) {
 				return result, nil
 			}
 

--- a/internal/executor/terminal_status_inventory_test.go
+++ b/internal/executor/terminal_status_inventory_test.go
@@ -18,6 +18,7 @@ var executionStatusVocabulary = map[string]bool{
 	"queued": true, "pending": true, "running": true,
 	"completed": true, "failed": true, "cancelled": true, "declined": true,
 	"no_op": true, "rate_limited": true, "skipped": true, "stalled": true, "infra": true,
+	"superseded": true,
 }
 
 // terminalStatusInventoryAllowFiles lists the source files permitted to

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -953,6 +953,14 @@ const (
 	StageNoOp             Stage = "no_op"
 	StageSkipped          Stage = "skipped"
 	StageStalled          Stage = "stalled"
+	// StageSuperseded records that an execution was finalized without running
+	// (pickup-time) or without opening a PR (pre-PR-create) because its
+	// GitHub issue was found closed — GH-4656, closing the 2026-07-31
+	// GH-4649 incident window (a retry finished after its issue had already
+	// been closed as superseded by a sibling/parent run and opened PR#4653
+	// against the closed issue anyway). Detail carries the observed issue
+	// state and whether a pilot-superseded label was present.
+	StageSuperseded Stage = "superseded"
 	// StageResearchPhase records the parallel-research phase's duration and
 	// token spend once per direct-path execution (GH-4129). Detail is a JSON
 	// object: {"duration_ms","total_tokens","findings"}.


### PR DESCRIPTION
## Summary

Closes GH-4656 — the 2026-07-31 incident window: child GH-4649's retry was claimed legitimately, sat queued behind the serial `ProjectWorker`, and physically ran after its scope had already merged via the parent's PR and its issue had been closed as superseded. The run completed anyway and opened a PR against the closed issue, born merge-conflicting.

Existing pickup-time re-checks are strictly task_id-local (this task's own ledger rows) and the merged-PR preflight is keyed to the task's own branch — neither sees a sibling/parent delivering the same scope on a different branch. Nothing previously gated PR creation on live GitHub issue state.

- Adds a shared `IssueStateChecker` abstraction (`internal/executor/issue_state.go`), with an SDK-backed implementation (in-process, `ghbudget`-visible, registered per-repo alongside the existing PR creator — `internal/adapters/sdkshim/github_issue_state_checker.go`, wired in `cmd/pilot/poller_github.go`) and a `gh` CLI fallback for repos without a registered SDK client.
- **Pickup-time guard** (`dispatcher.go`, before `Execute()`): if the issue is closed, the row is finalized with a new typed terminal status (`superseded`) — no execution, journaled event naming the closed state and any `pilot-superseded` label.
- **PR-creation preflight** (`runner.go`, `checkIssueSupersededBeforePR`, immediately before opening a PR): if the issue is closed, PR creation is refused (branch stays pushed) and the result classifies as `superseded` through the existing `TerminalStatus`/dispatcher chokepoint — no new dispatcher-side branching needed for this path.
- Both guards fail open on any lookup error (pipeline availability outranks the guard) and are no-ops for non-GitHub-sourced tasks.
- At most one issue GET per pickup and one per PR-create, through the same in-process client already used for PR creation.

## Test plan

- [x] `make build`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite, all green)
- [x] New table-driven regression tests (`internal/executor/gh4656_issue_state_test.go`), stdlib only:
  - claim admitted → issue closed before pickup → zero backend invocations, row finalized `superseded`
  - run finishes → issue closed mid-run → PR refused, `checkIssueSupersededBeforePR` returns handled, result classified `superseded`
  - open issue → identical behavior to today (backend still invoked, no spurious `superseded`)
  - GitHub 5xx on the state fetch → fails open (backend still invoked) with a logged warning, at both call sites
- [x] `golangci-lint` not installed in this environment; `gofmt -l` clean on all touched files