### PR TITLE
GH-4719: feat(asana): post 'Pilot started' comment at SDK dispatch — wire asanaSDK Notifier (notify-started audit)

### DIFF
--- a/.agent/system/notify-started-adapter-audit.md
+++ b/.agent/system/notify-started-adapter-audit.md
@@ -34,7 +34,7 @@ dispatch-correctness gap. Sized S–M below.
 |---|---|---|---|---|---|---|
 | Linear | label (`pilot-in-progress`, SDK-managed) | Yes | No | **Yes** (GH-4717, `poller_linear.go`) | none | — |
 | Jira | label (SDK-managed) **+** native workflow-status transition | Yes (label only) | No | **Yes** (GH-4718, `poller_jira.go`) | none | — |
-| Asana | tag (`pilot-in-progress`, SDK-managed) | Yes | No | No (GH-4719 filed, not yet merged to main as of this edit) | comment-only | S |
+| Asana | tag (`pilot-in-progress`, SDK-managed) | Yes | No | **Yes** (GH-4719, `poller_asana.go`) | none | — |
 | Plane | label (SDK-managed) **+** native issue-state transition | Yes (label; state via `startedStateIDs`) | No | **Yes** (GH-2132, `poller_plane.go:58`) | none | — |
 | GitLab | label (SDK-managed) | Yes | No | **Yes** (GH-4720, `poller_gitlab.go`) | none | — |
 | AzureDevOps | tag (SDK-managed) | Yes | No | No | comment-only | S |
@@ -118,7 +118,7 @@ dispatch-correctness gap. Sized S–M below.
   (three-way table test: label-only success / transition-failure-then-comment-success /
   comment-failure), plus the wiring-order source-inspection test.
 
-### Asana — `handleAsanaIssueWithResult` (`cmd/pilot/handlers.go:254`)
+### Asana — `handleAsanaIssueWithResult` (`cmd/pilot/handlers.go:254`) — **fixed, GH-4719**
 
 - **Status mechanism**: tag only (`pilot-in-progress`, SDK-managed via `TagInProgress`,
   `studio-sdk/sdk/integrations/asana/poller.go:18`). Asana has no native "in progress" status
@@ -127,17 +127,23 @@ dispatch-correctness gap. Sized S–M below.
 - **Poller auto-tags**: `poller.go:297-298` — `processIssueAsync` calls
   `p.client.AddTag(ctx, task.GID, p.inProgressTagGID)` unconditionally before `p.onIssue`.
   `recoverOrphanedTasks` (`poller.go:198-…`) is tag-driven and correct.
