### PR TITLE
GH-4701: feat(dashboard): HISTORY renders operator-superseded issues as pipeline failures — add muted 'superseded' status distinct from failed/ci_failed

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -192,6 +192,14 @@ type EvalStore interface {
 	// externally can never leave a non-terminal row behind that resurrects as
 	// a stuck running dashboard card on the next restart. GH-4499.
 	TerminateNonTerminalExecution(taskID, projectPath, reason string) error
+	// ReclassifyCompletionAsSuperseded is ReclassifyCompletionAsFailed's
+	// sibling for a close notifyExternalClose can prove was deliberate
+	// operator cleanup (issue closed not-planned, or already tagged
+	// pilot-superseded) rather than a genuine failure. GH-4701.
+	ReclassifyCompletionAsSuperseded(taskID, projectPath, reason string) error
+	// TerminateNonTerminalExecutionAsSuperseded is TerminateNonTerminalExecution's
+	// sibling for the same GH-4701 deliberate-close case.
+	TerminateNonTerminalExecutionAsSuperseded(taskID, projectPath, reason string) error
 	// SelfHealExecutionByPRURL is the pr_url-keyed fallback self-heal used when
 	// a merged PR's issue number can't be resolved from branch or body markers
 	// at all. TASK-399/GH-4209.
@@ -6645,14 +6653,34 @@ func (c *Controller) notifyExternalClose(ctx context.Context, prState *PRState) 
 		reason = "closed without merging (no reason recorded)"
 	}
 
+	// GH-4701: prState.TerminalLabel already says pilot-superseded when an
+	// earlier stage (e.g. closeConflictSourceIssueClosed) proved a
+	// sibling/duplicate execution delivered this issue's scope first — that
+	// is deliberate operator/execution-invalidation cleanup, not a genuine
+	// pipeline failure, so it must not collapse into "failed" below. Without
+	// this split the row freezes at whatever ladder rung it last reached and
+	// HISTORY renders it as a pipeline ✗ (the 2026-08-03 #4655 cluster:
+	// #4660-#4665 closed en masse and re-filed as #4677 rendered this way).
+	supersededClose := prState.TerminalLabel == github.LabelSuperseded
+
 	// GH-3818/D10: reclassify any "completed" execution row for this issue to
 	// "failed" now that we know its PR was discarded — otherwise HasCompletedExecution
 	// keeps trusting the stale row and the poller re-marks the issue pilot-done on
 	// every subsequent poll even though nothing shipped. A later merge heals this
 	// back to "completed" via SelfHealExecutionAfterMerge.
