### PR TITLE
fix(executor): strip pilot-in-progress on terminal non-deliverable outcomes

### DIFF
--- a/internal/executor/lifecycle.go
+++ b/internal/executor/lifecycle.go
@@ -1,9 +1,11 @@
 package executor
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -348,7 +350,109 @@ func (l *ExecutionLifecycle) Persist(execID string, outcome FinishOutcome, resul
 	// write.
 	runFinishTripwireSweep(l.store, l.alertProcessor, execID)
 
+	// GH-4740: strip the GitHub pilot-in-progress marker whenever this
+	// terminal write leaves no deliverable behind. Persist is the same
+	// universal chokepoint the tripwire sweep above relies on — every
+	// production terminal-status write reaches here, including the
+	// dispatcher's ProjectWorker loop (a genuine execution failure),
+	// alerts.Engine's stuck-task tripwire eviction (a hard-killed/wedged
+	// child that never returns control to the normal teardown path), and
+	// epic.go's sub-issue finalizer — so hooking it here, rather than only
+	// in the SDK-dispatch handler that applies the label at start
+	// (handlers.go's notifyTaskStartedSDK), is the only way a SIGKILLed
+	// child can't skip the strip.
+	l.stripInProgressLabelOnTerminalFailure(execID, outcome.Status)
+
 	return statusErr
+}
+
+// requiresInProgressLabelStrip reports whether status is a terminal outcome
+// that leaves no deliverable behind — the set GH-4740's acceptance criteria
+// names explicitly. ExecStatusCompleted is deliberately excluded: a PR
+// exists, and pilot-in-progress is kept on purpose until the PR merges
+// (autopilot's controller.go strips it then, see RemoveLabel call sites
+// there). ExecStatusSuperseded/ExecStatusDecomposed are excluded too —
+// superseded means the issue was already found closed at pickup time
+// (nothing left to re-pick), and decomposed means this row's own work moved
+// to child rows that carry their own label lifecycle.
+//
+// A switch (not a map literal) deliberately avoids growing a second
+// execution-status classification map outside dispatcher.go's
+// terminalExecutionStatuses (see terminal_status_inventory_test.go's guard
+// against exactly that, mem-154 pitfall class).
+func requiresInProgressLabelStrip(status Status) bool {
+	switch status {
+	case ExecStatusFailed, ExecStatusStalled, ExecStatusRateLimited, ExecStatusInfra,
+		ExecStatusNoOp, ExecStatusDeclined, ExecStatusSkipped, ExecStatusCanceled:
+		return true
+	default:
+		return false
+	}
+}
+
+// stripInProgressLabelOnTerminalFailure removes the pilot-in-progress marker
+// from execID's GitHub issue when the terminal outcome left no deliverable
+// behind (GH-4740). Evidence: console#98 failed at 14:41:05Z and sat with
+// pilot-in-progress still on the OPEN issue for 1.5h+ — the poller treats
+// that marker as "still in-flight" and never re-picks the issue even though
+// the `pilot` trigger label remains present, inert behind it. An operator
+// had to strip the label by hand before the poller picked it back up.
+//
+// Best-effort and GitHub-only, mirroring the adapter guard every other
+// GitHub-issue side channel in this package already uses (surfaceStalledIssue
+// in dispatcher.go, ghAddLabels in title_rejection.go): a strip failure must
+// never invalidate the store-side status write Persist already committed
+// above — that write is the durable source of truth regardless of whether
+// this side channel succeeds.
+func (l *ExecutionLifecycle) stripInProgressLabelOnTerminalFailure(execID string, status Status) {
+	if !requiresInProgressLabelStrip(status) {
+		return
+	}
+	if l.store == nil || execID == "" {
+		return
+	}
+
+	exec, err := l.store.GetExecution(execID)
+	if err != nil || exec == nil {
+		return
+	}
+	// Require an exact "github" match rather than "anything but a known
+	// non-GitHub adapter" — most CLI-driven and hand-constructed executions
+	// (including the bulk of this package's own tests) leave
+	// TaskSourceAdapter empty, and an empty adapter has no GitHub issue to
+	// edit. Mirrors checkLabelLifecycle's TaskSourceAdapter == "" skip
+	// (finish_tripwires.go) rather than runner.go's "!= '' && != 'github'"
+	// routing check, which exists to pick an adapter PRCreator and would
+	// wrongly let an empty adapter through here.
+	if exec.TaskSourceAdapter != "github" {
+		return
+	}
+
+	issueNum := strings.TrimPrefix(exec.TaskID, "GH-")
+	if exec.TaskSourceIssueID != "" {
+		issueNum = exec.TaskSourceIssueID
+	}
+	var parsed int
+	if _, sErr := fmt.Sscanf(issueNum, "%d", &parsed); sErr != nil || parsed <= 0 {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	log := logging.WithComponent("executor.lifecycle")
+	if err := ghEditLabels(ctx, exec.ProjectPath, issueNum, nil, []string{"pilot-in-progress"}); err != nil {
+		// GH-4692 lesson (studio-sdk's "labels removed" log line fired on
+		// labels that were never applied at all): log this failure loudly —
+		// Error, not Warn — because a silent miss here is exactly the class
+		// of bug GH-4740 was filed for: the issue stays stuck behind an
+		// inert marker with no visible signal that anything went wrong.
+		log.Error("failed to strip pilot-in-progress label after terminal execution — issue may stay stuck behind the marker",
+			"execution_id", execID, "task_id", exec.TaskID, "issue", parsed, "status", string(status), "error", err)
+		return
+	}
+	log.Info("stripped pilot-in-progress label after terminal execution",
+		"execution_id", execID, "task_id", exec.TaskID, "issue", parsed, "status", string(status))
 }
 
 // Finish terminates execID in one call: Classify followed by Persist.

--- a/internal/executor/lifecycle_test.go
+++ b/internal/executor/lifecycle_test.go
@@ -2,6 +2,9 @@ package executor
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -744,4 +747,130 @@ func TestExecutionLifecycle_Cancel(t *testing.T) {
 			t.Errorf("expected nil execution for a not-found cancel, got: %+v", exec)
 		}
 	})
