### PR TITLE
GH-4720: feat(gitlab): post 'Pilot started' note at SDK dispatch — wrap existing client in gitlabSDK Notifier (notify-started audit)

### DIFF
--- a/.agent/system/notify-started-adapter-audit.md
+++ b/.agent/system/notify-started-adapter-audit.md
@@ -34,7 +34,7 @@ dispatch-correctness gap. Sized S–M below.
 |---|---|---|---|---|---|---|
 | Linear | label (`pilot-in-progress`, SDK-managed) | Yes | No | **Yes** (GH-4717, `poller_linear.go`) | none | — |
 | Jira | label (SDK-managed) **+** native workflow-status transition | Yes (label only) | No | **Yes** (GH-4718, `poller_jira.go`) | none | — |
-| Asana | tag (`pilot-in-progress`, SDK-managed) | Yes | No | **Yes** (GH-4719, `poller_asana.go`) | none | — |
+| Asana | tag (`pilot-in-progress`, SDK-managed) | Yes | No | No (GH-4719 filed, not yet merged to main as of this edit) | comment-only | S |
 | Plane | label (SDK-managed) **+** native issue-state transition | Yes (label; state via `startedStateIDs`) | No | **Yes** (GH-2132, `poller_plane.go:58`) | none | — |
 | GitLab | label (SDK-managed) | Yes | No | **Yes** (GH-4720, `poller_gitlab.go`) | none | — |
 | AzureDevOps | tag (SDK-managed) | Yes | No | No | comment-only | S |
@@ -229,8 +229,8 @@ dispatch-correctness gap. Sized S–M below.
 
 ## Recommended fix shape, in general (mirrors GH-4692 / GH-2132)
 