+	//
+	// GH-4701: unless supersededClose says this was deliberate operator
+	// cleanup, not a failure — then the row is reclassified to "superseded"
+	// instead, so HISTORY renders it muted rather than as a pipeline ✗.
 	if c.evalStore != nil && prState.IssueNumber > 0 {
 		taskID := fmt.Sprintf("GH-%d", prState.IssueNumber)
-		if err := c.evalStore.ReclassifyCompletionAsFailed(taskID, c.projectPath, reason); err != nil {
+		var err error
+		if supersededClose {
+			err = c.evalStore.ReclassifyCompletionAsSuperseded(taskID, c.projectPath, reason)
+		} else {
+			err = c.evalStore.ReclassifyCompletionAsFailed(taskID, c.projectPath, reason)
+		}
+		if err != nil {
 			c.log.Warn("failed to reclassify completed execution after PR close",
 				"task_id", taskID, "pr", prState.PRNumber, "error", err)
 		}
@@ -6666,10 +6694,16 @@ func (c *Controller) notifyExternalClose(ctx context.Context, prState *PRState) 
 	// non-terminal forever, HydrateFromStore re-seeds it into the Monitor as
 	// a running card on the next restart, and Monitor.ReconcileWithStore
 	// (GH-4490) can't rescue it because the reconciler trusts the executions
-	// row as source of truth.
+	// row as source of truth. GH-4701: same supersededClose split as above.
 	if c.evalStore != nil && prState.IssueNumber > 0 {
 		taskID := fmt.Sprintf("GH-%d", prState.IssueNumber)
-		if err := c.evalStore.TerminateNonTerminalExecution(taskID, c.projectPath, reason); err != nil {
+		var err error
+		if supersededClose {
+			err = c.evalStore.TerminateNonTerminalExecutionAsSuperseded(taskID, c.projectPath, reason)
+		} else {
+			err = c.evalStore.TerminateNonTerminalExecution(taskID, c.projectPath, reason)
+		}
+		if err != nil {
 			c.log.Warn("failed to terminate non-terminal execution after PR close",
 				"task_id", taskID, "pr", prState.PRNumber, "error", err)
 		}

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -5612,6 +5612,11 @@ type mockEvalStore struct {
 	updateStatus []updateStatusCall
 	reclassified []reclassifyCall
 	terminated   []terminateCall
+	// GH-4701: separate call logs for the superseded-close siblings so tests
+	// can assert which variant fired without disturbing the failed-path
+	// assertions above.
+	reclassifiedSuperseded []reclassifyCall
+	terminatedSuperseded   []terminateCall
 	// execStatusByTaskID configures GetExecutionStatusByTaskID responses keyed by
 	// task ID (e.g. "GH-11"). Missing keys return sql.ErrNoRows, matching a real
 	// store's behavior when no execution row exists for that task.
@@ -5689,6 +5694,18 @@ func (m *mockEvalStore) ReclassifyCompletionAsFailed(taskID, projectPath, reason
 // TerminateNonTerminalExecution records the call for assertions. GH-4499.
 func (m *mockEvalStore) TerminateNonTerminalExecution(taskID, projectPath, reason string) error {
 	m.terminated = append(m.terminated, terminateCall{TaskID: taskID, ProjectPath: projectPath, Reason: reason})
+	return nil
+}
+
+// ReclassifyCompletionAsSuperseded records the call for assertions. GH-4701.
+func (m *mockEvalStore) ReclassifyCompletionAsSuperseded(taskID, projectPath, reason string) error {
+	m.reclassifiedSuperseded = append(m.reclassifiedSuperseded, reclassifyCall{TaskID: taskID, ProjectPath: projectPath, Reason: reason})
+	return nil
+}
+
+// TerminateNonTerminalExecutionAsSuperseded records the call for assertions. GH-4701.
+func (m *mockEvalStore) TerminateNonTerminalExecutionAsSuperseded(taskID, projectPath, reason string) error {
+	m.terminatedSuperseded = append(m.terminatedSuperseded, terminateCall{TaskID: taskID, ProjectPath: projectPath, Reason: reason})
 	return nil
 }
 
@@ -7149,6 +7166,85 @@ func TestNotifyExternalClose_TerminatesNonTerminalExecution(t *testing.T) {
 				}
 			} else if len(evalMock.terminated) != 0 {
 				t.Errorf("expected no terminate calls, got %+v", evalMock.terminated)
+			}
+		})
+	}
+}
+
+// TestNotifyExternalClose_SupersededCloseRoutesToSupersededVariants covers
+// GH-4701: when prState.TerminalLabel already says pilot-superseded (e.g.
+// closeConflictSourceIssueClosed proved a sibling/duplicate execution
+// delivered this issue's scope first), notifyExternalClose must route both
+// the reclassify and terminate calls to their "AsSuperseded" siblings
+// instead of the plain "failed" variants — otherwise HISTORY renders
+// deliberate operator cleanup as a pipeline ✗ (the 2026-08-03 #4655 cluster
+// that motivated this task).
+func TestNotifyExternalClose_SupersededCloseRoutesToSupersededVariants(t *testing.T) {
+	tests := []struct {
+		name           string
+		terminalLabel  string
+		wantSuperseded bool
+	}{
+		{
+			name:           "TerminalLabel pilot-superseded - routes to superseded variants",
+			terminalLabel:  github.LabelSuperseded,
+			wantSuperseded: true,
+		},
+		{
+			name:           "TerminalLabel empty - routes to plain failed variants",
+			terminalLabel:  "",
+			wantSuperseded: false,
+		},
+		{
+			name:           "TerminalLabel pilot-failed - routes to plain failed variants",
+			terminalLabel:  github.LabelFailed,
+			wantSuperseded: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("[]"))
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+			evalMock := &mockEvalStore{}
+			c.SetEvalStore(evalMock)
+
+			prState := &PRState{PRNumber: 42, IssueNumber: 4701, Error: "source issue #4701 is closed", TerminalLabel: tt.terminalLabel}
+			c.notifyExternalClose(context.Background(), prState)
+
+			if tt.wantSuperseded {
+				if len(evalMock.reclassifiedSuperseded) != 1 {
+					t.Errorf("reclassifiedSuperseded calls = %d, want 1: %+v", len(evalMock.reclassifiedSuperseded), evalMock.reclassifiedSuperseded)
+				}
+				if len(evalMock.terminatedSuperseded) != 1 {
+					t.Errorf("terminatedSuperseded calls = %d, want 1: %+v", len(evalMock.terminatedSuperseded), evalMock.terminatedSuperseded)
+				}
+				if len(evalMock.reclassified) != 0 {
+					t.Errorf("expected no plain reclassify calls, got %+v", evalMock.reclassified)
+				}
+				if len(evalMock.terminated) != 0 {
+					t.Errorf("expected no plain terminate calls, got %+v", evalMock.terminated)
+				}
+			} else {
+				if len(evalMock.reclassified) != 1 {
+					t.Errorf("reclassified calls = %d, want 1: %+v", len(evalMock.reclassified), evalMock.reclassified)
+				}
+				if len(evalMock.terminated) != 1 {
+					t.Errorf("terminated calls = %d, want 1: %+v", len(evalMock.terminated), evalMock.terminated)
+				}
+				if len(evalMock.reclassifiedSuperseded) != 0 {
+					t.Errorf("expected no superseded reclassify calls, got %+v", evalMock.reclassifiedSuperseded)
+				}
+				if len(evalMock.terminatedSuperseded) != 0 {
+					t.Errorf("expected no superseded terminate calls, got %+v", evalMock.terminatedSuperseded)
+				}
 			}
 		})
 	}

