### PR TITLE
GH-4746: feat(github): route gh CLI subprocess calls through the App installation token when app auth is active

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1692,9 +1692,19 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 	// CLI credential helper — the SPOF this ticket kills. No-op (nil
 	// provider) when App auth isn't configured, so git commands keep using
 	// the ambient environment exactly as before the cutover.
+	// GH-4746: same cutover, closing the matching gap for `gh` CLI
+	// subprocesses (PR creation, issue comments, label ops) — the daemon's
+	// highest-volume writes, previously left riding the ambient
+	// GITHUB_TOKEN/gh-CLI login even with App auth configured. Both
+	// providers mint through the same mintGitHubAppToken/TokenSource cache,
+	// so git and gh always agree on the current token. No-op (nil provider)
+	// when App auth isn't configured, matching the git provider above.
 	if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.App != nil {
 		appCfg := cfg.Adapters.GitHub.App
 		executor.SetGitCredentialProvider(func(ctx context.Context) (string, error) {
+			return mintGitHubAppToken(ctx, appCfg)
+		})
+		executor.SetGhCredentialProvider(func(ctx context.Context) (string, error) {
 			return mintGitHubAppToken(ctx, appCfg)
 		})
 	}

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -834,7 +834,7 @@ func queryParentDoneViaGitHub(taskID, dir string) bool {
 		return false
 	}
 	args := []string{"issue", "view", issueNum, "--json", "state,labels"}
-	cmd := exec.Command("gh", args...)
+	cmd := withGhCredentials(context.Background(), exec.Command("gh", args...))
 	if dir != "" {
 		cmd.Dir = dir
 	}
@@ -1038,7 +1038,7 @@ func queryRecentSubIssues(ctx context.Context, dir, parentID string) (bool, erro
 		"--json", "number",
 		"--limit", "3",
 	}
-	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd := withGhCredentials(ctx, exec.CommandContext(ctx, "gh", args...))
 	if dir != "" {
 		cmd.Dir = dir
 	}
@@ -1066,7 +1066,7 @@ func recoverExistingSubIssues(ctx context.Context, dir, parentID string) ([]Crea
 		"--json", "number,url,state,title,body",
 		"--limit", "50",
 	}
-	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd := withGhCredentials(ctx, exec.CommandContext(ctx, "gh", args...))
 	if dir != "" {
 		cmd.Dir = dir
 	}
