### PR TITLE
GH-4718: feat(jira): wire jiraSDK Notifier at dispatch — start comment + native workflow transition; closes dead Transitions config (notify-started audit)

### DIFF
--- a/cmd/pilot/jira_sdk_notify_started_test.go
+++ b/cmd/pilot/jira_sdk_notify_started_test.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	jiraSDK "github.com/qf-studio/studio-sdk/sdk/integrations/jira"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// notifyStartedJiraFake is a minimal mock Jira Cloud server covering the two
+// calls NotifyTaskStarted can make: POST .../transitions (workflow status
+// change) and POST .../comment (start comment). GET .../transitions backs the
+// SDK's by-name fallback lookup when no transition ID is configured. Either
+// endpoint can be configured to fail, to exercise the non-fatal error paths.
+type notifyStartedJiraFake struct {
+	server           *httptest.Server
+	mu               sync.Mutex
+	transitionCalled bool
+	commentsAdded    []string
+	failTransition   bool
+	failComment      bool
+	// transitionsAvailable seeds the GET .../transitions response used by the
+	// SDK's by-name fallback (empty transitions.in_progress config).
+	transitionsAvailable []jiraSDK.Transition
+}
+
+func newNotifyStartedJiraFake() *notifyStartedJiraFake {
+	f := &notifyStartedJiraFake{}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/transitions"):
+			f.mu.Lock()
+			transitions := f.transitionsAvailable
+			f.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(jiraSDK.TransitionsResponse{Transitions: transitions})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/transitions"):
+			f.mu.Lock()
+			fail := f.failTransition
+			f.mu.Unlock()
+			if fail {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"errorMessages":["injected transition failure"]}`))
+				return
+			}
+			f.mu.Lock()
+			f.transitionCalled = true
+			f.mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/comment"):
+			f.mu.Lock()
+			fail := f.failComment
+			f.mu.Unlock()
+			if fail {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"errorMessages":["injected comment failure"]}`))
+				return
+			}
+			var reqBody map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&reqBody)
+			f.mu.Lock()
+			f.commentsAdded = append(f.commentsAdded, r.URL.Path)
+			f.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(jiraSDK.Comment{ID: "1"})
+		default:
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	return f
+}
+
+// TestNotifyTaskStartedJiraSDK is the GH-4718 table-driven acceptance test:
+// the SDK-native Notifier's NotifyTaskStarted call posts a "Pilot started"
+// comment and (when an in_progress transition ID is configured) transitions
+// the issue's native workflow status. A transition failure must never block
+// the comment attempt (or vice versa) — degrade gracefully per surface. Before
+// GH-4718 no dispatch path ever called this, and the SDK config's Transitions
+// field was plumbed but never read by any constructed Notifier (dead wiring).
+func TestNotifyTaskStartedJiraSDK(t *testing.T) {
+	tests := []struct {
+		name           string
+		inProgress     string
+		failTransition bool
+		failComment    bool
+		wantErr        bool
+		wantComment    bool
+		wantTransition bool
+	}{
+		{
+			name:           "success transitions and posts comment",
+			inProgress:     "21",
+			wantErr:        false,
+			wantComment:    true,
+			wantTransition: true,
+		},
+		{
+			name:           "transition failure does not block the comment and is not returned",
+			inProgress:     "21",
+			failTransition: true,
+			wantErr:        false,
+			wantComment:    true,
+			wantTransition: false,
+		},
+		{
+			name:           "comment failure surfaces as an error",
+			inProgress:     "21",
+			failComment:    true,
+			wantErr:        true,
+			wantComment:    false,
+			wantTransition: true,
+		},
+		{
+			name:           "no transition configured is not an error — comment only",
+			inProgress:     "",
+			wantErr:        false,
+			wantComment:    true,
+			wantTransition: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newNotifyStartedJiraFake()
+			defer f.server.Close()
+			f.failTransition = tt.failTransition
+			f.failComment = tt.failComment
+
+			client := jiraSDK.NewClient(f.server.URL, testutil.FakeJiraUsername, testutil.FakeJiraAPIToken, jiraSDK.PlatformCloud)
+			notifier := jiraSDK.NewNotifier(client, tt.inProgress, "")
+
+			err := notifier.NotifyTaskStarted(context.Background(), "PROJ-42", "JIRA-PROJ-42")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NotifyTaskStarted() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			gotComment := len(f.commentsAdded) > 0
+			if gotComment != tt.wantComment {
+				t.Errorf("comment posted = %v, want %v (commentsAdded = %v)", gotComment, tt.wantComment, f.commentsAdded)
+			}
+			if f.transitionCalled != tt.wantTransition {
+				t.Errorf("transition applied = %v, want %v", f.transitionCalled, tt.wantTransition)
+			}
+		})
+	}
+}
+
+// TestJiraPollerRegistration_NotifyTaskStartedWired is a source-level guard
+// proving jiraPollerRegistration's CreateAndStart calls
+// notifier.NotifyTaskStarted( on the dispatch path before
+// handleJiraSDKIssueWithResult, and that a notify failure is only logged
+// (WARN) rather than aborting dispatch — mirroring the established
+// source-inspection pattern (see TestLinearPollerRegistration_NotifyTaskStartedWired).
+func TestJiraPollerRegistration_NotifyTaskStartedWired(t *testing.T) {
+	body := githubFuncBody(t, "poller_jira.go", "func jiraPollerRegistration() PollerRegistration {")
+
+	if !strings.Contains(body, "NotifyTaskStarted(") {
+		t.Error("jiraPollerRegistration must call notifier.NotifyTaskStarted to post the started comment and transition on the SDK-dispatch path (GH-4718)")
+	}
+
+	notifyIdx := strings.Index(body, "NotifyTaskStarted(")
+	handleIdx := strings.Index(body, "handleJiraSDKIssueWithResult(issueCtx")
+	if notifyIdx < 0 || handleIdx < 0 || notifyIdx >= handleIdx {
+		t.Error("NotifyTaskStarted must be called before handleJiraSDKIssueWithResult so the comment/transition happen at the start of work")
+	}
+
+	// The error must be logged, not propagated — a notify failure must never
+	// block dispatch (mirrors the Linear/GitHub SDK notify patterns).
+	if !strings.Contains(body, `logging.WithComponent("jira").Warn("Failed to notify task started"`) {
+		t.Error("NotifyTaskStarted errors must be logged as a non-fatal WARN, not propagated")
+	}
+}
+
+// TestJiraPollerRegistration_NotifierWiredFromTransitionsConfig is a
+// source-level guard proving the notifier is constructed from a
+// package-level jiraSDK client (mirroring poller_gitlab.go's client
+// construction pattern) using cfg.Adapters.Jira.Transitions, closing the
+// notify-started audit's "dead config wiring" finding: sdkCfg.Transitions
+// was plumbed into jiraSDK.Config but never read by the SDK poller package —
+// the only consumer is jiraSDK.NewNotifier, which nothing constructed before
+// GH-4718.
+func TestJiraPollerRegistration_NotifierWiredFromTransitionsConfig(t *testing.T) {
+	body := githubFuncBody(t, "poller_jira.go", "func jiraPollerRegistration() PollerRegistration {")
+
+	if !strings.Contains(body, "jiraSDK.NewClient(") {
+		t.Error("jiraPollerRegistration must construct a jiraSDK client for the notifier, mirroring poller_gitlab.go's client-construction pattern")
+	}
+	if !strings.Contains(body, "jiraSDK.NewNotifier(") {
+		t.Error("jiraPollerRegistration must construct a jiraSDK.Notifier")
+	}
+	if !strings.Contains(body, "deps.Cfg.Adapters.Jira.Transitions.InProgress") || !strings.Contains(body, "deps.Cfg.Adapters.Jira.Transitions.Done") {
+		t.Error("jiraSDK.NewNotifier must be wired from cfg.Adapters.Jira.Transitions.InProgress/.Done, not left unused")
+	}
+}

