### PR TITLE
fix(memory): GetBriefMetrics success-rate denominator + canary exclusion (GH-4742)

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1930,11 +1930,19 @@ func (s *Store) ResolveOrphanedRunningExecution(id, prURL string) error {
 
 // GetBriefMetrics calculates aggregate metrics for a time period including
 // task counts, success rates, average duration, and PR creation statistics.
+//
+// GH-4742: the canary tenant is excluded from every aggregate below (see
+// GetWindowedStats/GetLifetimeTaskCounts for the same COALESCE(is_canary, 0)
+// = 0 predicate), and SuccessRate is computed over completed+failed only —
+// queued/running rows and neutral terminals (no_op, skipped, declined,
+// stalled, rate_limited, infra, superseded, decomposed, canceled) are
+// excluded from the rate denominator. TotalTasks remains COUNT(*) as a
+// volume stat and is NOT the SuccessRate denominator.
 func (s *Store) GetBriefMetrics(query BriefQuery) (*BriefMetricsData, error) {
 	var result BriefMetricsData
 
 	var args []interface{}
-	whereClause := "WHERE created_at >= ? AND created_at < ?"
+	whereClause := "WHERE created_at >= ? AND created_at < ? AND COALESCE(is_canary, 0) = 0"
 	args = append(args, query.Start, query.End)
 
 	if len(query.Projects) > 0 {
@@ -1966,8 +1974,8 @@ func (s *Store) GetBriefMetrics(query BriefQuery) (*BriefMetricsData, error) {
 		return nil, fmt.Errorf("failed to get metrics: %w", err)
 	}
 
-	if result.TotalTasks > 0 {
-		result.SuccessRate = float64(result.CompletedCount) / float64(result.TotalTasks)
+	if attempted := result.CompletedCount + result.FailedCount; attempted > 0 {
+		result.SuccessRate = float64(result.CompletedCount) / float64(attempted)
 	}
 
 	return &result, nil
@@ -1975,9 +1983,17 @@ func (s *Store) GetBriefMetrics(query BriefQuery) (*BriefMetricsData, error) {
 
 // BriefMetricsData holds aggregate metrics calculated from execution data.
 type BriefMetricsData struct {
-	TotalTasks       int
-	CompletedCount   int
-	FailedCount      int
+	// TotalTasks is COUNT(*) over the canary-excluded period population — a
+	// volume stat. It includes queued/running rows and neutral terminals and
+	// is NOT the SuccessRate denominator (see SuccessRate).
+	TotalTasks     int
+	CompletedCount int
+	FailedCount    int
+	// SuccessRate is CompletedCount / (CompletedCount + FailedCount): the
+	// GH-4735 attempt-success rate. In-flight (queued/running) rows and
+	// neutral terminals (no_op, skipped, declined, stalled, rate_limited,
+	// infra, superseded, decomposed, canceled) are excluded from both the
+	// numerator and denominator.
 	SuccessRate      float64
 	AvgDurationMs    int64
 	PRsCreated       int

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1710,6 +1710,61 @@ func TestGetBriefMetrics(t *testing.T) {
 	}
 }
 
+// TestGetBriefMetrics_SuccessRateExcludesInFlightNeutralAndCanary is GH-4742:
+// SuccessRate must be completed / (completed + failed) — in-flight (running)
+// rows and neutral terminals (e.g. no_op) are excluded from both the
+// numerator and denominator — and every aggregate must exclude canary rows,
+// matching the GH-4735 population rules applied elsewhere (GetWindowedStats,
+// GetLifetimeTaskCounts).
+func TestGetBriefMetrics_SuccessRateExcludesInFlightNeutralAndCanary(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	start := time.Now().Add(-24 * time.Hour)
+	end := time.Now().Add(24 * time.Hour)
+	inPeriod := time.Now()
+
+	execs := []*Execution{
+		{ID: "bm-completed", TaskID: "T-COMPLETED", ProjectPath: "/p", Status: "completed", CreatedAt: inPeriod, EstimatedCostUSD: 1.00},
+		{ID: "bm-failed", TaskID: "T-FAILED", ProjectPath: "/p", Status: "failed", CreatedAt: inPeriod, EstimatedCostUSD: 1.00},
+		{ID: "bm-running", TaskID: "T-RUNNING", ProjectPath: "/p", Status: "running", CreatedAt: inPeriod, EstimatedCostUSD: 1.00},
+		{ID: "bm-noop", TaskID: "T-NOOP", ProjectPath: "/p", Status: "no_op", CreatedAt: inPeriod, EstimatedCostUSD: 1.00},
+		{ID: "bm-canary", TaskID: "T-CANARY", ProjectPath: "/p", Status: "completed", CreatedAt: inPeriod, EstimatedCostUSD: 100.00, TokensTotal: 9000, IsCanary: true},
+	}
+	for _, e := range execs {
+		if err := store.SaveExecution(e); err != nil {
+			t.Fatalf("SaveExecution %s: %v", e.ID, err)
+		}
+	}
+
+	metrics, err := store.GetBriefMetrics(BriefQuery{Start: start, End: end})
+	if err != nil {
+		t.Fatalf("GetBriefMetrics failed: %v", err)
+	}
+
+	if metrics.SuccessRate != 0.5 {
+		t.Errorf("SuccessRate = %v, want 0.5 (completed / (completed+failed), in-flight/neutral/canary excluded)", metrics.SuccessRate)
+	}
+	if metrics.TotalTasks != 4 {
+		t.Errorf("TotalTasks = %d, want 4 (canary row excluded, count is a volume stat over completed+failed+running+no_op)", metrics.TotalTasks)
+	}
+	if metrics.CompletedCount != 1 {
+		t.Errorf("CompletedCount = %d, want 1 (canary completed row must be excluded)", metrics.CompletedCount)
+	}
+	if metrics.FailedCount != 1 {
+		t.Errorf("FailedCount = %d, want 1", metrics.FailedCount)
+	}
+	if metrics.EstimatedCostUSD != 4.00 {
+		t.Errorf("EstimatedCostUSD = %.2f, want 4.00 (canary row's cost must be excluded)", metrics.EstimatedCostUSD)
+	}
+	if metrics.TotalTokensUsed != 0 {
+		t.Errorf("TotalTokensUsed = %d, want 0 (canary row's tokens must be excluded)", metrics.TotalTokensUsed)
+	}
+}
+
 func TestProjectSettings(t *testing.T) {
 	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
 	defer func() { _ = os.RemoveAll(tmpDir) }()


### PR DESCRIPTION
## Summary
- `GetBriefMetrics` now excludes canary rows (`COALESCE(is_canary, 0) = 0`) from every aggregate — counts, duration, PRs, tokens, cost — matching `GetWindowedStats`/`GetLifetimeTaskCounts`.
- `SuccessRate` denominator is now `completed + failed` (attempt-success semantics from GH-4735): in-flight (queued/running) rows and neutral terminals (`no_op`, `skipped`, `declined`, `stalled`, `rate_limited`, `infra`, `superseded`, `decomposed`, `canceled`) no longer dilute the rate. `TotalTasks` remains `COUNT(*)` as a volume stat, documented as not being the rate denominator.
- Added `TestGetBriefMetrics_SuccessRateExcludesInFlightNeutralAndCanary`, seeding one completed + one failed + one running + one no_op + one canary row in-period, asserting `SuccessRate == 0.5` and the canary row absent from every aggregate.

Closes GH-4742.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/memory/... ./internal/briefs/...`