### PR TITLE
GH-4719: feat(asana): post 'Pilot started' comment at SDK dispatch — wire asanaSDK Notifier (notify-started audit)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -150,6 +150,7 @@
 | GitHub comments | ✅ | adapters/github | - | - | PR/issue updates |
 | Rich PR comments | ✅ | main | - | - | Execution metrics (duration, tokens, cost, model) in PR comments (v0.24.1) |
 | Outbound webhooks | ✅ | webhooks | `pilot webhooks` | `webhooks` | Dispatches task.started/completed/failed/progress events |
+| Asana SDK "Pilot started" comment | ✅ | cmd/pilot (poller_asana.go) | - | - | Wire SDK-native `asanaSDK.Notifier.NotifyTaskStarted` at dispatch, before `handleAsanaIssueWithResult`; WARN-only on failure (v2.253.x, GH-4719, notify-started audit) |
 | Adapter state transitions | ✅ | adapters | - | - | Move Linear/Jira/Asana issues to Done on success (v1.19.0, GH-1396) |
 | Environment context in notifications | ✅ | main | - | - | Env name included in Slack/Telegram PR notifications (v1.60.2, GH-1643) |
 | Messenger refactor | ✅ | adapters | - | - | Shared Handler with TelegramMessenger/SlackMessenger (v2.25.0) |

--- a/cmd/pilot/asana_sdk_notify_started_test.go
+++ b/cmd/pilot/asana_sdk_notify_started_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	asanaSDK "github.com/qf-studio/studio-sdk/sdk/integrations/asana"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// notifyStartedAsanaFake is a minimal mock Asana server covering the single
+// POST NotifyTaskStarted makes (add comment / "story" on a task). Can be
+// configured to fail, to exercise the non-fatal error path.
+type notifyStartedAsanaFake struct {
+	server        *httptest.Server
+	mu            sync.Mutex
+	commentsAdded []string
+	fail          bool
+}
+
+func newNotifyStartedAsanaFake() *notifyStartedAsanaFake {
+	f := &notifyStartedAsanaFake{}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if !(r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/stories")) {
+			_, _ = w.Write([]byte(`{"data":{}}`))
+			return
+		}
+
+		f.mu.Lock()
+		fail := f.fail
+		f.mu.Unlock()
+		if fail {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"errors":[{"message":"injected comment failure"}]}`))
+			return
+		}
+
+		var body struct {
+			Data struct {
+				Text string `json:"text"`
+			} `json:"data"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		f.mu.Lock()
+		f.commentsAdded = append(f.commentsAdded, body.Data.Text)
+		f.mu.Unlock()
+		_, _ = w.Write([]byte(`{"data":{"gid":"1"}}`))
+	}))
+	return f
+}
+
+// TestNotifyTaskStartedAsanaSDK is the GH-4719 acceptance test: the SDK
+// notifier's NotifyTaskStarted call posts a "Pilot started" comment on
+// success, and surfaces (not swallows) the underlying error on failure so the
+// caller can log it as a non-fatal WARN. Before GH-4719 no dispatch path ever
+// called this — the SDK-native Notifier (studio-sdk/sdk/integrations/asana)
+// was tested but wired to nothing in production.
+func TestNotifyTaskStartedAsanaSDK(t *testing.T) {
+	tests := []struct {
+		name    string
+		fail    bool
+		wantErr bool
+	}{
+		{
+			name:    "success posts started comment",
+			wantErr: false,
+		},
+		{
+			name:    "comment failure surfaces as an error, not a panic",
+			fail:    true,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newNotifyStartedAsanaFake()
+			defer f.server.Close()
+			f.fail = tt.fail
+
+			client := asanaSDK.NewClientWithBaseURL(f.server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+			notifier := asanaSDK.NewNotifier(client, "pilot")
+
+			err := notifier.NotifyTaskStarted(context.Background(), "1234567890", "ASANA-1234567890")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NotifyTaskStarted() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			gotComment := len(f.commentsAdded) > 0
+			wantComment := !tt.wantErr
+			if gotComment != wantComment {
+				t.Errorf("comment posted = %v, want %v (commentsAdded = %v)", gotComment, wantComment, f.commentsAdded)
+			}
+		})
+	}
+}
+
+// TestAsanaPollerRegistration_NotifyTaskStartedWired is a source-level guard
+// proving asanaPollerRegistration's CreateAndStart calls
+// asanaNotifier.NotifyTaskStarted( on the dispatch path before
+// handleAsanaIssueWithResult, and that a notify failure is only logged
+// (WARN) rather than aborting dispatch — mirroring the established
+// source-inspection pattern for otherwise-unexercisable closures (see
+// TestLinearPollerRegistration_NotifyTaskStartedWired).
+func TestAsanaPollerRegistration_NotifyTaskStartedWired(t *testing.T) {
+	body := githubFuncBody(t, "poller_asana.go", "func asanaPollerRegistration() PollerRegistration {")
+
+	if !strings.Contains(body, "NotifyTaskStarted(") {
+		t.Error("asanaPollerRegistration must call asanaNotifier.NotifyTaskStarted to post the started comment on the SDK-dispatch path (GH-4719)")
+	}
+
+	notifyIdx := strings.Index(body, "NotifyTaskStarted(")
+	handleIdx := strings.Index(body, "handleAsanaIssueWithResult(issueCtx")
+	if notifyIdx < 0 || handleIdx < 0 || notifyIdx >= handleIdx {
+		t.Error("NotifyTaskStarted must be called before handleAsanaIssueWithResult so the comment posts at the start of work")
+	}
+
+	// The error must be logged, not propagated — a comment failure must
+	// never block dispatch (mirrors the Plane/Linear/GitHub SDK notify patterns).
+	if !strings.Contains(body, `logging.WithComponent("asana").Warn("Failed to notify task started"`) {
+		t.Error("NotifyTaskStarted errors must be logged as a non-fatal WARN, not propagated")
+	}
+}
+
+// TestAsanaPollerRegistration_NotifierUsesSDKClient is a source-level guard
+// proving the notifier is built from the SDK-native asana.NewClient/NewNotifier,
+// not the dead in-tree internal/adapters/asana notifier (see
+// TestAsanaPollerNoLegacyImport in poller_asana_test.go for the import-level
+// guard on the same invariant).
+func TestAsanaPollerRegistration_NotifierUsesSDKClient(t *testing.T) {
+	body := githubFuncBody(t, "poller_asana.go", "func asanaPollerRegistration() PollerRegistration {")
+
+	if !strings.Contains(body, "asanaSDK.NewClient(") {
+		t.Error("asanaPollerRegistration must construct the notifier's client via asanaSDK.NewClient")
+	}
+	if !strings.Contains(body, "asanaSDK.NewNotifier(asanaClient, pilotTag)") {
+		t.Error("asanaPollerRegistration must construct asanaNotifier via asanaSDK.NewNotifier(asanaClient, pilotTag)")
+	}
+}

