### PR TITLE
fix(executor): guard epic child-close against open unmerged PR

### DIFF
--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -1931,6 +1931,39 @@ func (r *Runner) CloseIssueWithComment(ctx context.Context, projectPath string, 
 	return nil
 }
 
+// getSubIssuePRState queries a sub-issue's PR state before the child issue is
+// closed (GH-4697). Uses r.subIssuePRStateCheck if wired (tests), otherwise
+// shells out to `gh pr view --json state`. State is one of GitHub's own
+// values: "OPEN", "MERGED", "CLOSED" — never derived from `mergedAt`, which
+// can read null on an already-merged squash-merge PR (see
+// .agent/sops/integrations/cascade-detection-forensics.md, "Ghost merge").
+func (r *Runner) getSubIssuePRState(ctx context.Context, projectPath string, prNumber int) (*SubIssuePRState, error) {
+	if r.subIssuePRStateCheck != nil {
+		return r.subIssuePRStateCheck(ctx, projectPath, prNumber)
+	}
+	if r.dryRun {
+		// dry-run never makes real gh calls, and CloseIssueWithComment already
+		// no-ops the close itself — report a terminal state so this check
+		// can't be the thing that changes dry-run behavior.
+		return &SubIssuePRState{State: "MERGED", Merged: true}, nil
+	}
+
+	cmd := exec.CommandContext(ctx, "gh", "pr", "view", strconv.Itoa(prNumber), "--json", "state", "--jq", ".state")
+	if projectPath != "" {
+		cmd.Dir = projectPath
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to query PR #%d state: %w (stderr: %s)", prNumber, err, stderr.String())
+	}
+
+	state := strings.ToUpper(strings.TrimSpace(string(out)))
+	return &SubIssuePRState{State: state, Merged: state == "MERGED"}, nil
+}
+
 // childTerminalStateOrder fixes the iteration order summarizeChildTerminalStates
 // renders its per-state counts in, so the summary text is deterministic despite
 // being built from a map.
@@ -3129,7 +3162,41 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 		if result.PRUrl != "" {
 			closeComment = fmt.Sprintf("✅ Completed as part of %s\nPR: %s", parent.ID, result.PRUrl)
 		}