--- a/internal/dashboard/stage_strip.go
+++ b/internal/dashboard/stage_strip.go
@@ -104,6 +104,16 @@ func displayStatus(execStatus string) string {
 // — but it's listed here anyway so the label always reads the deliberate
 // outcome even for a row cancelled before any event exists (e.g. a queued
 // row that never reached "running").
+//
+// superseded (GH-4701): an operator's deliberate cleanup, not a pipeline
+// failure — either a sibling/duplicate execution already delivered the same
+// scope (GH-4656's dispatcher/PR-preflight guards write this status before
+// any work starts or a PR opens), or a human closed the issue outright as
+// not-planned (notifyExternalClose's supersededClose classification).
+// Without this entry the row freezes at whatever ladder rung it last
+// reached and renders `✗ pr_created` / `✗ ci_passed` — indistinguishable
+// from a genuine failure (the 2026-08-03 #4655 cluster: #4660-#4665 closed
+// en masse and re-filed as #4677 rendered as 6 of 43 rows misread this way).
 var mutedOutcomes = map[string]bool{
 	"skipped":            true,
 	"no_op":              true,
@@ -113,6 +123,7 @@ var mutedOutcomes = map[string]bool{
 	"declined-preflight": true,
 	"cancelled":          true,
 	"canceled":           true,
+	"superseded":         true,
 }
 
 // stageStripCleanTerminalEvents are execution_events that close out a run

--- a/internal/dashboard/stage_strip_test.go
+++ b/internal/dashboard/stage_strip_test.go
@@ -416,6 +416,32 @@ func TestStageInfoForExecution_MutedOutcomesTable(t *testing.T) {
 			events: []*memory.Event{evt(memory.StageRunning)},
 			want:   StageInfo{Reached: 2, Label: "cancelled", Failed: false, Known: true, Muted: true},
 		},
+		{
+			// GH-4701: an operator's deliberate not-planned close (or a
+			// sibling/duplicate execution already delivering this issue's
+			// scope, GH-4656) is not a pipeline failure — the row must
+			// render muted "superseded", not the blank/unknown meter a
+			// zero-event row would otherwise get.
+			status: "superseded",
+			events: nil,
+			want:   StageInfo{Reached: 0, Label: "superseded", Failed: false, Known: true, Muted: true},
+		},
+		{
+			// Same outcome, but with the realistic #4655-cluster shape: the
+			// run had already reached pr_created before the operator closed
+			// the issue. The muted-outcome override must still win over the
+			// running-max reducer's frozen "pr_created" label — without it
+			// this row renders "✗ pr_created", indistinguishable from a
+			// genuine failure.
+			status: "superseded",
+			events: []*memory.Event{
+				evt(memory.StageSpecValidated),
+				evt(memory.StageRunning),
+				evt(memory.StageCommit),
+				evt(memory.StagePRCreated),
+			},
+			want: StageInfo{Reached: 4, Label: "superseded", Failed: false, Known: true, Muted: true},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.status, func(t *testing.T) {
@@ -479,4 +505,71 @@ func TestResolveHistoryStatus_SharedByAllCallSites(t *testing.T) {
 			t.Error("expected cancelled outcome to be muted, matching other terminal-without-ladder-rung statuses")
 		}
 	})
+}
+
+// TestResolveHistoryStatus_SupersededNotRenderedAsFailure is the GH-4701
+// regression test: an issue an operator closes as not-planned / superseded
+// (or a sibling/duplicate execution that already delivered the same scope,
+// GH-4656) must render a distinct muted "superseded" row, not "✗ <rung>" —
+// indistinguishable from a genuine pipeline failure (the 2026-08-03 #4655
+// cluster: #4660-#4665 closed en masse and re-filed as #4677 rendered as 6
+// of 43 HISTORY rows misread this way). Table-driven per the three cases
+// called out in the acceptance criteria: a superseded row, a genuine
+// ci_failed row (unchanged ✗ rendering), and a legacy row with no events
+// (unchanged Known=false — no stage evidence must never be fabricated into
+// either outcome).
+func TestResolveHistoryStatus_SupersededNotRenderedAsFailure(t *testing.T) {
+	tests := []struct {
+		name       string
+		execStatus string
+		events     []*memory.Event
+		want       HistoryStatus
+	}{
+		{
+			name:       "superseded row renders muted, not a failure",
+			execStatus: "superseded",
+			events: []*memory.Event{
+				evt(memory.StageSpecValidated),
+				evt(memory.StageRunning),
+				evt(memory.StageCommit),
+				evt(memory.StagePRCreated),
+			},
+			want: HistoryStatus{
+				Status: "superseded",
+				Stage:  StageInfo{Reached: 4, Label: "superseded", Failed: false, Known: true, Muted: true},
+			},
+		},
+		{
+			name:       "genuine ci_failed row keeps the unmuted failure rendering",
+			execStatus: "failed",
+			events:     []*memory.Event{evt(memory.StageCIFailed)},
+			want: HistoryStatus{
+				Status: "failed",
+				Stage:  StageInfo{Reached: 4, Label: "ci_failed", Failed: true, Known: true, Muted: false},
+			},
+		},
+		{
+			name:       "legacy row with no events stays unknown, not fabricated into a failure or superseded",
+			execStatus: "completed",
+			events:     nil,
+			want: HistoryStatus{
+				Status: "success",
+				Stage:  StageInfo{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveHistoryStatus(tt.execStatus, tt.events)
+			if got != tt.want {
+				t.Errorf("resolveHistoryStatus(%q, %v) = %+v, want %+v", tt.execStatus, tt.events, got, tt.want)
+			}
+			if tt.execStatus == "superseded" && (got.Stage.Failed || !got.Stage.Muted) {
+				t.Errorf("superseded row must render muted and non-failed: got %+v", got.Stage)
+			}
+			if tt.execStatus == "failed" && (!got.Stage.Failed || got.Stage.Muted) {
+				t.Errorf("genuine failure row must keep the unmuted ✗ rendering: got %+v", got.Stage)
+			}
+		})
+	}
 }

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1376,6 +1376,30 @@ func (s *Store) ReclassifyCompletionAsFailed(taskID, projectPath, reason string)
 	})
 }
 