-- **Handler wiring**: `handleAsanaIssueWithResult` never calls `NotifyTaskStarted`.
-  `poller_asana.go`'s closure (`:46-48`) calls the handler directly, no pre-dispatch step.
-- **Notifier surfaces available but unused**: `internal/adapters/asana/notifier.go:28` (in-tree,
-  comment-only, unit-tested but dead in production) and
-  `studio-sdk/sdk/integrations/asana/notifier.go:32` (SDK-native, same signature as the
+- **Notifier surfaces available but unused (pre-fix)**: `internal/adapters/asana/notifier.go:28`
+  (in-tree, comment-only, unit-tested but dead in production — remains dead, not used by the fix)
+  and `studio-sdk/sdk/integrations/asana/notifier.go:32` (SDK-native, same signature as the
   `planeSDK`/`githubSDK` ones already wired elsewhere).
-- **Gap**: no start comment posts to the Asana task.
-- **Fix shape (S)**: same pattern as Linear — construct `asanaSDK.NewNotifier(asanaClient,
-  pilotTag)` once in `asanaPollerRegistration().CreateAndStart`, call `NotifyTaskStarted(issueCtx,
-  ev.IssueID, ev.SequenceID)` before `handleAsanaIssueWithResult(...)`, WARN-log on error. Test:
-  httptest fake + wiring-order test, mirroring GH-4692's pattern.
+- **Gap (closed)**: no start comment posted to the Asana task at dispatch time. Fixed by GH-4719:
+  `asanaPollerRegistration().CreateAndStart` (`cmd/pilot/poller_asana.go`) now builds a
+  single-purpose `asanaSDK.NewClient(deps.Cfg.Adapters.Asana.AccessToken,
+  deps.Cfg.Adapters.Asana.WorkspaceID)` (mirroring `poller_jira.go`'s pattern —
+  `handleAsanaIssueWithResult` takes no client param, so this client exists solely to back the
+  notifier) wrapped in `asanaSDK.NewNotifier(asanaClient, pilotTag)`, and the
+  `sdkcore.IssueHandlerFunc` closure calls `notifier.NotifyTaskStarted(issueCtx, ev.IssueID,
+  ev.SequenceID)` before `handleAsanaIssueWithResult(...)`, WARN-logging (non-fatal) on error.
+  Additive only — does not touch the poller's own unconditional pre-dispatch tagging at
+  `poller.go:297-298`. Tests: `cmd/pilot/asana_sdk_notify_started_test.go` (httptest fake over the
+  `/stories` comment-POST endpoint, plus two source-inspection wiring tests — one for
+  call-ordering, one confirming the SDK-native notifier is used rather than
+  `internal/adapters/asana/notifier.go`).
 
 ### Plane — `handlePlaneIssueWithResult` (`cmd/pilot/handlers.go:381`) — **no gap, already fixed**
 
@@ -229,8 +235,8 @@ dispatch-correctness gap. Sized S–M below.
 
 ## Recommended fix shape, in general (mirrors GH-4692 / GH-2132)
 
-For the remaining gaps (Asana, AzureDevOps — Linear closed by GH-4717, Jira by GH-4718, GitLab by
-GH-4720; Asana's fix (GH-4719) is filed but not yet merged into main as of this edit):
+For the remaining gap (AzureDevOps — Linear closed by GH-4717, Jira by GH-4718, GitLab by GH-4720,
+Asana by GH-4719):
 
 1. Construct the adapter's SDK-native `Notifier` (`{adapter}SDK.NewNotifier(client, ...)`) once
    inside that adapter's `*PollerRegistration().CreateAndStart` closure in `cmd/pilot/poller_*.go`
@@ -258,4 +264,5 @@ GH-4720; Asana's fix (GH-4719) is filed but not yet merged into main as of this 
 
 Estimated total: 3×S + 1×M across four remaining PRs (one per adapter, matching the existing
 one-PR-per-adapter granularity of GH-4692/GH-2132), no shared blocking dependency between them.
-Linear (S) shipped as GH-4717.
+Linear (S) shipped as GH-4717, Jira (M) as GH-4718, GitLab (S) as GH-4720, Asana (S) as GH-4719.
+Only AzureDevOps (S) remains.

--- a/cmd/pilot/asana_sdk_notify_started_test.go
+++ b/cmd/pilot/asana_sdk_notify_started_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	asanaSDK "github.com/qf-studio/studio-sdk/sdk/integrations/asana"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// notifyStartedAsanaFake is a minimal mock Asana server covering the single
+// call NotifyTaskStarted makes: POST .../stories (the start comment). The
+// endpoint can be configured to fail, to exercise the non-fatal error path.
+type notifyStartedAsanaFake struct {
+	server        *httptest.Server
+	mu            sync.Mutex
+	commentsAdded []string
+	failComment   bool
+}
+
+func newNotifyStartedAsanaFake() *notifyStartedAsanaFake {
+	f := &notifyStartedAsanaFake{}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/stories"):
+			f.mu.Lock()
+			fail := f.failComment
+			f.mu.Unlock()
+			if fail {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"errors":[{"message":"injected comment failure"}]}`))
+				return
+			}
+			var body struct {
+				Data struct {
+					Text string `json:"text"`
+				} `json:"data"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			f.mu.Lock()
+			f.commentsAdded = append(f.commentsAdded, body.Data.Text)
+			f.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]string{"gid": "story-1", "text": body.Data.Text},
+			})
+		default:
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	return f
+}
+
+// TestNotifyTaskStartedAsanaSDK is the GH-4719 acceptance test: the SDK
+// notifier's NotifyTaskStarted call posts a "Pilot started" comment on
+// success and surfaces (not swallows) the underlying error on failure so the
+// caller can log it as a non-fatal WARN. Before GH-4719 no dispatch path
+// ever called this — poller_asana.go never constructed an asanaSDK.Notifier.
+func TestNotifyTaskStartedAsanaSDK(t *testing.T) {
+	tests := []struct {
+		name        string
+		failComment bool
+		wantErr     bool
+		wantComment bool
+	}{
+		{
+			name:        "success posts started comment",
+			wantErr:     false,
+			wantComment: true,
+		},
+		{
+			name:        "comment failure surfaces as an error, not a panic",
+			failComment: true,
+			wantErr:     true,
+			wantComment: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newNotifyStartedAsanaFake()
+			defer f.server.Close()
+			f.failComment = tt.failComment
+
+			client := asanaSDK.NewClientWithBaseURL(f.server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+			notifier := asanaSDK.NewNotifier(client, "pilot")
+
+			err := notifier.NotifyTaskStarted(context.Background(), "123456", "ASANA-123456")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NotifyTaskStarted() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			gotComment := len(f.commentsAdded) > 0
+			if gotComment != tt.wantComment {
+				t.Errorf("comment posted = %v, want %v (commentsAdded = %v)", gotComment, tt.wantComment, f.commentsAdded)
+			}
+		})
+	}
+}
+
+// TestAsanaPollerRegistration_NotifyTaskStartedWired is a source-level guard
+// proving asanaPollerRegistration's CreateAndStart calls
+// notifier.NotifyTaskStarted( on the dispatch path before
+// handleAsanaIssueWithResult, and that a notify failure is only logged
+// (WARN) rather than aborting dispatch — mirroring the established
+// source-inspection pattern (see TestLinearPollerRegistration_NotifyTaskStartedWired).
+func TestAsanaPollerRegistration_NotifyTaskStartedWired(t *testing.T) {
+	body := githubFuncBody(t, "poller_asana.go", "func asanaPollerRegistration() PollerRegistration {")
+
+	if !strings.Contains(body, "NotifyTaskStarted(") {
+		t.Error("asanaPollerRegistration must call notifier.NotifyTaskStarted to post the started comment on the SDK-dispatch path (GH-4719)")
+	}
+
+	notifyIdx := strings.Index(body, "NotifyTaskStarted(")
+	handleIdx := strings.Index(body, "handleAsanaIssueWithResult(issueCtx")
+	if notifyIdx < 0 || handleIdx < 0 || notifyIdx >= handleIdx {
+		t.Error("NotifyTaskStarted must be called before handleAsanaIssueWithResult so the comment posts at the start of work")
+	}
+
+	// The error must be logged, not propagated — a notify failure must never
+	// block dispatch (mirrors the Linear/Jira/GitLab/GitHub SDK notify patterns).
+	if !strings.Contains(body, `logging.WithComponent("asana").Warn("Failed to notify task started"`) {
+		t.Error("NotifyTaskStarted errors must be logged as a non-fatal WARN, not propagated")
+	}
+}
+
+// TestAsanaPollerRegistration_NotifierWiredFromSDKClient is a source-level
+// guard proving the notifier is constructed from an asanaSDK.Client built
+// with the configured AccessToken/WorkspaceID (mirroring poller_jira.go's
+// single-purpose client construction pattern) and that it does not use the
+// dead in-tree internal/adapters/asana notifier, which would bypass the
+// SDK's request signing/error handling and duplicate the poller's own
+// pilotTag mechanism (poller.go:297-298).
+func TestAsanaPollerRegistration_NotifierWiredFromSDKClient(t *testing.T) {
+	body := githubFuncBody(t, "poller_asana.go", "func asanaPollerRegistration() PollerRegistration {")
+
+	if !strings.Contains(body, "asanaSDK.NewClient(") {
+		t.Error("asanaPollerRegistration must construct an asanaSDK client for the notifier")
+	}
+	if !strings.Contains(body, "asanaSDK.NewNotifier(asanaClient, pilotTag)") {
+		t.Error("asanaPollerRegistration must construct asanaSDK.NewNotifier(asanaClient, pilotTag) from the constructed asanaClient")
+	}
+	if strings.Contains(body, `"github.com/qf-studio/pilot/internal/adapters/asana"`) {
+		t.Error("asanaPollerRegistration must use the SDK-native notifier, not internal/adapters/asana/notifier.go")
+	}
+}

