### PR TITLE
GH-4717: feat(linear): post 'Pilot started' comment at SDK dispatch — wire linearSDK Notifier per workspace (notify-started audit)

### DIFF
--- a/.agent/system/notify-started-adapter-audit.md
+++ b/.agent/system/notify-started-adapter-audit.md
@@ -32,7 +32,7 @@ dispatch-correctness gap. Sized S–M below.
 
 | Adapter | Status mechanism(s) | Poller auto-labels on dispatch? | GH-4692-class (label/dedup) gap? | Notify-started comment wired? | Gap | Size |
 |---|---|---|---|---|---|---|
-| Linear | label (`pilot-in-progress`, SDK-managed) | Yes | No | No | comment-only | S |
+| Linear | label (`pilot-in-progress`, SDK-managed) | Yes | No | **Yes** (GH-4717, `poller_linear.go`) | none | — |
 | Jira | label (SDK-managed) **+** native workflow-status transition | Yes (label only) | No | No | comment + status transition | M |
 | Asana | tag (`pilot-in-progress`, SDK-managed) | Yes | No | No | comment-only | S |
 | Plane | label (SDK-managed) **+** native issue-state transition | Yes (label; state via `startedStateIDs`) | No | **Yes** (GH-2132, `poller_plane.go:58`) | none | — |
@@ -41,7 +41,7 @@ dispatch-correctness gap. Sized S–M below.
 
 ## Per-adapter detail
 
-### Linear — `handleLinearIssueWithResult` (`cmd/pilot/handlers.go:124`)
+### Linear — `handleLinearIssueWithResult` (`cmd/pilot/handlers.go:124`) — **fixed, GH-4717**
 
 - **Status mechanism**: label only. `linear.Config.TriggerLabel`/workspace `PilotLabel`
   (`cmd/pilot/poller_linear.go:33-45`) drives an SDK-internal `pilot-in-progress` label.
@@ -60,17 +60,17 @@ dispatch-correctness gap. Sized S–M below.
   (SDK-native, same shape as the `planeSDK.NewNotifier` GH-2132 used) — both dead with respect to
   being invoked from `cmd/pilot`, confirmed via `grep -rn "NotifyTaskStarted(ctx" cmd/`, which
   only matches `handlers.go:889` (the GH-4692 GitHub path).
