### PR TITLE
GH-4708: test(executor): ban argument-discarding mocks — CI grep check, fix 4 live offenders, PR-checklist rule (TASK-441 L1)

### DIFF
--- a/.agent/system/PR-CHECKLIST.md
+++ b/.agent/system/PR-CHECKLIST.md
@@ -12,6 +12,16 @@
 - [ ] Tests pass: `go test ./...`
 - [ ] Linter passes: `make lint`
 - [ ] No new warnings introduced
+- [ ] No argument-discarding mocks: `make check-mocks`. Test doubles that
+      stand in for an execution boundary (e.g. `Backend.Execute`) must
+      record the arguments they receive and the test must assert on them
+      (at minimum `ProjectPath` for `Backend.Execute`) — a mock whose
+      signature is `Execute(_ context.Context, _ ExecuteOptions)` certifies
+      nothing about the call. See
+      `internal/executor/backend_execute_guard_test.go`'s
+      `guardRecordingBackend` for the pattern. Exec boundaries (spawning
+      `claude`/`gh`) must stay stubbed in tests, never invoked for real —
+      see the `learn_test_suite_live_fire_ghost_issues` postmortem.
 
 ### CLI Flag Changes
 If PR adds/modifies CLI flags:
@@ -62,6 +72,9 @@ make test
 
 # Lint
 make lint
