### PR TITLE
fix(executor): raise intent judge deadlines to end 17-day 100% fail-open streak (GH-4669)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -87,7 +87,7 @@
 | Model routing | ✅ | executor | - | - | Haiku (trivial), Opus 4.6 (complex), Sonnet 4.6 (simple/medium) (v0.20.0) |
 | Effort routing | ✅ | executor | - | - | Map complexity to Claude thinking depth (v0.20.0) |
 | LLM intent classification | ✅ | adapters/telegram | - | - | Pattern-based intent detection for Telegram messages |
-| Intent judge (pipeline) | ✅ | executor | - | - | Wired into execution pipeline for task classification (v0.24.0) |
+| Intent judge (pipeline) | ✅ | executor | - | - | Wired into execution pipeline for task classification (v0.24.0). GH-4669: judge subprocess deadlines raised 30s/20s→60s/60s (config-overridable via `intent_judge.timeout`/`pre_flight_judge.timeout`) after live-box repro showed real invocations baselining at 18.7-22.5s, which had left near-zero margin and caused a 17-day, 100%-failure fail-open streak (4,321 kills) hidden by the SDK poller's fail-open path; `pilot_intent_judge_failures_total` (GH-4377) is now paired with an `intent_judge_failure_streak` alert rule that fires once a repo's consecutive judge failures hit 10, so a dead judge pages instead of failing silently. |
 | Research subagents | ✅ | executor | - | - | Haiku-powered parallel codebase exploration |
 | Drift detection | ✅ | executor | - | - | Collaboration alignment monitor with re-anchoring (v0.61.0) |
 | Workflow enforcement | ✅ | executor | - | - | Embedded autonomous execution instructions (v0.61.0) |

