### PR TITLE
GH-4702: fix(executor): runSelfReview runs in the daemon repo root, not the worktree — empty diff triggers phantom reimplementation staged into the shared root (3rd recurrence of the TASK-323/GH-3577 class)

### DIFF
--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -4592,7 +4592,7 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 			wg.Add(1)
 			logging.SafeGo("executor-runner", func() {
 				defer wg.Done()
-				if err := r.runSelfReview(ctx, task, state); err != nil {
+				if err := r.runSelfReview(ctx, task, executionPath, state); err != nil {
 					selfReviewErr = err
 				}
 			})
@@ -5432,7 +5432,7 @@ func (r *Runner) IsRunning(taskID string) bool {
 // runSelfReview executes a self-review phase where Claude examines its changes.
 // This catches issues like unwired config, undefined methods, or incomplete implementations.
 // Returns nil if review passes or is skipped, error only for critical failures.
-func (r *Runner) runSelfReview(ctx context.Context, task *Task, state *progressState) error {
+func (r *Runner) runSelfReview(ctx context.Context, task *Task, executionPath string, state *progressState) error {
 	// Skip self-review if disabled in config
 	if r.config != nil && r.config.SkipSelfReview {
 		r.log.Debug("Self-review skipped (disabled in config)", slog.String("task_id", task.ID))
@@ -5477,7 +5477,7 @@ func (r *Runner) runSelfReview(ctx context.Context, task *Task, state *progressS
 	result, err := r.backend.Execute(reviewCtx, ExecuteOptions{
 		Prompt:          reviewPrompt,
 		TaskID:          task.ID,
-		ProjectPath:     task.ProjectPath,
+		ProjectPath:     executionPath, // GH-4702: review the worktree, not the daemon's repo root
 		Verbose:         task.Verbose,
 		Model:           selectedModel,
 		Effort:          selectedEffort,

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -3257,13 +3257,24 @@ func TestRunner_recordExecutionEvent_WritesEvent(t *testing.T) {
 
 // mockSelfReviewBackend implements Backend for self-review tests.
 type mockSelfReviewBackend struct {
-	output string
+	mu       sync.Mutex
+	output   string
+	lastOpts ExecuteOptions
 }
 
 func (m *mockSelfReviewBackend) Name() string      { return "mock" }
 func (m *mockSelfReviewBackend) IsAvailable() bool { return true }
-func (m *mockSelfReviewBackend) Execute(_ context.Context, _ ExecuteOptions) (*BackendResult, error) {
+func (m *mockSelfReviewBackend) Execute(_ context.Context, opts ExecuteOptions) (*BackendResult, error) {
+	m.mu.Lock()
+	m.lastOpts = opts
+	m.mu.Unlock()
 	return &BackendResult{Success: true, Output: m.output}, nil
+}
+
+func (m *mockSelfReviewBackend) lastExecuteOptions() ExecuteOptions {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastOpts
 }
 
 // mockSelfReviewExtractor implements SelfReviewExtractor for testing.
@@ -3336,7 +3347,7 @@ func TestRunSelfReview_ExtractsPatterns(t *testing.T) {
 	}
 	state := &progressState{}
 
-	err := runner.runSelfReview(context.Background(), task, state)
+	err := runner.runSelfReview(context.Background(), task, task.ProjectPath, state)
 	if err != nil {
 		t.Fatalf("runSelfReview returned error: %v", err)
 	}
@@ -3374,7 +3385,7 @@ func TestRunSelfReview_SkipsExtractionWhenNoExtractor(t *testing.T) {
 	}
 	state := &progressState{}
 
-	err := runner.runSelfReview(context.Background(), task, state)
+	err := runner.runSelfReview(context.Background(), task, task.ProjectPath, state)
 	if err != nil {
 		t.Fatalf("runSelfReview returned error: %v", err)
 	}
@@ -3398,7 +3409,7 @@ func TestRunSelfReview_SkipsExtractionWhenEmptyOutput(t *testing.T) {
 	}
 	state := &progressState{}
 
-	err := runner.runSelfReview(context.Background(), task, state)
+	err := runner.runSelfReview(context.Background(), task, task.ProjectPath, state)
 	if err != nil {
 		t.Fatalf("runSelfReview returned error: %v", err)
 	}
@@ -3437,7 +3448,7 @@ func TestRunSelfReview_SkipsSaveWhenNoPatternsExtracted(t *testing.T) {
 	}
 	state := &progressState{}
 
-	err := runner.runSelfReview(context.Background(), task, state)
+	err := runner.runSelfReview(context.Background(), task, task.ProjectPath, state)
 	if err != nil {
 		t.Fatalf("runSelfReview returned error: %v", err)
 	}
@@ -3450,6 +3461,47 @@ func TestRunSelfReview_SkipsSaveWhenNoPatternsExtracted(t *testing.T) {
 	}
 	if extractor.saveCalls != 0 {
 		t.Errorf("expected 0 save calls when no patterns extracted, got %d", extractor.saveCalls)
+	}
+}
+
+// TestRunSelfReview_RunsInWorktree is the GH-4702 regression guard.
+//
+// Before the fix runSelfReview always passed ProjectPath: task.ProjectPath —
+// the daemon's repo root — even when worktree isolation was active, so the
+// review's `git diff --cached` saw nothing and its own instructions to "FIX
+// the issue" if the diff looked empty caused it to re-derive the spec and
+// stage a phantom reimplementation into the shared root (the 2026-08-04
+// orphan-staged-GH-4659-helper incident). This is the third recurrence of the
+// TASK-323/GH-3577 class; runSelfReview was missed by both prior fixes. With
+// the fix, self-review runs in executionPath (the worktree), not
+// task.ProjectPath.
+func TestRunSelfReview_RunsInWorktree(t *testing.T) {
+	backend := &mockSelfReviewBackend{output: "REVIEW_PASSED"}
+	runner := NewRunnerWithBackend(backend)
+	runner.skipPreflightChecks = true
+
+	worktreePath := t.TempDir()
+	task := &Task{
+		ID:          "GH-4702",
+		Title:       "Add complex feature with multiple components",
+		Description: "Implement a complex multi-step feature requiring significant changes",
+		ProjectPath: t.TempDir(), // simulates the daemon's shared repo root
+	}
+	state := &progressState{}
+
+	// executionPath (worktreePath) is deliberately different from
+	// task.ProjectPath to simulate worktree isolation being active.
+	err := runner.runSelfReview(context.Background(), task, worktreePath, state)
+	if err != nil {
+		t.Fatalf("runSelfReview returned error: %v", err)
+	}
+
+	got := backend.lastExecuteOptions().ProjectPath
+	if got != worktreePath {
+		t.Errorf("self-review ProjectPath = %q, want worktree path %q", got, worktreePath)
+	}
+	if got == task.ProjectPath {
+		t.Errorf("self-review ran in task.ProjectPath %q; it must run in the worktree", task.ProjectPath)
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4702.

Closes #4702

## Changes

GitHub Issue GH-4702: fix(executor): runSelfReview runs in the daemon repo root, not the worktree — empty diff triggers phantom reimplementation staged into the shared root (3rd recurrence of the TASK-323/GH-3577 class)

## Context

Found 2026-08-04: an orphan STAGED change in the box repo root — an independent reimplementation of GH-4659's helper (`hasNonTerminalDecomposedChild` vs the merged `decomposedChildLedgerNonTerminal`), staged, never committed. Root cause traced:

`runSelfReview` (`internal/executor/runner.go:5223-5226`) spawns its review subprocess with `ProjectPath: task.ProjectPath` — the **daemon repo root** — instead of `executionPath` (the worktree). `task.ProjectPath` is never reassigned; `executionPath` is (`runner.go:2201`). So every self-review runs `cmd.Dir = <shared root>` (`backend_claudecode.go:554`) while the task's real diff lives only in the worktree.

Consequence chain: self-review runs `git diff --cached` in the root (`prompt_builder.go:542`) → sees nothing → its own instructions ("If files mentioned in the issue are NOT in the diff... FIX the issue by making the required changes", `prompt_builder.go:565-584`) → re-derives the spec from the embedded issue text and **stages a phantom reimplementation into the shared root**. This is what blocked the 2026-08-04 rebuild (`git checkout` refused over the dirty root).

This is the **third recurrence** of the same defect class: TASK-323 fixed it at (now) `runner.go:3402`/`:3759`; GH-3577/PR#3580 fixed it at `:4120`/`:4402`. `runSelfReview` was missed by both. No regression test catches it — `mockSelfReviewBackend.Execute` discards `ExecuteOptions` (`runner_test.go:3209`).

## Acceptance

- `runSelfReview` executes with `ProjectPath: executionPath` — mirror the exact GH-3577 diff shape (comment included).
- Regression test: `mockSelfReviewBackend` asserts the received `ExecuteOptions.ProjectPath` equals the worktree path, not `task.ProjectPath`, when worktree isolation is active.
- Single-file change surface (`runner.go` + `runner_test.go`).

## Refs

- Prior fixes of the class: TASK-323, GH-3577 → PR#3580.
- Incident: 2026-08-04 root-checkout stash on the box ("orphan staged GH-4659 helper"); nav-research trace same day.
- Structural follow-up (do NOT fold in here): chokepoint guard issue, filed separately and chained on this one.