-- **Gap**: no "Pilot started working on this issue" comment ever posts to the Linear issue.
-  Label-driven orphan recovery and dashboard status are unaffected.
-- **Fix shape (S)**: mirror `poller_plane.go:56-63` — construct
-  `linearSDK.NewNotifier(linearClient)` once per workspace inside
-  `linearPollerRegistration().CreateAndStart`, call `NotifyTaskStarted(issueCtx, ev.IssueID,
-  ev.SequenceID)` before `handleLinearIssueWithResult(...)`, WARN-log (non-fatal) on error. Test:
-  httptest fake covering the comment POST + a source-inspection "wiring order" test
-  (`TestLinearHandlerSDK_NotifyTaskStartedWired`-shaped), mirroring
-  `cmd/pilot/github_sdk_notify_started_test.go`'s two-test pattern. Per-workspace multiplicity
-  (Linear supports multiple workspaces, `GetWorkspaces()`) means the notifier must be built
-  per-workspace client, not once globally — check `sdkWorkspaces` loop at `poller_linear.go:32-51`.
+- **Gap (closed)**: no "Pilot started working on this issue" comment ever posted to the Linear
+  issue. Fixed by GH-4717: `linearPollerRegistration().CreateAndStart`
+  (`cmd/pilot/poller_linear.go`) now builds one `linearSDK.NewNotifier(linearSDK.NewClient(ws.APIKey))`
+  per workspace, keyed by team ID, inside the existing `sdkWorkspaces` loop, and the
+  `sdkcore.IssueHandlerFunc` closure calls `notifier.NotifyTaskStarted(issueCtx, ev.IssueID,
+  ev.SequenceID)` (selecting the workspace notifier via `ev.ProjectID`, which the SDK's
+  `toIssueEvent` populates with the issue's Linear team ID) before
+  `handleLinearIssueWithResult(...)`, WARN-logging (non-fatal) on error. Tests:
+  `cmd/pilot/linear_sdk_notify_started_test.go` (httptest fake over the `commentCreate` mutation +
+  two source-inspection wiring tests). Label-driven orphan recovery and dashboard status were
+  already unaffected by this gap.
 
 ### Jira — `handleJiraSDKIssueWithResult` (`cmd/pilot/handlers.go:192`)
 
@@ -222,7 +222,7 @@ dispatch-correctness gap. Sized S–M below.
 
 ## Recommended fix shape, in general (mirrors GH-4692 / GH-2132)
 
-For each of the five real gaps (Linear, Jira, Asana, GitLab, AzureDevOps):
+For each of the remaining four gaps (Jira, Asana, GitLab, AzureDevOps — Linear closed by GH-4717):
 
 1. Construct the adapter's SDK-native `Notifier` (`{adapter}SDK.NewNotifier(client, ...)`) once
    inside that adapter's `*PollerRegistration().CreateAndStart` closure in `cmd/pilot/poller_*.go`
@@ -248,5 +248,6 @@ For each of the five real gaps (Linear, Jira, Asana, GitLab, AzureDevOps):
    `processIssueAsync`/`processWorkItemAsync` already manages structurally. No recommendation in
    this doc touches that mechanism.
 
-Estimated total: 4×S + 1×M across five PRs (one per adapter, matching the existing one-PR-per-
-adapter granularity of GH-4692/GH-2132), no shared blocking dependency between them.
+Estimated total: 3×S + 1×M across four remaining PRs (one per adapter, matching the existing
+one-PR-per-adapter granularity of GH-4692/GH-2132), no shared blocking dependency between them.
+Linear (S) shipped as GH-4717.

--- a/cmd/pilot/linear_sdk_notify_started_test.go
+++ b/cmd/pilot/linear_sdk_notify_started_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	linearSDK "github.com/qf-studio/studio-sdk/sdk/integrations/linear"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// notifyStartedLinearFake is a minimal mock Linear GraphQL server covering the
+// single POST NotifyTaskStarted makes (commentCreate mutation). Can be
+// configured to fail, to exercise the non-fatal error path.
+type notifyStartedLinearFake struct {
+	server        *httptest.Server
+	mu            sync.Mutex
+	commentsAdded []string
+	fail          bool
+}
+
+func newNotifyStartedLinearFake() *notifyStartedLinearFake {
+	f := &notifyStartedLinearFake{}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		var reqBody struct {
+			Query     string                 `json:"query"`
+			Variables map[string]interface{} `json:"variables"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&reqBody)
+
+		if !strings.Contains(reqBody.Query, "commentCreate") {
+			_, _ = w.Write([]byte(`{"data":{}}`))
+			return
+		}
+
+		f.mu.Lock()
+		fail := f.fail
+		f.mu.Unlock()
+		if fail {
+			_, _ = w.Write([]byte(`{"errors":[{"message":"injected comment failure"}]}`))
+			return
+		}
+
+		body, _ := reqBody.Variables["body"].(string)
+		f.mu.Lock()
+		f.commentsAdded = append(f.commentsAdded, body)
+		f.mu.Unlock()
+		_, _ = w.Write([]byte(`{"data":{"commentCreate":{"success":true}}}`))
+	}))
+	return f
+}
+
+// TestNotifyTaskStartedLinearSDK is the GH-4717 acceptance test: the SDK
+// notifier's NotifyTaskStarted call posts a "Pilot started" comment on
+// success, and surfaces (not swallows) the underlying error on failure so the
+// caller can log it as a non-fatal WARN. Before GH-4717 no dispatch path ever
+// called this — the SDK-native Notifier (studio-sdk/sdk/integrations/linear)
+// was tested but wired to nothing in production.
+func TestNotifyTaskStartedLinearSDK(t *testing.T) {
+	tests := []struct {
+		name    string
+		fail    bool
+		wantErr bool
+	}{
+		{
+			name:    "success posts started comment",
+			wantErr: false,
+		},
+		{
+			name:    "comment failure surfaces as an error, not a panic",
+			fail:    true,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newNotifyStartedLinearFake()
+			defer f.server.Close()
+			f.fail = tt.fail
+
+			client := linearSDK.NewClientWithBaseURL(testutil.FakeLinearAPIKey, f.server.URL)
+			notifier := linearSDK.NewNotifier(client)
+
+			err := notifier.NotifyTaskStarted(context.Background(), "issue-1", "APP-42")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NotifyTaskStarted() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			gotComment := len(f.commentsAdded) > 0
+			wantComment := !tt.wantErr
+			if gotComment != wantComment {
+				t.Errorf("comment posted = %v, want %v (commentsAdded = %v)", gotComment, wantComment, f.commentsAdded)
+			}
+		})
+	}
+}
+
+// TestLinearPollerRegistration_NotifyTaskStartedWired is a source-level guard
+// proving linearPollerRegistration's CreateAndStart calls
+// notifier.NotifyTaskStarted( on the dispatch path before
+// handleLinearIssueWithResult, and that a notify failure is only logged
+// (WARN) rather than aborting dispatch — mirroring the established
+// source-inspection pattern for otherwise-unexercisable closures (see
+// TestGithubHandlerSDK_NotifyTaskStartedWired).
+func TestLinearPollerRegistration_NotifyTaskStartedWired(t *testing.T) {
+	body := githubFuncBody(t, "poller_linear.go", "func linearPollerRegistration() PollerRegistration {")
+
+	if !strings.Contains(body, "NotifyTaskStarted(") {
+		t.Error("linearPollerRegistration must call notifier.NotifyTaskStarted to post the started comment on the SDK-dispatch path (GH-4717)")
+	}
+
+	notifyIdx := strings.Index(body, "NotifyTaskStarted(")
+	handleIdx := strings.Index(body, "handleLinearIssueWithResult(issueCtx")
+	if notifyIdx < 0 || handleIdx < 0 || notifyIdx >= handleIdx {
+		t.Error("NotifyTaskStarted must be called before handleLinearIssueWithResult so the comment posts at the start of work")
+	}
+
+	// The error must be logged, not propagated — a comment failure must
+	// never block dispatch (mirrors the Plane/GitHub SDK notify patterns).
+	if !strings.Contains(body, `logging.WithComponent("linear").Warn("Failed to notify task started"`) {
+		t.Error("NotifyTaskStarted errors must be logged as a non-fatal WARN, not propagated")
+	}
+}
+
+// TestLinearPollerRegistration_NotifierPerWorkspace is a source-level guard
+// proving the notifier is built per workspace (keyed by team ID), not as a
+// single global notifier — Linear supports multiple workspaces, each with
+// its own API key.
+func TestLinearPollerRegistration_NotifierPerWorkspace(t *testing.T) {
+	body := githubFuncBody(t, "poller_linear.go", "func linearPollerRegistration() PollerRegistration {")
+
+	if !strings.Contains(body, "notifiersByTeamID[ws.TeamID] = linearSDK.NewNotifier(linearSDK.NewClient(ws.APIKey))") {
+		t.Error("linearPollerRegistration must construct one SDK notifier per workspace client, keyed by team ID, inside the sdkWorkspaces loop")
+	}
+}

--- a/cmd/pilot/poller_linear.go
+++ b/cmd/pilot/poller_linear.go
@@ -26,9 +26,15 @@ func linearPollerRegistration() PollerRegistration {
 				interval = deps.Cfg.Adapters.Linear.Polling.Interval
 			}
 
-			// Map internal workspace configs → SDK workspace configs.
+			// Map internal workspace configs → SDK workspace configs, and
+			// build one SDK-native notifier per workspace (GH-4717). Linear
+			// supports multiple workspaces, each authenticating with its own
+			// API key, so a single global notifier/client would silently
+			// post every workspace's "started" comment using just one
+			// workspace's credentials.
 			internalWss := deps.Cfg.Adapters.Linear.GetWorkspaces()
 			sdkWorkspaces := make([]*linearSDK.WorkspaceConfig, 0, len(internalWss))
+			notifiersByTeamID := make(map[string]*linearSDK.Notifier, len(internalWss))
 			for _, ws := range internalWss {
 				triggerLabel := ws.PilotLabel
 				if triggerLabel == "" {
@@ -48,6 +54,7 @@ func linearPollerRegistration() PollerRegistration {
 						Interval: wsInterval,
 					},
 				})
+				notifiersByTeamID[ws.TeamID] = linearSDK.NewNotifier(linearSDK.NewClient(ws.APIKey))
 			}
 
 			sdkCfg := &linearSDK.Config{
@@ -61,6 +68,22 @@ func linearPollerRegistration() PollerRegistration {
 
 			pollerDeps := sdkcore.PollerDeps{
 				Handler: sdkcore.IssueHandlerFunc(func(issueCtx context.Context, ev sdkcore.IssueEvent) (*sdkcore.IssueResult, error) {
+					// GH-4717: notify Linear the task has started, mirroring
+					// GH-2132's Plane wiring (poller_plane.go). ev.ProjectID
+					// carries the Linear team ID for this adapter (see
+					// linearSDK's toIssueEvent), which selects the
+					// per-workspace notifier authenticated with that
+					// workspace's own API key. Failure is WARN-logged only —
+					// a comment failure must never abort dispatch.
+					if notifier := notifiersByTeamID[ev.ProjectID]; notifier != nil {
+						if err := notifier.NotifyTaskStarted(issueCtx, ev.IssueID, ev.SequenceID); err != nil {
+							logging.WithComponent("linear").Warn("Failed to notify task started",
+								slog.String("issue_id", ev.IssueID),
+								slog.Any("error", err),
+							)
+						}
+					}
+
 					return handleLinearIssueWithResult(issueCtx, deps.Cfg, ev, deps.ProjectPath, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
 				}),
 			}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4717.

Closes #4717

## Changes

GitHub Issue GH-4717: feat(linear): post 'Pilot started' comment at SDK dispatch — wire linearSDK Notifier per workspace (notify-started audit)

## Context

Audit `.agent/system/notify-started-adapter-audit.md` (TASK-441 L3, PR#4713): the Linear SDK poller auto-labels `pilot-in-progress` internally (`studio-sdk/sdk/integrations/linear/poller.go:309-310`), so orphan recovery and dedup are safe — **no GH-4692-class bug**. But no "🤖 Pilot started working on this" comment ever posts to the Linear issue: `handleLinearIssueWithResult` (`cmd/pilot/handlers.go:124`) and `poller_linear.go`'s `CreateAndStart` closure (`:63-65`) never call any `NotifyTaskStarted`. The SDK-native notifier (`studio-sdk/sdk/integrations/linear/notifier.go:22`) exists, is tested, and is dead in production.

## Acceptance

- `linearSDK.NewNotifier(client)` constructed **per workspace** inside `linearPollerRegistration().CreateAndStart` (Linear supports multiple workspaces — see the `sdkWorkspaces` loop at `poller_linear.go:32-51`; one notifier per workspace client, not one global).
- `notifier.NotifyTaskStarted(issueCtx, ev.IssueID, ev.SequenceID)` called **before** `handleLinearIssueWithResult(...)`, inside the handler closure — exactly where `poller_plane.go:56-63` (GH-2132) does it.
- Failure is WARN-logged, never propagated — dispatch must not abort on a comment failure (pattern: `notifyTaskStartedSDK`, `cmd/pilot/handlers.go:888-905`).
- Use the SDK-native notifier, **not** `internal/adapters/linear/notifier.go` (dead in-tree code).
- **Additive only** (saas-architecture correction #5): no change to the SDK-managed label mechanism.
- Tests mirroring `cmd/pilot/github_sdk_notify_started_test.go`: `httptest` fake covering the comment POST (never live creds), plus a source-inspection wiring-order test proving `NotifyTaskStarted(` precedes the handler call and errors are WARN-logged.

## Implementation

- `cmd/pilot/poller_linear.go` — notifier construction + call in the closure. No handler-signature changes expected.

## Refs

- Audit: `.agent/system/notify-started-adapter-audit.md` § Linear
- Pattern precedents: GH-4692 (GitHub) · GH-2132 (Plane, `poller_plane.go:56-63`)