### PR TITLE
fix(autopilot): self-upgrade drain deadlocks on a saturated queue (GH-4683)

### DIFF
--- a/.agent/knowledge/memories/pitfalls/one-method-two-interface-contracts-self-upgrade-drain.md
+++ b/.agent/knowledge/memories/pitfalls/one-method-two-interface-contracts-self-upgrade-drain.md
@@ -1,0 +1,78 @@
+---
+name: One concrete method silently satisfying two differently-scoped interfaces
+description: executor.Monitor.GetRunningTaskIDs() (running+queued, for the orphan-sweep's TaskMonitor contract) structurally also satisfies upgrade.TaskChecker (should be running-only) — Go's structural typing let the wrong semantics leak into self-upgrade's drain with no compiler signal, causing v2.252.0's drain to wait on a dispatcher-refilled queue and time out twice (GH-4683, 2026-08-03).
+type: pitfall
+---
+
+## What
+
+`internal/executor/monitor.go`'s `Monitor.GetRunningTaskIDs()` returns task IDs
+for both `StatusRunning` **and** `StatusQueued` entries. That's correct for its
+original consumer — the `autopilot.TaskMonitor` interface backing the
+orphan-running sweep's exclusion set, where "is this task ID live in the
+daemon's memory in any way" is exactly the right question.
+
+`internal/upgrade/graceful.go`'s `upgrade.TaskChecker` interface declares a
+method with the *same name and signature* —
+`GetRunningTaskIDs() []string` — but a different implied contract: "which
+tasks are actually executing right now, i.e. must block a drain." Because Go
+interfaces are satisfied structurally (no explicit `implements` declaration),
+`*executor.Monitor` satisfied `upgrade.TaskChecker` automatically the moment
+someone wired it in as the self-upgrade drain's `TaskChecker` — no compiler
+error, no lint warning, nothing to flag that the method's actual behavior
+(running+queued) didn't match what the interface's name/doc implied it should
+do (running only).
+
+## Why this matters
+
+The self-upgrade drain (`HotUpgrader.PerformHotUpgrade` → `WaitForTasks`)
+polled `GetRunningTaskIDs()` and waited for it to hit zero. With the dispatcher
+still admitting new work mid-drain (pollers re-queuing retries per the GH-4668
+heartbeat bug being fixed in the very release being installed), the
+running+queued count never dropped below ~5, and the drain timed out twice
+(two 30-minute windows) before failing outright and requiring manual
+intervention on the v2.252.0 rollout (2026-08-03).
+
+The bug was invisible at the type level: `TaskChecker` compiled fine, tests for
+`GetRunningTaskIDs()` itself passed (they correctly assert running+queued,
+because that's right for the *other* interface), and nothing about the
+`Monitor` struct signaled "this method is dual-purposed with conflicting
+semantics for its two callers."
+
+## How to apply
+
+- When a single concrete method backs two different named interfaces, check
+  whether both interfaces actually want the *same* semantics — don't assume
+  structural satisfaction implies contractual correctness. Read each
+  interface's doc comment/name, not just its signature.
+- Fix by adding a new, narrowly-scoped method (here:
+  `Monitor.GetActivelyRunningTaskIDs()`, `StatusRunning` only) and pointing the
+  interface that actually wants that narrower contract (here: an adapter,
+  `monitorRunningTaskChecker` in `cmd/pilot/upgrade.go`) at the new method —
+  rather than changing the existing method's behavior, which would silently
+  break its original (correctly running+queued) consumer and its existing
+  tests.
+- Prefer a small adapter type over widening/overloading one method when two
+  interfaces genuinely need different views of the same underlying state.
+- Grep for every interface a type satisfies before changing what a shared
+  method returns — `grep -rn "GetRunningTaskIDs" --include=*.go` here would
+  have surfaced both call sites (dispatcher's `TaskMonitor` wiring and
+  upgrade's `TaskChecker` wiring) immediately.
+
+## Evidence
+
+- `internal/executor/monitor.go` — `GetRunningTaskIDs()` (running+queued,
+  unchanged) vs. the new `GetActivelyRunningTaskIDs()` (running only)
+- `internal/upgrade/graceful.go` — `TaskChecker` interface definition
+- `cmd/pilot/upgrade.go` — `monitorRunningTaskChecker` adapter routing
+  `upgrade.TaskChecker` to the narrow method
+- `internal/executor/dispatcher.go` — companion fix: `PauseAdmission`/
+  `ResumeAdmission` stop the dispatcher from refilling the queue during a
+  drain attempt in the first place, so admission and drain-scope are both
+  addressed
+- `.agent/tasks/gh-4683.md` — incident timeline and acceptance criteria
+
+## Related
+
+- [[bug_hot_upgrade_restarting_ui_trap]] — a different hot-upgrade UX pitfall
+  in the same subsystem

--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -470,6 +470,7 @@
 | Shell completion | ✅ | main | `pilot completion` | - | bash/zsh/fish |
 | Zip archive support | ✅ | upgrade | - | - | Windows self-upgrade handles .zip archives |
 | Self-upgrade writability preflight | ✅ | upgrade | - | - | Upgrade() probes binary dir before downloading; typed ErrBinaryNotWritable (dir+uid+hint); ERROR log + service_unhealthy alert on auto-upgrade failure; download progress logging throttled to ≥1s/10% steps (GH-4468) |
+| Self-upgrade drain: pause admission, wait only for running | ✅ | executor/upgrade | - | - | Dispatcher.PauseAdmission/ResumeAdmission stop new pickups (queued rows survive restart untouched) while Monitor.GetActivelyRunningTaskIDs/WaitForTasks drain only actively-running executions, not queued+running — fixes v2.252.0 rollout drain timing out twice against a dispatcher-refilled queue (GH-4683) |
 | Pipeline hardening | ✅ | executor | - | - | 4 correctness checks: constants, parity, coverage, dropped features (v1.10.0, GH-1321) |
 | Pre-commit hooks | ✅ | - | `make install-hooks` | - | Git hooks for secret scanning + lint |
 | Qwen Code bug fixes | ✅ | executor | `--backend qwen` | - | 5x pricing correction, CLI version check, session_not_found handling (v1.9.2, GH-1316) |
@@ -497,8 +498,8 @@
 | Autopilot | 39 | 0 | 0 | 0 |
 | Epic Management | 6 | 0 | 0 | 0 |
 | Test Coverage | 9 | 0 | 0 | 0 |
-| Self-Management | 10 | 0 | 0 | 0 |
-| **Total** | **316** | **0** | **0** | **0** |
+| Self-Management | 11 | 0 | 0 | 0 |
+| **Total** | **317** | **0** | **0** | **0** |
 
 ---
 

--- a/.agent/tasks/archive/GH-4683-self-upgrade-drain-pause-admission.md
+++ b/.agent/tasks/archive/GH-4683-self-upgrade-drain-pause-admission.md
@@ -1,0 +1,92 @@
+# GH-4683
+
+**Created:** 2026-08-03
+
+## Problem
+
+GitHub Issue GH-4683: fix(autopilot): self-upgrade drain deadlocks on a saturated queue — pause admission, wait only for running executions
+
+## Context
+
+2026-08-03 v2.252.0 rollout: the release train published at 14:27Z and self-upgrade started at 14:28Z ("Waiting for 4 task(s) to complete..."). The drain waits for **all active executions (running + queued)** while the dispatcher **keeps admitting new work mid-drain** — #4677 was queued at 14:42Z, #4656 re-queued at 15:07Z, #4669 re-queued at 15:37Z, all after upgrade start. Two 30-minute drain windows timed out against a queue that never dropped below ~5; `self-upgrade failed` ERROR at 15:28Z. Operator had to manually install the binary and restart the daemon.
+
+The failure compounded itself: the old binary's heartbeat bug (GH-4668, fixed by the very release being installed) kept churning tasks back into the queue with `infra` outcomes, guaranteeing the queue never emptied. A busy box structurally cannot self-upgrade.
+
+## Acceptance
+
+- While a self-upgrade is pending, the dispatcher stops starting new executions: queued rows stay queued, no new picks, pollers may continue enqueuing.
+- The drain waits only for currently **running** executions (bounded by the existing timeout window); queued work survives the restart and resumes on the new binary.
+- With 1 running + 5 queued tasks, the upgrade completes shortly after the running task finishes instead of timing out.
+- The drain-timeout alert distinguishes "waiting on running task(s)" from the now-impossible "blocked by queue depth".
+
+## Resolution (2026-08-03)
+
+Root cause: `executor.Monitor.GetRunningTaskIDs()` returns task IDs for both
+`StatusRunning` and `StatusQueued` — correct for its original consumer, the
+orphan-running sweep's `autopilot.TaskMonitor` exclusion set ("is this task ID
+live in the daemon's memory at all"). But `*executor.Monitor` was also wired
+in as `upgrade.TaskChecker`'s implementation for the self-upgrade drain, and
+Go's structural interface satisfaction let the same method serve that
+interface too — even though `TaskChecker` needs "is this task *actually
+running right now*," a strictly narrower question. With the dispatcher still
+admitting new work mid-drain (pollers re-queuing retries per the GH-4668
+heartbeat bug), the running+queued count never hit zero and the drain timed
+out twice before failing outright.
+
+**Fix** — two independent, complementary changes:
+
+1. **Narrow the drain's view of "running"**: added
+   `Monitor.GetActivelyRunningTaskIDs()` (`internal/executor/monitor.go`),
+   `StatusRunning` only, reusing the existing `ReconcileDeadOwners` call so a
+   dead owner's zombie "running" entry still can't block a drain forever.
+   `Monitor.WaitForTasks` now polls this new method instead of
+   `GetRunningTaskIDs`, and its timeout error now reads `"waiting on %d
+   running task(s): %v"` (previously implied "blocked by queue depth" was
+   possible — it no longer is, satisfying the alert-wording acceptance
+   criterion directly, since `reportUpgradeFailure` surfaces this error text
+   verbatim). `GetRunningTaskIDs()` itself is unchanged — its running+queued
+   contract is still correct for the orphan-sweep's `TaskMonitor` interface,
+   and changing it would have broken that existing, intentional behavior
+   (and its tests).
+2. **Stop the queue refilling during a drain attempt**: added
+   `Dispatcher.PauseAdmission()` / `ResumeAdmission()` / `AdmissionPaused()`
+   (`internal/executor/dispatcher.go`), backed by a shared `atomic.Bool`
+   wired into every `ProjectWorker` via a new `setAdmissionGate` setter
+   (mirrors the existing `SetLiveWorkerChecker` pattern; nil-safe default
+   preserves today's always-admit behavior for the ~18 test call sites that
+   construct a `ProjectWorker` directly without wiring the gate).
+   `ProjectWorker.processQueue`'s main loop checks the gate *before* fetching
+   the next queued row — a task already mid-execution when the pause begins
+   is left completely alone and runs to completion normally; queued rows
+   simply stay queued in the store, and `ResumeAdmission` re-signals every
+   worker so anything queued during the pause is picked up immediately.
+   `cmd/pilot/main.go`'s self-upgrade goroutine now wraps each upgrade
+   attempt in `dispatcher.PauseAdmission()` / `defer
+   dispatcher.ResumeAdmission()`, and routes the drain through a new
+   `monitorRunningTaskChecker` adapter (`cmd/pilot/upgrade.go`) that
+   implements `upgrade.TaskChecker` via the narrow
+   `GetActivelyRunningTaskIDs()` method instead of the dual-purpose one.
+
+Regression tests: `internal/executor/monitor_test.go`
+(`TestMonitorGetActivelyRunningTaskIDs_ExcludesQueued`,
+`TestMonitorWaitForTasks_QueuedTasksDoNotBlockDrain`,
+`TestMonitorWaitForTasks_RunningPlusQueued_ResolvesWhenRunningCompletes` — the
+last one is the literal "1 running + 5 queued" acceptance scenario);
+`internal/executor/dispatcher_test.go`
+(`TestDispatcher_PauseAdmission_QueuedTasksStayQueuedUntilResumed`,
+`TestDispatcher_PauseAdmission_RunningTaskUnaffected`). `go build ./...` and
+`go test ./internal/executor/... ./cmd/pilot/... ./internal/upgrade/...` all
+green; `gofmt`/`go vet` clean. `golangci-lint` is not installed on this box
+(no lint-only changes were made beyond what `gofmt`/`go vet` already cover).
+
+A pitfall memory documenting the "one method, two interface contracts" root
+cause was recorded at
+`.agent/knowledge/memories/pitfalls/one-method-two-interface-contracts-self-upgrade-drain.md`.
+
+## Refs
+
+- Incident: v2.252.0 rollout 2026-08-03, `daemon.log` 14:28–15:28Z on the founder box
+- Compounding factor: GH-4668 heartbeat churn (its fix was aboard the blocked release)
+
+## Acceptance Criteria
+

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -3170,47 +3170,66 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 					// Drain pollers — stop accepting new issues before upgrade
 					program.Send(dashboard.AddLog("◌ draining pollers — no new issues will be accepted")())
 
-					// Perform hot upgrade with monitor as TaskChecker
-					// Monitor tracks running/queued tasks; upgrade waits for them to finish
-					hotUpgrader, err := upgrade.NewHotUpgrader(version, monitor)
-					if err != nil {
-						program.Send(dashboard.NotifyUpgradeComplete(false, err.Error())())
-						program.Send(dashboard.AddLog(fmt.Sprintf("✗ upgrade failed: %v", err))())
-						continue
-					}
-
-					upgradeCfg := &upgrade.HotUpgradeConfig{
-						WaitForTasks: true,
-						TaskTimeout:  30 * time.Minute,
-						OnProgress: func(pct int, msg string) {
-							program.Send(dashboard.NotifyUpgradeProgress(pct, msg)())
-						},
-						FlushSession: func() error {
-							// Future: flush session state to SQLite here
-							return nil
-						},
-					}
-
-					if err := hotUpgrader.PerformHotUpgrade(ctx, info.LatestRelease, upgradeCfg); err != nil {
-						program.Send(dashboard.NotifyUpgradeComplete(false, err.Error())())
-						program.Send(dashboard.AddLog(fmt.Sprintf("✗ upgrade failed: %v", err))())
-						if drainAlertGate.observe(err) {
-							reportUpgradeFailure(alertsEngine, version, info.Latest, err)
-						} else {
-							slog.Warn("self-upgrade drain timeout — retrying next check, not alerting yet (1st consecutive occurrence)",
-								slog.String("current_version", version),
-								slog.String("target_version", info.Latest),
-								slog.Any("error", err),
-							)
+					// GH-4683: pause the dispatcher's admission of new queued
+					// work for the duration of this attempt — the drain below
+					// only waits on ACTIVELY RUNNING executions, so a
+					// saturated/refilling queue must never be able to block
+					// it. Resumed on every return path via defer; on a
+					// successful Unix hot-restart the process image is
+					// replaced (RestartWithNewBinary) before this defer would
+					// ever run, which is harmless — the new process starts
+					// with its own fresh, unpaused Dispatcher.
+					func() {
+						if dispatcher != nil {
+							dispatcher.PauseAdmission()
+							defer dispatcher.ResumeAdmission()
 						}
-					} else {
-						drainAlertGate.observe(nil)
-						// On Unix, process is replaced and this line is never reached.
-						// On Windows, hot restart is not supported — binary is installed
-						// but process continues. Notify user to restart manually.
-						program.Send(dashboard.NotifyUpgradeComplete(true, "")())
-						program.Send(dashboard.AddLog("✓ upgrade installed — restart pilot to apply")())
-					}
+
+						// Perform hot upgrade with a running-only TaskChecker.
+						// monitorRunningTaskChecker (GH-4683) waits only for
+						// executions the Monitor considers actively RUNNING —
+						// queued work survives the restart untouched and
+						// resumes once ResumeAdmission fires.
+						hotUpgrader, err := upgrade.NewHotUpgrader(version, monitorRunningTaskChecker{monitor: monitor})
+						if err != nil {
+							program.Send(dashboard.NotifyUpgradeComplete(false, err.Error())())
+							program.Send(dashboard.AddLog(fmt.Sprintf("✗ upgrade failed: %v", err))())
+							return
+						}
+
+						upgradeCfg := &upgrade.HotUpgradeConfig{
+							WaitForTasks: true,
+							TaskTimeout:  30 * time.Minute,
+							OnProgress: func(pct int, msg string) {
+								program.Send(dashboard.NotifyUpgradeProgress(pct, msg)())
+							},
+							FlushSession: func() error {
+								// Future: flush session state to SQLite here
+								return nil
+							},
+						}
+
+						if err := hotUpgrader.PerformHotUpgrade(ctx, info.LatestRelease, upgradeCfg); err != nil {
+							program.Send(dashboard.NotifyUpgradeComplete(false, err.Error())())
+							program.Send(dashboard.AddLog(fmt.Sprintf("✗ upgrade failed: %v", err))())
+							if drainAlertGate.observe(err) {
+								reportUpgradeFailure(alertsEngine, version, info.Latest, err)
+							} else {
+								slog.Warn("self-upgrade drain timeout — retrying next check, not alerting yet (1st consecutive occurrence)",
+									slog.String("current_version", version),
+									slog.String("target_version", info.Latest),
+									slog.Any("error", err),
+								)
+							}
+						} else {
+							drainAlertGate.observe(nil)
+							// On Unix, process is replaced and this line is never reached.
+							// On Windows, hot restart is not supported — binary is installed
+							// but process continues. Notify user to restart manually.
+							program.Send(dashboard.NotifyUpgradeComplete(true, "")())
+							program.Send(dashboard.AddLog("✓ upgrade installed — restart pilot to apply")())
+						}
+					}()
 				}
 			}
 		}()

--- a/cmd/pilot/upgrade.go
+++ b/cmd/pilot/upgrade.go
@@ -22,6 +22,34 @@ import (
 	"github.com/qf-studio/pilot/internal/upgrade"
 )
 
+// monitorRunningTaskChecker adapts *executor.Monitor to upgrade.TaskChecker
+// using only ACTIVELY RUNNING executions — never queued ones (GH-4683).
+//
+// executor.Monitor.GetRunningTaskIDs (its TaskMonitor-facing method, used by
+// the orphan-running sweep's exclusion set) intentionally still returns
+// running+queued task IDs — a different contract entirely ("is this task ID
+// live in the daemon's memory in any way"). Reusing that method as-is here
+// would resurrect the exact bug this issue fixes: a saturated, dispatcher-
+// refilled queue blocking self-upgrade's drain forever. This adapter routes
+// the upgrade path through Monitor.GetActivelyRunningTaskIDs instead, so a
+// queued task can never count against the drain — it stays queued across
+// the restart and resumes on the new binary once admission is unpaused.
+type monitorRunningTaskChecker struct {
+	monitor *executor.Monitor
+}
+
+// GetRunningTaskIDs implements upgrade.TaskChecker, returning only tasks the
+// Monitor considers actively running (see monitorRunningTaskChecker's doc).
+func (m monitorRunningTaskChecker) GetRunningTaskIDs() []string {
+	return m.monitor.GetActivelyRunningTaskIDs()
+}
+
+// WaitForTasks implements upgrade.TaskChecker by delegating straight to the
+// Monitor, whose WaitForTasks already polls the running-only set (GH-4683).
+func (m monitorRunningTaskChecker) WaitForTasks(ctx context.Context, timeout time.Duration) error {
+	return m.monitor.WaitForTasks(ctx, timeout)
+}
+
 // reportUpgradeFailure makes a self-upgrade failure loud (GH-4468): before
 // this, the auto-upgrade path only logged progress at INFO and a failure
 // left no ERROR line and no alert — an operator found out from the TUI hours

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -123,6 +123,14 @@ type Dispatcher struct {
 	// so serializing it dispatcher-wide does not bottleneck actual task
 	// execution, which is unaffected by this lock.
 	dispatchMu sync.Mutex
+
+	// admissionPaused, while true, stops every ProjectWorker from picking up
+	// the NEXT queued task — but never interrupts a task already running.
+	// GH-4683: a self-upgrade drain sets this for the duration of its
+	// attempt so a saturated queue (pollers keep enqueuing retries) can
+	// never block the drain; QueueTask keeps accepting and persisting new
+	// rows exactly as before, they simply sit queued until ResumeAdmission.
+	admissionPaused atomic.Bool
 }
 
 // NewDispatcher creates a new task dispatcher.
@@ -2111,6 +2119,40 @@ func (d *Dispatcher) queueBlockInfo(projectPath string) (blockedBy string, posit
 	return status.CurrentTaskID, status.QueuedCount, true
 }
 
+// PauseAdmission stops every current and future ProjectWorker from picking
+// up new queued work. Already-running executions are unaffected — only the
+// NEXT pickup is blocked. Call ResumeAdmission to restore normal admission.
+// GH-4683: lets self-upgrade pause the dispatcher for the duration of its
+// drain instead of racing pollers that keep refilling the queue.
+func (d *Dispatcher) PauseAdmission() {
+	d.admissionPaused.Store(true)
+}
+
+// ResumeAdmission restores normal admission after a paused window (e.g. a
+// self-upgrade attempt that failed or timed out) and re-signals every
+// worker so anything queued during the pause is picked up immediately
+// instead of waiting for the next external Signal. GH-4683.
+func (d *Dispatcher) ResumeAdmission() {
+	d.admissionPaused.Store(false)
+
+	d.mu.RLock()
+	workers := make([]*ProjectWorker, 0, len(d.workers))
+	for _, w := range d.workers {
+		workers = append(workers, w)
+	}
+	d.mu.RUnlock()
+
+	for _, w := range workers {
+		w.Signal()
+	}
+}
+
+// AdmissionPaused reports whether the dispatcher is currently refusing to
+// start new executions. GH-4683.
+func (d *Dispatcher) AdmissionPaused() bool {
+	return d.admissionPaused.Load()
+}
+
 // ensureWorker creates a worker for the project if it doesn't exist and starts it.
 func (d *Dispatcher) ensureWorker(projectPath string) {
 	d.mu.Lock()
@@ -2124,6 +2166,7 @@ func (d *Dispatcher) ensureWorker(projectPath string) {
 
 	// Create new worker
 	worker := NewProjectWorker(projectPath, d.store, d.runner, d.log)
+	worker.setAdmissionGate(&d.admissionPaused)
 	d.workers[projectPath] = worker
 
 	// Start worker in background
@@ -2355,6 +2398,20 @@ type ProjectWorker struct {
 	currentTaskID atomic.Value // stores string
 	stopCh        chan struct{}
 	mu            sync.Mutex
+
+	// admissionPaused is shared with the owning Dispatcher (GH-4683); nil
+	// when not wired via setAdmissionGate (e.g. tests constructing a
+	// ProjectWorker directly), which preserves today's always-admit
+	// behavior for those call sites.
+	admissionPaused *atomic.Bool
+}
+
+// setAdmissionGate wires the shared pause flag a Dispatcher uses to stop
+// this worker from picking up new queued work during a self-upgrade drain
+// (GH-4683). Called once from ensureWorker before the worker's goroutine
+// starts.
+func (w *ProjectWorker) setAdmissionGate(paused *atomic.Bool) {
+	w.admissionPaused = paused
 }
 
 // NewProjectWorker creates a new project worker.
@@ -2447,6 +2504,16 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 		case <-w.stopCh:
 			return
 		default:
+		}
+
+		// GH-4683: while admission is paused (self-upgrade draining running
+		// executions), never pick up the NEXT queued task. This check runs
+		// before fetching a new row, so a task already mid-execution when
+		// the pause began is left completely alone — it runs to completion
+		// like normal. Queued rows stay queued in the store untouched;
+		// ResumeAdmission signals this worker again once the pause lifts.
+		if w.admissionPaused != nil && w.admissionPaused.Load() {
+			return
 		}
 
 		// Get next queued task for THIS project

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -5459,3 +5459,140 @@ func TestDispatcher_QueueDecomposedTask_ClaimLostDropsSilently(t *testing.T) {
 		t.Errorf("expected winning execution to belong to %q, got %q", parent.ID, exec.TaskID)
 	}
 }
+
+// TestDispatcher_PauseAdmission_QueuedTasksStayQueuedUntilResumed is the
+// GH-4683 dispatcher-level acceptance test for the self-upgrade drain fix:
+// PauseAdmission must stop a worker from picking up newly queued rows even
+// though it is completely idle, and ResumeAdmission must release them again.
+// Uses syntheticDispatchBackend (always succeeds instantly) specifically so
+// that any erroneous pickup during the paused window would show up
+// immediately as a "completed" row — there's no other way for these rows to
+// leave "queued" in this test.
+func TestDispatcher_PauseAdmission_QueuedTasksStayQueuedUntilResumed(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runner := NewRunnerWithBackend(syntheticDispatchBackend{})
+	runner.skipPreflightChecks = true
+	runner.SetLogStore(store)
+	runner.SetRecordingEnabled(false)
+
+	dispatcher := NewDispatcher(store, runner, nil)
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	dispatcher.PauseAdmission()
+	if !dispatcher.AdmissionPaused() {
+		t.Fatal("expected AdmissionPaused() to be true immediately after PauseAdmission()")
+	}
+
+	projectPath := t.TempDir()
+	var execIDs []string
+	for i := 0; i < 3; i++ {
+		task := &Task{
+			ID:          fmt.Sprintf("GH-PAUSE-%d", i),
+			Title:       "Queued during admission pause",
+			Description: "GH-4683 admission pause coverage",
+			ProjectPath: projectPath,
+		}
+		execID, err := dispatcher.QueueTask(context.Background(), task)
+		if err != nil {
+			t.Fatalf("failed to queue task %d: %v", i, err)
+		}
+		execIDs = append(execIDs, execID)
+	}
+
+	// Give the (idle, would-otherwise-pick-up-instantly) worker every chance
+	// to wrongly drain the queue before asserting nothing moved.
+	time.Sleep(200 * time.Millisecond)
+	for i, execID := range execIDs {
+		exec, err := store.GetExecution(execID)
+		if err != nil {
+			t.Fatalf("failed to get execution %d: %v", i, err)
+		}
+		if exec.Status != "queued" {
+			t.Errorf("task %d: expected status to remain 'queued' while admission is paused, got %q", i, exec.Status)
+		}
+	}
+
+	dispatcher.ResumeAdmission()
+	if dispatcher.AdmissionPaused() {
+		t.Fatal("expected AdmissionPaused() to be false after ResumeAdmission()")
+	}
+
+	for i, execID := range execIDs {
+		exec := waitForTerminalStatus(t, store, execID, 10*time.Second)
+		if exec.Status != "completed" {
+			t.Errorf("task %d: expected status completed after resume, got %q (error: %s)", i, exec.Status, exec.Error)
+		}
+	}
+}
+
+// TestDispatcher_PauseAdmission_RunningTaskUnaffected is the GH-4683
+// companion test: PauseAdmission must never interrupt a task that is
+// already running when the pause begins — the drain it backs only waits
+// for such in-flight work, so the task must be left completely alone
+// (still reported as running, its row still "running" in the store) for as
+// long as the pause is held.
+func TestDispatcher_PauseAdmission_RunningTaskUnaffected(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runner := NewRunnerWithBackend(&blockingBackend{})
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+
+	dispatcher := NewDispatcher(store, runner, nil)
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	task := &Task{
+		ID:          "GH-PAUSE-RUNNING",
+		Title:       "Running when admission pauses",
+		Description: "GH-4683 admission pause coverage",
+		ProjectPath: t.TempDir(),
+	}
+	execID, err := dispatcher.QueueTask(context.Background(), task)
+	if err != nil {
+		t.Fatalf("failed to queue task: %v", err)
+	}
+
+	// Wait for the worker to pick it up and start blocking in Execute.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		exec, err := store.GetExecution(execID)
+		if err != nil {
+			t.Fatalf("failed to get execution: %v", err)
+		}
+		if exec.Status == "running" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("task never reached status running (last status: %s)", exec.Status)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	dispatcher.PauseAdmission()
+	defer dispatcher.ResumeAdmission()
+
+	// The already-running task must be completely unaffected by the pause:
+	// still running, still reported live.
+	time.Sleep(200 * time.Millisecond)
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("failed to get execution: %v", err)
+	}
+	if exec.Status != "running" {
+		t.Errorf("expected running task to be unaffected by PauseAdmission, got status %q", exec.Status)
+	}
+
+	ids := dispatcher.GetRunningTaskIDs()
+	if len(ids) != 1 || ids[0] != task.ID {
+		t.Errorf("expected running task %q still reported live during admission pause, got %v", task.ID, ids)
+	}
+}