--- a/cmd/pilot/poller_jira.go
+++ b/cmd/pilot/poller_jira.go
@@ -47,8 +47,39 @@ func jiraPollerRegistration() PollerRegistration {
 			sdkCfg.Transitions.InProgress = deps.Cfg.Adapters.Jira.Transitions.InProgress
 			sdkCfg.Transitions.Done = deps.Cfg.Adapters.Jira.Transitions.Done
 
+			// Separate client + notifier for the start comment / native
+			// workflow transition (GH-4718). sdkCfg.Transitions is plumbed
+			// above but never read by the SDK poller package itself — the
+			// only consumer is jiraSDK.NewNotifier, so without constructing
+			// it here the config field was dead wiring (notify-started audit).
+			jiraClient := jiraSDK.NewClient(
+				deps.Cfg.Adapters.Jira.BaseURL,
+				deps.Cfg.Adapters.Jira.Username,
+				deps.Cfg.Adapters.Jira.APIToken,
+				deps.Cfg.Adapters.Jira.Platform,
+			)
+			notifier := jiraSDK.NewNotifier(
+				jiraClient,
+				deps.Cfg.Adapters.Jira.Transitions.InProgress,
+				deps.Cfg.Adapters.Jira.Transitions.Done,
+			)
+
 			pollerDeps := sdkcore.PollerDeps{
 				Handler: sdkcore.IssueHandlerFunc(func(issueCtx context.Context, ev sdkcore.IssueEvent) (*sdkcore.IssueResult, error) {
+					// GH-4718: notify Jira the task has started — posts a
+					// "Pilot started" comment and, when transitions.in_progress
+					// is configured, transitions the issue's native workflow
+					// status (the board column, distinct from the SDK-managed
+					// pilot-in-progress label). Mirrors GH-4717's Linear
+					// wiring. Failure is WARN-logged only — a notify failure
+					// must never abort dispatch.
+					if err := notifier.NotifyTaskStarted(issueCtx, ev.IssueID, ev.SequenceID); err != nil {
+						logging.WithComponent("jira").Warn("Failed to notify task started",
+							slog.String("issue_id", ev.IssueID),
+							slog.Any("error", err),
+						)
+					}
+
 					return handleJiraSDKIssueWithResult(issueCtx, deps.Cfg, ev, deps.ProjectPath, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
 				}),
 			}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4718.

Closes #4718

## Changes

GitHub Issue GH-4718: feat(jira): wire jiraSDK Notifier at dispatch — start comment + native workflow transition; closes dead Transitions config (notify-started audit)

## Context

Audit `.agent/system/notify-started-adapter-audit.md` (TASK-441 L3, PR#4713): the Jira SDK poller auto-labels `pilot-in-progress` internally (`studio-sdk/sdk/integrations/jira/poller.go:282`) — **no GH-4692-class bug**. Two things ARE missing:

1. **No start comment and no native workflow-status transition.** Jira has two independent status surfaces: the `labels` field (SDK-managed, largely invisible) and the native workflow status (the board column). The poller never calls `TransitionIssue`/`TransitionIssueTo` — a human watching the Jira board sees zero indication work started.
2. **Dead config wiring (pre-existing bug, fixed as a side effect):** `poller_jira.go:47-48` plumbs `adapters.jira.transitions.in_progress`/`.done` into `jiraSDK.Config.Transitions`, which is **never read** by the SDK poller package. The only consumer is `jiraSDK.NewNotifier(client, inProgressTransition, doneTransition, ...)` (`notifier.go:21`) — never constructed in `cmd/pilot`. Users configuring transitions today get silently nothing.

## Acceptance

- A package-level `jiraSDK` client constructed in `jiraPollerRegistration().CreateAndStart` (currently none exists separate from the poller's internal one — mirror `poller_gitlab.go:48-60`'s client-construction pattern).
- `jiraSDK.NewNotifier(jiraClient, cfg.Adapters.Jira.Transitions.InProgress, cfg.Adapters.Jira.Transitions.Done, ...)` constructed there; `NotifyTaskStarted` called **before** `handleJiraSDKIssueWithResult(...)` in the closure (`poller_jira.go:50-53`), which performs both the start comment and the in-progress workflow transition.
- Failure WARN-logged, never propagated; a transition failure must not prevent the comment attempt (or vice versa) — degrade gracefully per surface.
- **Constraint check (correction #5)**: a workflow-status transition changes the status field, NOT the `pilot-*` label set the dedup/orphan recovery depends on — additive, compliant. Do not touch the SDK-managed label mechanism.
- Empty/unset `transitions.in_progress` config must mean "comment only, skip transition" — not an error (most users won't have transition IDs configured).
- Tests mirroring `cmd/pilot/github_sdk_notify_started_test.go`: `httptest` fake covering both the transition POST and comment POST, table-driven (success / transition-fails-comment-succeeds / comment-fails / no-transition-configured), plus the wiring-order source-inspection test. Never live creds.
- PR description should note it closes the dead `Transitions` config wiring.

## Implementation

- `cmd/pilot/poller_jira.go` — client + notifier construction, call in closure.

## Refs

- Audit: `.agent/system/notify-started-adapter-audit.md` § Jira (incl. "Dead config wiring" finding)
- Pattern precedents: GH-4692 (GitHub) · GH-2132 (Plane) · `poller_gitlab.go:48-60` (client construction)