+// ReclassifyCompletionAsSuperseded is ReclassifyCompletionAsFailed's sibling
+// for the GH-4701 case: a completed execution row whose PR was closed
+// because an operator deliberately closed the issue as not-planned (or a
+// prior stage already tagged the close pilot-superseded — e.g. a
+// sibling/duplicate execution delivered the same scope first), not because
+// anything actually failed. Demoting to "failed" here would render the row
+// as a pipeline failure in HISTORY (the 2026-08-03 #4655 cluster: 6 of 43
+// rows misread that way); "superseded" is a muted, distinct outcome instead
+// (see internal/dashboard/stage_strip.go's mutedOutcomes).
+func (s *Store) ReclassifyCompletionAsSuperseded(taskID, projectPath, reason string) error {
+	return s.withRetry("ReclassifyCompletionAsSuperseded", func() error {
+		_, err := s.db.Exec(`
+			UPDATE executions
+			SET status = 'superseded',
+				error = ?,
+				completed_at = CURRENT_TIMESTAMP
+			WHERE task_id = ? AND (? = '' OR project_path = ?) AND status = 'completed'
+				AND (error IS NULL OR error = '')
+				AND (commit_sha != '' OR pr_url != '')
+		`, reason, taskID, projectPath, projectPath)
+		return err
+	})
+}
+
 // TerminateNonTerminalExecution flips the latest execution row for taskID
 // (same created_at DESC, rowid DESC selection as GetExecutionStatusByTaskID)
 // to status='failed' when it is still queued/pending/running. GH-4499: covers
