### PR TITLE
fix(metrics): propagate pilot_window_* gauges through AggregateMetrics (GH-4738)

### DIFF
--- a/internal/autopilot/metrics_aggregate.go
+++ b/internal/autopilot/metrics_aggregate.go
@@ -32,6 +32,13 @@ type SnapshotSource interface {
 // owned by exactly one controller — the default, see the HydrateFromStore
 // call site in main.go — so summing the other (zero-valued for these
 // fields) controllers alongside it does not double-count.
+//
+// GH-4735/GH-4738: the rolling-window gauges (WindowDays, WindowCostUSD,
+// WindowCostPerDeliveredUSD, WindowDeliveryRate, WindowAttemptSuccessRate)
+// are likewise owned by exactly one controller, but are taken verbatim from
+// that source (first WindowDays > 0 wins) rather than summed — two of them
+// are pre-computed rates that summing would corrupt even in the degenerate
+// single-owner case.
 type AggregateMetrics struct {
 	sources []*Metrics
 }
@@ -83,6 +90,29 @@ func (a *AggregateMetrics) Snapshot() MetricsSnapshot {
 		agg.PRsMergedLifetime += s.PRsMergedLifetime
 		agg.PRsFailedLifetime += s.PRsFailedLifetime
 		agg.PRsConflicting += s.PRsConflicting
+
+		// GH-4738: WindowDays/Window* (GH-4735) are, like the lifetime
+		// baselines above, seeded on exactly one controller — the default,
+		// see the HydrateWindowStats/StartWindowStatsRefresher call sites in
+		// cmd/pilot/main.go — so every other source's WindowDays stays 0.
+		// Unlike the lifetime baselines, two of these fields
+		// (WindowDeliveryRate, WindowAttemptSuccessRate) are already-computed
+		// rates in [0,1], so summing them across sources would be wrong even
+		// though only one source is ever non-zero in practice; take the
+		// whole group verbatim from the first source with WindowDays > 0
+		// instead. Before this fix, the aggregate never touched these five
+		// fields at all — they stayed at MetricsSnapshot's zero value
+		// regardless of what HydrateWindowStats seeded on the owning
+		// controller — so every daemon path that reads the aggregate (i.e.
+		// every real deployment via SetMetricsSource(autopilotMetricsAggregate))
+		// served pilot_window_*{window="0d"} 0 no matter what the store held.
+		if agg.WindowDays == 0 && s.WindowDays > 0 {
+			agg.WindowDays = s.WindowDays
+			agg.WindowCostUSD = s.WindowCostUSD
+			agg.WindowCostPerDeliveredUSD = s.WindowCostPerDeliveredUSD
+			agg.WindowDeliveryRate = s.WindowDeliveryRate
+			agg.WindowAttemptSuccessRate = s.WindowAttemptSuccessRate
+		}
 		for k, v := range s.CIRuns {
 			agg.CIRuns[k] += v
 		}

--- a/internal/autopilot/metrics_aggregate_test.go
+++ b/internal/autopilot/metrics_aggregate_test.go
@@ -188,3 +188,64 @@ func TestAggregateMetrics_EmptySourcesZeroSnapshot(t *testing.T) {
 		t.Errorf("expected all-zero snapshot for empty aggregate, got %+v", snap)
 	}
 }
+
+// TestAggregateMetrics_PropagatesWindowStatsFromOwningController pins
+// GH-4738: pilot_window_* (GH-4735) is seeded on exactly one controller (the
+// default — see HydrateWindowStats call sites in cmd/pilot/main.go), same
+// ownership pattern as the lifetime baselines pinned by
+// TestAggregateMetrics_SumsCountersAcrossControllers above. Before the fix,
+// AggregateMetrics.Snapshot never read WindowDays/Window* off any source at
+// all, so this always reported the zero value regardless of what
+// SetWindowStats seeded on the owning controller — exactly the box symptom
+// (window="0d", value 0, despite a clean hydration and no logged error).
+func TestAggregateMetrics_PropagatesWindowStatsFromOwningController(t *testing.T) {
+	defaultMetrics := NewMetrics()
+	otherMetrics := NewMetrics() // e.g. a per-project controller; never seeded with window stats
+
+	defaultMetrics.SetWindowStats(30, 12.5, 2.5, 0.8, 0.75)
+
+	agg := NewAggregateMetrics(defaultMetrics, otherMetrics)
+	snap := agg.Snapshot()
+
+	if snap.WindowDays != 30 {
+		t.Errorf("WindowDays = %d, want 30 (must propagate from the owning controller, not stay at the aggregate's zero value)", snap.WindowDays)
+	}
+	const epsilon = 0.0001
+	if got, want := snap.WindowCostUSD, 12.5; got < want-epsilon || got > want+epsilon {
+		t.Errorf("WindowCostUSD = %.4f, want %.4f", got, want)
+	}
+	if got, want := snap.WindowCostPerDeliveredUSD, 2.5; got < want-epsilon || got > want+epsilon {
+		t.Errorf("WindowCostPerDeliveredUSD = %.4f, want %.4f", got, want)
+	}
+	if got, want := snap.WindowDeliveryRate, 0.8; got < want-epsilon || got > want+epsilon {
+		t.Errorf("WindowDeliveryRate = %.4f, want %.4f", got, want)
+	}
+	if got, want := snap.WindowAttemptSuccessRate, 0.75; got < want-epsilon || got > want+epsilon {
+		t.Errorf("WindowAttemptSuccessRate = %.4f, want %.4f", got, want)
+	}
+}
+
+// TestAggregateMetrics_WindowStatsNotSummedAcrossControllers guards the
+// "verbatim, not summed" half of the GH-4738 fix: WindowDeliveryRate and
+// WindowAttemptSuccessRate are already-computed rates in [0,1] — if two
+// sources both somehow carried a seeded window (not expected in production,
+// but the aggregation logic must not assume it), summing them would produce
+// a nonsensical rate above 1. The first non-zero WindowDays source must win
+// outright, matching the "owned by exactly one controller" contract.
+func TestAggregateMetrics_WindowStatsNotSummedAcrossControllers(t *testing.T) {
+	m1 := NewMetrics()
+	m2 := NewMetrics()
+
+	m1.SetWindowStats(30, 10.0, 5.0, 0.9, 0.9)
+	m2.SetWindowStats(30, 999.0, 999.0, 0.9, 0.9) // must be ignored — m1 already won
+
+	agg := NewAggregateMetrics(m1, m2)
+	snap := agg.Snapshot()
+
+	if snap.WindowCostUSD != 10.0 {
+		t.Errorf("WindowCostUSD = %.4f, want 10.0 (first seeded source wins, not summed to 1009.0)", snap.WindowCostUSD)
+	}
+	if snap.WindowDeliveryRate > 1.0 {
+		t.Errorf("WindowDeliveryRate = %.4f, must never exceed 1.0", snap.WindowDeliveryRate)
+	}
+}

--- a/internal/autopilot/metrics_hydrator.go
+++ b/internal/autopilot/metrics_hydrator.go
@@ -7,8 +7,17 @@ import (
 	"sync"
 	"time"
 
+	"github.com/qf-studio/pilot/internal/logging"
 	"github.com/qf-studio/pilot/internal/memory"
 )
+
+// defaultStatsWindowDays mirrors config.DefaultDashboardStatsWindowDays
+// (GH-4735). This package cannot import internal/config directly — config
+// imports autopilot (for autopilot.Config), so importing back would create a
+// cycle — so the value is kept in sync by hand, the same fallback pattern
+// already used by internal/gateway/dashboard.go's defaultDashboardStatsWindowDays
+// and internal/dashboard/tui.go's defaultStatsWindowDays.
+const defaultStatsWindowDays = 30
 
 // HydrateFromStore restores Prometheus counter baselines from the store's
 // lifetime execution history into metrics, so external dashboards match
@@ -217,12 +226,34 @@ func HydrateWindowStats(store *memory.Store, metrics *Metrics, windowDays int) e
 	if store == nil || metrics == nil {
 		return nil
 	}
+	// GH-4738: defensive clamp — a caller passing windowDays <= 0 (e.g. a
+	// zero-value from a config path that skipped the
+	// config.DefaultDashboardStatsWindowDays fallback) must not silently
+	// query since=now() and seed an all-zero window; fall back to the same
+	// default the TUI/gateway dashboard paths already use in this situation
+	// (defaultDashboardStatsWindowDays / defaultStatsWindowDays there).
+	if windowDays <= 0 {
+		windowDays = defaultStatsWindowDays
+	}
 	since := time.Now().AddDate(0, 0, -windowDays)
 	ws, err := store.GetWindowedStats("", since)
 	if err != nil {
 		return fmt.Errorf("hydrate window stats: %w", err)
 	}
 	metrics.SetWindowStats(windowDays, ws.TotalCostUSD, ws.CostPerDelivered, ws.DeliveryRate, ws.AttemptSuccessRate)
+	// GH-4738: log the seeded values at INFO (not just on failure) so
+	// operators can grep daemon.log to confirm the pilot_window_* gauges
+	// actually got a non-zero seed on this boot — the prior silent-success
+	// path is exactly how a downstream aggregation bug (the gauges reaching
+	// the exporter as window="0d"/0 despite a clean seed here) went
+	// unnoticed for a full release.
+	logging.WithComponent("autopilot").Info("window stats seeded",
+		slog.Int("window_days", windowDays),
+		slog.Float64("window_cost_usd", ws.TotalCostUSD),
+		slog.Float64("window_cost_per_delivered_usd", ws.CostPerDelivered),
+		slog.Float64("window_delivery_rate", ws.DeliveryRate),
+		slog.Float64("window_attempt_success_rate", ws.AttemptSuccessRate),
+	)
 	return nil
 }
 