--- a/cmd/pilot/poller_asana.go
+++ b/cmd/pilot/poller_asana.go
@@ -42,8 +42,26 @@ func asanaPollerRegistration() PollerRegistration {
 				},
 			}
 
+			// Separate client for notifier calls (adapter creates its own internally).
+			asanaClient := asanaSDK.NewClient(deps.Cfg.Adapters.Asana.AccessToken, deps.Cfg.Adapters.Asana.WorkspaceID)
+			asanaNotifier := asanaSDK.NewNotifier(asanaClient, pilotTag)
+
 			pollerDeps := sdkcore.PollerDeps{
 				Handler: sdkcore.IssueHandlerFunc(func(issueCtx context.Context, ev sdkcore.IssueEvent) (*sdkcore.IssueResult, error) {
+					// GH-4719: notify Asana the task has started, mirroring
+					// GH-2132's Plane wiring (poller_plane.go). The SDK poller
+					// already applies the pilot-in-progress tag internally
+					// (studio-sdk/sdk/integrations/asana/poller.go); this only
+					// adds the missing "Pilot started" comment. Failure is
+					// WARN-logged only — a comment failure must never abort
+					// dispatch.
+					if err := asanaNotifier.NotifyTaskStarted(issueCtx, ev.IssueID, ev.SequenceID); err != nil {
+						logging.WithComponent("asana").Warn("Failed to notify task started",
+							slog.String("task_gid", ev.IssueID),
+							slog.Any("error", err),
+						)
+					}
+
 					return handleAsanaIssueWithResult(issueCtx, deps.Cfg, ev, deps.ProjectPath, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
 				}),
 			}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4719.

Closes #4719

## Changes

GitHub Issue GH-4719: feat(asana): post 'Pilot started' comment at SDK dispatch — wire asanaSDK Notifier (notify-started audit)

## Context

Audit `.agent/system/notify-started-adapter-audit.md` (TASK-441 L3, PR#4713): the Asana SDK poller auto-tags `pilot-in-progress` internally (`studio-sdk/sdk/integrations/asana/poller.go:297-298`) — **no GH-4692-class bug**. But no "Pilot started" comment ever posts to the Asana task: `handleAsanaIssueWithResult` (`cmd/pilot/handlers.go:254`) and `poller_asana.go`'s closure (`:46-48`) never call `NotifyTaskStarted`. The SDK-native notifier (`studio-sdk/sdk/integrations/asana/notifier.go:32`) exists and is dead in production.

## Acceptance

- `asanaSDK.NewNotifier(asanaClient, pilotTag)` constructed in `asanaPollerRegistration().CreateAndStart`; `NotifyTaskStarted(issueCtx, ev.IssueID, ev.SequenceID)` called **before** `handleAsanaIssueWithResult(...)` — pattern of `poller_plane.go:56-63` (GH-2132).
- Failure WARN-logged, never propagated (pattern: `notifyTaskStartedSDK`, `handlers.go:888-905`).
- Use the SDK-native notifier, not the dead in-tree `internal/adapters/asana/notifier.go`.
- **Additive only** (correction #5): no change to the SDK-managed tag mechanism.
- Tests mirroring `cmd/pilot/github_sdk_notify_started_test.go`: `httptest` fake for the comment POST + wiring-order source-inspection test. Never live creds.

## Implementation

- `cmd/pilot/poller_asana.go` — notifier construction + call in closure.

## Refs

- Audit: `.agent/system/notify-started-adapter-audit.md` § Asana
- Pattern precedents: GH-4692 · GH-2132