### PR TITLE
GH-4687: fix(poller): pilot-in-progress label never applied since 07-16 SDK cutover — wire NotifyTaskStarted into the SDK dispatch path (orphan recovery + label guards structurally dead)

### DIFF
--- a/cmd/pilot/github_sdk_notify_started_test.go
+++ b/cmd/pilot/github_sdk_notify_started_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	githubSDK "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// notifyStartedFake is a minimal mock GitHub server covering the two calls
+// NotifyTaskStarted makes: POST .../labels and POST .../comments. Either
+// endpoint can be configured to fail, to exercise the non-fatal error path.
+type notifyStartedFake struct {
+	server        *httptest.Server
+	mu            sync.Mutex
+	labelsAdded   []string
+	commentsAdded []string
+	failLabels    bool
+	failComments  bool
+}
+
+func newNotifyStartedFake() *notifyStartedFake {
+	f := &notifyStartedFake{}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels"):
+			f.mu.Lock()
+			fail := f.failLabels
+			f.mu.Unlock()
+			if fail {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"message":"injected label failure"}`))
+				return
+			}
+			var body struct {
+				Labels []string `json:"labels"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			f.mu.Lock()
+			f.labelsAdded = append(f.labelsAdded, body.Labels...)
+			f.mu.Unlock()
+			_, _ = w.Write([]byte("[]"))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/comments"):
+			f.mu.Lock()
+			fail := f.failComments
+			f.mu.Unlock()
+			if fail {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"message":"injected comment failure"}`))
+				return
+			}
+			var body struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			f.mu.Lock()
+			f.commentsAdded = append(f.commentsAdded, body.Body)
+			f.mu.Unlock()
+			_, _ = w.Write([]byte(`{"id":1}`))
+		default:
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	return f
+}
+
+// TestNotifyTaskStartedSDK is the GH-4687 table-driven acceptance test: the
+// SDK-dispatch path's notifyTaskStartedSDK helper (cmd/pilot/handlers.go)
+// must apply pilot-in-progress and post the start comment on success, and
+// must surface (not swallow) the underlying error on failure so the caller
+// can log it as a non-fatal WARN. Before GH-4687 the SDK-poller chain
+// performed zero label operations, which silently disabled
+// recoverOrphanedIssues and the pilot-done label removal on merge.
+func TestNotifyTaskStartedSDK(t *testing.T) {
+	tests := []struct {
+		name         string
+		failLabels   bool
+		failComments bool
+		wantErr      bool
+		wantLabel    bool
+	}{
+		{
+			name:      "success applies pilot-in-progress and posts comment",
+			wantErr:   false,
+			wantLabel: true,
+		},
+		{
+			name:       "label failure surfaces as an error, not a panic",
+			failLabels: true,
+			wantErr:    true,
+			wantLabel:  false,
+		},
+		{
+			name:         "comment failure surfaces as an error after the label succeeds",
+			failComments: true,
+			wantErr:      true,
+			wantLabel:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newNotifyStartedFake()
+			defer f.server.Close()
+			f.failLabels = tt.failLabels
+			f.failComments = tt.failComments
+
+			client := githubSDK.NewClientWithBaseURL(testutil.FakeGitHubToken, f.server.URL)
+
+			err := notifyTaskStartedSDK(context.Background(), client, "pilot", "o", "r", 7, "GH-4687")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("notifyTaskStartedSDK() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			f.mu.Lock()
+			defer f.mu.Unlock()
+
+			gotLabel := false
+			for _, l := range f.labelsAdded {
+				if l == githubSDK.LabelInProgress {
+					gotLabel = true
+				}
+			}
+			if gotLabel != tt.wantLabel {
+				t.Errorf("pilot-in-progress applied = %v, want %v (labelsAdded = %v)", gotLabel, tt.wantLabel, f.labelsAdded)
+			}
+		})
+	}
+}
+
+// TestGithubHandlerSDK_NotifyTaskStartedWired is a source-level guard proving
+// handleGithubIssueEventSDK actually calls notifyTaskStartedSDK on the
+// dispatch path (before handleIssueGeneric), and that a labeling failure is
+// only logged (WARN) rather than aborting dispatch — mirroring the
+// established source-inspection pattern for this otherwise-unexercisable
+// function (see TestGithubHandlerSDK_SpecGuardWired in spec_guard_sdk_test.go).
+func TestGithubHandlerSDK_NotifyTaskStartedWired(t *testing.T) {
+	body := githubFuncBody(t, "handlers.go", "func handleGithubIssueEventSDK(")
+
+	if !strings.Contains(body, "notifyTaskStartedSDK(") {
+		t.Error("handleGithubIssueEventSDK must call notifyTaskStartedSDK to apply pilot-in-progress on the SDK-dispatch path (GH-4687)")
+	}
+
+	notifyIdx := strings.Index(body, "notifyTaskStartedSDK(")
+	handleIssueGenericIdx := strings.Index(body, "handleIssueGeneric(ctx, deps, info, task)")
+	if notifyIdx < 0 || handleIssueGenericIdx < 0 || notifyIdx >= handleIssueGenericIdx {
+		t.Error("notifyTaskStartedSDK must be called before handleIssueGeneric so pilot-in-progress is applied at the start of work")
+	}
+
+	// The error must be logged, not propagated/returned — labeling failure
+	// must never block dispatch (mirrors pilot.go:1191-1195 / controller.go:3011-3015).
+	if !strings.Contains(body, `logging.WithComponent("github").Warn("Failed to notify task started (SDK path)"`) {
+		t.Error("notifyTaskStartedSDK errors must be logged as a non-fatal WARN, not propagated")
+	}
+}

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -777,6 +777,33 @@ func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkco
 		}
 	}
 
+	// GH-4687: apply pilot-in-progress at the start of work on the SDK-dispatch
+	// path. Since the 2026-07-16 SDK-poller cutover this was the only dispatch
+	// path with zero label operations — the legacy webhook-only handler
+	// (internal/pilot/pilot.go:1191) was the sole producer — which permanently
+	// disabled recoverOrphanedIssues (studio-sdk poller.go:350-380, cannot find
+	// in-flight issues by label after a restart) and made the pilot-in-progress
+	// removal at controller.go:3014 a silent no-op on every poller-dispatched
+	// issue. studio-sdk's Notifier.NotifyTaskStarted is already tested and
+	// auto-creates the label via AddLabels if the repo doesn't have it yet.
+	// Mirrors the non-fatal (WARN-only) pattern at pilot.go:1191-1195 and
+	// controller.go:3011-3015 — labeling must never block dispatch.
+	if specClient != nil {
+		pilotLabel := ""
+		if cfg.Adapters != nil && cfg.Adapters.GitHub != nil {
+			pilotLabel = cfg.Adapters.GitHub.PilotLabel
+		}
+		if pilotLabel == "" {
+			pilotLabel = "pilot"
+		}
+		if err := notifyTaskStartedSDK(ctx, specClient, pilotLabel, repoOwner, repoName, issueNum, taskID); err != nil {
+			logging.WithComponent("github").Warn("Failed to notify task started (SDK path)",
+				slog.String("task_id", taskID),
+				slog.Int("issue", issueNum),
+				slog.Any("error", err))
+		}
+	}
+
 	task := &executor.Task{
 		ID:                 taskID,
 		Title:              title,
@@ -851,6 +878,15 @@ func fetchGithubIssueForSDKTask(ctx context.Context, client *githubSDK.Client, o
 		return nil
 	}
 	return issue
+}
+
+// notifyTaskStartedSDK applies the pilot-in-progress label and posts the
+// task-started comment via studio-sdk's tested Notifier (GH-4687). Extracted
+// so the SDK-dispatch label wiring can be unit tested directly against a
+// mock GitHub server — handleGithubIssueEventSDK itself resolves a real
+// token/repo and can't be exercised end-to-end in a unit test.
+func notifyTaskStartedSDK(ctx context.Context, client *githubSDK.Client, pilotLabel, owner, repo string, issueNum int, taskID string) error {
+	return githubSDK.NewNotifier(client, pilotLabel).NotifyTaskStarted(ctx, owner, repo, issueNum, taskID)
 }
 
 // githubIssueURL builds the HTML URL for a GitHub issue. It prefers the resolved


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4687.

Closes #4687

## Changes

GitHub Issue GH-4687: fix(poller): pilot-in-progress label never applied since 07-16 SDK cutover — wire NotifyTaskStarted into the SDK dispatch path (orphan recovery + label guards structurally dead)

## Context

Since the 2026-07-16 SDK-poller cutover, **no live code path applies `pilot-in-progress`** — on any repo. Found via aws-infrastructure-pilot#2 (label absent, benign "labels removed" log loop every ~5 min), then confirmed platform-wide: timelines for qf-studio/pilot #4669 and #4656 (both dispatched and completed 2026-08-03) contain **zero** `pilot-in-progress` events, and `label:pilot-in-progress` searches return 0 across pilot and pilot-console. Repos that have the label in their label set (pilot, pilot-console, auth-service) carry a historical artifact, not evidence of a working mechanism.

Root cause: the only producer is the **webhook-only** legacy handler (`internal/pilot/pilot.go:1192` → `internal/adapters/github/notifier.go:26`). The SDK-poller chain — `cmd/pilot/poller_github.go` → studio-sdk `Poller` → `handleGithubIssueEventSDK` (`cmd/pilot/handlers.go:693`) → `handleIssueGeneric` (`cmd/pilot/handler_common.go:95`) — performs **zero label operations**. studio-sdk ships a tested `Notifier` (`sdk/integrations/github/notifier.go`) but it is dead code: `Poller` has no notifier field and `NewNotifier` has no call sites outside its own tests.

Structurally dead consumers that assume the label is maintained:
- `poller.go:350-380` `recoverOrphanedIssues` — permanent no-op (cannot find in-flight issues by label after a restart)
- `poller.go:984-987`, `:1101-1111` — pre-dispatch label guards never fire; dedup rests entirely on the processed map/SQLite + execution guards
- `internal/autopilot/controller.go:3014` `RemoveLabel(LabelInProgress)` after merge — swallowed no-op on every poller-dispatched issue

Same class as GH-4669: a subsystem silently dead since the cutover, hidden by fail-open behavior.

## Implementation

- In `cmd/pilot/handlers.go` `handleGithubIssueEventSDK`: after `repoOwner`/`repoName`/`taskID` resolution (~line 758) and before `handleIssueGeneric` (~line 824), call `githubSDK.NewNotifier(specClient, pilotLabel).NotifyTaskStarted(ctx, repoOwner, repoName, issueNum, taskID)`. Failure = WARN log, non-fatal — mirror the existing pattern at `internal/pilot/pilot.go:1191-1203` and `internal/autopilot/controller.go:3011-3015`. GitHub's add-labels endpoint auto-creates missing labels (proven by `pilot-done` on aws-infrastructure-pilot#2), so no per-repo scaffolding is needed.
- Completion-side labeling stays owned by the autopilot controller merge path (`controller.go:3011` adds `pilot-done`, `:3014` removes `pilot-in-progress` — now actually exercised). Do not duplicate completion labels in the handler.
- **Out of scope** (studio-sdk, separate release cycle — note as follow-ups in the PR description only): rewording the misleading `"Issue was processed but status labels removed"` log at SDK `poller.go:790`/`:1043` (labels may have never been applied) + demoting repeats to DEBUG; wiring `Notifier` natively into the SDK `Poller`.

## Acceptance

- Dispatching a `pilot`-labeled issue via the SDK poller applies `pilot-in-progress` at start of work, auto-creating the label on repos that lack it.
- After merge, the issue ends with `pilot-done` present and `pilot-in-progress` removed (existing controller behavior, no longer a no-op).
- `recoverOrphanedIssues` can find an in-flight issue by label after a daemon restart mid-execution.
- Labeling failure never blocks dispatch (WARN only).
- Table-driven test asserting `NotifyTaskStarted` fires on the SDK-dispatch path and that its error is non-fatal.

## Refs

- Research: nav-research trace 2026-08-03; pitfall memory `poller-labels-removed-log-means-never-applied`
- Related: GH-4669 (silently-dead-since-cutover class), TASK-394/TASK-407 (the guards that kept this harmless)