+
+# Argument-discarding mocks
+make check-mocks
 ```
 
 ## Before Approving

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,15 @@ jobs:
       - name: Check for realistic secret patterns in tests
         run: ./scripts/check-secret-patterns.sh
 
+  mock-contracts:
+    name: Check Argument-Discarding Mocks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for argument-discarding Backend.Execute mocks
+        run: ./scripts/check-mocks.sh
+
   graph-check:
     name: Knowledge Graph Drift Gate
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test test-e2e clean install lint fmt deps dev install-hooks check-secrets check-graph gate check-integration auto-fix test-short test-integration test-chaos test-wiring package release docker-build docker-push desktop-dev desktop-build desktop-build-windows desktop-build-linux desktop desktop-deps desktop-package desktop-dmg desktop-clean build-with-dashboard
+.PHONY: build run test test-e2e clean install lint fmt deps dev install-hooks check-secrets check-mocks check-graph gate check-integration auto-fix test-short test-integration test-chaos test-wiring package release docker-build docker-push desktop-dev desktop-build desktop-build-windows desktop-build-linux desktop desktop-deps desktop-package desktop-dmg desktop-clean build-with-dashboard
 
 # Variables
 BINARY_NAME=pilot
@@ -128,6 +128,10 @@ install-hooks:
 # Check for realistic secret patterns in test files
 check-secrets:
 	@./scripts/check-secret-patterns.sh
+
+# Check for argument-discarding Backend.Execute mocks in test files (TASK-441 L1 / GH-4708)
+check-mocks:
+	@./scripts/check-mocks.sh
 
 # Check knowledge-graph drift (graph.json vs .agent/knowledge/memories/ on disk)
 check-graph:
@@ -275,6 +279,7 @@ help:
 	@echo "  make install-global Install to /usr/local/bin"
 	@echo "  make install-hooks  Install git pre-commit/pre-push hooks"
 	@echo "  make check-secrets  Check for secret patterns in tests"
+	@echo "  make check-mocks    Check for argument-discarding Backend.Execute mocks"
 	@echo "  make check-graph    Check knowledge-graph drift (graph.json vs disk)"
 	@echo "  make check-integration  Check for orphan code"
 	@echo "  make gate           Run pre-push validation gate"

--- a/internal/executor/gh4517_test.go
+++ b/internal/executor/gh4517_test.go
@@ -210,18 +210,23 @@ func TestApplyGhostSHAGuardWithPreserve_RecordsExecutionEvent(t *testing.T) {
 // B8): the model edits files on disk and reports success, but never runs
 // `git commit`. Used to exercise the runner's other no-op classification
 // site — the GH-916 "no commits after retry" path in Execute — end to end.
+// It records the ProjectPath from each call — GH-4708 (TASK-441 L1): a mock
+// whose Execute discards its arguments certifies nothing about the seam it
+// stands in for.
 type mockDirtyBackend struct {
-	mu        sync.Mutex
-	dir       string
-	execCount int
+	mu             sync.Mutex
+	dir            string
+	execCount      int
+	gotProjectPath string
 }
 
 func (m *mockDirtyBackend) Name() string      { return "mock-dirty" }
 func (m *mockDirtyBackend) IsAvailable() bool { return true }
-func (m *mockDirtyBackend) Execute(_ context.Context, _ ExecuteOptions) (*BackendResult, error) {
+func (m *mockDirtyBackend) Execute(_ context.Context, opts ExecuteOptions) (*BackendResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.execCount++
+	m.gotProjectPath = opts.ProjectPath
 	content := fmt.Sprintf("package x // attempt %d\n", m.execCount)
 	if err := os.WriteFile(filepath.Join(m.dir, "implementation.go"), []byte(content), 0o644); err != nil {
 		return nil, err
@@ -284,8 +289,12 @@ func TestRunner_DirtyWorktreeAfterNoCommitRetry_AutoPreserved(t *testing.T) {
 
 	backend.mu.Lock()
 	count := backend.execCount
+	gotProjectPath := backend.gotProjectPath
 	backend.mu.Unlock()
 	if count != 2 {
 		t.Errorf("expected backend called 2 times (initial + retry), got %d", count)
+	}
+	if gotProjectPath != dir {
+		t.Errorf("backend received ProjectPath %q, want %q", gotProjectPath, dir)
 	}
 }

--- a/internal/executor/gh4677_test.go
+++ b/internal/executor/gh4677_test.go
@@ -17,18 +17,24 @@ import (
 // Used to prove a decomposed parent's retry never reaches direct
 // implementation of its own scope (GH-4648/GH-4649, TASK-437 item A) — if
 // the pre-planning ledger gate in executeWithOptions were bypassed, this
-// backend would be invoked for the parent's own task.
+// backend would be invoked for the parent's own task. It also records the
+// ProjectPath from each call — GH-4708 (TASK-441 L1): a mock whose Execute
+// discards its arguments certifies nothing about the seam it stands in for,
+// so if the gate ever regresses and this backend does get invoked, the
+// recorded path is available rather than silently discarded.
 type gh4677CountingBackend struct {
-	mu        sync.Mutex
-	execCount int
+	mu             sync.Mutex
+	execCount      int
+	gotProjectPath string
 }
 
 func (b *gh4677CountingBackend) Name() string      { return "gh4677-counting" }
 func (b *gh4677CountingBackend) IsAvailable() bool { return true }
-func (b *gh4677CountingBackend) Execute(_ context.Context, _ ExecuteOptions) (*BackendResult, error) {
+func (b *gh4677CountingBackend) Execute(_ context.Context, opts ExecuteOptions) (*BackendResult, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.execCount++
+	b.gotProjectPath = opts.ProjectPath
 	return &BackendResult{Success: true}, nil
 }
 

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -3992,6 +3992,9 @@ func TestExecuteWithOptions_EmptyModelNameLogsWarn(t *testing.T) {
 	if result.ModelName == "" {
 		t.Fatal("expected fallbackModelName() to populate ModelName")
 	}
+	if got := backend.lastProjectPath(); got != dir {
+		t.Errorf("backend received ProjectPath %q, want %q", got, dir)
+	}
 
 	logOutput := buf.String()
 	if !strings.Contains(logOutput, "Telemetry produced no model name") {
@@ -4002,20 +4005,32 @@ func TestExecuteWithOptions_EmptyModelNameLogsWarn(t *testing.T) {
 	}
 }
 
-// mockFixedBackend returns a fixed BackendResult for every Execute call and tracks count.
+// mockFixedBackend returns a fixed BackendResult for every Execute call and
+// tracks count. It also records the ProjectPath each call received — GH-4708
+// (TASK-441 L1): a mock whose Execute discards every argument certifies
+// nothing about what crossed the seam (the recurrence class behind
+// GH-4702/#4706/#4707's undetected runSelfReview bug).
 type mockFixedBackend struct {
-	mu        sync.Mutex
-	result    *BackendResult
-	execCount int
+	mu             sync.Mutex
+	result         *BackendResult
+	execCount      int
+	gotProjectPath string
 }
 
 func (m *mockFixedBackend) Name() string      { return "mock-fixed" }
 func (m *mockFixedBackend) IsAvailable() bool { return true }
-func (m *mockFixedBackend) Execute(_ context.Context, _ ExecuteOptions) (*BackendResult, error) {
+func (m *mockFixedBackend) Execute(_ context.Context, opts ExecuteOptions) (*BackendResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.execCount++
+	m.gotProjectPath = opts.ProjectPath
 	return m.result, nil
+}
+
+func (m *mockFixedBackend) lastProjectPath() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.gotProjectPath
 }
 
 // setupPRGuardRepo creates a temp git repo with an initial commit on main and
@@ -4105,6 +4120,9 @@ func TestRunner_PRCreate_EmptyBranch_TriggersRetry(t *testing.T) {
 	if count != 2 {
 		t.Errorf("Expected backend called 2 times (initial + retry), got %d", count)
 	}
+	if got := backend.lastProjectPath(); got != dir {
+		t.Errorf("backend received ProjectPath %q, want %q", got, dir)
+	}
 }
 
 // TestRunner_PRCreate_HasCommits_ProceedsToCreate verifies the GH-2743 guard
@@ -4167,6 +4185,9 @@ func TestRunner_PRCreate_HasCommits_ProceedsToCreate(t *testing.T) {
 	}
 	if !strings.Contains(result.Error, "recovery_ref=refs/pilot-recovery/GH-9998") {
 		t.Errorf("Expected recovery_ref in error, got: %q", result.Error)
+	}
+	if got := backend.lastProjectPath(); got != dir {
+		t.Errorf("backend received ProjectPath %q, want %q", got, dir)
 	}
 
 	// The recovery ref must actually exist in the repo and resolve to a commit,
@@ -4249,23 +4270,34 @@ func TestParseDeclinedReason(t *testing.T) {
 }
 
 // mockSequentialBackend returns different results per call index. GH-2777.
+// It records the ProjectPath from every call — GH-4708 (TASK-441 L1): a mock
+// whose Execute discards its arguments certifies nothing about the seam it
+// stands in for.
 type mockSequentialBackend struct {
-	mu      sync.Mutex
-	results []*BackendResult
-	idx     int
+	mu              sync.Mutex
+	results         []*BackendResult
+	idx             int
+	gotProjectPaths []string
 }
 
 func (m *mockSequentialBackend) Name() string      { return "mock-sequential" }
 func (m *mockSequentialBackend) IsAvailable() bool { return true }
-func (m *mockSequentialBackend) Execute(_ context.Context, _ ExecuteOptions) (*BackendResult, error) {
+func (m *mockSequentialBackend) Execute(_ context.Context, opts ExecuteOptions) (*BackendResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.gotProjectPaths = append(m.gotProjectPaths, opts.ProjectPath)
 	if m.idx >= len(m.results) {
 		return m.results[len(m.results)-1], nil
 	}
 	r := m.results[m.idx]
 	m.idx++
 	return r, nil
+}
+
+func (m *mockSequentialBackend) projectPaths() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.gotProjectPaths...)
 }
 
 // TestRunner_DECLINED_Path verifies that when the retry result contains a
@@ -4318,6 +4350,11 @@ func TestRunner_DECLINED_Path(t *testing.T) {
 	if strings.HasPrefix(result.Error, "no_changes:") {
 		t.Errorf("Declined task should not have no_changes error, got: %q", result.Error)
 	}
+	for i, got := range backend.projectPaths() {
+		if got != dir {
+			t.Errorf("call %d: backend received ProjectPath %q, want %q", i, got, dir)
+		}
+	}
 }
 
 // TestRunner_NoChanges_NoDecline verifies that when the retry response contains
@@ -4360,6 +4397,11 @@ func TestRunner_NoChanges_NoDecline(t *testing.T) {
 	}
 	if !strings.HasPrefix(result.Error, "no_changes:") {
 		t.Errorf("Expected no_changes error, got: %q", result.Error)
+	}
+	for i, got := range backend.projectPaths() {
+		if got != dir {
+			t.Errorf("call %d: backend received ProjectPath %q, want %q", i, got, dir)
+		}
 	}
 }
 
@@ -4531,6 +4573,10 @@ func TestMetricsRecorder_CalledOncePerExecution(t *testing.T) {
 	} else if rec.durationCalls[0] <= 0 {
 		t.Errorf("RecordExecutionDuration got %v, want positive duration", rec.durationCalls[0])
 	}
+
+	if got := backend.lastProjectPath(); got != dir {
+		t.Errorf("backend received ProjectPath %q, want %q", got, dir)
+	}
 }
 
 // TestMetricsRecorder_SkipsCanaryTask covers GH-4240: a task carrying the
@@ -4597,6 +4643,13 @@ func TestMetricsRecorder_SkipsCanaryTask(t *testing.T) {
 	}
 	if len(rec.durationCalls) != 0 {
 		t.Errorf("RecordExecutionDuration called %d times for canary task, want 0", len(rec.durationCalls))
+	}
+
+	// The canary exclusion applies to metrics recording only — the backend
+	// must still have executed against the real ProjectPath, not been
+	// silently skipped or redirected.
+	if got := backend.lastProjectPath(); got != dir {
+		t.Errorf("backend received ProjectPath %q, want %q", got, dir)
 	}
 }
 

--- a/scripts/check-mocks.sh
+++ b/scripts/check-mocks.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Ban argument-discarding Backend.Execute mocks in test files.
+#
+# Incident: GH-4702/#4706/#4707 — mockSelfReviewBackend.Execute(_
+# context.Context, _ ExecuteOptions) discarded every argument it received,
+# so no test could ever have caught the runSelfReview path-identity bug
+# (self-review ran against the daemon's shared repo root instead of the
+# worktree, undetected for months). Root-caused and fixed in TASK-441 Leg 1
+# (GH-4708).
+#
+# A test double that receives a call across the Backend.Execute seam and
+# immediately throws every argument away certifies nothing about the call —
+# it can pass whether the caller sent the right ProjectPath or a completely
+# wrong one. See internal/executor/backend_execute_guard_test.go's
+# guardRecordingBackend for the pattern to use instead: record what crossed
+# the seam, assert on it.
+#
+# Scope: deliberately narrow to the Backend interface's Execute(ctx
+# context.Context, opts ExecuteOptions) shape (internal/executor/backend.go),
+# not "any mock method with discarded params" — the codebase has many
+# legitimate fixed-response test doubles (fake stores, fake classifiers,
+# error-injection stubs) where the caller's input genuinely doesn't matter
+# to the test's assertion. The Backend.Execute seam is different: it is the
+# exact chokepoint TASK-323/GH-3577/GH-4702/GH-4703 all recurred at, where
+# *what* crosses the seam (particularly ProjectPath) is the thing under
+# test. Broadening this check would produce false positives against dozens
+# of unrelated, correct test doubles and train contributors to ignore it.
+#
+# Used by CI (.github/workflows/ci.yml step: "Check Argument-Discarding
+# Mocks") and by `make check-mocks`.
+
+set -e
+
+echo "Scanning *_test.go files for argument-discarding Backend.Execute mocks..."
+
+# Matches a method with a receiver named Execute whose entire parameter
+# list is "_ context.Context, _ ExecuteOptions" — i.e. both parameters of
+# the Backend.Execute seam are discarded.
+PATTERN='func \([a-zA-Z0-9_]+ \*?[A-Za-z0-9_]+\) Execute\(_ context\.Context, _ ExecuteOptions\)'
+
+MATCHES=$(git ls-files '*_test.go' | xargs grep -HnE "$PATTERN" 2>/dev/null || true)
+
+if [ -n "$MATCHES" ]; then
+    echo ""
+    echo "❌ ERROR: found Backend.Execute mock(s) that discard every argument"
+    echo ""
+    echo "$MATCHES"
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "CI CHECK FAILED: argument-discarding Backend.Execute mock(s)"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+    echo "A mock's Execute(_ context.Context, _ ExecuteOptions) certifies"
+    echo "nothing about the call it received — it cannot catch bugs in what"
+    echo "crosses the seam (wrong ProjectPath, wrong options). This is how"
+    echo "the GH-4702 runSelfReview bug survived undetected for months."
+    echo ""
+    echo "Fix: name the second parameter, record what you care about, and"
+    echo "assert on it in the test. See"
+    echo "internal/executor/backend_execute_guard_test.go's"
+    echo "guardRecordingBackend for the pattern:"
+    echo ""
+    echo "  func (b *fooBackend) Execute(_ context.Context, opts ExecuteOptions) (*BackendResult, error) {"
+    echo "      b.gotProjectPath = opts.ProjectPath"
+    echo "      return &BackendResult{Success: true}, nil"
+    echo "  }"
+    echo ""
+    echo "...and in the test:"
+    echo "  if backend.gotProjectPath != wantPath {"
+    echo "      t.Errorf(\"backend received ProjectPath %q, want %q\", backend.gotProjectPath, wantPath)"
+    echo "  }"
+    echo ""
+    exit 1
+fi
+
+echo "✓ No argument-discarding Backend.Execute mocks found"
+exit 0

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -119,15 +119,26 @@ else
 fi
 echo ""
 
-# 5. KNOWLEDGE GRAPH
-echo -e "${BLUE}[5/6] Knowledge Graph${NC}"
+# 5. MOCKS
+echo -e "${BLUE}[5/7] Argument-Discarding Mocks${NC}"
+if [ -x "$SCRIPT_DIR/check-mocks.sh" ]; then
+    if ! run_check "check-mocks" "$SCRIPT_DIR/check-mocks.sh"; then
+        FAILURES=$((FAILURES + 1))
+    fi
+else
+    echo -e "  [check-mocks] ${YELLOW}skipped (script not found)${NC}"
+fi
+echo ""
+
+# 6. KNOWLEDGE GRAPH
+echo -e "${BLUE}[6/7] Knowledge Graph${NC}"
 if ! run_check "check-graph" "python3 $SCRIPT_DIR/check-graph.py"; then
     FAILURES=$((FAILURES + 1))
 fi
 echo ""
 
-# 6. INTEGRATION
-echo -e "${BLUE}[6/6] Integration${NC}"
+# 7. INTEGRATION
+echo -e "${BLUE}[7/7] Integration${NC}"
 if [ -x "$SCRIPT_DIR/check-integration.sh" ]; then
     if ! run_check "integration" "$SCRIPT_DIR/check-integration.sh"; then
         FAILURES=$((FAILURES + 1))


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4708.

Closes #4708

## Changes

GitHub Issue GH-4708: test(executor): ban argument-discarding mocks — CI grep check, fix 4 live offenders, PR-checklist rule (TASK-441 L1)

## Context

TASK-441 Leg 1 (`.agent/tasks/TASK-441-contract-hardening-tune-up.md`). This week's runSelfReview incident (GH-4702→#4706/#4707) survived undetected for months because its test double discards what crosses the seam: `mockSelfReviewBackend.Execute(_ context.Context, _ ExecuteOptions)` (`internal/executor/runner_test.go:3209`) certifies nothing about the call. Three more live offenders: `mockFixedBackend`, `mockSequentialBackend` (both `runner_test.go`), `mockDirtyBackend` (`internal/executor/gh4517_test.go`). The antidote pattern already exists in-tree: `guardRecordingBackend` (`internal/executor/backend_execute_guard_test.go`) records `gotProjectPath` and asserts it.

Prior-incident constraint (memory `learn_test_suite_live_fire_ghost_issues`): tests once live-fired real GitHub issues via unstubbed exec boundaries — any mock fix here must keep the exec boundary stubbed, never spawn real `claude`/`gh`.

## Acceptance

- A `make` target (e.g. `make check-mocks`, wired into CI alongside existing checks) fails on any `*_test.go` mock method whose parameters are all `_` (start with the `Execute(_ context.Context, _ ExecuteOptions)` shape; grep-based, no new tooling deps).
- The 4 offenders record their received arguments and their tests assert at minimum `ProjectPath` (modeled on `guardRecordingBackend`).
- `.agent/system/PR-CHECKLIST.md` gains the rule: test doubles must record + assert seam arguments; exec boundaries stubbed.
- A planted all-underscore mock in a scratch test fails the check (prove it in the PR description).
- `make build && make test && make lint` green.

## Implementation

- New script under `scripts/` + Makefile target, mirroring the `check-secrets` idiom.
- Fix the 4 mocks; strengthen their tests' assertions.
- Constraint: **no external contract changes** (no metric renames, no config schema, no label changes) — this leg is tests + CI + docs only.

## Refs

- Task doc: `.agent/tasks/TASK-441-contract-hardening-tune-up.md` (Leg 1)
- Pattern: `internal/executor/backend_execute_guard_test.go` · Incident: GH-4702/GH-4707