@@ -250,7 +281,14 @@ func StartWindowStatsRefresher(ctx context.Context, store *memory.Store, metrics
 			select {
 			case <-ticker.C:
 				if err := HydrateWindowStats(store, metrics, windowDays); err != nil {
-					slog.Warn("window stats refresh failed", slog.Any("error", err))
+					// GH-4738: route through the component logger, not bare
+					// slog.Warn — outside dashboard mode (which redirects
+					// slog's process-global default via
+					// logging.RedirectToFile), a bare slog call bypasses the
+					// configured Output/Format from logging.Init entirely
+					// and lands on the package-init stdout handler instead
+					// of daemon.log.
+					logging.WithComponent("autopilot").Warn("window stats refresh failed", slog.Any("error", err))
 				}
 			case <-ctx.Done():
 				return

--- a/internal/autopilot/metrics_hydrator_test.go
+++ b/internal/autopilot/metrics_hydrator_test.go
@@ -3,6 +3,7 @@ package autopilot
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -1125,4 +1126,44 @@ func TestStartWindowStatsRefresher_RefreshesOnTicker(t *testing.T) {
 func TestStartWindowStatsRefresher_NilStoreIsNoop(t *testing.T) {
 	stop := StartWindowStatsRefresher(context.Background(), nil, NewMetrics(), 30, time.Millisecond)
 	stop() // must not panic
+}
+
+// TestHydrateWindowStats_ZeroOrNegativeWindowDaysClamps pins GH-4738's
+// defensive fallback: a caller passing windowDays <= 0 (e.g. a config path
+// that skipped the config.DefaultDashboardStatsWindowDays fallback) must not
+// silently query since=now() — which would report window="0d" with all-zero
+// values even though the store has data — but instead clamp to
+// defaultStatsWindowDays, matching the TUI/gateway dashboard fallbacks.
+func TestHydrateWindowStats_ZeroOrNegativeWindowDaysClamps(t *testing.T) {
+	for _, windowDays := range []int{0, -5} {
+		t.Run(fmt.Sprintf("windowDays=%d", windowDays), func(t *testing.T) {
+			tmpDir := t.TempDir()
+			store, err := memory.NewStore(tmpDir)
+			if err != nil {
+				t.Fatalf("NewStore: %v", err)
+			}
+			defer func() { _ = store.Close() }()
+
+			if err := store.SaveExecution(&memory.Execution{
+				ID: "clamp-1", TaskID: "TASK-1", ProjectPath: "/p", Status: "completed",
+				CreatedAt: time.Now().UTC(), EstimatedCostUSD: 2.00,
+			}); err != nil {
+				t.Fatalf("SaveExecution: %v", err)
+			}
+
+			metrics := NewMetrics()
+			if err := HydrateWindowStats(store, metrics, windowDays); err != nil {
+				t.Fatalf("HydrateWindowStats: %v", err)
+			}
+
+			snap := metrics.Snapshot()
+			if snap.WindowDays != defaultStatsWindowDays {
+				t.Errorf("WindowDays = %d, want clamped default %d", snap.WindowDays, defaultStatsWindowDays)
+			}
+			const epsilon = 0.0001
+			if got, want := snap.WindowCostUSD, 2.00; got < want-epsilon || got > want+epsilon {
+				t.Errorf("WindowCostUSD = %.4f, want %.4f (clamp must still query a real window, not since=now())", got, want)
+			}
+		})
+	}
 }

--- a/internal/gateway/prometheus_test.go
+++ b/internal/gateway/prometheus_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/qf-studio/pilot/internal/alerts"
 	"github.com/qf-studio/pilot/internal/autopilot"
+	"github.com/qf-studio/pilot/internal/memory"
 )
 
 // mockMetricsSource implements MetricsSource for testing.
@@ -339,6 +340,82 @@ func TestPrometheusExporter_CIRunsCounter(t *testing.T) {
 	} {
 		if !strings.Contains(output, want) {
 			t.Errorf("Output missing expected string: %q\nGot:\n%s", want, output)
+		}
+	}
+}
+
+// TestPrometheusExporter_WindowStatsSurviveComposedDaemonWiring is GH-4738's
+// regression test. It reproduces the box symptom — pilot_window_* serving
+// window="0d" value 0 despite a clean seed and no logged error — by wiring
+// the exact same pieces cmd/pilot/main.go's runPollingMode composes at boot,
+// instead of testing HydrateWindowStats or AggregateMetrics in isolation
+// (both of those unit tests were green while production served zeros, which
+// is the gap this test closes):
+//
+//  1. A real store with an execution in the window.
+//  2. autopilot.HydrateWindowStats seeds the DEFAULT controller's *Metrics
+//     only (main.go never seeds any other project controller's Metrics).
+//  3. A second, unrelated per-project *Metrics never gets window-seeded —
+//     mirrors autopilotControllers always containing more than just the
+//     default in a multi-project config.
+//  4. Both are wrapped in autopilot.NewAggregateMetrics, exactly as
+//     autopilotMetricsAggregate is built in main.go.
+//  5. gwServer.SetMetricsSource(aggregate) is exactly what wires the
+//     aggregate into this package's PrometheusExporter.
+//
+// Before the GH-4738 fix, step 4's aggregate silently dropped the seeded
+// values from step 2, so this test's WritePrometheus output would show
+// window="0d" 0 despite the store holding real data.
+func TestPrometheusExporter_WindowStatsSurviveComposedDaemonWiring(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "gh4738-1", TaskID: "TASK-1", ProjectPath: "/p", Status: "completed",
+		CreatedAt: time.Now().UTC(), EstimatedCostUSD: 4.0,
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	// Step 2: seed only the default controller's Metrics, as main.go does.
+	defaultMetrics := autopilot.NewMetrics()
+	if err := autopilot.HydrateWindowStats(store, defaultMetrics, 30); err != nil {
+		t.Fatalf("HydrateWindowStats: %v", err)
+	}
+
+	// Step 3: a second controller's Metrics that never gets window-seeded.
+	projectMetrics := autopilot.NewMetrics()
+
+	// Step 4: the same aggregate main.go builds from fleetMetrics.
+	aggregate := autopilot.NewAggregateMetrics(defaultMetrics, projectMetrics)
+
+	// Step 5: the same wiring SetMetricsSource performs.
+	srv := NewServer(&Config{Host: "127.0.0.1", Port: 0})
+	srv.SetMetricsSource(aggregate)
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	w := httptest.NewRecorder()
+	srv.handleMetrics(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+
+	if strings.Contains(body, `pilot_window_cost_usd{window="0d"}`) {
+		t.Errorf("regression: pilot_window_cost_usd served window=\"0d\" through the composed daemon wiring:\n%s", body)
+	}
+	for _, want := range []string{
+		`pilot_window_cost_usd{window="30d"} 4`,
+		`pilot_window_delivery_rate{window="30d"} 1`,
+		`pilot_window_attempt_success_rate{window="30d"} 1`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected composed daemon wiring output to contain %q\ngot:\n%s", want, body)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

`AggregateMetrics.Snapshot()` never read the 5 rolling-window fields (`WindowDays`, `WindowCostUSD`, `WindowCostPerDeliveredUSD`, `WindowDeliveryRate`, `WindowAttemptSuccessRate`) off any source `MetricsSnapshot`, so they stayed at the zero value regardless of what `HydrateWindowStats` seeded on the owning default controller. Every real daemon deployment reads the aggregate via `SetMetricsSource(autopilotMetricsAggregate)`, so `pilot_window_*` always served `window="0d" 0` on the box despite a clean, error-free seed at boot.

- `metrics_aggregate.go`: take the whole `Window*` group verbatim from the first source with `WindowDays > 0` (not summed — `WindowDeliveryRate`/`WindowAttemptSuccessRate` are pre-computed rates that summing would corrupt).
- `metrics_hydrator.go`: clamp `windowDays <= 0` to `defaultStatsWindowDays` (30, mirroring `config.DefaultDashboardStatsWindowDays`) inside `HydrateWindowStats` so both call sites (seed + ticker refresh) share one chokepoint; route refresher errors through `logging.WithComponent` instead of bare `slog.Warn`; log seeded window values at INFO for grep-confirmability in `daemon.log`.
- Add a gateway regression test that reproduces the exact composed daemon wiring (store → `HydrateWindowStats` on the default controller only → `NewAggregateMetrics(default, project)` → `SetMetricsSource` → `/metrics`), which fails without the aggregate fix — closing the "unit tests green, production zero" gap.

Fixes GH-4738.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/autopilot/... ./internal/gateway/...`
- [x] `go test ./internal/autopilot/... ./internal/gateway/...` — all green, including new regression tests:
  - `TestAggregateMetrics_PropagatesWindowStatsFromOwningController`
  - `TestAggregateMetrics_WindowStatsNotSummedAcrossControllers`
  - `TestHydrateWindowStats_ZeroOrNegativeWindowDaysClamps`
  - `TestPrometheusExporter_WindowStatsSurviveComposedDaemonWiring` (composed daemon wiring — reproduces box symptom)