### PR TITLE
GH-4696: fix(autopilot): compare-before-close in conflict path — leave PR open when work not on main

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -4732,20 +4732,69 @@ func (c *Controller) attemptMechanicalConflictResolution(ctx context.Context, pr
 	return true, nil
 }
 
+// checkPRWorkOnMain reports whether prState.HeadSHA's changes are already
+// present on the repo's base branch. GH-4696: the GH-4657 closed-issue
+// short-circuit below assumed "source issue closed" always means "a sibling
+// delivered this scope and it's already on main" — but a closed issue can
+// also mean the issue was closed for an unrelated reason (e.g. manually, or
+// mis-labeled pilot-superseded) while this PR's own commits never landed.
+// Closing in that case would silently discard real work.
+//
+// Uses the same base...head reachability convention as guardReleaseSHAReachable
+// (GH-4519 above): compare(base=HeadSHA, head=mainSHA) is "ahead" when
+// mainSHA contains HeadSHA as an ancestor, and "identical" when they're the
+// same commit — either means HeadSHA's changes are already on main. This is
+// the single cheap way to distinguish "already merged" from "still only on
+// the PR branch" without walking full commit lists.
+func (c *Controller) checkPRWorkOnMain(ctx context.Context, prState *PRState) (bool, error) {
+	mainBranchName := c.resolveMainBranchName()
+	branch, err := c.ghClient.GetBranch(ctx, c.owner, c.repo, mainBranchName)
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch %s branch: %w", mainBranchName, err)
+	}
+	mainSHA := branch.SHA()
+
+	status, err := c.ghClient.CompareStatus(ctx, c.owner, c.repo, prState.HeadSHA, mainSHA)
+	if err != nil {
+		return false, fmt.Errorf("compare status failed: %w", err)
+	}
+	return status == "ahead" || status == "identical", nil
+}
+
 // closeConflictSourceIssueClosed handles the GH-4657 case where
 // handleMergeConflict discovers the PR's source issue is already closed —
 // almost always because a sibling/parent execution delivered the same scope
 // first (TASK-437's PR#4653/#4649 duplicate-execution race is the
 // motivating incident: #4649 was closed pilot-superseded while a sibling
-// run's PR#4652 for the same scope had already merged, so #4649's own PR
-// (#4653) was born conflicting against work already on main). Resolving
-// that conflict would just recreate merged work, so the honest action is
-// closing the PR with a terminal stage — not escalateAndHold's
+// run's PR#4652 for the same scope had already merged, so #4653 (this PR's
+// own predecessor) was born conflicting against work already on main).
+// Resolving that conflict would just recreate merged work, so the honest
+// action is closing the PR with a terminal stage — not escalateAndHold's
 // needs-manual-rebase/pilot-needs-human ask for a rebase nobody should
 // perform. Unlike closeAndReexecute, this never re-adds the pilot label or
 // removes pilot-in-progress: the issue is already closed, so there is
 // nothing to re-dispatch.