@@ -1666,7 +1666,7 @@ func (r *Runner) runGHIssueCreateWithRetry(ctx context.Context, args []string, e
 
 	var lastErr error
 	for attempt := 1; attempt <= attempts; attempt++ {
-		cmd := exec.CommandContext(ctx, "gh", args...)
+		cmd := withGhCredentials(ctx, exec.CommandContext(ctx, "gh", args...))
 		if executionPath != "" {
 			cmd.Dir = executionPath
 		}
@@ -1882,7 +1882,7 @@ func (r *Runner) UpdateIssueProgress(ctx context.Context, projectPath string, is
 	}
 
 	args := []string{"issue", "comment", issueID, "--body", message}
-	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd := withGhCredentials(ctx, exec.CommandContext(ctx, "gh", args...))
 	if projectPath != "" {
 		cmd.Dir = projectPath
 	}
@@ -1905,7 +1905,7 @@ func (r *Runner) CloseIssueWithComment(ctx context.Context, projectPath string, 
 	}
 
 	// Idempotency: check if issue is already closed before attempting close.
-	stateCmd := exec.CommandContext(ctx, "gh", "issue", "view", issueID, "--json", "state", "--jq", ".state")
+	stateCmd := withGhCredentials(ctx, exec.CommandContext(ctx, "gh", "issue", "view", issueID, "--json", "state", "--jq", ".state"))
 	if projectPath != "" {
 		stateCmd.Dir = projectPath
 	}
@@ -1917,7 +1917,7 @@ func (r *Runner) CloseIssueWithComment(ctx context.Context, projectPath string, 
 	}
 
 	args := []string{"issue", "close", issueID, "--comment", comment}
-	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd := withGhCredentials(ctx, exec.CommandContext(ctx, "gh", args...))
 	if projectPath != "" {
 		cmd.Dir = projectPath
 	}
@@ -1948,7 +1948,7 @@ func (r *Runner) getSubIssuePRState(ctx context.Context, projectPath string, prN
 		return &SubIssuePRState{State: "MERGED", Merged: true}, nil
 	}
 
-	cmd := exec.CommandContext(ctx, "gh", "pr", "view", strconv.Itoa(prNumber), "--json", "state", "--jq", ".state")
+	cmd := withGhCredentials(ctx, exec.CommandContext(ctx, "gh", "pr", "view", strconv.Itoa(prNumber), "--json", "state", "--jq", ".state"))
 	if projectPath != "" {
 		cmd.Dir = projectPath
 	}

--- a/internal/executor/gh_credentials.go
+++ b/internal/executor/gh_credentials.go
@@ -1,0 +1,70 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"sync"
+)
+
+// GhTokenProvider returns a currently-valid GitHub token to authenticate
+// `gh` CLI subprocess calls (PR creation, issue comments, label ops).
+// Implementations must never log the token.
+type GhTokenProvider func(ctx context.Context) (string, error)
+
+var (
+	ghCredentialProviderMu sync.RWMutex
+	ghCredentialProvider   GhTokenProvider
+)
+
+// SetGhCredentialProvider installs the token provider used by
+// withGhCredentials to authenticate `gh` CLI subprocess calls with a GitHub
+// App installation token (GH-4746). Passing nil clears it, reverting to the
+// ambient environment (GITHUB_TOKEN env / gh CLI login) — the default, and
+// the only behavior before this ticket. Called once at daemon startup from
+// cmd/pilot when adapters.github.app is configured, mirroring
+// SetGitCredentialProvider (GH-4743), which wired the same minted token
+// into raw `git` HTTPS operations — this closes the matching gap for `gh`
+// CLI subprocesses (PR creation, issue comments, label ops), the daemon's
+// highest-volume writes.
+func SetGhCredentialProvider(provider GhTokenProvider) {
+	ghCredentialProviderMu.Lock()
+	defer ghCredentialProviderMu.Unlock()
+	ghCredentialProvider = provider
+}
+
+func getGhCredentialProvider() GhTokenProvider {
+	ghCredentialProviderMu.RLock()
+	defer ghCredentialProviderMu.RUnlock()
+	return ghCredentialProvider
+}
+
+// withGhCredentials sets cmd.Env so a `gh` CLI subprocess authenticates
+// with the current GitHub App installation token via GITHUB_TOKEN, resolved
+// fresh at spawn time through the installed GhTokenProvider — refresh-aware,
+// since the provider (mintGitHubAppToken's shared TokenSource cache) is
+// asked for the current token on every call rather than a value captured
+// once at startup, so a token minted an hour ago is never reused after
+// rotation. It is a no-op — cmd.Env stays nil, ambient environment
+// inherited — when no provider is installed (the default; GITHUB_TOKEN env
+// / gh CLI login keep working exactly as before GH-4746).
+//
+// The token only ever exists in the child `gh` process's environment, never
+// in argv or a log line.
+func withGhCredentials(ctx context.Context, cmd *exec.Cmd) *exec.Cmd {
+	provider := getGhCredentialProvider()
+	if provider == nil {
+		return cmd
+	}
+	token, err := provider(ctx)
+	if err != nil || token == "" {
+		// Mint failure is already logged loudly by the provider (see
+		// mintGitHubAppToken / resolveGitHubToken in cmd/pilot); falling
+		// back to the ambient environment here lets a transient mint
+		// failure degrade to the pre-GH-4746 behavior instead of breaking
+		// every `gh` CLI call outright.
+		return cmd
+	}
+	cmd.Env = append(os.Environ(), "GITHUB_TOKEN="+token)
+	return cmd
+}

--- a/internal/executor/gh_credentials_test.go
+++ b/internal/executor/gh_credentials_test.go
@@ -1,0 +1,125 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// resetGhCredentialProvider clears the package-level provider after each
+// test so tests don't leak state into each other or into unrelated tests
+// elsewhere in the package (GH-4746: provider is a process-wide singleton,
+// same discipline as resetGitCredentialProvider for GH-4743).
+func resetGhCredentialProvider(t *testing.T) {
+	t.Helper()
+	SetGhCredentialProvider(nil)
+	t.Cleanup(func() { SetGhCredentialProvider(nil) })
+}
+
+func TestWithGhCredentials_NoProviderIsNoOp(t *testing.T) {
+	resetGhCredentialProvider(t)
+
+	cmd := exec.CommandContext(context.Background(), "gh", "issue", "view", "1")
+	withGhCredentials(context.Background(), cmd)
+
+	if cmd.Env != nil {
+		t.Errorf("cmd.Env = %v, want nil (no provider installed => ambient environment inherited)", cmd.Env)
+	}
+}
+
+func TestWithGhCredentials_InstallsGitHubTokenEnv(t *testing.T) {
+	resetGhCredentialProvider(t)
+	SetGhCredentialProvider(func(ctx context.Context) (string, error) {
+		return testutil.FakeGitHubToken, nil
+	})
+
+	cmd := exec.CommandContext(context.Background(), "gh", "issue", "view", "1")
+	withGhCredentials(context.Background(), cmd)
+
+	if cmd.Env == nil {
+		t.Fatal("cmd.Env is nil, want GITHUB_TOKEN set")
+	}
+	env := map[string]string{}
+	for _, kv := range cmd.Env {
+		if idx := strings.IndexByte(kv, '='); idx >= 0 {
+			env[kv[:idx]] = kv[idx+1:]
+		}
+	}
+	if env["GITHUB_TOKEN"] != testutil.FakeGitHubToken {
+		t.Errorf("GITHUB_TOKEN = %q, want %q", env["GITHUB_TOKEN"], testutil.FakeGitHubToken)
+	}
+}
+
+// TestWithGhCredentials_RotatesAfterRefresh verifies the provider is called
+// fresh on every invocation rather than a token being captured once, so a
+// token minted before a refresh is never reused after the provider starts
+// returning a newer one (GH-4746 acceptance).
+func TestWithGhCredentials_RotatesAfterRefresh(t *testing.T) {
+	resetGhCredentialProvider(t)
+	current := testutil.FakeGitHubToken
+	SetGhCredentialProvider(func(ctx context.Context) (string, error) {
+		return current, nil
+	})
+
+	cmd1 := exec.CommandContext(context.Background(), "gh", "issue", "view", "1")
+	withGhCredentials(context.Background(), cmd1)
+	if got := envValue(cmd1.Env, "GITHUB_TOKEN"); got != testutil.FakeGitHubToken {
+		t.Fatalf("first call GITHUB_TOKEN = %q, want %q", got, testutil.FakeGitHubToken)
+	}
+
+	current = testutil.FakeGitHubPAT // stand-in for a rotated/refreshed token
+
+	cmd2 := exec.CommandContext(context.Background(), "gh", "issue", "view", "1")
+	withGhCredentials(context.Background(), cmd2)
+	if got := envValue(cmd2.Env, "GITHUB_TOKEN"); got != testutil.FakeGitHubPAT {
+		t.Errorf("second call GITHUB_TOKEN = %q, want %q (rotated token, not the stale first one)", got, testutil.FakeGitHubPAT)
+	}
+}
+
+func TestWithGhCredentials_ProviderErrorFallsBackToAmbientEnv(t *testing.T) {
+	resetGhCredentialProvider(t)
+	SetGhCredentialProvider(func(ctx context.Context) (string, error) {
+		return "", errors.New("mint failed")
+	})
+
+	cmd := exec.CommandContext(context.Background(), "gh", "issue", "view", "1")
+	withGhCredentials(context.Background(), cmd)
+
+	if cmd.Env != nil {
+		t.Errorf("cmd.Env = %v, want nil (mint failure should degrade to ambient environment, not break the command)", cmd.Env)
+	}
+}
+
+func TestWithGhCredentials_EmptyTokenFallsBackToAmbientEnv(t *testing.T) {
+	resetGhCredentialProvider(t)
+	SetGhCredentialProvider(func(ctx context.Context) (string, error) {
+		return "", nil
+	})
+
+	cmd := exec.CommandContext(context.Background(), "gh", "issue", "view", "1")
+	withGhCredentials(context.Background(), cmd)
+
+	if cmd.Env != nil {
+		t.Errorf("cmd.Env = %v, want nil (empty token should degrade to ambient environment)", cmd.Env)
+	}
+}
+
+// envValue returns the value of the last occurrence of key in env — matching
+// os/exec.Cmd's own documented behavior ("If Env contains duplicate
+// environment keys, only the last value in the slice for each duplicate key
+// is used"), since withGhCredentials appends its GITHUB_TOKEN after
+// os.Environ(), which may already contain an ambient GITHUB_TOKEN.
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	value := ""
+	for _, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			value = strings.TrimPrefix(kv, prefix)
+		}
+	}
+	return value
+}

