### PR TITLE
GH-4703: refactor(executor): centralize backend.Execute behind a path-identity guard — make worktree routing a structural invariant, not a per-call-site convention

### DIFF
--- a/internal/executor/backend_execute_guard.go
+++ b/internal/executor/backend_execute_guard.go
@@ -1,0 +1,78 @@
+// Package executor — GH-4703
+//
+// Chokepoint for backend.Execute calls that centralizes ExecuteOptions.
+// ProjectPath assignment so worktree routing is a structural invariant
+// rather than a per-call-site convention.
+//
+// "ExecuteOptions.ProjectPath must be executionPath, not task.ProjectPath"
+// has been violated and reactively patched three times, each time at a
+// different call site in runner.go, because every call site rebuilt
+// ExecuteOptions{ProjectPath: ...} by hand and had to re-derive the
+// convention from memory:
+//
+//	TASK-323       runner.go (smart-retry, no-op-decline retry)
+//	GH-3577/PR#3580 runner.go (quality-gate retry, intent-judge retry)
+//	#4702          runner.go (self-review)
+//
+// The third recurrence (#4702) cost a blocked rebuild and a phantom
+// reimplementation staged into the shared daemon repo root. This file
+// applies the same pattern repo_guardrail.go already uses for repo
+// identity (see ValidateTargetRepo) to path identity: one function that
+// every backend.Execute call must route through, which sets the path
+// authoritatively and refuses loudly if it collapses back to the task's
+// (possibly shared, non-isolated) project root when worktree isolation
+// was expected.
+package executor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ErrProjectPathNotIsolated is the sentinel returned when backendExecute
+// detects that a call would run against task.ProjectPath (the daemon's
+// shared repo root / the user's real repo) while worktree isolation was
+// expected for this task. This is exactly the bug shape that recurred
+// across TASK-323, GH-3577/PR#3580, and #4702: a retry or review call site
+// silently falling back to the shared root instead of the task's worktree.
+var ErrProjectPathNotIsolated = errors.New("backend execute: project path not isolated from task project root")
+
+// backendExecute is the single chokepoint through which every
+// r.backend.Execute call in this package must flow (mirrors
+// repo_guardrail.go's ValidateTargetRepo chokepoint for repo identity).
+//
+// executionPath is the resolved execution directory for this call — the
+// worktree path when worktree isolation is active for the task, or the
+// project root for tasks that are legitimately root-scoped (LocalMode,
+// Q&A, CLI: task.Branch == "" or task.DirectCommit). It always wins over
+// whatever the caller populated in opts.ProjectPath, which removes the
+// "did this call site remember to use executionPath instead of
+// task.ProjectPath" decision from every call site — it is no longer
+// possible to build an ExecuteOptions with the wrong path field, only to
+// call backendExecute with the wrong executionPath argument, which the
+// guard below catches.
+//
+// The guard fires — returning ErrProjectPathNotIsolated instead of
+// silently proceeding — when the resolved path collapses to
+// task.ProjectPath while worktree isolation was expected
+// (r.config.UseWorktree && task.Branch != "" && !task.DirectCommit). That
+// condition is the exact shape of the historical bug: a worktree-eligible
+// task whose execution path resolved (correctly or via upstream failure)
+// to the shared root instead of an isolated worktree.
+//
+// The documented exception is preserved: LocalMode/Q&A/CLI tasks
+// (task.Branch == "" or task.DirectCommit) are not expected to be
+// worktree-isolated and legitimately pass through with
+// executionPath == task.ProjectPath.
+func (r *Runner) backendExecute(ctx context.Context, task *Task, executionPath string, opts ExecuteOptions) (*BackendResult, error) {
+	opts.ProjectPath = executionPath
+
+	worktreeExpected := task != nil && r.config != nil && r.config.UseWorktree && task.Branch != "" && !task.DirectCommit
+	if worktreeExpected && opts.ProjectPath == task.ProjectPath {
+		return nil, fmt.Errorf("%w: task %s expected worktree isolation (use_worktree=true, branch=%q, direct_commit=false) but execution path resolved to the project root %q instead of an isolated worktree",
+			ErrProjectPathNotIsolated, task.ID, task.Branch, task.ProjectPath)
+	}
+
+	return r.backend.Execute(ctx, opts)
+}