--- a/internal/executor/monitor.go
+++ b/internal/executor/monitor.go
@@ -559,6 +559,34 @@ func (m *Monitor) GetRunningTaskIDs() []string {
 	return ids
 }
 
+// GetActivelyRunningTaskIDs returns IDs of tasks that are actually RUNNING
+// right now — unlike GetRunningTaskIDs above, queued tasks are never
+// included. GH-4683: self-upgrade drain previously waited for
+// GetRunningTaskIDs' running+queued set, so a saturated queue that the
+// dispatcher kept refilling mid-drain (pollers re-queuing retries) could
+// never empty and the drain timed out even though every actual worker was
+// idle. A queued task has not started executing anything — it survives the
+// restart untouched and resumes on the new binary — so it must not block a
+// drain the way a running task legitimately does. GetRunningTaskIDs keeps
+// its existing running+queued contract unchanged: it also backs the
+// orphan-running sweep's exclusion set (TaskMonitor interface), a different
+// "is this task ID live in the daemon's memory at all" contract that this
+// method does not touch.
+func (m *Monitor) GetActivelyRunningTaskIDs() []string {
+	m.ReconcileDeadOwners()
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var ids []string
+	for _, state := range m.tasks {
+		if state.Status == StatusRunning {
+			ids = append(ids, state.ID)
+		}
+	}
+	return ids
+}
+
 // deadOwnerGracePeriod protects a task Monitor.Start just marked running from
 // being reconciled as a dead owner before its worker has had a chance to
 // register with the wired LiveWorkerChecker — Start() and the Dispatcher's