+//
+// GH-4696: "source issue is closed" alone is not proof the PR's own changes
+// are on main — verify reachability (checkPRWorkOnMain) before closing.
+// If the changes are NOT confirmed on main (either because the compare says
+// so, or because the check itself failed), fail safe by NOT closing: hold
+// the PR via escalateAndHold instead, so a human decides whether to land it
+// or close it. Closing is the irrecoverable side of this decision, so any
+// uncertainty must resolve toward not closing.
 func (c *Controller) closeConflictSourceIssueClosed(ctx context.Context, prState *PRState, issue *github.Issue) error {
+	onMain, err := c.checkPRWorkOnMain(ctx, prState)
+	if err != nil {
+		c.log.Warn("handleMergeConflict: reachability check failed, failing safe by not closing",
+			"pr", prState.PRNumber, "issue", prState.IssueNumber, "error", err)
+		return c.holdClosedIssueWorkNotOnMain(ctx, prState, fmt.Sprintf("this PR's changes could not be verified as already on the base branch (%v)", err))
+	}
+	if !onMain {
+		c.log.Warn("handleMergeConflict: source issue closed but PR's changes are not on main — escalating instead of closing",
+			"pr", prState.PRNumber, "issue", prState.IssueNumber)
+		return c.holdClosedIssueWorkNotOnMain(ctx, prState, "this PR's changes are not confirmed on the base branch")
+	}
+
 	reason := fmt.Sprintf("source issue #%d is closed", prState.IssueNumber)
 	comment := fmt.Sprintf(
 		"Source issue #%d is closed — closing this PR instead of attempting a rebase. Resolving this merge conflict would duplicate work already merged to main.",
@@ -4771,6 +4820,24 @@ func (c *Controller) closeConflictSourceIssueClosed(ctx context.Context, prState
 	// observed on GitHub) not to mark the already-closed issue
 	// pilot-retry-ready — there is nothing to retry.
 	prState.TerminalLabel = github.LabelSuperseded
+	return nil
+}
+
+// holdClosedIssueWorkNotOnMain is the GH-4696 fail-safe rung of
+// closeConflictSourceIssueClosed: the source issue is closed, but this PR's
+// changes are not confirmed to already be on main (either the reachability
+// check said so, or the check itself errored). Closing here would risk
+// discarding unmerged work, so hold the PR with the same escalation labels
+// the other handleMergeConflict rungs use (GH-4459) and post a comment
+// naming the exact situation (the situation argument) for a human to
+// resolve.
+func (c *Controller) holdClosedIssueWorkNotOnMain(ctx context.Context, prState *PRState, situation string) error {
+	comment := fmt.Sprintf(
+		"Source issue #%d is closed, but %s — closing it here would risk discarding unmerged work. This needs a human decision: land it or close it.",
+		prState.IssueNumber, situation,
+	)
+	reason := fmt.Sprintf("source issue #%d is closed but %s", prState.IssueNumber, situation)
+	c.escalateAndHold(ctx, prState, reason, []string{"needs-manual-rebase"}, comment)
 	return nil
 }
 

--- a/internal/autopilot/gh4657_test.go
+++ b/internal/autopilot/gh4657_test.go
@@ -13,33 +13,45 @@ import (
 	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 )
 
-// TestController_HandleMergeConflict_SourceIssueClosed covers GH-4657/TASK-437:
-// a conflicting PR whose source issue is already closed — because a
-// sibling/parent run delivered the same scope first (PR#4653 was born
-// conflicting against already-closed issue #4649, whose scope had already
-// merged via PR#4652) — must be closed with an honest terminal state
-// instead of escalated for a rebase nobody should perform.
+// TestController_HandleMergeConflict_SourceIssueClosed covers GH-4657/TASK-437
+// and its GH-4696 reachability follow-up: a conflicting PR whose source issue
+// is already closed — because a sibling/parent run delivered the same scope
+// first (PR#4653 was born conflicting against already-closed issue #4649,
+// whose scope had already merged via PR#4652) — must be closed with an
+// honest terminal state instead of escalated for a rebase nobody should
+// perform. GH-4696 tightened this: "source issue closed" alone is not proof
+// this PR's own changes are on main, so closeConflictSourceIssueClosed now
+// verifies reachability (compare base=HeadSHA, head=mainSHA is "ahead" or
+// "identical") before closing, and fails safe (holds instead of closing)
+// when that check says the work isn't there yet, or when the check itself
+// errors.
 //
-// Table-driven across the three branches of the new issue-state check added
-// to handleMergeConflict: a closed source issue (new short-circuit), an open
-// source issue (today's rebase/escalate ladder, unchanged), and a GetIssue
-// API error (fail-open to today's ladder, since escalation is the safe
-// default when issue state can't be confirmed).
+// Table-driven across five branches of handleMergeConflict's issue-state +
+// reachability checks: a closed source issue whose work IS on main (new
+// short-circuit, AC2), an open source issue (today's rebase/escalate ladder,
+// unchanged), a GetIssue API error (fail-open to today's ladder), a closed
+// source issue whose work is NOT on main (GH-4696: hold instead of close),
+// and a closed source issue where the reachability check itself errors
+// (GH-4696: fail-safe, hold instead of close).
 //
 // Every case uses the same source-file (non-go.mod/go.sum) conflict fixture
 // as TestController_HandleMergeConflict_SourceFileConflictEscalatesInsteadOfClosing
-// so that, absent the GH-4657 short-circuit, the path always falls through
-// to escalateAndHold — making "open issue" and "GetIssue error" genuine
-// regression checks that today's escalation behavior is untouched.
+// so that, absent the GH-4657/GH-4696 short-circuit closing the PR, the path
+// always falls through to escalateAndHold — making "open issue" and
+// "GetIssue error" genuine regression checks that today's escalation
+// behavior is untouched.
 func TestController_HandleMergeConflict_SourceIssueClosed(t *testing.T) {
 	tests := []struct {
-		name           string
-		issueHandler   func(w http.ResponseWriter, r *http.Request)
-		wantPRClosed   bool
-		wantEscalation bool
+		name              string
+		issueHandler      func(w http.ResponseWriter, r *http.Request)
+		compareStatus     string // GitHub compare "status" for base=HeadSHA...head=mainSHA; "" defaults to "ahead" (work already on main)
+		reachabilityFails bool   // simulate the GetBranch/CompareStatus reachability check itself erroring
+		wantPRClosed      bool
+		wantEscalation    bool
+		wantCommentSubstr string // optional: substring the posted comment must contain
 	}{
 		{
-			name: "closed issue: PR closed honestly, no escalation",
+			name: "closed issue + work on main: PR closed honestly, no escalation",
 			issueHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				_ = json.NewEncoder(w).Encode(github.Issue{
@@ -48,6 +60,7 @@ func TestController_HandleMergeConflict_SourceIssueClosed(t *testing.T) {
 					Labels: []github.Label{{Name: github.LabelSuperseded}},
 				})
 			},
+			compareStatus:  "ahead",
 			wantPRClosed:   true,
 			wantEscalation: false,
 		},
@@ -67,6 +80,36 @@ func TestController_HandleMergeConflict_SourceIssueClosed(t *testing.T) {
 			},
 			wantPRClosed:   false,
 			wantEscalation: true,
+		},
+		{
+			name: "closed issue + work NOT on main (GH-4696): held open, escalated, comment names the situation",
+			issueHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(github.Issue{
+					Number: 4649,
+					State:  "closed",
+					Labels: []github.Label{{Name: github.LabelSuperseded}},
+				})
+			},
+			compareStatus:     "diverged",
+			wantPRClosed:      false,
+			wantEscalation:    true,
+			wantCommentSubstr: "not confirmed on the base branch",
+		},
+		{
+			name: "closed issue + reachability check errors (GH-4696): fail-safe, held open instead of closed",
+			issueHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(github.Issue{
+					Number: 4649,
+					State:  "closed",
+					Labels: []github.Label{{Name: github.LabelSuperseded}},
+				})
+			},
+			reachabilityFails: true,
+			wantPRClosed:      false,
+			wantEscalation:    true,
+			wantCommentSubstr: "could not be verified",
 		},
 	}
 
