### PR TITLE
GH-4691: fix(executor): hard heartbeat (flat 5m) SIGKILLs legitimately-silent high-effort/epic runs — parity gap with the effort-aware stall watchdog survived GH-4668; epic also excluded from effortAwareStallTimeout

### DIFF
--- a/.agent/sops/executor-heartbeat-kills-live-local-tool.md
+++ b/.agent/sops/executor-heartbeat-kills-live-local-tool.md
@@ -2,8 +2,31 @@
 title: Heartbeat Monitor Killing Healthy Runs During Long Local Tool Calls
 created: 2026-08-03
 status: active
-related: GH-4668, GH-4648, GH-4649, GH-4521, GH-4401, TASK-437
+related: GH-4668, GH-4648, GH-4649, GH-4521, GH-4401, TASK-437, GH-4691, GH-4501, GH-4679
 ---
+
+## GH-4691 addendum: a second silent class, and a coordination gap
+
+GH-4668/this SOP fixed the *local-tool-execution* silent class (liveness
+grace via process-group probing). It did **not** fix a second, distinct
+silent class documented separately at `runner.go` (GH-4501): high-effort/
+epic turns with long **in-process, network-bound** stretches — no forked
+child, no advancing CPU ticks (I/O-wait doesn't register as utime/stime), so
+`probeProcessLiveness` correctly reports "idle" and the heartbeat kills a
+session that was never hung. GH-4679 (epic, 17m40s in) was killed this way
+post-GH-4668.
+
+The deeper bug: **two uncoordinated silent-stdout detectors** exist —
+this heartbeat (flat `DefaultHeartbeatTimeout = 5m`, backend-construction-time
+only, zero per-task awareness) and the effort-aware stall watchdog
+(`watchdog.go`, `highEffortStallFloor = 10m` for high-effort/heavy-complexity
+lanes). The hard heartbeat always fired first (5m < 10m), so the softer
+watchdog's tolerance never applied. GH-4691 gave the heartbeat the same
+effort-aware floor via `ExecuteOptions.HeartbeatFloor` /
+`effortAwareHeartbeatFloor()` (watchdog.go) so both mechanisms agree — but
+this is a parity patch, not a unification. If a third instance of this class
+surfaces, unify the two detectors into one source of truth rather than
+patching a third floor.
 
 # Heartbeat Monitor Killing Healthy Runs During Long Local Tool Calls
 

--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -74,6 +74,21 @@ type ExecuteOptions struct {
 	// When set (> 0), a watchdog goroutine will kill the process after this duration.
 	WatchdogTimeout time.Duration
 
+	// HeartbeatFloor raises the backend's hard heartbeat timeout for this
+	// call when it exceeds the backend's own configured/default value —
+	// the backend must apply max(its own heartbeatTimeout, HeartbeatFloor).
+	// Zero means no floor (backend default applies unchanged).
+	//
+	// GH-4691: the hard heartbeat (backend_claudecode.go) SIGKILLs on a flat,
+	// backend-construction-time timeout with zero per-task awareness, so it
+	// always fired before the effort-aware stall watchdog's higher floor
+	// (watchdog.go's effortAwareStallTimeout) could apply for high-effort/
+	// heavy-complexity (complex/epic) lanes. The runner computes this via
+	// effortAwareHeartbeatFloor using the same effort/complexity signal as
+	// the stall watchdog, so both mechanisms agree on how long a legitimately
+	// silent high-effort/epic turn is tolerated.
+	HeartbeatFloor time.Duration
+
 	// WatchdogCallback is invoked when the watchdog kills a subprocess.
 	// The callback receives the process PID and the watchdog timeout duration.
 	// Called BEFORE the process is killed, allowing for alert emission.

--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -379,6 +379,20 @@ func (b *ClaudeCodeBackend) SetHeartbeatTimeout(d time.Duration) {
 	b.heartbeatTimeout = d
 }
 
+// effectiveHeartbeatTimeout applies opts.HeartbeatFloor (GH-4691) on top of
+// the backend's own configured/default heartbeat timeout: the larger of the
+// two wins, so a per-call floor (set by the runner for high-effort/heavy-
+// complexity lanes via effortAwareHeartbeatFloor) can only raise the
+// timeout, never lower it below the backend's own configured value. The
+// returned source string ("config" or "effort_floor") is logged alongside
+// the kill so the effective timeout is diagnosable from one line.
+func effectiveHeartbeatTimeout(base, floor time.Duration) (timeout time.Duration, source string) {
+	if floor > base {
+		return floor, "effort_floor"
+	}
+	return base, "config"
+}
+
 // SetSubprocessLimits configures RSS telemetry and optional memory cap for the
 // Claude Code subprocess. GH-3028.
 func (b *ClaudeCodeBackend) SetSubprocessLimits(cfg *SubprocessLimitsConfig) {
@@ -675,7 +689,15 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 	// repo. hbMonitor checks process-group liveness (descendant PIDs and/or
 	// advancing CPU time) before killing; a genuinely idle, silent group is
 	// still killed exactly as before.
-	hbMonitor := newHeartbeatMonitor(b.heartbeatTimeout, opts.WatchdogTimeout, probeProcessLiveness)
+	//
+	// GH-4691: opts.HeartbeatFloor (set by the runner via
+	// effortAwareHeartbeatFloor for high-effort/heavy-complexity lanes) can
+	// raise the effective timeout above the backend's flat
+	// default/configured value — the hard heartbeat must never fire before
+	// the stall watchdog's own effort-aware floor would. timeoutSource is
+	// logged on kill so the effective timeout is diagnosable from one line.
+	heartbeatTimeout, timeoutSource := effectiveHeartbeatTimeout(b.heartbeatTimeout, opts.HeartbeatFloor)
+	hbMonitor := newHeartbeatMonitor(heartbeatTimeout, opts.WatchdogTimeout, probeProcessLiveness)
 	heartbeatCtx, cancelHeartbeat := context.WithCancel(context.Background())
 	defer cancelHeartbeat()
 	logging.SafeGo("executor-backend-claudecode", func() {
@@ -720,7 +742,8 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 				b.log.Warn("Heartbeat timeout detected, killing hung process",
 					slog.Int("pid", cmd.Process.Pid),
 					slog.Duration("last_event_age", age),
-					slog.Duration("timeout", b.heartbeatTimeout),
+					slog.Duration("timeout", heartbeatTimeout),
+					slog.String("timeout_source", timeoutSource),
 					slog.String("reason", string(reason)),
 					slog.Int("descendants", descendants),
 					slog.Uint64("cpu_delta_ticks", cpuDelta),

--- a/internal/executor/backend_claudecode_test.go
+++ b/internal/executor/backend_claudecode_test.go
@@ -654,6 +654,60 @@ func TestClaudeCodeBackendHeartbeatTimeout(t *testing.T) {
 	}
 }
 
+// TestEffectiveHeartbeatTimeoutWithFloor covers GH-4691: opts.HeartbeatFloor
+// (computed by the runner via effortAwareHeartbeatFloor for high-effort/
+// heavy-complexity lanes) must raise the effective heartbeat timeout above
+// the backend's own configured/default value, but never lower it — and the
+// returned source string must reflect which one won, so a kill log line is
+// diagnosable without cross-referencing the runner's decision separately.
+func TestEffectiveHeartbeatTimeoutWithFloor(t *testing.T) {
+	tests := []struct {
+		name        string
+		base        time.Duration
+		floor       time.Duration
+		wantTimeout time.Duration
+		wantSource  string
+	}{
+		{
+			name:        "zero floor: base (config) wins unchanged",
+			base:        5 * time.Minute,
+			floor:       0,
+			wantTimeout: 5 * time.Minute,
+			wantSource:  "config",
+		},
+		{
+			name:        "floor below base: base (config) wins",
+			base:        5 * time.Minute,
+			floor:       3 * time.Minute,
+			wantTimeout: 5 * time.Minute,
+			wantSource:  "config",
+		},
+		{
+			name:        "floor above base (GH-4691 epic/high-effort case): floor wins",
+			base:        DefaultHeartbeatTimeout, // 5m
+			floor:       10 * time.Minute,        // highEffortStallFloor
+			wantTimeout: 10 * time.Minute,
+			wantSource:  "effort_floor",
+		},
+		{
+			name:        "floor exactly equal to base: base wins (not >, so no stacking noise)",
+			base:        10 * time.Minute,
+			floor:       10 * time.Minute,
+			wantTimeout: 10 * time.Minute,
+			wantSource:  "config",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotTimeout, gotSource := effectiveHeartbeatTimeout(tt.base, tt.floor)
+			if gotTimeout != tt.wantTimeout || gotSource != tt.wantSource {
+				t.Errorf("effectiveHeartbeatTimeout(%v, %v) = (%v, %q), want (%v, %q)",
+					tt.base, tt.floor, gotTimeout, gotSource, tt.wantTimeout, tt.wantSource)
+			}
+		})
+	}
+}
+
 func TestBackendFactoryHeartbeatTimeout(t *testing.T) {
 	// Factory should wire heartbeat timeout from BackendConfig
 	config := &BackendConfig{

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -3233,6 +3233,12 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 	// partial-message streaming fix. An explicit stall_timeout_ms config value
 	// higher than the floor still wins.
 	stallTimeout := effortAwareStallTimeout(r.effectiveStallTimeout(), selectedEffort, complexity)
+	// GH-4691: the hard heartbeat in the backend (backend_claudecode.go) has
+	// its own, uncoordinated flat timeout that otherwise always fires before
+	// this stall watchdog's own effort-aware floor could apply. Compute the
+	// same floor here and pass it through on every backend.Execute call in
+	// this function (initial + retries) so both mechanisms agree.
+	heartbeatFloor := effortAwareHeartbeatFloor(selectedEffort, complexity)
 	var stallExecutionCtx context.Context
 	var stallCancel context.CancelFunc
 	if stallTimeout > 0 {
@@ -3269,6 +3275,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		MaxTurns:        workflowMaxTurns, // TASK-304: per-repo .pilot/workflow.yaml override
 		FromPR:          task.FromPR,      // GH-1267: session resumption from PR context
 		WatchdogTimeout: watchdogTimeout,
+		HeartbeatFloor:  heartbeatFloor, // GH-4691
 		AllowedTools:    allowedTools,
 		MCPConfigPath:   mcpConfigPath,
 		WatchdogCallback: func(pid int, watchdogDuration time.Duration) {
@@ -3620,6 +3627,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 							Model:           selectedModel,
 							Effort:          selectedEffort,
 							WatchdogTimeout: 2 * retryTimeout,
+							HeartbeatFloor:  heartbeatFloor, // GH-4691
 							AllowedTools:    smartAllowed,
 							MCPConfigPath:   smartMCP,
 							EventHandler: func(event BackendEvent) {
@@ -3984,6 +3992,7 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 					Model:           selectedModel,
 					Effort:          selectedEffort,
 					WatchdogTimeout: watchdogTimeout,
+					HeartbeatFloor:  heartbeatFloor, // GH-4691
 					AllowedTools:    noopRetryAllowed,
 					MCPConfigPath:   noopRetryMCP,
 					EventHandler: func(event BackendEvent) {
@@ -4338,14 +4347,15 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 					// Re-invoke backend with retry prompt
 					feedbackAllowed, feedbackMCP := r.executionToolOptions()
 					retryResult, retryErr := r.backend.Execute(ctx, ExecuteOptions{
-						Prompt:        retryPrompt,
-						TaskID:        task.ID,
-						ProjectPath:   executionPath, // GH-3577: retry in the worktree, not the daemon's repo root
-						Verbose:       task.Verbose,
-						Model:         selectedModel,
-						Effort:        selectedEffort,
-						AllowedTools:  feedbackAllowed,
-						MCPConfigPath: feedbackMCP,
+						Prompt:         retryPrompt,
+						TaskID:         task.ID,
+						ProjectPath:    executionPath, // GH-3577: retry in the worktree, not the daemon's repo root
+						Verbose:        task.Verbose,
+						Model:          selectedModel,
+						Effort:         selectedEffort,
+						HeartbeatFloor: heartbeatFloor, // GH-4691
+						AllowedTools:   feedbackAllowed,
+						MCPConfigPath:  feedbackMCP,
 						EventHandler: func(event BackendEvent) {
 							if recorder != nil {
 								if recErr := recorder.RecordEvent(event.Raw); recErr != nil {
@@ -4620,14 +4630,15 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 
 					intentAllowed, intentMCP := r.executionToolOptions()
 					_, retryErr := r.backend.Execute(ctx, ExecuteOptions{
-						Prompt:        retryPrompt,
-						TaskID:        task.ID,
-						ProjectPath:   executionPath, // GH-3577: retry in the worktree, not the daemon's repo root
-						Verbose:       task.Verbose,
-						Model:         selectedModel,
-						Effort:        selectedEffort,
-						AllowedTools:  intentAllowed,
-						MCPConfigPath: intentMCP,
+						Prompt:         retryPrompt,
+						TaskID:         task.ID,
+						ProjectPath:    executionPath, // GH-3577: retry in the worktree, not the daemon's repo root
+						Verbose:        task.Verbose,
+						Model:          selectedModel,
+						Effort:         selectedEffort,
+						HeartbeatFloor: heartbeatFloor, // GH-4691
+						AllowedTools:   intentAllowed,
+						MCPConfigPath:  intentMCP,
 						EventHandler: func(event BackendEvent) {
 							state.tokensInput += event.TokensInput
 							state.tokensOutput += event.TokensOutput
@@ -5456,6 +5467,7 @@ func (r *Runner) runSelfReview(ctx context.Context, task *Task, state *progressS
 		Model:           selectedModel,
 		Effort:          selectedEffort,
 		ResumeSessionID: resumeSessionID,
+		HeartbeatFloor:  effortAwareHeartbeatFloor(selectedEffort, complexity), // GH-4691
 		AllowedTools:    reviewAllowed,
 		MCPConfigPath:   reviewMCP,
 		EventHandler: func(event BackendEvent) {

--- a/internal/executor/watchdog.go
+++ b/internal/executor/watchdog.go
@@ -21,21 +21,44 @@ const minStallWatchdogInterval = time.Second
 const highEffortStallFloor = 10 * time.Minute
 
 // effortAwareStallTimeout raises configured to highEffortStallFloor for
-// high-effort or complex-lane executions, unless configured (an explicit
-// stall_timeout_ms) is already higher — an explicit config value always wins
-// when it's the larger of the two. When configured <= 0 (stall detection
-// disabled via a negative StallTimeoutMs), it is returned unchanged so the
-// watchdog stays off for every lane. GH-4501.
+// high-effort or heavy-complexity (complex/epic) executions, unless
+// configured (an explicit stall_timeout_ms) is already higher — an explicit
+// config value always wins when it's the larger of the two. When configured
+// <= 0 (stall detection disabled via a negative StallTimeoutMs), it is
+// returned unchanged so the watchdog stays off for every lane. GH-4501.
+//
+// GH-4691: was `complexity == ComplexityComplex`, silently excluding
+// ComplexityEpic — epic runs are at least as likely as complex ones to have
+// long silent-stdout stretches, so they must get the same floor.
+// Complexity.IsHeavy() covers both.
 func effortAwareStallTimeout(configured time.Duration, effort string, complexity Complexity) time.Duration {
 	if configured <= 0 {
 		return configured
 	}
-	if effort == "high" || complexity == ComplexityComplex {
+	if effort == "high" || complexity.IsHeavy() {
 		if configured < highEffortStallFloor {
 			return highEffortStallFloor
 		}
 	}
 	return configured
+}
+
+// effortAwareHeartbeatFloor derives the minimum hard-heartbeat timeout for
+// high-effort or heavy-complexity (complex/epic) executions, using the same
+// highEffortStallFloor threshold as effortAwareStallTimeout (GH-4691).
+//
+// This is intentionally independent of the *configured* stall timeout (and
+// thus of whether stall detection is enabled at all): the hard heartbeat in
+// backend_claudecode.go is a separate kill path from the stall watchdog
+// above, and must not fire before the stall watchdog's own effort-aware
+// floor would — regardless of whether that watchdog happens to be disabled
+// for this run. Returns 0 (no floor) for lanes that don't qualify, letting
+// the backend's default/configured heartbeat timeout stand unchanged.
+func effortAwareHeartbeatFloor(effort string, complexity Complexity) time.Duration {
+	if effort == "high" || complexity.IsHeavy() {
+		return highEffortStallFloor
+	}
+	return 0
 }
 
 // watchdogTickInterval derives the watchdog poll interval from stallTimeout so a

--- a/internal/executor/watchdog_test.go
+++ b/internal/executor/watchdog_test.go
@@ -278,6 +278,22 @@ func TestEffortAwareStallTimeout(t *testing.T) {
 			want:       highEffortStallFloor,
 		},
 		{
+			// GH-4691: epic was silently excluded before Complexity.IsHeavy()
+			// replaced the ComplexityComplex-only check.
+			name:       "epic-lane raises 3m default to the 10m floor",
+			configured: 3 * time.Minute,
+			effort:     "medium",
+			complexity: ComplexityEpic,
+			want:       highEffortStallFloor,
+		},
+		{
+			name:       "simple lane, low effort: unchanged at 3m",
+			configured: 3 * time.Minute,
+			effort:     "low",
+			complexity: ComplexitySimple,
+			want:       3 * time.Minute,
+		},
+		{
 			name:       "explicit config already above the floor wins",
 			configured: 15 * time.Minute,
 			effort:     "high",
@@ -312,6 +328,68 @@ func TestEffortAwareStallTimeout(t *testing.T) {
 			if got != tt.want {
 				t.Errorf("effortAwareStallTimeout(%v, %q, %q) = %v, want %v",
 					tt.configured, tt.effort, tt.complexity, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEffortAwareHeartbeatFloor covers GH-4691: the hard heartbeat's floor
+// must apply to high-effort and heavy-complexity (complex, epic) lanes —
+// mirroring effortAwareStallTimeout's own effort/complexity gate — and must
+// NOT depend on any configured stall-timeout value (unlike
+// effortAwareStallTimeout, there is no "configured" input here at all).
+func TestEffortAwareHeartbeatFloor(t *testing.T) {
+	tests := []struct {
+		name       string
+		effort     string
+		complexity Complexity
+		want       time.Duration
+	}{
+		{
+			name:       "simple lane, low effort: no floor",
+			effort:     "low",
+			complexity: ComplexitySimple,
+			want:       0,
+		},
+		{
+			name:       "medium lane, medium effort: no floor",
+			effort:     "medium",
+			complexity: ComplexityMedium,
+			want:       0,
+		},
+		{
+			name:       "high effort raises the floor regardless of complexity",
+			effort:     "high",
+			complexity: ComplexityMedium,
+			want:       highEffortStallFloor,
+		},
+		{
+			name:       "complex-lane raises the floor",
+			effort:     "medium",
+			complexity: ComplexityComplex,
+			want:       highEffortStallFloor,
+		},
+		{
+			// The GH-4679 incident lane: epic complexity must get the same
+			// floor as complex — this was the confirmed secondary defect.
+			name:       "epic-lane raises the floor",
+			effort:     "medium",
+			complexity: ComplexityEpic,
+			want:       highEffortStallFloor,
+		},
+		{
+			name:       "high effort and epic: still just the floor (no stacking)",
+			effort:     "high",
+			complexity: ComplexityEpic,
+			want:       highEffortStallFloor,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := effortAwareHeartbeatFloor(tt.effort, tt.complexity)
+			if got != tt.want {
+				t.Errorf("effortAwareHeartbeatFloor(%q, %q) = %v, want %v",
+					tt.effort, tt.complexity, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4691.

Closes #4691

## Changes

GitHub Issue GH-4691: fix(executor): hard heartbeat (flat 5m) SIGKILLs legitimately-silent high-effort/epic runs — parity gap with the effort-aware stall watchdog survived GH-4668; epic also excluded from effortAwareStallTimeout

## Context

The heartbeat SIGKILL class **survived PR #4680** (v2.252.0). Post-upgrade kills on 2026-08-03: GH-4678 (16:27Z), pilot-console GH-91 attempt 1 (17:28Z), GH-4679 (19:04Z — complexity=epic, 17m40s in, `shutdown_terminated: Process terminated by SIGKILL after Pilot heartbeat timeout (exit code 137)`).

Root cause — **two uncoordinated silent-stdout detectors, and #4680 extended the wrong one**:

1. **Hard heartbeat** (the actual killer): `internal/executor/backend_claudecode.go:671-755` + `heartbeat_monitor.go`. Flat `DefaultHeartbeatTimeout = 5m` (`backend_claudecode.go:57`), set **once at backend construction** (`backend_factory.go:13,18`) — zero per-task/effort/complexity parameterization (exhaustive grep: `SetHeartbeatTimeout` has no other call sites). SIGKILLs directly via `killProcessGroup`.
2. **Stall watchdog** (GH-4501, the softer one): `watchdog.go:67-100`, effort-aware — `highEffortStallFloor = 10m` for high-effort/complex lanes, cancels context gracefully, classifies `stalled`.

The hard heartbeat always fires first (5m < 10m), so the watchdog's complexity-aware tolerance never applies. PR #4680 added **subprocess/CPU-tick liveness grace** (`heartbeat_liveness_linux.go`) — correct for the local-tool-execution case (`make test`), but architecturally blind to the *other* known silence class, documented at `runner.go:3016-3021` (GH-4501): high-effort/epic turns with extended in-process, network-bound stretches — no forked child, no advancing CPU ticks (I/O-wait doesn't register as utime/stime) → `probeProcessLiveness` sees "idle" → kill.

Note on misleading evidence: the kill-time `stdout_tail` showing active `input_json_delta` events is a **frozen last snapshot**, not concurrent activity — the tail and the heartbeat's `lastEventAt` are fed at the same instant per line (`backend_claudecode.go:808-837`), so both freeze together.

**Confirmed secondary defect**: `effortAwareStallTimeout` (`watchdog.go:33`) tests `complexity == ComplexityComplex`, silently excluding `ComplexityEpic` — GH-4679's own tier — even though `Complexity.IsHeavy()` (`complexity.go:291-293`) exists and covers `Complex || Epic`.

## Implementation

1. `internal/executor/watchdog.go:33` — replace `effort == "high" || complexity == ComplexityComplex` with `effort == "high" || complexity.IsHeavy()`.
2. Give the hard heartbeat the same effort/complexity awareness: add a per-call floor (e.g. `ExecuteOptions.HeartbeatFloor time.Duration` — `backend.go:43-46` already carries `Effort`, and `WatchdogTimeout` at `runner.go:3058` proves the per-task plumbing pattern), computed by the runner with the same effort-aware logic as the stall watchdog; at `backend_claudecode.go:678` construct the monitor with `max(b.heartbeatTimeout, opts.HeartbeatFloor)`.
3. Out of scope (follow-up note in PR only): unify the two detectors into one source of truth so the floors cannot drift again.

## Acceptance

- An epic/high-effort task with a >5-minute in-process silent stretch (no descendant processes, no CPU ticks) is NOT SIGKILLed by the heartbeat before the stall watchdog's effort-aware floor elapses.
- `effortAwareStallTimeout` applies the raised floor to `ComplexityEpic` (table-driven test covering complex, epic, and simple lanes).
- Existing #4680 behavior preserved: local-tool-execution silence with active descendants still gets liveness grace; genuinely dead sessions still die within the (possibly raised) window.
- Heartbeat kill log includes the effective timeout and floor source, so the next incident is diagnosable from one line.

## Refs

- Prior art: GH-4668 / PR #4680 (liveness grace — correct fix, wrong mechanism for this class; do not reopen), GH-4501 (documented the silent high-effort class, fixed only in the watchdog), GH-4519 / PR #4521 (reader robustness).
- Incident evidence: box daemon.log 2026-08-03 16:27Z / 17:28Z / 19:04Z; marker `2026-08-03_v2252-manual-upgrade-wave2-landed-heartbeat-persists.md`.