--- a/cmd/pilot/poller_asana.go
+++ b/cmd/pilot/poller_asana.go
@@ -42,8 +42,33 @@ func asanaPollerRegistration() PollerRegistration {
 				},
 			}
 
+			// GH-4719: SDK-native client + notifier for the "Pilot started"
+			// comment (mirrors poller_jira.go's single-purpose client
+			// construction — handleAsanaIssueWithResult takes no client
+			// param, so this client exists solely to back the notifier).
+			// Additive only — the poller already guarantees the pilotTag
+			// tag internally (poller.go:297-298); this does not touch that
+			// mechanism.
+			asanaClient := asanaSDK.NewClient(
+				deps.Cfg.Adapters.Asana.AccessToken,
+				deps.Cfg.Adapters.Asana.WorkspaceID,
+			)
+			notifier := asanaSDK.NewNotifier(asanaClient, pilotTag)
+
 			pollerDeps := sdkcore.PollerDeps{
 				Handler: sdkcore.IssueHandlerFunc(func(issueCtx context.Context, ev sdkcore.IssueEvent) (*sdkcore.IssueResult, error) {
+					// GH-4719: notify Asana the task has started — posts a
+					// "Pilot started" comment on the task. Mirrors GH-4718's
+					// Jira wiring / GH-2132's Plane wiring. Failure is
+					// WARN-logged only — a notify failure must never abort
+					// dispatch.
+					if err := notifier.NotifyTaskStarted(issueCtx, ev.IssueID, ev.SequenceID); err != nil {
+						logging.WithComponent("asana").Warn("Failed to notify task started",
+							slog.String("issue_id", ev.IssueID),
+							slog.Any("error", err),
+						)
+					}
+
 					return handleAsanaIssueWithResult(issueCtx, deps.Cfg, ev, deps.ProjectPath, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
 				}),
 			}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4719.

Closes #4719

## Changes

GitHub Issue GH-4719: feat(asana): post 'Pilot started' comment at SDK dispatch — wire asanaSDK Notifier (notify-started audit)

## Context

Audit `.agent/system/notify-started-adapter-audit.md` (TASK-441 L3, PR#4713): the Asana SDK poller auto-tags `pilot-in-progress` internally (`studio-sdk/sdk/integrations/asana/poller.go:297-298`) — **no GH-4692-class bug**. But no "Pilot started" comment ever posts to the Asana task: `handleAsanaIssueWithResult` (`cmd/pilot/handlers.go:254`) and `poller_asana.go`'s closure (`:46-48`) never call `NotifyTaskStarted`. The SDK-native notifier (`studio-sdk/sdk/integrations/asana/notifier.go:32`) exists and is dead in production.

## Acceptance

- `asanaSDK.NewNotifier(asanaClient, pilotTag)` constructed in `asanaPollerRegistration().CreateAndStart`; `NotifyTaskStarted(issueCtx, ev.IssueID, ev.SequenceID)` called **before** `handleAsanaIssueWithResult(...)` — pattern of `poller_plane.go:56-63` (GH-2132).
- Failure WARN-logged, never propagated (pattern: `notifyTaskStartedSDK`, `handlers.go:888-905`).
- Use the SDK-native notifier, not the dead in-tree `internal/adapters/asana/notifier.go`.
- **Additive only** (correction #5): no change to the SDK-managed tag mechanism.
- Tests mirroring `cmd/pilot/github_sdk_notify_started_test.go`: `httptest` fake for the comment POST + wiring-order source-inspection test. Never live creds.

## Implementation

- `cmd/pilot/poller_asana.go` — notifier construction + call in closure.

## Refs

- Audit: `.agent/system/notify-started-adapter-audit.md` § Asana
- Pattern precedents: GH-4692 · GH-2132