-For the one remaining gap (AzureDevOps — Linear closed by GH-4717, Jira by GH-4718, Asana by
-GH-4719, GitLab by GH-4720):
+For the remaining gaps (Asana, AzureDevOps — Linear closed by GH-4717, Jira by GH-4718, GitLab by
+GH-4720; Asana's fix (GH-4719) is filed but not yet merged into main as of this edit):
 
 1. Construct the adapter's SDK-native `Notifier` (`{adapter}SDK.NewNotifier(client, ...)`) once
    inside that adapter's `*PollerRegistration().CreateAndStart` closure in `cmd/pilot/poller_*.go`

--- a/.agent/system/notify-started-adapter-audit.md
+++ b/.agent/system/notify-started-adapter-audit.md
@@ -33,10 +33,10 @@ dispatch-correctness gap. Sized S–M below.
 | Adapter | Status mechanism(s) | Poller auto-labels on dispatch? | GH-4692-class (label/dedup) gap? | Notify-started comment wired? | Gap | Size |
 |---|---|---|---|---|---|---|
 | Linear | label (`pilot-in-progress`, SDK-managed) | Yes | No | **Yes** (GH-4717, `poller_linear.go`) | none | — |
-| Jira | label (SDK-managed) **+** native workflow-status transition | Yes (label only) | No | No | comment + status transition | M |
-| Asana | tag (`pilot-in-progress`, SDK-managed) | Yes | No | No | comment-only | S |
+| Jira | label (SDK-managed) **+** native workflow-status transition | Yes (label only) | No | **Yes** (GH-4718, `poller_jira.go`) | none | — |
+| Asana | tag (`pilot-in-progress`, SDK-managed) | Yes | No | **Yes** (GH-4719, `poller_asana.go`) | none | — |
 | Plane | label (SDK-managed) **+** native issue-state transition | Yes (label; state via `startedStateIDs`) | No | **Yes** (GH-2132, `poller_plane.go:58`) | none | — |
-| GitLab | label (SDK-managed) | Yes | No | No | comment-only | S |
+| GitLab | label (SDK-managed) | Yes | No | **Yes** (GH-4720, `poller_gitlab.go`) | none | — |
 | AzureDevOps | tag (SDK-managed) | Yes | No | No | comment-only | S |
 
 ## Per-adapter detail
@@ -157,7 +157,7 @@ dispatch-correctness gap. Sized S–M below.
   `NotifyTaskFailed` are not called for Plane or any of the other five — see "Adjacent, explicitly
   out of scope" below.)
 
-### GitLab — `handleGitlabIssueWithResult` (`cmd/pilot/handlers.go:507`)
+### GitLab — `handleGitlabIssueWithResult` (`cmd/pilot/handlers.go:507`) — **fixed, GH-4720**
 
 - **Status mechanism**: label only (`pilot-in-progress`, SDK-managed,
   `studio-sdk/sdk/integrations/gitlab/poller.go:18`).
@@ -173,14 +173,21 @@ dispatch-correctness gap. Sized S–M below.
 - **Notifier surfaces available but unused**: `internal/adapters/gitlab/notifier.go:24` (in-tree,
   comment **+ redundant label add**, since the poller already labels — unit-tested, dead in
   production) and `studio-sdk/sdk/integrations/gitlab/notifier.go:24` (SDK-native).
-- **Gap**: no start comment/note posts to the GitLab issue at dispatch time (the first note the
-  issue gets today is the post-execution success/failure note already wired at
-  `handlers.go:570-617`).
-- **Fix shape (S)**: construct `gitlabSDK.NewNotifier(gitlabClient, pilotLabel)` in
-  `gitlabPollerRegistration().CreateAndStart` (the `gitlabClient` is already constructed there at
-  `poller_gitlab.go:48-60` — just needs a notifier wrapping it), call
-  `NotifyTaskStarted(issueCtx, iid, ev.SequenceID)` before `handleGitlabIssueWithResult(...)`,
-  WARN-log on error. Test: httptest fake + wiring-order test.
+- **Gap (closed)**: no start comment/note posted to the GitLab issue at dispatch time (the first
+  note the issue got before this fix was the post-execution success/failure note already wired at
+  `handlers.go:570-617`). Fixed by GH-4720: `gitlabPollerRegistration().CreateAndStart`
+  (`cmd/pilot/poller_gitlab.go`) now builds `gitlabNotifier := gitlabSDK.NewNotifier(gitlabClient,
+  pilotLabel)` from the client already constructed there (`:48-60`), and the
+  `sdkcore.IssueHandlerFunc` closure calls `gitlabNotifier.NotifyTaskStarted(issueCtx, iid,
+  ev.SequenceID)` (IID parsed from `ev.IssueID` via `strconv.Atoi`, mirroring
+  `handlers.go:569,743`) before `handleGitlabIssueWithResult(...)`, WARN-logging (non-fatal) on
+  error — including the `strconv.Atoi` parse-failure path. `NotifyTaskStarted`'s own
+  `AddIssueLabels` call is additive/idempotent (the client merges label sets, `client.go:187-213`),
+  so it does not conflict with or replace the poller's own unconditional pre-dispatch labeling at
+  `poller.go:520`. Tests: `cmd/pilot/gitlab_sdk_notify_started_test.go` (httptest fake over the
+  label GET/PUT + note POST endpoints, plus two source-inspection wiring tests — one for
+  call-ordering, one confirming the SDK-native notifier is used rather than
+  `internal/adapters/gitlab/notifier.go`).
 
 ### AzureDevOps — `handleAzureDevOpsIssueWithResult` (`cmd/pilot/handlers.go:624`)
 
@@ -222,7 +229,8 @@ dispatch-correctness gap. Sized S–M below.
 
 ## Recommended fix shape, in general (mirrors GH-4692 / GH-2132)
 
-For each of the remaining four gaps (Jira, Asana, GitLab, AzureDevOps — Linear closed by GH-4717):
+For the one remaining gap (AzureDevOps — Linear closed by GH-4717, Jira by GH-4718, Asana by
+GH-4719, GitLab by GH-4720):
 
 1. Construct the adapter's SDK-native `Notifier` (`{adapter}SDK.NewNotifier(client, ...)`) once
    inside that adapter's `*PollerRegistration().CreateAndStart` closure in `cmd/pilot/poller_*.go`

--- a/cmd/pilot/gitlab_sdk_notify_started_test.go
+++ b/cmd/pilot/gitlab_sdk_notify_started_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	gitlabSDK "github.com/qf-studio/studio-sdk/sdk/integrations/gitlab"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// notifyStartedGitlabFake is a minimal mock GitLab server covering the calls
+// NotifyTaskStarted makes: GET .../issues/{iid} + PUT .../issues/{iid} (the
+// label merge round-trip behind AddIssueLabels) and POST .../notes (the start
+// note). Either surface can be configured to fail, to exercise the non-fatal
+// error path.
+type notifyStartedGitlabFake struct {
+	server     *httptest.Server
+	mu         sync.Mutex
+	labelsPut  []string
+	notesAdded []string
+	failLabel  bool
+	failNote   bool
+}
+
+func newNotifyStartedGitlabFake() *notifyStartedGitlabFake {
+	f := &notifyStartedGitlabFake{}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/issues/"):
+			_ = json.NewEncoder(w).Encode(gitlabSDK.Issue{IID: 42, Labels: []string{"pilot"}})
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/issues/"):
+			f.mu.Lock()
+			fail := f.failLabel
+			f.mu.Unlock()
+			if fail {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"message":"injected label failure"}`))
+				return
+			}
+			var body struct {
+				Labels []string `json:"labels"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			f.mu.Lock()
+			f.labelsPut = body.Labels
+			f.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(gitlabSDK.Issue{IID: 42, Labels: body.Labels})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/notes"):
+			f.mu.Lock()
+			fail := f.failNote
+			f.mu.Unlock()
+			if fail {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"message":"injected note failure"}`))
+				return
+			}
+			var body struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			f.mu.Lock()
+			f.notesAdded = append(f.notesAdded, body.Body)
+			f.mu.Unlock()
+			_, _ = w.Write([]byte(`{"id":1}`))
+		default:
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	return f
+}
+
+// TestNotifyTaskStartedGitlabSDK is the GH-4720 acceptance test: the SDK
+// notifier's NotifyTaskStarted call adds the in-progress label and posts a
+// "Pilot started" note on success, and surfaces (not swallows) the
+// underlying error on failure so the caller can log it as a non-fatal WARN.
+// Before GH-4720 no dispatch path ever called this — poller_gitlab.go
+// constructed a *gitlabSDK.Client but never wrapped it in a Notifier.
+func TestNotifyTaskStartedGitlabSDK(t *testing.T) {
+	tests := []struct {
+		name      string
+		failLabel bool
+		failNote  bool
+		wantErr   bool
+		wantNote  bool
+	}{
+		{
+			name:     "success adds label and posts started note",
+			wantErr:  false,
+			wantNote: true,
+		},
+		{
+			name:      "label failure surfaces as an error, not a panic",
+			failLabel: true,
+			wantErr:   true,
+			wantNote:  false,
+		},
+		{
+			name:     "note failure surfaces as an error after the label succeeds",
+			failNote: true,
+			wantErr:  true,
+			wantNote: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newNotifyStartedGitlabFake()
+			defer f.server.Close()
+			f.failLabel = tt.failLabel
+			f.failNote = tt.failNote
+
+			client := gitlabSDK.NewClientWithBaseURL(testutil.FakeGitLabToken, "1", f.server.URL)
+			notifier := gitlabSDK.NewNotifier(client, "pilot")
+
+			err := notifier.NotifyTaskStarted(context.Background(), 42, "GL-42")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NotifyTaskStarted() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			gotNote := len(f.notesAdded) > 0
+			if gotNote != tt.wantNote {
+				t.Errorf("note posted = %v, want %v (notesAdded = %v)", gotNote, tt.wantNote, f.notesAdded)
+			}
+		})
+	}
+}
+
+// TestGitlabPollerRegistration_NotifyTaskStartedWired is a source-level guard
+// proving gitlabPollerRegistration's CreateAndStart calls
+// gitlabNotifier.NotifyTaskStarted( on the dispatch path before
+// handleGitlabIssueWithResult, and that a notify failure is only logged
+// (WARN) rather than aborting dispatch — mirroring the established
+// source-inspection pattern (see TestLinearPollerRegistration_NotifyTaskStartedWired).
+func TestGitlabPollerRegistration_NotifyTaskStartedWired(t *testing.T) {
+	body := githubFuncBody(t, "poller_gitlab.go", "func gitlabPollerRegistration() PollerRegistration {")
+
+	if !strings.Contains(body, "NotifyTaskStarted(") {
+		t.Error("gitlabPollerRegistration must call gitlabNotifier.NotifyTaskStarted to post the started note on the SDK-dispatch path (GH-4720)")
+	}
+
+	notifyIdx := strings.Index(body, "NotifyTaskStarted(")
+	handleIdx := strings.Index(body, "handleGitlabIssueWithResult(issueCtx")
+	if notifyIdx < 0 || handleIdx < 0 || notifyIdx >= handleIdx {
+		t.Error("NotifyTaskStarted must be called before handleGitlabIssueWithResult so the note posts at the start of work")
+	}
+
+	// The error must be logged, not propagated — a notify failure must never
+	// block dispatch (mirrors the Linear/Jira/GitHub SDK notify patterns).
+	if !strings.Contains(body, `logging.WithComponent("gitlab").Warn("Failed to notify task started"`) {
+		t.Error("NotifyTaskStarted errors must be logged as a non-fatal WARN, not propagated")
+	}
+}
+
+// TestGitlabPollerRegistration_NotifierFromExistingClient is a source-level
+// guard proving the notifier is constructed by wrapping the *gitlabSDK.Client
+// that poller_gitlab.go already builds for handler calls (AddIssueNote,
+// SetPRCreator) — not a second, independently-constructed client — and that
+// it does not use the in-tree internal/adapters/gitlab notifier, which would
+// double-apply the label the SDK poller already guarantees (poller.go:520).
+func TestGitlabPollerRegistration_NotifierFromExistingClient(t *testing.T) {
+	body := githubFuncBody(t, "poller_gitlab.go", "func gitlabPollerRegistration() PollerRegistration {")
+
+	if !strings.Contains(body, "gitlabSDK.NewNotifier(gitlabClient, pilotLabel)") {
+		t.Error("gitlabPollerRegistration must construct gitlabSDK.NewNotifier(gitlabClient, pilotLabel) from the existing gitlabClient, not a new client")
+	}
+	if strings.Contains(body, `"github.com/qf-studio/pilot/internal/adapters/gitlab"`) {
+		t.Error("gitlabPollerRegistration must use the SDK-native notifier, not internal/adapters/gitlab/notifier.go")
+	}
+}

--- a/cmd/pilot/poller_gitlab.go
+++ b/cmd/pilot/poller_gitlab.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log/slog"
+	"strconv"
 	"time"
 
 	sdkcore "github.com/qf-studio/studio-sdk/sdk/core"
@@ -59,8 +60,30 @@ func gitlabPollerRegistration() PollerRegistration {
 				)
 			}
 
+			// GH-4720: SDK-native notifier for the "Pilot started" note.
+			// Additive only — the poller already guarantees LabelInProgress
+			// internally (poller.go:520); NotifyTaskStarted's own label add
+			// is idempotent (AddIssueLabels merges), so this does not
+			// duplicate or replace the SDK-managed label mechanism.
+			gitlabNotifier := gitlabSDK.NewNotifier(gitlabClient, pilotLabel)
+
 			pollerDeps := sdkcore.PollerDeps{
 				Handler: sdkcore.IssueHandlerFunc(func(issueCtx context.Context, ev sdkcore.IssueEvent) (*sdkcore.IssueResult, error) {
+					// GH-4720: Notify task started (start note on the issue).
+					if iid, err := strconv.Atoi(ev.IssueID); err == nil {
+						if err := gitlabNotifier.NotifyTaskStarted(issueCtx, iid, ev.SequenceID); err != nil {
+							logging.WithComponent("gitlab").Warn("Failed to notify task started",
+								slog.String("issue_id", ev.IssueID),
+								slog.Any("error", err),
+							)
+						}
+					} else {
+						logging.WithComponent("gitlab").Warn("Failed to notify task started",
+							slog.String("issue_id", ev.IssueID),
+							slog.Any("error", err),
+						)
+					}
+
 					return handleGitlabIssueWithResult(issueCtx, deps.Cfg, gitlabClient, ev, deps.ProjectPath, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
 				}),
 			}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4720.

Closes #4720

## Changes

GitHub Issue GH-4720: feat(gitlab): post 'Pilot started' note at SDK dispatch — wrap existing client in gitlabSDK Notifier (notify-started audit)

## Context

Audit `.agent/system/notify-started-adapter-audit.md` (TASK-441 L3, PR#4713): the GitLab SDK poller auto-labels internally (`studio-sdk/sdk/integrations/gitlab/poller.go:520`) — **no GH-4692-class bug**. But no start note posts to the GitLab issue at dispatch time; the first note today is the post-execution success/failure note (`handlers.go:570-617`). `poller_gitlab.go` already constructs a `*gitlabSDK.Client` (`:48-60`) — it just never wraps it in a notifier.

## Acceptance

- `gitlabSDK.NewNotifier(gitlabClient, pilotLabel)` constructed in `gitlabPollerRegistration().CreateAndStart` (client already exists there); `NotifyTaskStarted(issueCtx, iid, ev.SequenceID)` called **before** `handleGitlabIssueWithResult(...)` in the closure (`:62-65`) — pattern of `poller_plane.go:56-63`.
- Failure WARN-logged, never propagated.
- Use the SDK-native notifier — **not** the in-tree `internal/adapters/gitlab/notifier.go`, which would double-apply a label the poller already guarantees.
- **Additive only** (correction #5): no change to the SDK-managed label mechanism.
- Tests mirroring `cmd/pilot/github_sdk_notify_started_test.go`: `httptest` fake for the note POST + wiring-order source-inspection test. Never live creds.

## Implementation

- `cmd/pilot/poller_gitlab.go` — notifier wrap + call in closure.

## Refs

- Audit: `.agent/system/notify-started-adapter-audit.md` § GitLab
- Pattern precedents: GH-4692 · GH-2132