--- a/.agent/tasks/archive/GH-4669-intent-judge-timeout-fix.md
+++ b/.agent/tasks/archive/GH-4669-intent-judge-timeout-fix.md
@@ -1,0 +1,71 @@
+# GH-4669
+
+**Created:** 2026-08-03
+
+## Problem
+
+GitHub Issue GH-4669: fix(executor): intent judge 100% dead since 07-16 cutover — 4,321 context_deadline kills, fail-open hid it; diagnose, restore-or-retire, and alert on judge failure streaks
+
+## Context
+
+Found 2026-08-03 while diagnosing the GH-4648 incident: **the pre-flight intent judge has failed on every single invocation since the 2026-07-16 AWS cutover** — a 17-day, 100% failure rate hidden by fail-open.
+
+Box evidence (daemon.log, single unrotated file since 07-16):
+
+- `grep -c 'pre-flight judge error' daemon.log` → **4321**
+- First: `2026-07-16T23:56:11Z ... repo=qf-studio/pointer issue=8 error="intent judge subprocess: signal: killed (cause=context_deadline peak_rss_mb=252)"`
+- Latest: `2026-08-03T10:30:28Z ... repo=qf-studio/pilot issue=4664 ... (cause=context_deadline peak_rss_mb=262)`
+- Zero observed judge-success lines over the same window.
+- Signature is uniform: killed at context_deadline, peak RSS ~250–270MB, every repo, every poll cycle.
+
+Consequences: (1) the judge's protection has been silently absent for 17 days — every issue dispatches unjudged; (2) each poll cycle burns a doomed subprocess spawn+kill (~4.3k so far) — pure CPU/API churn on the box.
+
+Root cause is NOT yet established — that diagnosis is part of this issue. Candidate causes to check, in order: the judge subprocess's deadline is too short for the box's model-call latency (t3.xlarge + shared load; laptop-era constant?); env/auth for the child model call on the box (which credentials does the judge child inherit — note the box moved to `~/.claude/.credentials.json`-based auth at cutover); model routing changes; the subprocess deadline not accounting for cold starts. The 07-16 cutover date being the exact onset strongly suggests a box-environment factor, not a code regression.
+
+## Acceptance
+
+1. **Diagnose**: instrument or reproduce on the box (SSM) to identify why every judge subprocess exceeds its deadline. Record the finding in the PR description with evidence.
+2. **Restore or explicitly retire**: either (a) the judge completes and produces verdicts on the box — verified by log lines from real dispatches after deploy; or (b) if restoring is impractical, add a config flag to disable the pre-flight judge cleanly (no subprocess spawn at all when disabled), default reflecting the decision, and log ONE startup-level WARN instead of 300+/day poll-cycle warnings.
+3. **Fail-open becomes observable**: a counter metric (e.g. `pilot_intent_judge_failures_total`) exposed on :9091 and an alert-engine rule so a >N-consecutive-failures streak pages instead of hiding for 17 days. This part is mandatory regardless of (a)/(b).
+4. Regression test: judge subprocess timeout path increments the metric and fails open exactly once per dispatch (no retry storm).
+5. `make build`, `make test`, `make lint` green.
+
+## Implementation
+
+Judge invocation lives in the github-sdk-poller pre-flight path (component `github-sdk-poller`, "pre-flight judge error (fail-open)") with the subprocess spawn in `internal/executor` intent-judge code. Deadline constants and child env construction are the first places to look. Metrics: mirror existing pilot_* gauge/counter registration.
+
+Out of scope: heartbeat-kill of main executions (separate issue #4668), judge prompt/quality changes.
+
+## Resolution (2026-08-03)
+
+**Root cause**: too-short deadlines, not contention/env/auth/routing/binary resolution.
+
+Ruled out on the live box (this session runs on `i-0e0c1ca34e7b561f9`, the production Pilot daemon host):
+- CPU contention: 8 concurrent trivial `claude` calls all completed in 6-10s.
+- Env/model-routing leakage: read the daemon's real `/proc/<pid>/environ` — neither `ANTHROPIC_MODEL` nor `ANTHROPIC_BASE_URL` is set.
+- Shorter parent context deadline: traced the SDK poller's `Start(ctx)` chain back to the daemon's long-lived root context — no shorter deadline anywhere in the chain.
+- Stale/wrong `claude` binary: only one `claude` resolves on PATH (`/usr/bin/claude`, v2.1.104).
+
+Confirmed via direct reproduction: realistic-size prompts (5.8KB and ~27KB, matching real issue bodies/diffs) reliably take **18.7-22.5s** with the real `claude` CLI subprocess on this box, vs. 5-9s for trivial prompts. The old `preflightTimeout` (20s) and `judgeTimeout` (30s) left near-zero margin over that baseline, so any real (non-trivial) issue reliably blew the deadline — a self-inflicted 100% failure rate, not an outage.
+
+**Fix**: raised both deadlines to 60s (config-overridable via `intent_judge.timeout` / `pre_flight_judge.timeout`), plus made the fail-open path observable per acceptance criterion 3:
+- `internal/executor/intent_judge.go`: `NewIntentJudge` defaults `judgeTimeout`/`preflightTimeout` to 60s each; added `SetJudgeTimeout`/`SetPreflightTimeout` setters.
+- `internal/executor/backend.go`: `IntentJudgeConfig.Timeout` / `PreFlightJudgeConfig.Timeout` (string, `time.ParseDuration`), default `"60s"`.
+- `internal/executor/runner.go`: wires `config.IntentJudge.Timeout` into the post-hoc judge.
+- `cmd/pilot/poller_github.go`: wires `pre_flight_judge.timeout` into the pre-flight judge; `sdkPreFlightJudge` is now a pointer receiver with its own consecutive-failure counter, firing `alerts.EventTypeIntentJudgeFailureStreak` exactly once when the streak hits `judgeFailureStreakAlertThreshold` (10), resetting on success.
+- `internal/alerts/{types,engine}.go`: new `AlertTypeIntentJudgeFailureStreak` / `EventTypeIntentJudgeFailureStreak`, default rule (severity Critical), `handleIntentJudgeFailureStreak`.
+- Existing `pilot_intent_judge_failures_total` (GH-4377) is unchanged — it already exists; this issue adds the alert on top of it.
+
+Went with acceptance option (a) "restore" rather than (b) "retire a disable flag", since the root cause was directly fixable.
+
+Regression tests added: `internal/executor/intent_judge_test.go` (`TestNewIntentJudge_Defaults` updated to 60s/60s, `TestIntentJudge_SetTimeouts`), `internal/executor/runner_test.go` (`TestNewRunnerWithConfig_IntentJudgeTimeout`/`_IntentJudgeDefaultTimeout`), `cmd/pilot/poller_github_test.go` (`TestSdkPreFlightJudge_JudgeIssue_TimeoutIncrementsMetricOnce` — real subprocess timeout, single metric increment; `TestSdkPreFlightJudge_FiresStreakAlertExactlyOnceAtThreshold` — fires once, no retry storm past threshold; `TestSdkPreFlightJudge_SuccessResetsStreak`), `internal/alerts/{engine_test,types_test}.go` (`TestHandleIntentJudgeFailureStreak`, default-rules count).
+
+`make build`, `go test ./...`, `gofmt -l`, `go vet ./...` all green. `golangci-lint` is not installed on this box (`make lint` no-ops); no lint-only changes were made that would need it beyond what `go vet`/`gofmt` already cover.
+
+## Refs
+
+- Incident record: `.agent/tasks/TASK-437-duplicate-execution-race-prevention.md` (found during its diagnosis)
+- Context: TASK-409 / S6-lite cutover 2026-07-16 (onset date), #4391 (box rate-pool pressure), GH-4401 (subprocess limits history — RLIMIT disabled since 07-17, so not the cause window)
+
+## Acceptance Criteria
+

--- a/cmd/pilot/poller_github.go
+++ b/cmd/pilot/poller_github.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	sdkcore "github.com/qf-studio/studio-sdk/sdk/core"
@@ -80,29 +81,80 @@ func verifySDKGithubToken(ctx context.Context, client *githubSDK.Client, tokenSo
 	return true
 }
 
+// judgeFailureStreakAlertThreshold mirrors repickLoopBreakerThreshold
+// (cmd/pilot/repick_backoff.go): the number of consecutive pre-flight judge
+// failures (fail-open) after which sdkPreFlightJudge.JudgeIssue fires
+// alerts.EventTypeIntentJudgeFailureStreak exactly once (GH-4669). This is
+// the "observable fail-open" requirement — without it, a dead judge silently
+// fails open forever, which is exactly what hid the 17-day, 4,321-invocation
+// incident this issue is named after.
+const judgeFailureStreakAlertThreshold = 10
+
 // sdkPreFlightJudge adapts *executor.IntentJudge to sdkcore.PreFlightJudger,
-// returning the SDK's core.Verdict.
+// returning the SDK's core.Verdict. Pointer receiver (GH-4669) so
+// consecutiveFailures can be mutated across calls from the SDK poller's
+// per-repo goroutine.
 type sdkPreFlightJudge struct {
 	judge *executor.IntentJudge
 	// metrics records judge subprocess failures by cause (GH-4377); nil-safe
 	// (a repo with no autopilot controller just skips the metric).
 	metrics *autopilot.Metrics
+	// alertsEngine fires EventTypeIntentJudgeFailureStreak; nil-safe.
+	alertsEngine *alerts.Engine
+	// repoFullName identifies the repo in the fired alert's metadata.
+	repoFullName string
+
+	mu                  sync.Mutex
+	consecutiveFailures int
 }
 
-func (s sdkPreFlightJudge) JudgeIssue(ctx context.Context, title, body, repoContext string) (sdkcore.Verdict, error) {
+func (s *sdkPreFlightJudge) JudgeIssue(ctx context.Context, title, body, repoContext string) (sdkcore.Verdict, error) {
 	v, err := s.judge.JudgeIssue(ctx, title, body, repoContext)
 	if err != nil {
 		if s.metrics != nil {
 			s.metrics.RecordIntentJudgeFailure(judgeFailureCause(err))
 		}
+		s.recordFailure()
 		return sdkcore.Verdict{}, err
 	}
+	s.recordSuccess()
 	return sdkcore.Verdict{
 		Accepted:   !v.IsRejection(),
 		Decision:   string(v.Decision),
 		Reason:     v.Reason,
 		Confidence: v.Confidence,
 	}, nil
+}
+
+// recordFailure increments the consecutive-failure streak and fires exactly
+// one alert when it reaches judgeFailureStreakAlertThreshold — an equality
+// check (not >=), so a judge that never recovers pages once, not on every
+// poll cycle thereafter (GH-4669, mirroring fireLoopBreakerAlert's pattern in
+// cmd/pilot/handler_common.go).
+func (s *sdkPreFlightJudge) recordFailure() {
+	s.mu.Lock()
+	s.consecutiveFailures++
+	consecutive := s.consecutiveFailures
+	s.mu.Unlock()
+
+	if consecutive == judgeFailureStreakAlertThreshold && s.alertsEngine != nil {
+		s.alertsEngine.ProcessEvent(alerts.Event{
+			Type: alerts.EventTypeIntentJudgeFailureStreak,
+			Metadata: map[string]string{
+				"repo":                 s.repoFullName,
+				"consecutive_failures": strconv.Itoa(consecutive),
+			},
+			Timestamp: time.Now(),
+		})
+	}
+}
+
+// recordSuccess resets the streak so a transient blip doesn't compound
+// toward the alert threshold across unrelated failures.
+func (s *sdkPreFlightJudge) recordSuccess() {
+	s.mu.Lock()
+	s.consecutiveFailures = 0
+	s.mu.Unlock()
 }
 
 // judgeFailureCause extracts the GH-4377 diagnostic cause (context_deadline,
@@ -383,7 +435,19 @@ func startGithubSDKPollerForRepo(ctx context.Context, deps *PollerDeps, log *slo
 			if controller != nil {
 				judgeMetrics = controller.Metrics()
 			}
-			pollerDeps.PreFlightJudge = sdkPreFlightJudge{judge: executor.NewIntentJudge(claudeCmd), metrics: judgeMetrics}
+			preflightJudge := executor.NewIntentJudge(claudeCmd)
+			// GH-4669: allow overriding the raised 60s default from config.
+			if deps.Cfg.Executor.PreFlightJudge.Timeout != "" {
+				if d, err := time.ParseDuration(deps.Cfg.Executor.PreFlightJudge.Timeout); err == nil {
+					preflightJudge.SetPreflightTimeout(d)
+				}
+			}
+			pollerDeps.PreFlightJudge = &sdkPreFlightJudge{
+				judge:        preflightJudge,
+				metrics:      judgeMetrics,
+				alertsEngine: deps.AlertsEngine,
+				repoFullName: target.repoFullName,
+			}
 			if deps.Store != nil {
 				pollerDeps.ExecutionSaver = storeExecutionSaver{store: deps.Store}
 			}

--- a/cmd/pilot/poller_github_test.go
+++ b/cmd/pilot/poller_github_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/qf-studio/pilot/internal/adapters/github"
 	"github.com/qf-studio/pilot/internal/adapters/sdkshim"
+	"github.com/qf-studio/pilot/internal/alerts"
 	"github.com/qf-studio/pilot/internal/autopilot"
 	"github.com/qf-studio/pilot/internal/config"
 	"github.com/qf-studio/pilot/internal/executor"
@@ -320,7 +322,7 @@ func TestJudgeFailureCause_PlainErrorDefaultsToOther(t *testing.T) {
 // a metric" acceptance criterion.
 func TestSdkPreFlightJudge_JudgeIssue_RecordsFailureMetric(t *testing.T) {
 	metrics := autopilot.NewMetrics()
-	sp := sdkPreFlightJudge{
+	sp := &sdkPreFlightJudge{
 		judge:   executor.NewIntentJudge("/nonexistent/gh-4377-claude-binary"),
 		metrics: metrics,
 	}
@@ -338,13 +340,137 @@ func TestSdkPreFlightJudge_JudgeIssue_RecordsFailureMetric(t *testing.T) {
 // TestSdkPreFlightJudge_JudgeIssue_NilMetricsSafe verifies a repo with no
 // autopilot controller (nil metrics) doesn't panic on judge failure.
 func TestSdkPreFlightJudge_JudgeIssue_NilMetricsSafe(t *testing.T) {
-	sp := sdkPreFlightJudge{
+	sp := &sdkPreFlightJudge{
 		judge:   executor.NewIntentJudge("/nonexistent/gh-4377-claude-binary"),
 		metrics: nil,
 	}
 
 	if _, err := sp.JudgeIssue(context.Background(), "title", "body", ""); err == nil {
 		t.Fatal("expected error for a nonexistent claude binary")
+	}
+}
+
+// TestSdkPreFlightJudge_JudgeIssue_TimeoutIncrementsMetricOnce drives a real
+// subprocess (not a mock) that outlives its preflight deadline, confirming
+// the GH-4669 acceptance criterion directly: the timeout path both (a)
+// increments pilot_intent_judge_failures_total with cause=context_deadline,
+// and (b) fails open exactly once for a single JudgeIssue call — no internal
+// retry loop inflates the failure count for one dispatch.
+func TestSdkPreFlightJudge_JudgeIssue_TimeoutIncrementsMetricOnce(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available on this system")
+	}
+
+	dir := t.TempDir()
+	scriptPath := dir + "/slow-claude.sh"
+	// Ignores all args (title/body/model/flags) and just outlives any
+	// reasonable preflight deadline, forcing a real context-deadline kill.
+	// Uses `exec` so sleep replaces the shell in-place (single PID) — without
+	// it, killing the shell leaves an orphaned sleep holding the stdout pipe
+	// open, and Wait() blocks on pipe EOF for the full 5s regardless of the
+	// context deadline.
+	script := "#!/bin/sh\nexec sleep 5\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("failed to write test script: %v", err)
+	}
+
+	judge := executor.NewIntentJudge(scriptPath)
+	judge.SetPreflightTimeout(50 * time.Millisecond)
+
+	metrics := autopilot.NewMetrics()
+	sp := &sdkPreFlightJudge{judge: judge, metrics: metrics}
+
+	if _, err := sp.JudgeIssue(context.Background(), "title", "body", ""); err == nil {
+		t.Fatal("expected error from a subprocess killed by context deadline")
+	}
+
+	snap := metrics.Snapshot()
+	if snap.IntentJudgeFailures["context_deadline"] != 1 {
+		t.Errorf("expected exactly 1 context_deadline judge failure recorded, got: %+v", snap.IntentJudgeFailures)
+	}
+	if sp.consecutiveFailures != 1 {
+		t.Errorf("expected consecutiveFailures=1 after a single dispatch's timeout, got %d", sp.consecutiveFailures)
+	}
+}
+
+// --- GH-4669: fail-open observability (streak alert + no retry storm) ---
+
+// TestSdkPreFlightJudge_FiresStreakAlertExactlyOnceAtThreshold drives
+// judgeFailureStreakAlertThreshold consecutive failures through JudgeIssue
+// and confirms exactly one alerts.EventTypeIntentJudgeFailureStreak event is
+// emitted, at the failure that makes the streak equal to the threshold —
+// not before, and not fired again on further failures past it (no retry
+// storm).
+func TestSdkPreFlightJudge_FiresStreakAlertExactlyOnceAtThreshold(t *testing.T) {
+	config := &alerts.AlertConfig{
+		Enabled: true,
+		Channels: []alerts.ChannelConfig{
+			{Name: "test-channel", Type: "webhook", Enabled: true},
+		},
+		Rules: []alerts.AlertRule{
+			{
+				Name:     "intent_judge_failure_streak",
+				Type:     alerts.AlertTypeIntentJudgeFailureStreak,
+				Enabled:  true,
+				Severity: alerts.SeverityCritical,
+				Channels: []string{"test-channel"},
+				Cooldown: 0,
+			},
+		},
+	}
+	mockCh := newMockAlertChannel("test-channel")
+	dispatcher := alerts.NewDispatcher(config)
+	dispatcher.RegisterChannel(mockCh)
+	engine := alerts.NewEngine(config, alerts.WithDispatcher(dispatcher))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = engine.Start(ctx)
+
+	sp := &sdkPreFlightJudge{
+		judge:        executor.NewIntentJudge("/nonexistent/gh-4669-claude-binary"),
+		alertsEngine: engine,
+		repoFullName: "qf-studio/pilot",
+	}
+
+	// Drive one more failure than the threshold to confirm no retry storm:
+	// the alert must fire exactly once, at the threshold-th failure.
+	for i := 0; i < judgeFailureStreakAlertThreshold+2; i++ {
+		if _, err := sp.JudgeIssue(context.Background(), "title", "body", ""); err == nil {
+			t.Fatal("expected error for a nonexistent claude binary")
+		}
+	}
+
+	waitForMockAlerts(t, mockCh, 1, 2*time.Second)
+	got := mockCh.getAlerts()
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 streak alert (no retry storm), got %d", len(got))
+	}
+	if got[0].Type != alerts.AlertTypeIntentJudgeFailureStreak {
+		t.Errorf("expected alert type %s, got %s", alerts.AlertTypeIntentJudgeFailureStreak, got[0].Type)
+	}
+}
+
+// TestSdkPreFlightJudge_SuccessResetsStreak verifies a successful JudgeIssue
+// call resets the consecutive-failure counter, so failures before and after
+// an intervening success don't compound toward the alert threshold.
+func TestSdkPreFlightJudge_SuccessResetsStreak(t *testing.T) {
+	sp := &sdkPreFlightJudge{
+		judge: executor.NewIntentJudge("/nonexistent/gh-4669-claude-binary"),
+	}
+
+	for i := 0; i < judgeFailureStreakAlertThreshold-1; i++ {
+		if _, err := sp.JudgeIssue(context.Background(), "title", "body", ""); err == nil {
+			t.Fatal("expected error for a nonexistent claude binary")
+		}
+	}
+	if sp.consecutiveFailures != judgeFailureStreakAlertThreshold-1 {
+		t.Fatalf("expected streak of %d, got %d", judgeFailureStreakAlertThreshold-1, sp.consecutiveFailures)
+	}
+
+	sp.recordSuccess()
+	if sp.consecutiveFailures != 0 {
+		t.Fatalf("expected streak reset to 0 after success, got %d", sp.consecutiveFailures)
 	}
 }
 

--- a/internal/alerts/engine.go
+++ b/internal/alerts/engine.go
@@ -162,6 +162,15 @@ const (
 	// than the issue the session was dispatched to fix — the GH-4649
 	// incident class. Metadata carries repo, issue, state, and task_issue.
 	EventTypeGithubSideEffect EventType = "github_sideeffect"
+
+	// Intent judge failure streak events (GH-4669): fired exactly once by
+	// the pre-flight judge wrapper (cmd/pilot/poller_github.go,
+	// sdkPreFlightJudge.JudgeIssue) when its own consecutive-failure counter
+	// reaches judgeFailureStreakAlertThreshold — the fail-open path that
+	// hid a 17-day, 100%-failure incident (4,321 context_deadline kills)
+	// until it was caught while diagnosing GH-4648. Metadata carries repo
+	// and consecutive_failures.
+	EventTypeIntentJudgeFailureStreak EventType = "intent_judge_failure_streak"
 )
 
 const (
@@ -421,6 +430,8 @@ func (e *Engine) handleEvent(ctx context.Context, event Event) {
 		e.handleEvalRegression(ctx, event)
 	case EventTypeGithubSideEffect:
 		e.handleGithubSideEffect(ctx, event)
+	case EventTypeIntentJudgeFailureStreak:
+		e.handleIntentJudgeFailureStreak(ctx, event)
 	}
 }
 
@@ -686,6 +697,26 @@ func (e *Engine) handleDispatchLoopBreaker(ctx context.Context, event Event) {
 		if rule.Type == AlertTypeDispatchLoopBreaker && e.shouldFire(rule) {
 			message := fmt.Sprintf("Task %s has been dispatched-and-rejected %s consecutive times without completing — stopping until operator action or backoff expiry",
 				event.TaskID, event.Metadata["consecutive_drops"])
+			alert := e.createAlert(rule, event, message)
+			e.fireAlert(ctx, rule, alert)
+		}
+	}
+}
+
+// handleIntentJudgeFailureStreak fires AlertTypeIntentJudgeFailureStreak
+// rules when the intent judge's consecutive fail-open streak reaches the
+// caller's threshold (GH-4669). The caller (sdkPreFlightJudge.JudgeIssue,
+// cmd/pilot/poller_github.go) already computed and gated on the exact
+// threshold before emitting this event — mirroring handleDispatchLoopBreaker
+// — so no Condition-based counting happens here.
+func (e *Engine) handleIntentJudgeFailureStreak(ctx context.Context, event Event) {
+	for _, rule := range e.config.Rules {
+		if !rule.Enabled {
+			continue
+		}
+		if rule.Type == AlertTypeIntentJudgeFailureStreak && e.shouldFire(rule) {
+			message := fmt.Sprintf("Pre-flight intent judge for %s has failed open %s consecutive times — judge is not producing verdicts",
+				event.Metadata["repo"], event.Metadata["consecutive_failures"])
 			alert := e.createAlert(rule, event, message)
 			e.fireAlert(ctx, rule, alert)
 		}

--- a/internal/alerts/engine_test.go
+++ b/internal/alerts/engine_test.go
@@ -1538,6 +1538,108 @@ func TestHandleDispatchLoopBreaker(t *testing.T) {
 	})
 }
 
+// TestHandleIntentJudgeFailureStreak covers the GH-4669 intent-judge
+// failure-streak rule: the emitting side (sdkPreFlightJudge.JudgeIssue,
+// cmd/pilot/poller_github.go) does its own threshold counting (fires exactly
+// once, at consecutive failures == judgeFailureStreakAlertThreshold), so this
+// test only needs to verify the event turns into exactly one alert carrying
+// the repo and consecutive-failures metadata — mirroring
+// TestHandleDispatchLoopBreaker above.
+func TestHandleIntentJudgeFailureStreak(t *testing.T) {
+	t.Run("fires with repo and consecutive_failures metadata", func(t *testing.T) {
+		config := &AlertConfig{
+			Enabled: true,
+			Channels: []ChannelConfig{
+				{Name: "test-channel", Type: "webhook", Enabled: true},
+			},
+			Rules: []AlertRule{
+				{
+					Name:     "intent_judge_failure_streak",
+					Type:     AlertTypeIntentJudgeFailureStreak,
+					Enabled:  true,
+					Severity: SeverityCritical,
+					Channels: []string{"test-channel"},
+					Cooldown: 0,
+				},
+			},
+		}
+
+		mockCh := newMockChannel("test-channel", "webhook")
+		dispatcher := NewDispatcher(config)
+		dispatcher.RegisterChannel(mockCh)
+
+		engine := NewEngine(config, WithDispatcher(dispatcher))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = engine.Start(ctx)
+
+		engine.ProcessEvent(Event{
+			Type: EventTypeIntentJudgeFailureStreak,
+			Metadata: map[string]string{
+				"repo":                 "qf-studio/pilot",
+				"consecutive_failures": "10",
+			},
+			Timestamp: time.Now(),
+		})
+
+		waitForAlerts(t, mockCh, 1, 2*time.Second)
+		alerts := mockCh.getAlerts()
+		if len(alerts) != 1 {
+			t.Fatalf("expected 1 alert, got %d", len(alerts))
+		}
+		if alerts[0].Type != AlertTypeIntentJudgeFailureStreak {
+			t.Errorf("expected alert type %s, got %s", AlertTypeIntentJudgeFailureStreak, alerts[0].Type)
+		}
+		if !strings.Contains(alerts[0].Message, "qf-studio/pilot") || !strings.Contains(alerts[0].Message, "10") {
+			t.Errorf("expected alert message to mention the repo and consecutive-failure count, got %q", alerts[0].Message)
+		}
+	})
+
+	t.Run("disabled rule does not fire", func(t *testing.T) {
+		config := &AlertConfig{
+			Enabled: true,
+			Channels: []ChannelConfig{
+				{Name: "test-channel", Type: "webhook", Enabled: true},
+			},
+			Rules: []AlertRule{
+				{
+					Name:     "intent_judge_failure_streak",
+					Type:     AlertTypeIntentJudgeFailureStreak,
+					Enabled:  false,
+					Severity: SeverityCritical,
+					Channels: []string{"test-channel"},
+					Cooldown: 0,
+				},
+			},
+		}
+
+		mockCh := newMockChannel("test-channel", "webhook")
+		dispatcher := NewDispatcher(config)
+		dispatcher.RegisterChannel(mockCh)
+
+		engine := NewEngine(config, WithDispatcher(dispatcher))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = engine.Start(ctx)
+
+		engine.ProcessEvent(Event{
+			Type: EventTypeIntentJudgeFailureStreak,
+			Metadata: map[string]string{
+				"repo":                 "qf-studio/pilot",
+				"consecutive_failures": "10",
+			},
+			Timestamp: time.Now(),
+		})
+		engine.flushForTest()
+
+		if got := len(mockCh.getAlerts()); got != 0 {
+			t.Errorf("expected 0 alerts (rule disabled), got %d", got)
+		}
+	})
+}
+
 // TestHandleLaneStarvation covers the GH-4454 lane-starvation rule: the
 // emitting side (autopilot.Controller.reconcileLaneStarvation) does no
 // threshold filtering of its own and sends the raw streak on every starved

--- a/internal/alerts/types.go
+++ b/internal/alerts/types.go
@@ -70,6 +70,13 @@ const (
 	// GH-4649 incident class (an executor session improvised `gh issue
 	// close` plus a label on a sibling issue mid-run).
 	AlertTypeGithubSideEffect AlertType = "github_sideeffect"
+
+	// Intent judge failure streak (GH-4669): the pre-flight/post-hoc intent
+	// judge subprocess has failed (fail-open) N consecutive times in a row —
+	// the class of incident that hid a 17-day, 100%, 4,321-invocation
+	// failure streak (all context_deadline exceeded) behind a silent
+	// fail-open, discovered only while diagnosing GH-4648.
+	AlertTypeIntentJudgeFailureStreak AlertType = "intent_judge_failure_streak"
 )
 
 // Alert represents an alert event
@@ -428,6 +435,23 @@ func defaultRules() []AlertRule {
 			Channels:    []string{},
 			Cooldown:    30 * time.Minute,
 			Description: "Alert when a session mutates a GitHub issue other than the one it was dispatched to fix",
+		},
+		// Intent judge failure streak (GH-4669): caller (sdkPreFlightJudge.
+		// JudgeIssue) does its own threshold counting and fires the event
+		// exactly once per streak (at consecutive failures ==
+		// judgeFailureStreakAlertThreshold), so no Condition field is needed
+		// here — mirrors dispatch_loop_breaker and github_sideeffect. Severity
+		// is Critical because this is the exact incident class (17-day, 100%
+		// fail-open, silently hidden) the rule exists to page on.
+		{
+			Name:        "intent_judge_failure_streak",
+			Type:        AlertTypeIntentJudgeFailureStreak,
+			Enabled:     true,
+			Condition:   RuleCondition{},
+			Severity:    SeverityCritical,
+			Channels:    []string{},
+			Cooldown:    30 * time.Minute,
+			Description: "Alert when the pre-flight intent judge fails open N+ consecutive times without producing a verdict",
 		},
 	}
 }

--- a/internal/alerts/types_test.go
+++ b/internal/alerts/types_test.go
@@ -70,6 +70,8 @@ func TestDefaultRules(t *testing.T) {
 		AlertTypeDispatchLoopBreaker: {"dispatch_loop_breaker", true},
 		// GitHub side-effect audit (GH-4670)
 		AlertTypeGithubSideEffect: {"github_sideeffect", true},
+		// Intent judge failure streak (GH-4669)
+		AlertTypeIntentJudgeFailureStreak: {"intent_judge_failure_streak", true},
 	}
 
 	if len(rules) != len(expectedRules) {

--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -625,6 +625,13 @@ type IntentJudgeConfig struct {
 	// falls back to per-file truncation with a full file manifest (GH-4407).
 	// Default: 32000.
 	MaxDiffChars int `yaml:"max_diff_chars,omitempty"`
+
+	// Timeout is the maximum time to wait for the judge subprocess. GH-4669:
+	// raised default from 30s to 60s after live-box reproduction showed real
+	// (non-trivial diff) invocations baseline at 18.7-22.5s, leaving the old
+	// deadline almost no margin and causing a 17-day, 100%-failure fail-open
+	// streak. Default: "60s".
+	Timeout string `yaml:"timeout,omitempty"`
 }
 
 // DefaultIntentJudgeConfig returns default intent judge configuration.
@@ -634,6 +641,7 @@ func DefaultIntentJudgeConfig() *IntentJudgeConfig {
 		Enabled:      &enabled,
 		Model:        "claude-haiku-4-5-20251001",
 		MaxDiffChars: 32000,
+		Timeout:      "60s",
 	}
 }
 
@@ -655,6 +663,11 @@ type PreFlightJudgeConfig struct {
 	// and bills to the operator's subscription. Field retained for backwards-compatible YAML
 	// parsing; will be removed in a future major version.
 	APIKey string `yaml:"api_key,omitempty"`
+
+	// Timeout is the maximum time to wait for the judge subprocess. GH-4669:
+	// empty falls back to IntentJudge's raised 60s default (see
+	// IntentJudgeConfig.Timeout doc for the RCA behind the raise).
+	Timeout string `yaml:"timeout,omitempty"`
 }
 
 // MemoryInjectionConfig controls whether relevant knowledge-graph memories

--- a/internal/executor/intent_judge.go
+++ b/internal/executor/intent_judge.go
@@ -43,6 +43,19 @@ type IntentJudge struct {
 
 // NewIntentJudge creates a new IntentJudge that calls Claude Code subprocess.
 // claudeCmd defaults to "claude" when empty.
+//
+// GH-4669 RCA: on the production box (post 2026-07-16 AWS cutover) the judge
+// subprocess failed open on effectively every real (non-trivial) invocation
+// for 17 days — 4,321 consecutive context_deadline kills, all silently
+// absorbed by the SDK poller's fail-open path. Live reproduction on the box
+// with realistic prompt sizes (5.8KB-27KB, matching real issue bodies/diffs)
+// showed baseline `claude` CLI subprocess latency of ~18.7-22.5s, leaving the
+// old 20s preflightTimeout / 30s judgeTimeout almost no margin. Contention,
+// env/model-routing leakage, ctx-deadline propagation from a shorter parent
+// context, and stale binary resolution were all ruled out empirically. The
+// timeouts below are raised to give real headroom over that measured
+// baseline; both default to 60s (overridable via IntentJudgeConfig.Timeout /
+// PreFlightJudgeConfig.Timeout).
 func NewIntentJudge(claudeCmd string) *IntentJudge {
 	if claudeCmd == "" {
 		claudeCmd = "claude"
@@ -50,13 +63,29 @@ func NewIntentJudge(claudeCmd string) *IntentJudge {
 	j := &IntentJudge{
 		claudeCmd:        claudeCmd,
 		model:            "claude-haiku-4-5-20251001",
-		judgeTimeout:     30 * time.Second,
-		preflightTimeout: 20 * time.Second,
+		judgeTimeout:     60 * time.Second,
+		preflightTimeout: 60 * time.Second,
 		maxDiffChars:     maxDiffCharsDefault,
 		log:              slog.Default(),
 	}
 	j.cmdRunner = j.defaultCmdRunner
 	return j
+}
+
+// SetJudgeTimeout overrides the post-hoc Judge() subprocess deadline. Values
+// <= 0 are ignored (keeps the constructor default). GH-4669.
+func (j *IntentJudge) SetJudgeTimeout(d time.Duration) {
+	if d > 0 {
+		j.judgeTimeout = d
+	}
+}
+
+// SetPreflightTimeout overrides the pre-flight JudgeIssue() subprocess
+// deadline. Values <= 0 are ignored (keeps the constructor default). GH-4669.
+func (j *IntentJudge) SetPreflightTimeout(d time.Duration) {
+	if d > 0 {
+		j.preflightTimeout = d
+	}
 }
 
 // judgeRSSSampleInterval controls how often the judge subprocess's RSS is

--- a/internal/executor/intent_judge_test.go
+++ b/internal/executor/intent_judge_test.go
@@ -224,14 +224,44 @@ func TestNewIntentJudge_Defaults(t *testing.T) {
 	if judge.model != "claude-haiku-4-5-20251001" {
 		t.Errorf("unexpected model: %s", judge.model)
 	}
-	if judge.judgeTimeout != 30*1e9 {
+	// GH-4669: raised from 30s/20s after live-box reproduction showed real
+	// (non-trivial) invocations baseline at 18.7-22.5s — the old deadlines
+	// left near-zero margin and caused a 17-day, 100%-failure fail-open streak.
+	if judge.judgeTimeout != 60*time.Second {
 		t.Errorf("unexpected judgeTimeout: %v", judge.judgeTimeout)
 	}
-	if judge.preflightTimeout != 20*1e9 {
+	if judge.preflightTimeout != 60*time.Second {
 		t.Errorf("unexpected preflightTimeout: %v", judge.preflightTimeout)
 	}
 	if judge.cmdRunner == nil {
 		t.Error("expected non-nil cmdRunner")
+	}
+}
+
+// TestIntentJudge_SetTimeouts verifies the GH-4669 config-override setters:
+// positive durations apply, non-positive values are ignored (keeping the
+// constructor default) rather than silently zeroing the deadline.
+func TestIntentJudge_SetTimeouts(t *testing.T) {
+	judge := NewIntentJudge("")
+
+	judge.SetJudgeTimeout(90 * time.Second)
+	if judge.judgeTimeout != 90*time.Second {
+		t.Errorf("expected judgeTimeout override to apply, got %v", judge.judgeTimeout)
+	}
+
+	judge.SetPreflightTimeout(45 * time.Second)
+	if judge.preflightTimeout != 45*time.Second {
+		t.Errorf("expected preflightTimeout override to apply, got %v", judge.preflightTimeout)
+	}
+
+	judge.SetJudgeTimeout(0)
+	if judge.judgeTimeout != 90*time.Second {
+		t.Errorf("expected non-positive SetJudgeTimeout to be ignored, got %v", judge.judgeTimeout)
+	}
+
+	judge.SetPreflightTimeout(-1 * time.Second)
+	if judge.preflightTimeout != 45*time.Second {
+		t.Errorf("expected non-positive SetPreflightTimeout to be ignored, got %v", judge.preflightTimeout)
 	}
 }
 

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -979,9 +979,15 @@ func NewRunnerWithConfig(config *BackendConfig) (*Runner, error) {
 			if config.IntentJudge.MaxDiffChars > 0 {
 				runner.intentJudge.maxDiffChars = config.IntentJudge.MaxDiffChars
 			}
+			if config.IntentJudge.Timeout != "" {
+				if d, err := time.ParseDuration(config.IntentJudge.Timeout); err == nil {
+					runner.intentJudge.SetJudgeTimeout(d)
+				}
+			}
 			runner.log.Info("Intent judge initialized",
 				slog.String("model", runner.intentJudge.model),
 				slog.Int("max_diff_chars", runner.intentJudge.maxDiffChars),
+				slog.Duration("timeout", runner.intentJudge.judgeTimeout),
 			)
 		}
 	} else if config != nil && config.IntentJudge == nil {

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -2301,6 +2301,62 @@ func TestNewRunnerWithConfig_IntentJudgeDefaultMaxDiffChars(t *testing.T) {
 	}
 }
 
+// Test that IntentJudgeConfig.Timeout flows into the wired IntentJudge's
+// judgeTimeout (GH-4669: the raised-default fix needs a config override path
+// too, so an operator can tune it without a binary rebuild).
+func TestNewRunnerWithConfig_IntentJudgeTimeout(t *testing.T) {
+	enabled := true
+	config := &BackendConfig{
+		Type: "claude-code",
+		ClaudeCode: &ClaudeCodeConfig{
+			Command: "sh",
+		},
+		IntentJudge: &IntentJudgeConfig{
+			Enabled: &enabled,
+			Timeout: "90s",
+		},
+	}
+
+	runner, err := NewRunnerWithConfig(config)
+	if err != nil {
+		t.Fatalf("NewRunnerWithConfig failed: %v", err)
+	}
+	if runner.intentJudge == nil {
+		t.Fatal("expected intent judge to be wired")
+	}
+	if runner.intentJudge.judgeTimeout != 90*time.Second {
+		t.Errorf("judgeTimeout = %v, want 90s", runner.intentJudge.judgeTimeout)
+	}
+}
+
+// Test that an unset Timeout falls back to the raised 60s default rather
+// than the pre-GH-4669 30s, which live-box reproduction showed leaves
+// near-zero margin over real subprocess latency.
+func TestNewRunnerWithConfig_IntentJudgeDefaultTimeout(t *testing.T) {
+	enabled := true
+	config := &BackendConfig{
+		Type: "claude-code",
+		ClaudeCode: &ClaudeCodeConfig{
+			Command: "sh",
+		},
+		IntentJudge: &IntentJudgeConfig{
+			Enabled: &enabled,
+			// Timeout left empty - NewIntentJudge should apply the 60s default.
+		},
+	}
+
+	runner, err := NewRunnerWithConfig(config)
+	if err != nil {
+		t.Fatalf("NewRunnerWithConfig failed: %v", err)
+	}
+	if runner.intentJudge == nil {
+		t.Fatal("expected intent judge to be wired")
+	}
+	if runner.intentJudge.judgeTimeout != 60*time.Second {
+		t.Errorf("judgeTimeout = %v, want default 60s", runner.intentJudge.judgeTimeout)
+	}
+}
+
 // Test ExtractRepoName function (GH-386)
 func TestExtractRepoName(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

Fixes GH-4669: the pre-flight intent judge has failed on **every single invocation (4,321 times)** since the 2026-07-16 AWS cutover — a 17-day, 100% failure rate hidden by fail-open, discovered while diagnosing GH-4648.

### Diagnosis (evidence)

This session ran directly on the production Pilot daemon box (`i-0e0c1ca34e7b561f9`), enabling live reproduction:

- `daemon.log` confirms 4,321+ `pre-flight judge error (fail-open)` lines, **all** `cause=context_deadline`, `peak_rss_mb` ~250-270, starting exactly at the 07-16 cutover, still ongoing.
- Ruled out, with evidence, before landing on the real cause:
  - **CPU contention**: 8 concurrent trivial `claude` calls all completed in 6-10s.
  - **Env/model-routing leakage**: read the daemon's real `/proc/<pid>/environ` — neither `ANTHROPIC_MODEL` nor `ANTHROPIC_BASE_URL` is set.
  - **Shorter parent context deadline**: traced the SDK poller's `Start(ctx)` chain back to the daemon's long-lived root context — no shorter deadline anywhere.
  - **Stale/wrong `claude` binary**: only one `claude` resolves on PATH (v2.1.104).
- **Confirmed root cause**: direct reproduction with realistic prompt sizes (5.8KB and ~27KB, matching real issue bodies/diffs) reliably took **18.7-22.5s** with the real `claude` CLI subprocess on this box, vs 5-9s for trivial prompts. The old 20s (`preflightTimeout`) / 30s (`judgeTimeout`) deadlines left near-zero margin over that baseline — any real (non-trivial) issue reliably blew the deadline.

Went with acceptance option **(a) restore** (raise the timeouts) over (b) retire, since the cause was directly fixable.

### Changes

- `internal/executor/intent_judge.go`: raised `judgeTimeout`/`preflightTimeout` defaults 30s/20s → 60s/60s; added `SetJudgeTimeout`/`SetPreflightTimeout`.
- `internal/executor/backend.go` + `runner.go`: new `intent_judge.timeout` / `pre_flight_judge.timeout` config overrides (`time.ParseDuration`).
- `cmd/pilot/poller_github.go`: `sdkPreFlightJudge` is now a pointer type tracking its own consecutive-failure streak; fires `alerts.EventTypeIntentJudgeFailureStreak` **exactly once** when the streak hits `judgeFailureStreakAlertThreshold` (10), resets on success — no retry storm.
- `internal/alerts/{types,engine}.go`: new `intent_judge_failure_streak` alert type + default rule (severity critical), pairing with the existing `pilot_intent_judge_failures_total` counter (GH-4377) so a dead judge pages instead of hiding for 17 days.
- Full diagnosis and evidence: `.agent/tasks/archive/GH-4669-intent-judge-timeout-fix.md`.

## Test plan

- [x] `make build` — green
- [x] `go test ./...` — all packages green
- [x] `gofmt -l` / `go vet ./...` — clean (golangci-lint not installed on this box; `make lint` no-ops, no lint-affecting patterns introduced)
- [x] New regression tests:
  - `TestSdkPreFlightJudge_JudgeIssue_TimeoutIncrementsMetricOnce` — real subprocess timeout increments `pilot_intent_judge_failures_total{cause=context_deadline}` exactly once
  - `TestSdkPreFlightJudge_FiresStreakAlertExactlyOnceAtThreshold` — fires once at threshold, not again past it (no retry storm)
  - `TestSdkPreFlightJudge_SuccessResetsStreak` — success resets the counter
  - `TestNewRunnerWithConfig_IntentJudgeTimeout`/`_IntentJudgeDefaultTimeout` — config wiring
  - `TestHandleIntentJudgeFailureStreak` — alert engine dispatch
  - `TestIntentJudge_SetTimeouts`, updated `TestNewIntentJudge_Defaults`

🤖 Generated with [Claude Code](https://claude.com/claude-code)