--- a/internal/executor/git.go
+++ b/internal/executor/git.go
@@ -880,7 +880,7 @@ func (g *GitOperations) CreatePR(ctx context.Context, title, body, baseBranch st
 		args = append(args, "--head", headBranch)
 	}
 
-	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd := withGhCredentials(ctx, exec.CommandContext(ctx, "gh", args...))
 	cmd.Dir = g.projectPath
 	output, err := cmd.CombinedOutput()
 	outputStr := string(output)
@@ -926,12 +926,12 @@ func extractPRURL(text string) string {
 // dependency CreatePR already relies on — so the executor needs no github.Client
 // wiring (the merge-detection API lives only on *github.Client).
 func (g *GitOperations) FindMergedPRByBranch(ctx context.Context, branch string) (string, error) {
-	cmd := exec.CommandContext(ctx, "gh", "pr", "list",
+	cmd := withGhCredentials(ctx, exec.CommandContext(ctx, "gh", "pr", "list",
 		"--head", branch,
 		"--state", "merged",
 		"--json", "url",
 		"--limit", "1",
-	)
+	))
 	cmd.Dir = g.projectPath
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -945,12 +945,12 @@ func (g *GitOperations) FindMergedPRByBranch(ctx context.Context, branch string)
 // already-open PR from a prior/retried dispatch of the same branch instead of
 // racing gh CLI into a duplicate PR.
 func (g *GitOperations) FindOpenPRByBranch(ctx context.Context, branch string) (string, error) {
-	cmd := exec.CommandContext(ctx, "gh", "pr", "list",
+	cmd := withGhCredentials(ctx, exec.CommandContext(ctx, "gh", "pr", "list",
 		"--head", branch,
 		"--state", "open",
 		"--json", "url",
 		"--limit", "1",
-	)
+	))
 	cmd.Dir = g.projectPath
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/executor/issue_state.go
+++ b/internal/executor/issue_state.go
@@ -89,7 +89,7 @@ func (ghCLIIssueStateChecker) GetIssueState(ctx context.Context, owner, repo str
 		"--repo", owner + "/" + repo,
 		"--json", "state,labels",
 	}
-	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd := withGhCredentials(ctx, exec.CommandContext(ctx, "gh", args...))
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/executor/sideeffect_audit.go
+++ b/internal/executor/sideeffect_audit.go
@@ -87,7 +87,7 @@ func (ghCLISideEffectSearcher) SearchClosedOrReopenedSince(ctx context.Context, 
 		"--updated", ">=" + since.UTC().Format(time.RFC3339),
 		"--json", "number,title,state,url",
 	}
-	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd := withGhCredentials(ctx, exec.CommandContext(ctx, "gh", args...))
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 

--- a/internal/executor/title_rejection.go
+++ b/internal/executor/title_rejection.go
@@ -225,7 +225,7 @@ func (r *Runner) postTitleRejectionEscalation(ctx context.Context, task *Task) e
 }
 
 func ghIssueComment(ctx context.Context, dir, issueID, body string) error {
-	cmd := exec.CommandContext(ctx, "gh", "issue", "comment", issueID, "--body", body)
+	cmd := withGhCredentials(ctx, exec.CommandContext(ctx, "gh", "issue", "comment", issueID, "--body", body))
 	if dir != "" {
 		cmd.Dir = dir
 	}
@@ -264,7 +264,7 @@ func ghEditLabels(ctx context.Context, dir, issueID string, addLabels, removeLab
 	for _, l := range removeLabels {
 		args = append(args, "--remove-label", l)
 	}
-	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd := withGhCredentials(ctx, exec.CommandContext(ctx, "gh", args...))
 	if dir != "" {
 		cmd.Dir = dir
 	}
@@ -294,7 +294,7 @@ func ghEnsureLabels(ctx context.Context, dir string, labels []string) {
 			continue
 		}
 		seen[l] = true
-		cmd := exec.CommandContext(ctx, "gh", "label", "create", l, "--color", pilotLabelColor, "--force")
+		cmd := withGhCredentials(ctx, exec.CommandContext(ctx, "gh", "label", "create", l, "--color", pilotLabelColor, "--force"))
 		if dir != "" {
 			cmd.Dir = dir
 		}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4746.

Closes #4746

## Changes

GitHub Issue GH-4746: feat(github): route gh CLI subprocess calls through the App installation token when app auth is active

## Problem

GH-4743 (PR #4745) wired the minted App installation token into `resolveGitHubToken` and raw `git` HTTPS operations (GIT_ASKPASS/`PILOT_GIT_TOKEN`), but `gh` CLI subprocess calls — PR creation, issue comments, label ops — still ride the ambient `GITHUB_TOKEN`/gh-CLI login. Documented as scope boundary (1) in `sops/config/github-token-architecture.md` §App-token. Until closed, flipping `adapters.github.app` on still leaves the daemon's highest-volume writes on the OAuth SPOF and the shared per-user pool — the cutover doesn't deliver its point.

## Acceptance

1. When the App TokenSource is active, every `gh` subprocess the daemon spawns gets `GITHUB_TOKEN=<current minted token>` in its child env — resolved at spawn time through the same provider seam PR #4745 installed (refresh-aware; a token minted an hour ago must not be reused after refresh), never argv, never logged.
2. One chokepoint: wire it where gh subprocess construction already funnels (mirror `executor.SetGitCredentialProvider`'s pattern); no per-call-site env plumbing.
3. When app auth is not configured, behavior is byte-identical to today (ambient env inherited).
4. Tests: provider installed → child env carries the current token and rotates after refresh; provider absent → env untouched. Fake tokens per `internal/testutil` rules.

## Scope fence

No SDK-client changes (that is the sibling ticket) · no gh-CLI config file writes · no cutover (operator flips config separately).

**This task must NOT be decomposed — implement as a single PR.** <!-- pilot:no-decompose -->