--- a/internal/executor/backend_execute_guard_test.go
+++ b/internal/executor/backend_execute_guard_test.go
@@ -1,0 +1,169 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// guardRecordingBackend records whether Execute was invoked and with which
+// ProjectPath, so tests can assert that a rejected call never reaches the
+// backend at all (a loud error, not a silent skip that still executes).
+type guardRecordingBackend struct {
+	called         bool
+	gotProjectPath string
+}
+
+func (b *guardRecordingBackend) Name() string      { return "guard-recording" }
+func (b *guardRecordingBackend) IsAvailable() bool { return true }
+
+func (b *guardRecordingBackend) Execute(_ context.Context, opts ExecuteOptions) (*BackendResult, error) {
+	b.called = true
+	b.gotProjectPath = opts.ProjectPath
+	return &BackendResult{Success: true}, nil
+}
+
+// TestRunner_BackendExecute_PathIdentityGuard is the GH-4703 regression
+// guard for the backendExecute chokepoint. It covers the recurrence class
+// from TASK-323, GH-3577/PR#3580, and #4702: a call site whose resolved
+// execution path collapses back to task.ProjectPath (the daemon's shared
+// repo root) while worktree isolation was expected for the task.
+func TestRunner_BackendExecute_PathIdentityGuard(t *testing.T) {
+	const projectRoot = "/repo/root"
+	const worktreePath = "/repo/.worktrees/GH-4703"
+
+	tests := []struct {
+		name          string
+		config        *BackendConfig
+		task          *Task
+		executionPath string
+		wantErr       bool
+		wantCalled    bool
+	}{
+		{
+			name:   "worktree expected but execution path collapses to project root: guarded error",
+			config: &BackendConfig{UseWorktree: true},
+			task: &Task{
+				ID:           "GH-4703-a",
+				ProjectPath:  projectRoot,
+				Branch:       "pilot/GH-4703",
+				DirectCommit: false,
+			},
+			executionPath: projectRoot, // bug shape: should have been worktreePath
+			wantErr:       true,
+			wantCalled:    false,
+		},
+		{
+			name:   "LocalMode exception (task.Branch empty): root-scoped call allowed",
+			config: &BackendConfig{UseWorktree: true},
+			task: &Task{
+				ID:          "GH-4703-b",
+				ProjectPath: projectRoot,
+				Branch:      "", // LocalMode/Q&A/CLI: legitimately root-scoped
+			},
+			executionPath: projectRoot,
+			wantErr:       false,
+			wantCalled:    true,
+		},
+		{
+			name:   "DirectCommit exception: root-scoped call allowed",
+			config: &BackendConfig{UseWorktree: true},
+			task: &Task{
+				ID:           "GH-4703-c",
+				ProjectPath:  projectRoot,
+				Branch:       "pilot/GH-4703",
+				DirectCommit: true,
+			},
+			executionPath: projectRoot,
+			wantErr:       false,
+			wantCalled:    true,
+		},
+		{
+			name:   "correct worktree path: allowed",
+			config: &BackendConfig{UseWorktree: true},
+			task: &Task{
+				ID:          "GH-4703-d",
+				ProjectPath: projectRoot,
+				Branch:      "pilot/GH-4703",
+			},
+			executionPath: worktreePath,
+			wantErr:       false,
+			wantCalled:    true,
+		},
+		{
+			name:   "UseWorktree disabled entirely: root-scoped call allowed",
+			config: &BackendConfig{UseWorktree: false},
+			task: &Task{
+				ID:          "GH-4703-e",
+				ProjectPath: projectRoot,
+				Branch:      "pilot/GH-4703",
+			},
+			executionPath: projectRoot,
+			wantErr:       false,
+			wantCalled:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := &guardRecordingBackend{}
+			runner := NewRunnerWithBackend(backend)
+			runner.config = tt.config
+			runner.SetSkipPreflightChecks(true)
+			runner.SetRecordingEnabled(false)
+
+			_, err := runner.backendExecute(context.Background(), tt.task, tt.executionPath, ExecuteOptions{
+				Prompt: "test prompt",
+				TaskID: tt.task.ID,
+			})
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !errors.Is(err, ErrProjectPathNotIsolated) {
+					t.Errorf("expected ErrProjectPathNotIsolated, got: %v", err)
+				}
+			} else if err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+
+			if backend.called != tt.wantCalled {
+				t.Errorf("backend.called = %v, want %v", backend.called, tt.wantCalled)
+			}
+
+			if tt.wantCalled && backend.gotProjectPath != tt.executionPath {
+				t.Errorf("backend received ProjectPath %q, want %q", backend.gotProjectPath, tt.executionPath)
+			}
+		})
+	}
+}
+
+// TestRunner_BackendExecute_SetsProjectPathAuthoritatively verifies that
+// backendExecute always assigns opts.ProjectPath from the executionPath
+// argument, ignoring whatever the caller populated in the ExecuteOptions
+// literal — the structural half of the GH-4703 fix. A call site can no
+// longer pass a stale or incorrect ProjectPath in the literal and have it
+// silently win.
+func TestRunner_BackendExecute_SetsProjectPathAuthoritatively(t *testing.T) {
+	backend := &guardRecordingBackend{}
+	runner := NewRunnerWithBackend(backend)
+	runner.config = &BackendConfig{UseWorktree: false}
+	runner.SetSkipPreflightChecks(true)
+	runner.SetRecordingEnabled(false)
+
+	task := &Task{ID: "GH-4703-f", ProjectPath: "/repo/root"}
+
+	_, err := runner.backendExecute(context.Background(), task, "/repo/.worktrees/expected", ExecuteOptions{
+		Prompt:      "test prompt",
+		TaskID:      task.ID,
+		ProjectPath: "/some/stale/path-a-call-site-mistakenly-set",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if backend.gotProjectPath != "/repo/.worktrees/expected" {
+		t.Errorf("backend received ProjectPath %q, want the executionPath argument to win", backend.gotProjectPath)
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -721,6 +721,12 @@ type SubIssueLinker interface {
 // progress tracking, PR creation, and execution recording. Runner is safe for
 // concurrent use and tracks all running tasks for cancellation support.
 type Runner struct {
+	// backend is the AI execution backend. GH-4703: do not call
+	// r.backend.Execute(...) directly outside of backendExecute
+	// (backend_execute_guard.go) — that wrapper is the single chokepoint
+	// that assigns ExecuteOptions.ProjectPath and guards against it
+	// silently collapsing to task.ProjectPath when worktree isolation was
+	// expected. A direct r.backend.Execute call bypasses that guard.
 	backend                Backend // AI execution backend
 	config                 *BackendConfig
 	onProgress             ProgressCallback
@@ -3280,10 +3286,9 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 
 	watchdogTimeout := 2 * timeout
 	allowedTools, mcpConfigPath := r.executionToolOptions()
-	backendResult, err := r.backend.Execute(stallExecutionCtx, ExecuteOptions{
+	backendResult, err := r.backendExecute(stallExecutionCtx, task, executionPath, ExecuteOptions{
 		Prompt:          prompt,
 		TaskID:          task.ID,
-		ProjectPath:     executionPath, // Use worktree path if active
 		Verbose:         task.Verbose,
 		Model:           selectedModel,
 		Effort:          selectedEffort,
@@ -3634,10 +3639,9 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 						r.reportProgress(task.ID, "Re-executing", 55, fmt.Sprintf("Retry attempt %d with %v timeout...", state.smartRetryAttempt, retryTimeout))
 
 						smartAllowed, smartMCP := r.executionToolOptions()
-						retryResult, retryErr := r.backend.Execute(retryCtx, ExecuteOptions{
+						retryResult, retryErr := r.backendExecute(retryCtx, task, executionPath, ExecuteOptions{
 							Prompt:          prompt,
 							TaskID:          task.ID,
-							ProjectPath:     executionPath, // TASK-323: retry in the worktree, not the user's real repo
 							Verbose:         task.Verbose,
 							Model:           selectedModel,
 							Effort:          selectedEffort,
@@ -3999,10 +4003,9 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 
 				// Execute retry
 				noopRetryAllowed, noopRetryMCP := r.executionToolOptions()
-				retryResult, retryErr := r.backend.Execute(ctx, ExecuteOptions{
+				retryResult, retryErr := r.backendExecute(ctx, task, executionPath, ExecuteOptions{
 					Prompt:          retryPrompt,
 					TaskID:          task.ID,
-					ProjectPath:     executionPath, // TASK-323: retry in the worktree so CountNewCommits can see its commits
 					Verbose:         task.Verbose,
 					Model:           selectedModel,
 					Effort:          selectedEffort,
@@ -4361,10 +4364,9 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 
 					// Re-invoke backend with retry prompt
 					feedbackAllowed, feedbackMCP := r.executionToolOptions()
-					retryResult, retryErr := r.backend.Execute(ctx, ExecuteOptions{
+					retryResult, retryErr := r.backendExecute(ctx, task, executionPath, ExecuteOptions{
 						Prompt:         retryPrompt,
 						TaskID:         task.ID,
-						ProjectPath:    executionPath, // GH-3577: retry in the worktree, not the daemon's repo root
 						Verbose:        task.Verbose,
 						Model:          selectedModel,
 						Effort:         selectedEffort,
@@ -4644,10 +4646,9 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 					)
 
 					intentAllowed, intentMCP := r.executionToolOptions()
-					_, retryErr := r.backend.Execute(ctx, ExecuteOptions{
+					_, retryErr := r.backendExecute(ctx, task, executionPath, ExecuteOptions{
 						Prompt:         retryPrompt,
 						TaskID:         task.ID,
-						ProjectPath:    executionPath, // GH-3577: retry in the worktree, not the daemon's repo root
 						Verbose:        task.Verbose,
 						Model:          selectedModel,
 						Effort:         selectedEffort,
@@ -5474,10 +5475,9 @@ func (r *Runner) runSelfReview(ctx context.Context, task *Task, executionPath st
 	}
 
 	reviewAllowed, reviewMCP := r.executionToolOptions()
-	result, err := r.backend.Execute(reviewCtx, ExecuteOptions{
+	result, err := r.backendExecute(reviewCtx, task, executionPath, ExecuteOptions{
 		Prompt:          reviewPrompt,
 		TaskID:          task.ID,
-		ProjectPath:     executionPath, // GH-4702: review the worktree, not the daemon's repo root
 		Verbose:         task.Verbose,
 		Model:           selectedModel,
 		Effort:          selectedEffort,


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4703.

Closes #4703

## Changes

GitHub Issue GH-4703: refactor(executor): centralize backend.Execute behind a path-identity guard — make worktree routing a structural invariant, not a per-call-site convention

## Context

The "ExecuteOptions.ProjectPath must be executionPath, not task.ProjectPath" invariant has now been violated and reactively patched **three times** (TASK-323 → runner.go:3402/:3759; GH-3577/PR#3580 → :4120/:4402; #4702 → :5226). Six call sites in runner.go build ExecuteOptions{ProjectPath: ...} by hand (runner.go:3049, 3402, 3759, 4120, 4402, 5223); each new call site re-decides the convention from memory, and the third miss cost a blocked rebuild and a phantom staged reimplementation in the shared root.

The codebase already has the right idiom for this: repo_guardrail.go's ValidateTargetRepo — a single chokepoint asserting repo identity before any gh issue create. This issue applies the same pattern to path identity.

## Acceptance

- All backend.Execute calls in runner.go route through one wrapper (e.g. r.backendExecute(ctx, task, executionPath, opts)) that returns a loud error — never a silent skip — when opts.ProjectPath == task.ProjectPath AND worktree isolation was expected (r.config.UseWorktree && task.Branch != "" && !task.DirectCommit).
- Explicit exception preserved: LocalMode/Q&A/CLI tasks (task.Branch == "" or task.DirectCommit) legitimately run root-scoped and must pass the guard.
- All 6 existing call sites migrated; direct backend.Execute use outside the wrapper flagged (lint note or code comment convention).
- Table-driven tests: guarded path with worktree expected (error), LocalMode exception (allowed), correct worktree path (allowed).

Blocked by: #4702

## Refs

- Chokepoint template: internal/executor/repo_guardrail.go (ValidateTargetRepo).
- Recurrence history: TASK-323, GH-3577/PR#3580, #4702.
- Known adjacent gap (out of scope, note only): LocalMode q-doc writes to root .agent/tasks/ (comms/handler.go:410) — intentional root-scoped tasks, but their doc side-effects in a shared checkout deserve their own look.