### PR TITLE
GH-4677: fix(executor): decomposed-parent retry must resume coordinator, never re-implement (single-PR re-file of #4655)

### DIFF
--- a/internal/executor/gh4677_test.go
+++ b/internal/executor/gh4677_test.go
@@ -1,0 +1,303 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// gh4677CountingBackend is a Backend stub whose Execute increments a counter.
+// Used to prove a decomposed parent's retry never reaches direct
+// implementation of its own scope (GH-4648/GH-4649, TASK-437 item A) — if
+// the pre-planning ledger gate in executeWithOptions were bypassed, this
+// backend would be invoked for the parent's own task.
+type gh4677CountingBackend struct {
+	mu        sync.Mutex
+	execCount int
+}
+
+func (b *gh4677CountingBackend) Name() string      { return "gh4677-counting" }
+func (b *gh4677CountingBackend) IsAvailable() bool { return true }
+func (b *gh4677CountingBackend) Execute(_ context.Context, _ ExecuteOptions) (*BackendResult, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.execCount++
+	return &BackendResult{Success: true}, nil
+}
+
+func (b *gh4677CountingBackend) count() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.execCount
+}
+
+// gh4677SeedDecomposedParent writes the ledger state a decomposed parent
+// leaves behind after decomposing into the given children: a parent
+// executions row carrying a StageDecomposed event naming every child
+// (Store.GetDecomposedChildTaskIDs' source), plus one executions row per
+// child reflecting its terminal/non-terminal state. Mirrors the seeding
+// pattern in TestFinalizeEpicBranchPR_AbortSweepsRunningChildren
+// (epic_abort_sweep_test.go).
+type gh4677ChildSpec struct {
+	number int    // GitHub issue number -> childID "GH-<number>"
+	status string // "completed", "failed", or "open" (still-running/no evidence)
+	prURL  string // set for a genuinely completed child
+}
+
+func gh4677SeedDecomposedParent(t *testing.T, store *memory.Store, parentTask *Task, children []gh4677ChildSpec) {
+	t.Helper()
+	lifecycle := NewExecutionLifecycle(store)
+	parentExecID, err := lifecycle.Begin(parentTask, ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("Begin(parent): %v", err)
+	}
+	parentTask.ExecutionID = parentExecID
+
+	refs := make([]string, len(children))
+	for i, c := range children {
+		refs[i] = fmt.Sprintf("#%d", c.number)
+	}
+	detail := fmt.Sprintf("decomposed into %d children: %s", len(children), strings.Join(refs, ", "))
+	if err := store.RecordExecutionEvent(parentExecID, memory.StageDecomposed, detail); err != nil {
+		t.Fatalf("RecordExecutionEvent(StageDecomposed): %v", err)
+	}
+
+	for _, c := range children {
+		childID := fmt.Sprintf("GH-%d", c.number)
+		exec := &memory.Execution{
+			ID:          fmt.Sprintf("exec-%d", c.number),
+			TaskID:      childID,
+			ProjectPath: parentTask.ProjectPath,
+			Status:      c.status,
+			PRUrl:       c.prURL,
+		}
+		if c.status == "failed" {
+			exec.Error = "heartbeat timeout: exit 137"
+		}
+		if err := store.SaveExecution(exec); err != nil {
+			t.Fatalf("SaveExecution(%s): %v", childID, err)
+		}
+	}
+}
+
+// TestRunner_Execute_DecomposedParentRetryResumesCoordinator is the GH-4677
+// regression test for the GH-4648/GH-4649 incident (TASK-437 prevention item
+// A): a decomposed parent retried after one child failed must resume
+// coordination — re-dispatching the failed child and waiting on the rest —
+// never re-run classification/planning and re-implement the full spec
+// itself. Table-driven per acceptance: the main incident shape plus one case
+// per bypass branch the fix must pre-empt (planning-failure fallback,
+// isSinglePackageScope collapse) — both must remain unreachable once
+// children are on record, regardless of what planFn or complexity would
+// have produced.
+func TestRunner_Execute_DecomposedParentRetryResumesCoordinator(t *testing.T) {
+	tests := []struct {
+		name    string
+		planFn  func(callCount *int) func(ctx context.Context, task *Task, dir string) (*EpicPlan, error)
+		wantErr bool
+	}{
+		{
+			// The incident shape: without this fix, GH-4648 gen-2's planFn ran
+			// successfully and produced a fresh plan the parent then executed
+			// directly, racing its own still-alive child (GH-4649). planFn
+			// must never even be invoked once children are on record.
+			name: "planning would succeed — bypass N/A, gate must still pre-empt",
+			planFn: func(callCount *int) func(context.Context, *Task, string) (*EpicPlan, error) {
+				return func(_ context.Context, task *Task, _ string) (*EpicPlan, error) {
+					*callCount++
+					return &EpicPlan{ParentTask: &Task{ID: task.ID}, Subtasks: []PlannedSubtask{
+						{Order: 1, Title: "re-implement", Description: "would re-implement the whole spec"},
+					}}, nil
+				}
+			},
+		},
+		{
+			// Bypass branch 1 (runner.go's planning-failure fallback,
+			// GH-1687): a planEpicFn error used to fall straight through to
+			// direct execution, unconditionally. Must be unreachable here.
+			name: "planning-failure fallback bypass must be unreachable",
+			planFn: func(callCount *int) func(context.Context, *Task, string) (*EpicPlan, error) {
+				return func(_ context.Context, _ *Task, _ string) (*EpicPlan, error) {
+					*callCount++
+					return nil, fmt.Errorf("epic planning backend unavailable")
+				}
+			},
+		},
+		{
+			// Bypass branch 2 (runner.go's isSinglePackageScope collapse,
+			// GH-1265/epic.go): a plan whose subtasks all target the same
+			// package collapses to hasNoDecompose=true and executes directly.
+			// Must be unreachable here.
+			name: "isSinglePackageScope collapse bypass must be unreachable",
+			planFn: func(callCount *int) func(context.Context, *Task, string) (*EpicPlan, error) {
+				return func(_ context.Context, task *Task, _ string) (*EpicPlan, error) {
+					*callCount++
+					return &EpicPlan{ParentTask: &Task{ID: task.ID}, Subtasks: []PlannedSubtask{
+						{Order: 1, Title: "impl", Description: "internal/executor/runner.go change"},
+						{Order: 2, Title: "test", Description: "internal/executor/runner_test.go change"},
+					}}, nil
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, err := memory.NewStore(t.TempDir())
+			if err != nil {
+				t.Fatalf("memory.NewStore: %v", err)
+			}
+			defer func() { _ = store.Close() }()
+
+			projectPath := t.TempDir()
+			task := &Task{
+				ID:          "GH-4648",
+				Title:       "[epic] duplicate-execution race repro",
+				Description: "reproduces the GH-4648/GH-4649 decomposed-parent retry race",
+				ProjectPath: projectPath,
+			}
+
+			// Child #4649 failed (heartbeat SIGKILL, the GH-4649 shape);
+			// child #4650 completed cleanly.
+			gh4677SeedDecomposedParent(t, store, task, []gh4677ChildSpec{
+				{number: 4649, status: "failed"},
+				{number: 4650, status: "completed", prURL: "https://github.com/owner/repo/pull/9650"},
+			})
+
+			backend := &gh4677CountingBackend{}
+			r := NewRunnerWithBackend(backend)
+			r.log = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+			r.skipPreflightChecks = true
+			r.dryRun = true
+			r.logStore = store
+
+			planCallCount := 0
+			r.planEpicFn = tt.planFn(&planCallCount)
+
+			// recoverSubIssuesFn hydrates the ledger's child refs into
+			// CreatedIssues: #4649 still open on GitHub (the failed child
+			// never merged), #4650 closed (its PR merged).
+			r.recoverSubIssuesFn = func(_ context.Context, _, parentID string) ([]CreatedIssue, error) {
+				if parentID != task.ID {
+					t.Errorf("recoverSubIssuesFn parentID = %q, want %q", parentID, task.ID)
+				}
+				return []CreatedIssue{
+					{Number: 4649, Identifier: "4649", URL: "https://github.com/owner/repo/issues/4649", State: "open",
+						Subtask: PlannedSubtask{Title: "impl", Description: "the failed child's original task description"}},
+					{Number: 4650, Identifier: "4650", URL: "https://github.com/owner/repo/issues/4650", State: "closed",
+						Subtask: PlannedSubtask{Title: "test", Description: "the completed child's original task description"}},
+				}, nil
+			}
+
+			// executeFunc stands in for the sub-issue dispatch/re-dispatch
+			// point (executeSubIssuesTracked) — the ONLY place that may be
+			// invoked with a child task in this scenario.
+			var executedChildIDs []string
+			var mu sync.Mutex
+			r.executeFunc = func(_ context.Context, subTask *Task) (*ExecutionResult, error) {
+				mu.Lock()
+				executedChildIDs = append(executedChildIDs, subTask.ID)
+				mu.Unlock()
+				return &ExecutionResult{TaskID: subTask.ID, Success: true, PRUrl: "https://github.com/owner/repo/pull/9649"}, nil
+			}
+
+			result, err := r.Execute(context.Background(), task)
+			if err != nil {
+				t.Fatalf("Execute returned unexpected error: %v", err)
+			}
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+			if !result.IsEpic {
+				t.Error("expected IsEpic=true — the parent must resolve via the epic coordinator path, not direct execution")
+			}
+
+			// (a) zero fresh planning invocations.
+			if planCallCount != 0 {
+				t.Errorf("planEpicFn call count = %d, want 0 (classification/planning must never run once children are on record)", planCallCount)
+			}
+
+			// (b) no direct-implementation path taken for the PARENT itself.
+			if got := backend.count(); got != 0 {
+				t.Errorf("backend.Execute call count = %d, want 0 (parent must never directly implement its own scope)", got)
+			}
+
+			// (c) the failed child was re-dispatched; the already-completed
+			// child was not re-executed.
+			mu.Lock()
+			gotExecuted := append([]string(nil), executedChildIDs...)
+			mu.Unlock()
+			if len(gotExecuted) != 1 || gotExecuted[0] != "GH-4649" {
+				t.Errorf("executed child IDs = %v, want [GH-4649] (only the failed child re-dispatched, the completed one skipped)", gotExecuted)
+			}
+		})
+	}
+}
+
+// TestRunner_ResumeDecomposedParent_AllChildrenTerminalFinalizes covers
+// acceptance criterion 3 at the unit level: resumeDecomposedParent itself
+// (the coordinator-resume path decomposedChildLedgerNonTerminal routes
+// into) still finalizes as already-complete when every recovered child
+// evidences completion, reusing the same allChildrenDone check the
+// existing ErrSubIssuesAlreadyExist recovery branch relies on. In
+// production this exact scenario is intercepted earlier by the
+// dispatcher-level decomposedChildrenAllComplete guard (dispatcher.go,
+// covered by TestDecomposedChildrenAllComplete* in dispatcher_test.go)
+// before Runner.Execute is ever invoked — decomposedChildLedgerNonTerminal
+// deliberately only reports true when at least one child is NOT yet
+// terminal, so resumeDecomposedParent is reached from executeWithOptions
+// only in that non-terminal case. This test exercises
+// resumeDecomposedParent directly to confirm its own all-terminal branch
+// (unreachable from executeWithOptions today, but shared logic with the
+// ErrSubIssuesAlreadyExist recovery branch) still behaves correctly rather
+// than leaving it untested.
+func TestRunner_ResumeDecomposedParent_AllChildrenTerminalFinalizes(t *testing.T) {
+	projectPath := t.TempDir()
+	task := &Task{
+		ID:          "GH-4700",
+		Title:       "[epic] all children already shipped",
+		Description: "both children already completed",
+		ProjectPath: projectPath,
+	}
+
+	backend := &gh4677CountingBackend{}
+	r := NewRunnerWithBackend(backend)
+	r.log = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	r.dryRun = true
+
+	r.recoverSubIssuesFn = func(_ context.Context, _, _ string) ([]CreatedIssue, error) {
+		return []CreatedIssue{
+			{Number: 4701, Identifier: "4701", URL: "https://github.com/owner/repo/issues/4701", State: "closed"},
+			{Number: 4702, Identifier: "4702", URL: "https://github.com/owner/repo/issues/4702", State: "closed"},
+		}, nil
+	}
+	execCalled := false
+	r.executeFunc = func(_ context.Context, subTask *Task) (*ExecutionResult, error) {
+		execCalled = true
+		return &ExecutionResult{TaskID: subTask.ID, Success: true}, nil
+	}
+
+	result, err := r.resumeDecomposedParent(context.Background(), task, projectPath, []string{"GH-4701", "GH-4702"}, time.Now())
+	if err != nil {
+		t.Fatalf("resumeDecomposedParent returned unexpected error: %v", err)
+	}
+	if result == nil || !result.Success {
+		t.Fatalf("expected successful result, got: %+v", result)
+	}
+	if !result.IsEpic {
+		t.Error("expected IsEpic=true")
+	}
+	if execCalled {
+		t.Error("executeFunc should NOT have been called — every child already terminal")
+	}
+	if backend.count() != 0 {
+		t.Errorf("backend.Execute call count = %d, want 0", backend.count())
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2080,6 +2080,130 @@ func decomposedChildLedgerNonTerminal(store *memory.Store, taskID, projectPath s
 	return false, childIDs, nil
 }
 
+// resumeDecomposedParent is the coordinator-resume path a decomposed parent
+// MUST take once decomposedChildLedgerNonTerminal shows recorded children
+// with at least one non-terminal/failed — it must never re-derive epic mode
+// from scratch and re-implement its own scope (GH-4648/GH-4649, TASK-437
+// prevention item A). It is the single call site both bypass branches in
+// executeWithOptions (planning-failure fallback, isSinglePackageScope
+// collapse) are pre-empted by: the caller checks the child ledger BEFORE
+// DetectComplexity/PlanEpic ever run, so neither bypass is reachable when
+// children are on record.
+//
+// It hydrates the children via the same recoverExistingSubIssues helper (or
+// r.recoverSubIssuesFn override) the ErrSubIssuesAlreadyExist recovery
+// branch below uses, then either finalizes the epic as complete (every
+// child terminal) or resumes execution of the still-open ones — which
+// includes a previously-failed child still sitting open on GitHub. That
+// resumed run flows through executeSubIssuesTracked's existing sub-issue
+// Begin()/ErrClaimLost/reconcileChildOutcome machinery, the only place that
+// grants a failed child a fresh generation (reclaimSelfOwnedQueuedChildFn ->
+// beginWithGenerationRetry) — no new retry/claim logic is added here.
+func (r *Runner) resumeDecomposedParent(ctx context.Context, task *Task, executionPath string, childIDs []string, start time.Time) (*ExecutionResult, error) {
+	r.log.Info("Resuming decomposed-parent coordinator instead of re-classifying",
+		slog.String("task_id", task.ID),
+		slog.Any("children", childIDs),
+	)
+	r.reportProgress(task.ID, "Resuming", 10, fmt.Sprintf("Resuming coordination for %d recorded children...", len(childIDs)))
+
+	recoverTimeout := r.modelRouter.GetTimeoutForComplexity(ComplexityComplex) * time.Duration(len(childIDs))
+	if recoverTimeout <= 0 {
+		recoverTimeout = r.modelRouter.GetTimeoutForComplexity(ComplexityComplex)
+	}
+	recoverCtx, recoverCancel := context.WithTimeout(ctx, recoverTimeout)
+	defer recoverCancel()
+
+	recover := r.recoverSubIssuesFn
+	if recover == nil {
+		recover = recoverExistingSubIssues
+	}
+	recovered, err := recover(recoverCtx, executionPath, task.ID)
+	if err != nil || len(recovered) == 0 {
+		// The ledger says children were recorded but recovery couldn't
+		// hydrate them (gh CLI hiccup, non-GitHub adapter, ...). Fail loud
+		// rather than falling through to direct execution — that fallthrough
+		// is exactly the race this function exists to close.
+		failMsg := fmt.Sprintf("decomposed parent has recorded children (%s) but recovery found none: %v", strings.Join(childIDs, ", "), err)
+		r.recordExecutionEvent(task.LogExecutionID(), memory.StageFailed, truncateForLog(failMsg, 200))
+		return &ExecutionResult{TaskID: task.ID, Success: false, Error: failMsg, Duration: time.Since(start), IsEpic: true}, nil
+	}
+
+	if allChildrenDone(recovered) {
+		r.log.Info("resumeDecomposedParent: all recorded children already terminal, treating epic as complete",
+			slog.String("task_id", task.ID),
+			slog.Int("child_count", len(recovered)),
+		)
+		summary := formatDecomposedChildrenSummary(recovered)
+		r.reportProgress(task.ID, "Complete", 100, "All sub-issues already completed")
+		r.recordExecutionEvent(task.LogExecutionID(), memory.StageDecomposed, summary)
+		r.recordExecutionEvent(task.LogExecutionID(), memory.StageCompleted, summary)
+		return &ExecutionResult{
+			TaskID:    task.ID,
+			Success:   true,
+			Output:    fmt.Sprintf("Epic already completed: %s", summary),
+			Duration:  time.Since(start),
+			IsEpic:    true,
+			ModelName: r.fallbackModelName(),
+		}, nil
+	}
+
+	var open []CreatedIssue
+	for _, iss := range recovered {
+		if strings.ToLower(iss.State) == "open" {
+			open = append(open, iss)
+		}
+	}
+	if len(open) == 0 {
+		failMsg := fmt.Sprintf("decomposed parent's recorded children (%s) are all closed but none evidenced completion", strings.Join(childIDs, ", "))
+		r.recordExecutionEvent(task.LogExecutionID(), memory.StageFailed, truncateForLog(failMsg, 200))
+		return &ExecutionResult{TaskID: task.ID, Success: false, Error: failMsg, Duration: time.Since(start), IsEpic: true}, nil
+	}
+
+	r.log.Info("resumeDecomposedParent: resuming execution of open recorded children (includes any previously-failed child)",
+		slog.String("task_id", task.ID),
+		slog.Int("open_count", len(open)),
+	)
+	childStates, childMetrics, execErr := r.executeSubIssuesTracked(recoverCtx, task, open, executionPath, task.ProjectPath)
+	if execErr != nil {
+		execErrMsg := fmt.Sprintf("sub-issue execution failed: %v", execErr)
+		r.recordExecutionEvent(task.LogExecutionID(), memory.StageFailed, truncateForLog(execErrMsg, 200))
+		return &ExecutionResult{TaskID: task.ID, Success: false, Error: execErrMsg, Duration: time.Since(start), IsEpic: true}, nil
+	}
+
+	epicResult := &ExecutionResult{
+		TaskID:    task.ID,
+		Success:   true,
+		Output:    fmt.Sprintf("Epic completed: %s", formatDecomposedChildrenSummary(open)),
+		Duration:  time.Since(start),
+		IsEpic:    true,
+		ModelName: r.fallbackModelName(),
+	}
+	if childMetrics != nil {
+		epicResult.TokensInput = childMetrics.TokensInput
+		epicResult.TokensOutput = childMetrics.TokensOutput
+		epicResult.TokensTotal = childMetrics.TokensTotal
+		epicResult.CacheCreationInputTokens = childMetrics.CacheCreationInputTokens
+		epicResult.CacheReadInputTokens = childMetrics.CacheReadInputTokens
+		epicResult.ResearchTokens = childMetrics.ResearchTokens
+		epicResult.FilesChanged = childMetrics.FilesChanged
+		epicResult.LinesAdded = childMetrics.LinesAdded
+		epicResult.LinesRemoved = childMetrics.LinesRemoved
+		epicResult.EstimatedCostUSD = childMetrics.EstimatedCostUSD
+		if childMetrics.ModelName != "" {
+			epicResult.ModelName = childMetrics.ModelName
+		}
+	}
+
+	if task.CreatePR && task.Branch != "" {
+		r.finalizeEpicBranchPR(recoverCtx, task, NewGitOperations(executionPath), epicResult, childStates)
+	} else {
+		r.reportProgress(task.ID, "Complete", 100, "Epic completed successfully")
+	}
+	classifyZeroDeliveryEpicCompletion(epicResult)
+	r.recordEpicTerminalEvent(task.LogExecutionID(), epicResult)
+	return epicResult, nil
+}
+
 // executeWithOptions is the internal implementation that allows controlling worktree creation.
 // When allowWorktree is false, it skips worktree creation even if configured.
 // This prevents recursive worktree creation in sub-issues and decomposed tasks.
@@ -2263,6 +2387,32 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		if err := r.maybeInitNavigator(executionPath); err != nil {
 			r.log.Warn("Navigator auto-init failed", slog.Any("error", err))
 			// Continue without Navigator - graceful degradation
+		}
+	}
+
+	// GH-4677 (TASK-437 prevention item A): a decomposed parent's retry must
+	// resume coordination, never re-derive epic mode from scratch and
+	// re-implement its own scope. Consult the child ledger unconditionally,
+	// BEFORE complexity detection or any planning call —
+	// decomposedChildrenAllComplete (dispatcher.go, checked at pickup) only
+	// short-circuits when EVERY child is terminal; a FAILED child falls
+	// through to here, and nothing previously stopped a fresh
+	// DetectComplexity/PlanEpic re-derivation from taking over and racing its
+	// own still-alive child into a duplicate PR (the GH-4648/GH-4649
+	// incident, TASK-437). Placing this ahead of DetectComplexity closes both
+	// bypass branches below (planning-failure fallback, isSinglePackageScope
+	// collapse) by making them structurally unreachable whenever children are
+	// on record — a decomposed parent must be unable to produce code of its
+	// own.
+	if r.logStore != nil {
+		hasNonTerminal, childIDs, ledgerErr := decomposedChildLedgerNonTerminal(r.logStore, task.ID, task.ProjectPath)
+		if ledgerErr != nil {
+			r.log.Warn("decomposed-parent child ledger check failed; proceeding with normal epic classification",
+				slog.String("task_id", task.ID),
+				slog.Any("error", ledgerErr),
+			)
+		} else if hasNonTerminal {
+			return r.resumeDecomposedParent(ctx, task, executionPath, childIDs, start)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4677.

Closes #4677

## Changes

GitHub Issue GH-4677: fix(executor): decomposed-parent retry must resume coordinator, never re-implement (single-PR re-file of #4655)

Supersedes #4655 (closed not-planned — dispatched without `no-decompose`, fragmented into 7 children producing 4 incoherent/conflicting PRs, all closed).

## Context

2026-07-31 incident GH-4648/GH-4649: a decomposed parent whose child died re-implemented the full spec itself instead of resuming coordination, racing its own still-alive child into a duplicate conflicting PR. Full record: `.agent/tasks/TASK-437-duplicate-execution-race-prevention.md`.

**Already on main — do not rebuild it**: PR #4666 landed the child-ledger gate *check function* (`internal/executor/runner.go`, near the `Store.GetDecomposedChildTaskIDs` call ~line 2063). It is currently **called by nothing** — main is inert, not half-broken. This issue wires it in and closes both bypass branches. Verify the function's current signature/semantics before use; adapt it if it doesn't fit (it was written for this purpose but never integrated).

Verified mechanism (refs at `d959cfd6`, re-verify against current main):

- `decomposedChildrenAllComplete` (`dispatcher.go:2778-2829`, via `Store.GetDecomposedChildTaskIDs`, `memory/store.go:1206-1237`) is **all-or-nothing**: it acts only when EVERY child is `completed`/`no_op`/`merged_pr` (`childCompletionEvidence`, `dispatcher.go:2842-2858`). A FAILED child makes it a no-op → falls through to `w.runner.Execute()` (`dispatcher.go:2586`).
- Inside `Execute()`, epic mode is re-derived from scratch every run (`runner.go:2224` DetectComplexity → `:2253` epic gate → `:2290` fresh `PlanEpic` LLM call). Planning is non-deterministic: GH-4648 gen-0 planned 1 subtask ("Single-package scope detected, skipping epic decomposition"), gen-1 planned 2 and decomposed — same issue, same prompt.
- Two branches bypass `CreateSubIssues` — the ONLY place holding the `ErrSubIssuesAlreadyExist` dedup/recovery check (`epic.go:1221-1234` → `recoverExistingSubIssues`, `runner.go:2384-2477`):
  1. **planning-failure fallback** (`runner.go:2291-2298`) — "Planning failure is non-fatal — fall through to direct execution", unconditional;
  2. **`isSinglePackageScope` collapse** (`runner.go:2307-2332`, `epic.go:419-451`/`462-501`) — an "impl + test" split is a textbook collapse case → `hasNoDecompose=true` → single direct execution.

## Acceptance

1. **Gate wired before the epic decision** (`runner.go` ~2253, BEFORE complexity detection and any planning call): consult the child ledger for `task.ID`/`task.ProjectPath` unconditionally. If children exist AND any is non-terminal or failed → skip classification/planning entirely and route into the existing `recoverExistingSubIssues` coordinator flow: re-dispatch failed children (generation+1 via existing claim machinery), wait on the rest. **A decomposed parent must be structurally unable to produce code of its own.**
2. **Both bypass branches covered** — neither the planning-failure fallback nor the `isSinglePackageScope` collapse can reach direct execution when children exist for this task_id.
3. **All-children-terminal behavior unchanged** (existing `decomposedChildrenAllComplete` finalize path).
4. **Regression test reproducing the incident**: parent with two recorded children (one failed, one completed) → parent retry picked up → asserts (a) zero fresh planning invocations (fake planner counts calls), (b) no direct-implementation path taken, (c) the failed child re-dispatched. Plus a case per bypass branch. Table-driven, stdlib only.
5. `make build`, `make test`, `make lint` green. Conventional-commit PR title.

## Implementation

ONE PR. Expected surface: `runner.go` (gate call + both bypass guards), possibly `dispatcher.go`, plus one focused test file. Target ~100-200 lines total — the four superseded PRs totalled ~1,270 lines of overlapping re-derivation; that sprawl is the anti-goal.

Keep the diff tight and prefer scoped test commands (`go test ./internal/executor/... -count=1`) while iterating; the quality gate runs the full suite at the end. (Context: the box's heartbeat monitor currently SIGKILLs runs silent >5m during long local tool execution — fix in flight as #4668 — so long unbroken `make test` invocations mid-run are a real hazard until it lands.)

**This task must NOT be decomposed — implement as a single PR.** <!-- pilot:no-decompose -->

**Out of scope**: pickup/PR-creation issue-state revalidation (#4656), autopilot conflict handling (#4657, merged), heartbeat liveness (#4668), executor gh scoping (#4670/#4671).

## Refs

- Supersedes #4655; children #4659-#4665 and PRs #4666(merged)/#4667/#4672/#4674/#4675 all closed
- Incident record: `.agent/tasks/TASK-437-duplicate-execution-race-prevention.md`
- Prior art: TASK-401/#4216 (`GetDecomposedChildTaskIDs` + the narrow all-shipped guard), GH-4536/TASK-419 (takeover discipline)