+}
+
+// setupFakeGHForLifecycleTest installs a fake `gh` binary at the front of
+// PATH (mirroring dispatcher_test.go's TestDispatcher_StallTaskAfterRepickHardCap_*
+// pattern) that appends its argv to a log file instead of touching GitHub, and
+// returns that log file's path so the test can assert on the exact CLI
+// invocation.
+func setupFakeGHForLifecycleTest(t *testing.T) (logFile string) {
+	t.Helper()
+	fakeBin := t.TempDir()
+	logFile = filepath.Join(t.TempDir(), "gh-calls.log")
+	script := filepath.Join(fakeBin, "gh")
+	content := "#!/bin/sh\n" + `echo "$@" >> "` + logFile + `"` + "\nexit 0\n"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+os.Getenv("PATH"))
+	return logFile
+}
+
+// TestExecutionLifecycle_Finish_FailedGitHubTask_StripsInProgressLabel is the
+// GH-4740 regression test: a failed execution against a GitHub-sourced task
+// must strip pilot-in-progress from the issue through the same Persist
+// chokepoint every terminal write (including a hard-killed executor's
+// tripwire/Finish path) goes through — not just the happy-path teardown.
+// Evidence this guards against: console#98 failed 14:41:05Z and sat with
+// pilot-in-progress on the OPEN issue for 1.5h+, inert behind the still-present
+// `pilot` trigger label, until an operator stripped it by hand.
+func TestExecutionLifecycle_Finish_FailedGitHubTask_StripsInProgressLabel(t *testing.T) {
+	logFile := setupFakeGHForLifecycleTest(t)
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{
+		ID:            "GH-4740",
+		ProjectPath:   t.TempDir(),
+		SourceAdapter: "github",
+		SourceIssueID: "4740",
+	}
+	lifecycle := NewExecutionLifecycle(store)
+	execID, err := lifecycle.Begin(task, ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	result := &ExecutionResult{TaskID: task.ID, Success: false, Error: "unknown: exit status 1"}
+	outcome, err := lifecycle.Finish(execID, result, errors.New("unknown: exit status 1"), 42*time.Second)
+	if err != nil {
+		t.Fatalf("Finish failed: %v", err)
+	}
+	if outcome.Status != ExecStatusFailed {
+		t.Fatalf("expected outcome status %q, got %q", ExecStatusFailed, outcome.Status)
+	}
+
+	logBytes, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("expected gh CLI to be invoked to strip pilot-in-progress, but log file missing: %v", err)
+	}
+	calls := string(logBytes)
+	if !strings.Contains(calls, "issue edit 4740") {
+		t.Errorf("expected a label edit on issue 4740, got calls:\n%s", calls)
+	}
+	if !strings.Contains(calls, "--remove-label pilot-in-progress") {
+		t.Errorf("expected pilot-in-progress to be removed, got calls:\n%s", calls)
+	}
+}
+
+// TestExecutionLifecycle_Finish_NonGitHubTask_SkipsInProgressStrip mirrors
+// TestDispatcher_StallTaskAfterRepickHardCap_NonGitHubTaskSkipsGHCLI: a failed
+// execution for a non-GitHub-sourced task (or a CLI-driven task with no
+// source adapter at all) has no GitHub issue to edit, so Finish must not
+// shell out to `gh`.
+func TestExecutionLifecycle_Finish_NonGitHubTask_SkipsInProgressStrip(t *testing.T) {
+	logFile := setupFakeGHForLifecycleTest(t)
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GL-4740", ProjectPath: t.TempDir(), SourceAdapter: "gitlab", SourceIssueID: "4740"}
+	lifecycle := NewExecutionLifecycle(store)
+	execID, err := lifecycle.Begin(task, ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	if _, err := lifecycle.Finish(execID, &ExecutionResult{TaskID: task.ID, Success: false, Error: "boom"}, errors.New("boom"), time.Second); err != nil {
+		t.Fatalf("Finish failed: %v", err)
+	}
+
+	if _, err := os.ReadFile(logFile); err == nil {
+		t.Error("expected no gh CLI invocation for a non-GitHub task")
+	}
+}
+
+// TestExecutionLifecycle_Finish_Completed_DoesNotStripInProgressLabel verifies
+// a successful/completed execution does NOT strip pilot-in-progress: a PR
+// exists at that point, and the label is deliberately kept until the PR
+// merges (autopilot's post-merge RemoveLabel path), per GH-4740's acceptance
+// criteria that scoped the strip to terminal outcomes leaving no deliverable
+// behind.
+func TestExecutionLifecycle_Finish_Completed_DoesNotStripInProgressLabel(t *testing.T) {
+	logFile := setupFakeGHForLifecycleTest(t)
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GH-4740-OK", ProjectPath: t.TempDir(), SourceAdapter: "github", SourceIssueID: "9999"}
+	lifecycle := NewExecutionLifecycle(store)
+	execID, err := lifecycle.Begin(task, ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	result := &ExecutionResult{TaskID: task.ID, Success: true, PRUrl: "https://github.com/qf-studio/pilot/pull/1", CommitSHA: "deadbeef"}
+	outcome, err := lifecycle.Finish(execID, result, nil, time.Second)
+	if err != nil {
+		t.Fatalf("Finish failed: %v", err)
+	}
+	if outcome.Status != ExecStatusCompleted {
+		t.Fatalf("expected outcome status %q, got %q", ExecStatusCompleted, outcome.Status)
+	}
+
+	if _, err := os.ReadFile(logFile); err == nil {
+		t.Error("expected no gh CLI invocation for a completed execution")
+	}
 }


### PR DESCRIPTION
## Summary

Fixes GH-4740: a failed (or stalled/rate_limited/infra/no_op/declined/skipped/canceled) execution left the `pilot-in-progress` marker label on its GitHub issue, so the poller treated the issue as still in-flight and never re-picked it — even though the `pilot` trigger label remained present, inert behind the marker. Evidence: console#98 failed at 14:41:05Z and sat stuck for 1.5h+ until an operator manually stripped the label.

Root cause: the live SDK-dispatch path (`cmd/pilot/handlers.go`'s `handleGithubIssueEventSDK` → `handleIssueGeneric`) only applies `pilot-in-progress` at dispatch start (`notifyTaskStartedSDK`) and never strips it on any terminal outcome. `internal/adapters/github/notifier.go`'s `NotifyTaskCompleted`/`NotifyTaskFailed`/`NotifyTaskDeclined` do implement the strip correctly, but are never called anywhere in `cmd/pilot/`.

## Changes

- `internal/executor/lifecycle.go`: `ExecutionLifecycle.Persist` — the single terminal-write chokepoint shared by the dispatcher's `ProjectWorker` loop, `alerts.Engine`'s stuck-task tripwire eviction (covers a hard-killed/wedged child), and `epic.go`'s sub-issue finalizer — now strips `pilot-in-progress` whenever the outcome is one of `failed, stalled, rate_limited, infra, no_op, declined, skipped, canceled`. `completed` is untouched (label is kept on purpose until the PR merges). Best-effort, GitHub-only (`TaskSourceAdapter == "github"`), never invalidates the store-side status write on strip failure, logs loudly (Error) on failure per the GH-4692 lesson.
- `internal/executor/lifecycle_test.go`: three new regression tests using the existing fake-`gh`-via-PATH pattern — a failed GitHub task strips the label, a non-GitHub task is skipped, a completed task is skipped.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full suite green)
- [x] New regression tests pass and assert the exact `gh issue edit <N> --remove-label pilot-in-progress` invocation
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] Confirmed no pre-existing test incidentally triggers a real `gh` CLI call (guarded by requiring `TaskSourceAdapter == "github"` exactly, matching `checkLabelLifecycle`'s existing convention)