@@ -1398,6 +1422,27 @@ func (s *Store) TerminateNonTerminalExecution(taskID, projectPath, reason string
 		_, err := s.db.Exec(`
 			UPDATE executions
 			SET status = 'failed',
+				error = ?,
+				completed_at = CURRENT_TIMESTAMP
+			WHERE id = (
+				SELECT id FROM executions
+				WHERE task_id = ? AND (? = '' OR project_path = ?)
+				ORDER BY created_at DESC, rowid DESC
+				LIMIT 1
+			) AND status IN ('queued', 'pending', 'running')
+		`, reason, taskID, projectPath, projectPath)
+		return err
+	})
+}
+
+// TerminateNonTerminalExecutionAsSuperseded is TerminateNonTerminalExecution's
+// sibling for the GH-4701 case: see ReclassifyCompletionAsSuperseded's doc
+// comment for when this applies over the "failed" variant.
+func (s *Store) TerminateNonTerminalExecutionAsSuperseded(taskID, projectPath, reason string) error {
+	return s.withRetry("TerminateNonTerminalExecutionAsSuperseded", func() error {
+		_, err := s.db.Exec(`
+			UPDATE executions
+			SET status = 'superseded',
 				error = ?,
 				completed_at = CURRENT_TIMESTAMP
 			WHERE id = (

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -3979,6 +3979,161 @@ func TestTerminateNonTerminalExecution_NewerRowShields(t *testing.T) {
 	}
 }
 
+// TestReclassifyCompletionAsSuperseded covers GH-4701: ReclassifyCompletionAsFailed's
+// sibling for a close notifyExternalClose can prove was deliberate operator
+// cleanup (issue closed not-planned, or already tagged pilot-superseded)
+// rather than a genuine failure — the row must land on "superseded", not
+// "failed", so HISTORY renders it muted instead of as a pipeline ✗.
+func TestReclassifyCompletionAsSuperseded(t *testing.T) {
+	tests := []struct {
+		name            string
+		row             Execution
+		taskID          string
+		projectPath     string
+		wantStatusAfter string
+	}{
+		{
+			name: "completed with PR closed as superseded - reclassified to superseded, not failed",
+			row: Execution{
+				ID: "exec-superseded", TaskID: "GH-4701", ProjectPath: "/project",
+				Status: "completed", PRUrl: "https://github.com/o/r/pull/4701",
+			},
+			taskID:          "GH-4701",
+			projectPath:     "/project",
+			wantStatusAfter: "superseded",
+		},
+		{
+			name: "different task ID - untouched",
+			row: Execution{
+				ID: "exec-other-task", TaskID: "GH-999", ProjectPath: "/project",
+				Status: "completed", PRUrl: "https://github.com/o/r/pull/1",
+			},
+			taskID:          "GH-4701", // reclassify call targets a different task
+			projectPath:     "/project",
+			wantStatusAfter: "completed",
+		},
+		{
+			name: "different project path - untouched (cross-repo isolation)",
+			row: Execution{
+				ID: "exec-other-project", TaskID: "GH-4701", ProjectPath: "/other-project",
+				Status: "completed", PRUrl: "https://github.com/o/r/pull/2",
+			},
+			taskID:          "GH-4701",
+			projectPath:     "/project", // reclassify call scoped to a different project
+			wantStatusAfter: "completed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			store, err := NewStore(tmpDir)
+			if err != nil {
+				t.Fatalf("NewStore: %v", err)
+			}
+			defer func() { _ = store.Close() }()
+
+			if err := store.SaveExecution(&tt.row); err != nil {
+				t.Fatalf("SaveExecution: %v", err)
+			}
+
+			if err := store.ReclassifyCompletionAsSuperseded(tt.taskID, tt.projectPath, "source issue closed as not-planned"); err != nil {
+				t.Fatalf("ReclassifyCompletionAsSuperseded: %v", err)
+			}
+
+			got, err := store.GetExecution(tt.row.ID)
+			if err != nil {
+				t.Fatalf("GetExecution: %v", err)
+			}
+			if got.Status != tt.wantStatusAfter {
+				t.Errorf("status after reclassify = %q, want %q", got.Status, tt.wantStatusAfter)
+			}
+		})
+	}
+}
+
+// TestTerminateNonTerminalExecutionAsSuperseded covers GH-4701:
+// TerminateNonTerminalExecution's sibling for the same deliberate-close case
+// — a still-running/queued/pending row must land on "superseded", not
+// "failed".
+func TestTerminateNonTerminalExecutionAsSuperseded(t *testing.T) {
+	tests := []struct {
+		name            string
+		row             Execution
+		taskID          string
+		projectPath     string
+		wantStatusAfter string
+	}{
+		{
+			name: "running row - terminated to superseded",
+			row: Execution{
+				ID: "exec-running", TaskID: "GH-4701", ProjectPath: "/project",
+				Status: "running",
+			},
+			taskID:          "GH-4701",
+			projectPath:     "/project",
+			wantStatusAfter: "superseded",
+		},
+		{
+			name: "queued row - terminated to superseded",
+			row: Execution{
+				ID: "exec-queued", TaskID: "GH-4701", ProjectPath: "/project",
+				Status: "queued",
+			},
+			taskID:          "GH-4701",
+			projectPath:     "/project",
+			wantStatusAfter: "superseded",
+		},
+		{
+			name: "completed row - untouched (ReclassifyCompletionAsSuperseded's job, not this method's)",
+			row: Execution{
+				ID: "exec-completed", TaskID: "GH-4701", ProjectPath: "/project",
+				Status: "completed", PRUrl: "https://github.com/o/r/pull/1",
+			},
+			taskID:          "GH-4701",
+			projectPath:     "/project",
+			wantStatusAfter: "completed",
+		},
+		{
+			name: "different task ID - untouched",
+			row: Execution{
+				ID: "exec-other-task", TaskID: "GH-999", ProjectPath: "/project",
+				Status: "running",
+			},
+			taskID:          "GH-4701", // terminate call targets a different task
+			projectPath:     "/project",
+			wantStatusAfter: "running",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			store, err := NewStore(tmpDir)
+			if err != nil {
+				t.Fatalf("NewStore: %v", err)
+			}
+			defer func() { _ = store.Close() }()
+
+			if err := store.SaveExecution(&tt.row); err != nil {
+				t.Fatalf("SaveExecution: %v", err)
+			}
+
+			if err := store.TerminateNonTerminalExecutionAsSuperseded(tt.taskID, tt.projectPath, "source issue closed as not-planned"); err != nil {
+				t.Fatalf("TerminateNonTerminalExecutionAsSuperseded: %v", err)
+			}
+
+			got, err := store.GetExecution(tt.row.ID)
+			if err != nil {
+				t.Fatalf("GetExecution: %v", err)
+			}
+			if got.Status != tt.wantStatusAfter {
+				t.Errorf("status after terminate = %q, want %q", got.Status, tt.wantStatusAfter)
+			}
+		})
+	}
+}
+
 func TestGetLifetimeTokens_ExcludesZeroTokenRows(t *testing.T) {
 	tmpDir := t.TempDir()
 	store, err := NewStore(tmpDir)


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4701.

Closes #4701

## Changes

GitHub Issue GH-4701: feat(dashboard): HISTORY renders operator-superseded issues as pipeline failures — add muted 'superseded' status distinct from failed/ci_failed

## Context

The dashboard HISTORY panel renders the last stage-ladder rung reached as the row's status label (`internal/dashboard/stage_strip.go`). For issues an operator closes as superseded (e.g. the 2026-08-03 #4655 cluster: #4660–#4665 closed en masse and re-filed as #4677), the ladder freezes at whatever rung was current — so the rows render `✗ pr_created` / `✗ ci_passed`, indistinguishable from genuine pipeline failures. Operators reading the panel see a wall of failures that were actually deliberate cleanup (observed confusion 2026-08-04: 6 of 43 visible rows misread this way).

## Acceptance

- A row whose issue was closed as not-planned / superseded (issue `state_reason=not_planned`, or execution invalidated by operator action) renders a distinct muted status (e.g. `superseded`), not `✗ <rung>`.
- Genuine failures (`failed`, `ci_failed`, `stalled`) keep the ✗ rendering unchanged.
- Existing muted outcomes (`no_op`, `skipped`, `declined-preflight`) unchanged.
- Table-driven test covering: superseded row, genuine ci_failed row, and a legacy row with no events.

## Implementation

- `internal/dashboard/stage_strip.go`: extend `mutedOutcomes`/`StageInfo` derivation with the superseded signal; label the row `superseded` and mute the meter.
- Signal source: prefer ledger evidence (execution invalidation / status override) over a GitHub API call; if only derivable at close-detection time, record it once in the events table when the poller/autopilot observes issue closed-without-merge while its PR was operator-closed.

## Refs

- Confusion incident: 2026-08-04 session review of HISTORY panel; #4655 cluster cleanup rows.
- Related: GH-4368 (declined-preflight muted rendering precedent), GH-3927/GH-4064 (displayStatus history).