-		if err := r.CloseIssueWithComment(ctx, projectPath, issueRef, closeComment); err != nil {
+
+		// GH-4697: a child that reports Success with a PR is not necessarily
+		// *merged* — this close previously fired unconditionally, seconds after
+		// PR creation, regardless of PR state. That is exactly how #4660/#4661
+		// were closed while their PRs (#4667/#4672) were still open+unmerged
+		// (TASK-437: #4660 closed 10:28:44Z, 3s after PR #4667 opened 10:28:41Z
+		// and 97 minutes before that PR itself closed unmerged at 12:05:06Z).
+		// Query the PR's real state before closing; an OPEN, not-yet-merged PR
+		// blocks the close so the issue stays open until the PR resolves
+		// (merged → close normally; closed-unmerged → also safe to close, the
+		// PR is already terminal and won't reopen).
+		skipClose := false
+		if result.PRUrl != "" {
+			if prNum := parsePRNumberFromURL(result.PRUrl); prNum > 0 {
+				state, stateErr := r.getSubIssuePRState(ctx, subTaskRepoPath, prNum)
+				switch {
+				case stateErr != nil:
+					// Fail safe: can't confirm the PR is done, so don't close
+					// blind — leaving the issue open is recoverable, an
+					// erroneous close is not.
+					r.log.Warn("could not determine sub-issue PR state before close; leaving issue open",
+						"parent_id", parent.ID, "sub_issue", issueRef, "pr_number", prNum, "pr_url", result.PRUrl, "error", stateErr)
+					skipClose = true
+				case state.State == "OPEN":
+					r.log.Warn("sub-issue PR still open and unmerged; deferring child-issue close",
+						"parent_id", parent.ID, "sub_issue", issueRef, "pr_number", prNum, "pr_url", result.PRUrl)
+					skipClose = true
+				}
+			}
+		}
+
+		if skipClose {
+			_ = r.UpdateIssueProgress(ctx, projectPath, issueRef,
+				fmt.Sprintf("⏳ Work delivered via %s but PR is still open — issue stays open until it merges.", result.PRUrl))
+		} else if err := r.CloseIssueWithComment(ctx, projectPath, issueRef, closeComment); err != nil {
 			r.log.Warn("Failed to close sub-issue", "issue", issueRef, "error", err)
 			// Non-fatal, continue
 		}

--- a/internal/executor/epic_child_close_test.go
+++ b/internal/executor/epic_child_close_test.go
@@ -1,0 +1,160 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// GH-4697: the epic child-completion close call (executeSubIssuesTracked,
+// epic.go ~line 3159) previously closed a sub-issue unconditionally the
+// moment its child run reported Success + a PR URL — with no check on
+// whether that PR had actually merged. That is the exact shape of the
+// TASK-437 incident: #4660 was closed at 10:28:44Z, three seconds after its
+// PR #4667 opened at 10:28:41Z, and 97 minutes before PR #4667 itself closed
+// unmerged at 12:05:06Z (same for #4661/#4672). This suite exercises the
+// guard added to getSubIssuePRState/executeSubIssuesTracked: an OPEN,
+// unmerged PR blocks the close and emits a WARN naming the PR; a MERGED PR
+// (or a state-query failure, fail-safe) is handled without regressing the
+// existing close-on-completion behavior.
+
+func TestExecuteSubIssuesTracked_OpenUnmergedPR_DefersClose(t *testing.T) {
+	var buf bytes.Buffer
+	var queriedPRNumber int
+
+	r := newTestRunnerWithExecFunc(func(_ context.Context, task *Task) (*ExecutionResult, error) {
+		return &ExecutionResult{TaskID: task.ID, Success: true, PRUrl: "https://github.com/owner/repo/pull/501"}, nil
+	})
+	r.log = slog.New(slog.NewTextHandler(&buf, nil))
+	r.subIssuePRStateCheck = func(_ context.Context, _ string, prNumber int) (*SubIssuePRState, error) {
+		queriedPRNumber = prNumber
+		return &SubIssuePRState{State: "OPEN", Merged: false}, nil
+	}
+
+	parent := &Task{ID: "GH-999"}
+	issues := []CreatedIssue{
+		{Number: 500, Identifier: "500", URL: "https://github.com/owner/repo/issues/500",
+			Subtask: PlannedSubtask{Title: "part 1", Description: "do part 1"}},
+	}
+
+	childStates, _, err := r.executeSubIssuesTracked(context.Background(), parent, issues, "", "")
+	if err != nil {
+		t.Fatalf("executeSubIssuesTracked returned unexpected error: %v", err)
+	}
+
+	if queriedPRNumber != 501 {
+		t.Errorf("expected PR state check to query PR #501, got #%d", queriedPRNumber)
+	}
+
+	// The child's internal terminal state must still be "completed" — the
+	// guard defers the GitHub-visible close, it does not change the epic's
+	// own bookkeeping of whether the child delivered.
+	if len(childStates) != 1 || childStates[0] != "completed" {
+		t.Errorf("expected childStates = [completed], got %v", childStates)
+	}
+
+	logs := buf.String()
+	if !strings.Contains(logs, "sub-issue PR still open and unmerged; deferring child-issue close") {
+		t.Errorf("expected WARN log deferring close for an open PR, got logs:\n%s", logs)
+	}
+	if !strings.Contains(logs, "pr_number=501") {
+		t.Errorf("expected WARN log to name the PR number (501), got logs:\n%s", logs)
+	}
+	if !strings.Contains(logs, "https://github.com/owner/repo/pull/501") {
+		t.Errorf("expected WARN log to name the PR URL, got logs:\n%s", logs)
+	}
+	// CloseIssueWithComment must never have been invoked for the *sub-issue*
+	// specifically (issue=500) — if it had been (even as a dry-run no-op), it
+	// logs its own "dry-run: skipping CloseIssueWithComment" line naming it.
+	// The parent (issue=999) is still closed as usual once the loop ends, so
+	// this must be scoped to the child issue, not a blanket substring check.
+	if strings.Contains(logs, `skipping CloseIssueWithComment" issue=500`) {
+		t.Errorf("expected the child issue's close to be skipped entirely (guard blocks the call), got logs:\n%s", logs)
+	}
+}
+
+func TestExecuteSubIssuesTracked_MergedPR_ClosesNormally(t *testing.T) {
+	var buf bytes.Buffer
+
+	r := newTestRunnerWithExecFunc(func(_ context.Context, task *Task) (*ExecutionResult, error) {
+		return &ExecutionResult{TaskID: task.ID, Success: true, PRUrl: "https://github.com/owner/repo/pull/502"}, nil
+	})
+	r.log = slog.New(slog.NewTextHandler(&buf, nil))
+	r.subIssuePRStateCheck = func(_ context.Context, _ string, _ int) (*SubIssuePRState, error) {
+		return &SubIssuePRState{State: "MERGED", Merged: true}, nil
+	}
+
+	parent := &Task{ID: "GH-999"}
+	issues := []CreatedIssue{
+		{Number: 500, Identifier: "500", URL: "https://github.com/owner/repo/issues/500",
+			Subtask: PlannedSubtask{Title: "part 1", Description: "do part 1"}},
+	}
+
+	if _, _, err := r.executeSubIssuesTracked(context.Background(), parent, issues, "", ""); err != nil {
+		t.Fatalf("executeSubIssuesTracked returned unexpected error: %v", err)
+	}
+
+	logs := buf.String()
+	if strings.Contains(logs, "deferring child-issue close") {
+		t.Errorf("did not expect the close to be deferred for a merged PR, got logs:\n%s", logs)
+	}
+	if !strings.Contains(logs, `skipping CloseIssueWithComment" issue=500`) {
+		t.Errorf("expected the normal close path to run (dry-run no-op) for the child issue on a merged PR, got logs:\n%s", logs)
+	}
+}
+
+func TestExecuteSubIssuesTracked_PRStateQueryError_FailsSafeAndWarns(t *testing.T) {
+	var buf bytes.Buffer
+
+	r := newTestRunnerWithExecFunc(func(_ context.Context, task *Task) (*ExecutionResult, error) {
+		return &ExecutionResult{TaskID: task.ID, Success: true, PRUrl: "https://github.com/owner/repo/pull/503"}, nil
+	})
+	r.log = slog.New(slog.NewTextHandler(&buf, nil))
+	r.subIssuePRStateCheck = func(_ context.Context, _ string, _ int) (*SubIssuePRState, error) {
+		return nil, errors.New("network blip talking to gh")
+	}
+
+	parent := &Task{ID: "GH-999"}
+	issues := []CreatedIssue{
+		{Number: 500, Identifier: "500", URL: "https://github.com/owner/repo/issues/500",
+			Subtask: PlannedSubtask{Title: "part 1", Description: "do part 1"}},
+	}
+
+	if _, _, err := r.executeSubIssuesTracked(context.Background(), parent, issues, "", ""); err != nil {
+		t.Fatalf("executeSubIssuesTracked returned unexpected error: %v", err)
+	}
+
+	logs := buf.String()
+	if !strings.Contains(logs, "could not determine sub-issue PR state before close; leaving issue open") {
+		t.Errorf("expected fail-safe WARN log when the PR state query errors, got logs:\n%s", logs)
+	}
+	if !strings.Contains(logs, "network blip talking to gh") {
+		t.Errorf("expected the WARN log to carry the underlying error, got logs:\n%s", logs)
+	}
+	if strings.Contains(logs, `skipping CloseIssueWithComment" issue=500`) {
+		t.Errorf("expected the child issue's close to be skipped when PR state can't be determined, got logs:\n%s", logs)
+	}
+}
+
+// TestGetSubIssuePRState_DryRunDefaultIsMerged verifies the fallback default
+// (no override wired) returns a terminal MERGED state under dry-run instead
+// of shelling out to a real `gh pr view` — dry-run never makes real gh calls
+// and CloseIssueWithComment already no-ops the close itself, so this check
+// must not be what changes dry-run behavior.
+func TestGetSubIssuePRState_DryRunDefaultIsMerged(t *testing.T) {
+	r := &Runner{
+		log:    slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+		dryRun: true,
+	}
+
+	state, err := r.getSubIssuePRState(context.Background(), "", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state == nil || !state.Merged || state.State != "MERGED" {
+		t.Errorf("expected dry-run default state {MERGED, true}, got %+v", state)
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -668,6 +668,20 @@ type SubIssuePRCallback func(prNumber int, prURL string, issueNumber int, headSH
 // to enforce sequential ordering: sub-issue N+1 only starts after sub-issue N is merged.
 type SubIssueMergeWaitFn func(ctx context.Context, prNumber int) error
 
+// SubIssuePRState is the merge state of a sub-issue's PR, as queried
+// immediately before the child issue would be closed (GH-4697). State is
+// GitHub's own vocabulary ("OPEN", "MERGED", "CLOSED") from `gh pr view
+// --json state`.
+type SubIssuePRState struct {
+	State  string
+	Merged bool
+}
+
+// SubIssuePRStateFn queries the current state of a sub-issue's PR by number.
+// Optional override on Runner for testing; production default shells out to
+// `gh pr view` (GH-4697).
+type SubIssuePRStateFn func(ctx context.Context, projectPath string, prNumber int) (*SubIssuePRState, error)
+
 // SubIssuePollerSkipFn is called with each newly-created GitHub sub-issue number and the
 // owner/repo it was created in so the poller for that repo marks it as already-processed
 // and does not re-dispatch it (GH-3240). The repo scopes the mark so a sub-issue number
@@ -733,6 +747,7 @@ type Runner struct {
 	tokenLimitCheck        TokenLimitCallback                                              // Optional per-task token/duration limit check (GH-539)
 	onSubIssuePRCreated    SubIssuePRCallback                                              // Optional callback when a sub-issue PR is created (GH-596)
 	subIssueMergeWait      SubIssueMergeWaitFn                                             // Optional fn to block between sub-issues until PR is merged (GH-2178)
+	subIssuePRStateCheck   SubIssuePRStateFn                                               // Optional override for querying a sub-issue PR's state before close (GH-4697); nil uses the gh CLI default
 	subIssuePollerSkip     SubIssuePollerSkipFn                                            // GH-3240: marks sub-issues in poller so they aren't re-dispatched
 	intentJudge            *IntentJudge                                                    // Optional intent judge for diff-vs-ticket alignment (GH-624)
 	teamChecker            TeamChecker                                                     // Optional team RBAC checker (GH-633)


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4697.

Closes #4697

## Finding (AC3): reachable-and-fixed

`executeSubIssuesTracked` (internal/executor/epic.go, child-close block
originally ~line 3132) closed a completed child's GitHub issue **unconditionally**
the moment its run reported `Success` + a non-empty `PRUrl` — with no check on
whether that PR had actually merged, was still open, or had been abandoned.

This is exactly what closed #4660/#4661 while their PRs (#4667/#4672) were
still open and unmerged (per `.agent/tasks/TASK-437-duplicate-execution-race-prevention.md`):

| Event | Time (UTC) |
|---|---|
| PR #4667 opened for child #4660 | 10:28:41Z |
| Issue #4660 closed | 10:28:44Z (**3 seconds later**) |
| PR #4667 itself closed, unmerged | 12:05:06Z (97 min later) |
| PR #4672 opened for child #4661 | 10:58:31Z |
| Issue #4661 closed | 10:58:34Z (**3 seconds later**) |
| PR #4672 itself closed, unmerged | 12:05:09Z |

The 3-second gap between PR creation and issue close, confirmed against the
live GitHub history via `gh pr view`/`gh issue view`, rules out a human or a
GitHub auto-close-on-merge action — the only code path that runs in that
window is this unconditional `CloseIssueWithComment` call right after PR
creation succeeds.

## Fix

Before closing a completed child's issue, query the PR's real state via
`gh pr view --json state` (`OPEN`/`MERGED`/`CLOSED` — deliberately **not**
`mergedAt`, which can read `null` on an already-merged squash-merge PR; see
`.agent/sops/integrations/cascade-detection-forensics.md`'s "ghost merge"
pitfall):

- **PR is `OPEN`** (still unmerged) → defer the close, log a WARN naming the
  PR number and URL, and leave a progress comment on the issue instead. The
  issue stays open until the PR resolves.
- **PR is `MERGED` or already `CLOSED`** → close normally, same as before —
  both are terminal states that won't reopen.
- **State query itself fails** (network blip, `gh` error) → fail safe: defer
  the close and WARN, rather than closing blind. An issue left open is
  recoverable; an erroneous close is not.

The PR-state lookup is injectable (`Runner.subIssuePRStateCheck`, mirroring
the existing `subIssueMergeWait` pattern) so tests exercise the guard logic
directly without shelling out to a real `gh` binary; production defaults to
shelling `gh pr view`.

## Testing

New coverage in `internal/executor/epic_child_close_test.go`:

- `TestExecuteSubIssuesTracked_OpenUnmergedPR_DefersClose` — an OPEN PR
  blocks the close and the WARN log names the PR number/URL.
- `TestExecuteSubIssuesTracked_MergedPR_ClosesNormally` — regression: a
  MERGED PR still closes the child issue as before.
- `TestExecuteSubIssuesTracked_PRStateQueryError_FailsSafeAndWarns` — a
  state-query error defers the close (fail-safe) and WARNs with the
  underlying error.
- `TestGetSubIssuePRState_DryRunDefaultIsMerged` — dry-run's default
  (no override wired) never shells to a real `gh` and reports a terminal
  state, so this check doesn't change dry-run behavior.

`make build`, `make test` (full suite, `-race`), and
`golangci-lint run --new-from-rev=origin/main ./...` are all green.

## Test plan

- [x] `make build`
- [x] `make test` (full suite, `go test -race ./...`)
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] New tests exercise: OPEN PR blocks close + WARNs, MERGED PR closes
      normally (regression), state-query error fails safe, dry-run default
      is non-blocking