@@ -678,15 +706,22 @@ func executionRecentlyProgressed(store *memory.Store, taskID, projectPath string
 // alerting immediately as before.
 var ErrDrainTimeout = errors.New("drain timeout")
 
-// WaitForTasks polls until all running/queued tasks complete or context expires.
-// Implements upgrade.TaskChecker interface for graceful drain during hot upgrade.
+// WaitForTasks polls until every ACTIVELY RUNNING task completes or context
+// expires. Implements upgrade.TaskChecker interface for graceful drain
+// during hot upgrade.
+//
+// GH-4683: deliberately polls GetActivelyRunningTaskIDs, not
+// GetRunningTaskIDs — a self-upgrade drain must wait only for work already
+// in flight. Queued tasks (however many the dispatcher's admission-paused
+// queue is holding) can never block this loop; they stay queued across the
+// restart and resume on the new binary.
 func (m *Monitor) WaitForTasks(ctx context.Context, timeout time.Duration) error {
 	deadline := time.After(timeout)
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
 
 	for {
-		ids := m.GetRunningTaskIDs()
+		ids := m.GetActivelyRunningTaskIDs()
 		if len(ids) == 0 {
 			return nil
 		}
@@ -695,7 +730,7 @@ func (m *Monitor) WaitForTasks(ctx context.Context, timeout time.Duration) error
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-deadline:
-			return fmt.Errorf("%w: %d tasks still active: %v", ErrDrainTimeout, len(ids), ids)
+			return fmt.Errorf("%w: waiting on %d running task(s): %v", ErrDrainTimeout, len(ids), ids)
 		case <-ticker.C:
 			// continue polling
 		}

--- a/internal/executor/monitor_test.go
+++ b/internal/executor/monitor_test.go
@@ -404,6 +404,75 @@ func TestMonitorGetRunningTaskIDs(t *testing.T) {
 	}
 }
 
+// GH-4683 acceptance: GetActivelyRunningTaskIDs must exclude queued tasks —
+// only a task that has actually started executing can block a self-upgrade
+// drain. GetRunningTaskIDs (the pre-existing method) keeps its own
+// running+queued contract unchanged for the orphan-sweep exclusion set.
+func TestMonitorGetActivelyRunningTaskIDs_ExcludesQueued(t *testing.T) {
+	monitor := NewMonitor()
+	monitor.Register("task-1", "Task 1", "")
+	monitor.Register("task-2", "Task 2", "")
+	monitor.Register("task-3", "Task 3", "")
+
+	monitor.Queue("task-1")
+	monitor.Start("task-2")
+	// task-3 stays pending
+
+	ids := monitor.GetActivelyRunningTaskIDs()
+	if len(ids) != 1 || ids[0] != "task-2" {
+		t.Fatalf("Expected only running task-2, got %v", ids)
+	}
+}
+
+// GH-4683 acceptance: a queue full of queued-but-not-started tasks must
+// never block WaitForTasks — this is the literal fix for the v2.252.0
+// self-upgrade incident (drain waited on running+queued while the
+// dispatcher kept refilling the queue, timing out twice against a queue
+// that never dropped below ~5).
+func TestMonitorWaitForTasks_QueuedTasksDoNotBlockDrain(t *testing.T) {
+	monitor := NewMonitor()
+	monitor.Register("task-1", "Task 1", "")
+	monitor.Register("task-2", "Task 2", "")
+	monitor.Register("task-3", "Task 3", "")
+	monitor.Queue("task-1")
+	monitor.Queue("task-2")
+	monitor.Queue("task-3")
+
+	ctx := context.Background()
+	if err := monitor.WaitForTasks(ctx, 100*time.Millisecond); err != nil {
+		t.Fatalf("WaitForTasks should not block on queued-only tasks, got: %v", err)
+	}
+}
+
+// GH-4683 acceptance: with a mix of one running task and several queued
+// tasks, the drain must resolve once the running task completes — it must
+// not wait on the queued ones at all.
+func TestMonitorWaitForTasks_RunningPlusQueued_ResolvesWhenRunningCompletes(t *testing.T) {
+	monitor := NewMonitor()
+	monitor.Register("running-task", "Running", "")
+	monitor.Register("queued-1", "Queued 1", "")
+	monitor.Register("queued-2", "Queued 2", "")
+	monitor.Register("queued-3", "Queued 3", "")
+	monitor.Register("queued-4", "Queued 4", "")
+	monitor.Register("queued-5", "Queued 5", "")
+	monitor.Start("running-task")
+	monitor.Queue("queued-1")
+	monitor.Queue("queued-2")
+	monitor.Queue("queued-3")
+	monitor.Queue("queued-4")
+	monitor.Queue("queued-5")
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		monitor.Complete("running-task", "")
+	}()
+
+	ctx := context.Background()
+	if err := monitor.WaitForTasks(ctx, 5*time.Second); err != nil {
+		t.Fatalf("WaitForTasks should resolve once the running task completes, got: %v", err)
+	}
+}
+
 func TestMonitorWaitForTasks(t *testing.T) {
 	monitor := NewMonitor()
 	monitor.Register("task-1", "Task 1", "")


### PR DESCRIPTION
## Summary

- Root cause: `Monitor.GetRunningTaskIDs()` returns running+queued task IDs (correct for the orphan-sweep's `TaskMonitor` exclusion set) but was also structurally satisfying `upgrade.TaskChecker`, which needs "actually running right now" only — so the self-upgrade drain waited on a queue the dispatcher kept refilling mid-drain (pollers re-queuing retries per GH-4668), timing out twice on the v2.252.0 rollout before failing outright.
- Adds `Monitor.GetActivelyRunningTaskIDs()` (`StatusRunning` only, reuses `ReconcileDeadOwners`) and repoints `WaitForTasks`/the drain-timeout error at it, leaving the original `GetRunningTaskIDs()` untouched for its existing orphan-sweep contract.
- Adds `Dispatcher.PauseAdmission()`/`ResumeAdmission()`/`AdmissionPaused()`, wired into every `ProjectWorker` via a nil-safe `setAdmissionGate` setter: while paused, a worker never picks up the *next* queued row (already-running work is left completely alone), and `ResumeAdmission` re-signals every worker so anything queued during the pause is picked up immediately.
- `cmd/pilot/main.go`'s self-upgrade goroutine now pauses admission for the duration of each attempt (deferred resume) and routes the drain through a new `monitorRunningTaskChecker` adapter (`cmd/pilot/upgrade.go`) using the narrow running-only method.
- Documents the "one method serving two differently-scoped interfaces" pitfall as a Navigator memory, and updates `FEATURE-MATRIX.md` + the archived task doc.

Closes GH-4683.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/executor/... ./cmd/pilot/... ./internal/upgrade/...` — all green, including new regression tests:
  - `TestMonitorGetActivelyRunningTaskIDs_ExcludesQueued`
  - `TestMonitorWaitForTasks_QueuedTasksDoNotBlockDrain`
  - `TestMonitorWaitForTasks_RunningPlusQueued_ResolvesWhenRunningCompletes` (the literal "1 running + 5 queued" acceptance scenario)
  - `TestDispatcher_PauseAdmission_QueuedTasksStayQueuedUntilResumed`
  - `TestDispatcher_PauseAdmission_RunningTaskUnaffected`
- [x] `gofmt -l` / `go vet ./...` clean