@@ -119,6 +162,29 @@ func TestController_HandleMergeConflict_SourceIssueClosed(t *testing.T) {
 					labelsAdded = append(labelsAdded, body["labels"]...)
 					w.WriteHeader(http.StatusOK)
 					_ = json.NewEncoder(w).Encode([]github.Label{})
+				case r.URL.Path == "/repos/owner/repo/branches/main" && r.Method == http.MethodGet:
+					// GH-4696: closeConflictSourceIssueClosed's reachability check
+					// fetches the base branch's SHA before comparing it to the PR's
+					// HeadSHA.
+					if tt.reachabilityFails {
+						w.WriteHeader(http.StatusInternalServerError)
+						return
+					}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(github.Branch{Name: "main", Commit: github.BranchCommit{SHA: "mainsha123"}})
+				case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/compare/deadbeef...mainsha123") && r.Method == http.MethodGet:
+					// GH-4696: compare(base=HeadSHA, head=mainSHA) — "ahead"/"identical"
+					// means the PR's changes are already reachable from main.
+					if tt.reachabilityFails {
+						w.WriteHeader(http.StatusInternalServerError)
+						return
+					}
+					status := tt.compareStatus
+					if status == "" {
+						status = "ahead"
+					}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(map[string]string{"status": status})
 				default:
 					w.WriteHeader(http.StatusOK)
 					_, _ = w.Write([]byte("{}"))
@@ -176,6 +242,10 @@ func TestController_HandleMergeConflict_SourceIssueClosed(t *testing.T) {
 				if prState.TerminalLabel == github.LabelSuperseded {
 					t.Errorf("TerminalLabel must not be set to %q when the PR wasn't closed via the GH-4657 path", github.LabelSuperseded)
 				}
+			}
+
+			if tt.wantCommentSubstr != "" && !strings.Contains(prComment, tt.wantCommentSubstr) {
+				t.Errorf("comment = %q, want substring %q", prComment, tt.wantCommentSubstr)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4696.

Closes #4696

## Changes

Modify internal/autopilot/controller.go handleMergeConflict closed-issue short-circuit added by PR#4658. Before calling close, add a reachability check: query GitHub once to determine whether the PR's changes are already present on the base branch (e.g., PR's merge_commit_sha/head commits reachable from base, or GET /repos/{o}/{r}/compare/{base}...{head} returning 'identical' or 'behind'). Justify the chosen signal in the PR description. Behavior split: if work IS on main, close (AC2, existing #4657 behavior preserved); if work is NOT on main, do NOT close, apply existing escalation labels, and post a comment naming the situation (issue closed but this PR's changes are not on main — needs a human decision: land it or close it). On API error, fail-safe by not closing (recoverable side). Extend gh4657_test.go (or add gh4679_test.go) in internal/autopilot/ covering: (a) closed-issue + conflicting + work-on-main → closed; (b) closed-issue + conflicting + work-NOT-on-main → open, escalated, comment posted; (c) API-error path → fail-safe open. Verify make build, make test, make lint are green.