### PR TITLE
GH-4753: fix(executor): gh credential injection — GH_TOKEN precedence + loud mint-failure fallback (PR#4750 review)

### DIFF
--- a/internal/executor/gh_credentials.go
+++ b/internal/executor/gh_credentials.go
@@ -2,9 +2,12 @@ package executor
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"os/exec"
 	"sync"
+
+	"github.com/qf-studio/pilot/internal/logging"
 )
 
 // GhTokenProvider returns a currently-valid GitHub token to authenticate
@@ -40,14 +43,23 @@ func getGhCredentialProvider() GhTokenProvider {
 }
 
 // withGhCredentials sets cmd.Env so a `gh` CLI subprocess authenticates
-// with the current GitHub App installation token via GITHUB_TOKEN, resolved
-// fresh at spawn time through the installed GhTokenProvider — refresh-aware,
-// since the provider (mintGitHubAppToken's shared TokenSource cache) is
-// asked for the current token on every call rather than a value captured
-// once at startup, so a token minted an hour ago is never reused after
-// rotation. It is a no-op — cmd.Env stays nil, ambient environment
-// inherited — when no provider is installed (the default; GITHUB_TOKEN env
-// / gh CLI login keep working exactly as before GH-4746).
+// with the current GitHub App installation token via GITHUB_TOKEN and
+// GH_TOKEN, resolved fresh at spawn time through the installed
+// GhTokenProvider — refresh-aware, since the provider (mintGitHubAppToken's
+// shared TokenSource cache) is asked for the current token on every call
+// rather than a value captured once at startup, so a token minted an hour
+// ago is never reused after rotation. It is a no-op — cmd.Env stays nil,
+// ambient environment inherited — when no provider is installed (the
+// default; GITHUB_TOKEN/GH_TOKEN env / gh CLI login keep working exactly as
+// before GH-4746).
+//
+// GH-4753: both GITHUB_TOKEN and GH_TOKEN are set — gh CLI resolves GH_TOKEN
+// with higher precedence than GITHUB_TOKEN, and cmd.Env inherits the
+// daemon's full ambient environment via os.Environ(). Setting only
+// GITHUB_TOKEN left an ambient GH_TOKEN (e.g. an OAuth PAT exported in the
+// daemon's shell) silently winning over the minted App token on every `gh`
+// invocation, with app auth looking active and no signal that it wasn't
+// actually being used.
 //
 // The token only ever exists in the child `gh` process's environment, never
 // in argv or a log line.
@@ -58,13 +70,49 @@ func withGhCredentials(ctx context.Context, cmd *exec.Cmd) *exec.Cmd {
 	}
 	token, err := provider(ctx)
 	if err != nil || token == "" {
-		// Mint failure is already logged loudly by the provider (see
-		// mintGitHubAppToken / resolveGitHubToken in cmd/pilot); falling
-		// back to the ambient environment here lets a transient mint
-		// failure degrade to the pre-GH-4746 behavior instead of breaking
-		// every `gh` CLI call outright.
+		// GH-4753: the provider closure installed in cmd/pilot calls
+		// mintGitHubAppToken directly, bypassing resolveGitHubToken — the
+		// only site that used to log mint failures loudly — so without this
+		// call a mint failure here degraded silently to the ambient
+		// GITHUB_TOKEN/GH_TOKEN/gh-CLI-login, indefinitely, with no signal.
+		// logGhMintFailure logs at ERROR on state change (not per-call) so a
+		// persistent failure doesn't flood logs on every `gh` invocation
+		// while still alerting loudly the moment it starts.
+		logGhMintFailure(err)
 		return cmd
 	}
-	cmd.Env = append(os.Environ(), "GITHUB_TOKEN="+token)
+	ghMintFailureMu.Lock()
+	ghMintFailureLast = ""
+	ghMintFailureMu.Unlock()
+	cmd.Env = append(os.Environ(),
+		"GITHUB_TOKEN="+token,
+		"GH_TOKEN="+token,
+	)
 	return cmd
+}
+
+var (
+	ghMintFailureMu   sync.Mutex
+	ghMintFailureLast string
+)
+
+// logGhMintFailure logs a `gh` CLI credential mint failure at ERROR, once
+// per distinct failure reason (GH-4753) — see the comment in
+// withGhCredentials for why this call site, and not resolveGitHubToken, is
+// the only place a mint failure on this leg gets logged at all.
+func logGhMintFailure(err error) {
+	reason := "empty token"
+	if err != nil {
+		reason = err.Error()
+	}
+	ghMintFailureMu.Lock()
+	defer ghMintFailureMu.Unlock()
+	if ghMintFailureLast == reason {
+		return
+	}
+	ghMintFailureLast = reason
+	logging.WithComponent("github-auth").Error(
+		"github app installation token mint failed for gh CLI — falling back to ambient GITHUB_TOKEN/GH_TOKEN/gh-CLI-login",
+		slog.String("reason", reason),
+	)
 }

--- a/internal/executor/gh_credentials_test.go
+++ b/internal/executor/gh_credentials_test.go
@@ -41,7 +41,7 @@ func TestWithGhCredentials_InstallsGitHubTokenEnv(t *testing.T) {
 	withGhCredentials(context.Background(), cmd)
 
 	if cmd.Env == nil {
-		t.Fatal("cmd.Env is nil, want GITHUB_TOKEN set")
+		t.Fatal("cmd.Env is nil, want GITHUB_TOKEN/GH_TOKEN set")
 	}
 	env := map[string]string{}
 	for _, kv := range cmd.Env {
@@ -51,6 +51,38 @@ func TestWithGhCredentials_InstallsGitHubTokenEnv(t *testing.T) {
 	}
 	if env["GITHUB_TOKEN"] != testutil.FakeGitHubToken {
 		t.Errorf("GITHUB_TOKEN = %q, want %q", env["GITHUB_TOKEN"], testutil.FakeGitHubToken)
+	}
+	// GH-4753: gh CLI resolves GH_TOKEN with higher precedence than
+	// GITHUB_TOKEN, so both must be set to the minted token or the App
+	// cutover is silently ineffective.
+	if env["GH_TOKEN"] != testutil.FakeGitHubToken {
+		t.Errorf("GH_TOKEN = %q, want %q", env["GH_TOKEN"], testutil.FakeGitHubToken)
+	}
+}
+
+// TestWithGhCredentials_OverridesAmbientGhToken verifies that an ambient
+// GH_TOKEN/GITHUB_TOKEN already present in the daemon's environment (e.g. an
+// OAuth PAT exported in the shell) is overridden by the minted App token
+// (GH-4753). cmd.Env inherits os.Environ() and appends the provider's token
+// after it, so os/exec's documented last-value-wins behavior for duplicate
+// keys is what makes this safe — this test pins that behavior against
+// regression instead of just asserting it in a comment.
+func TestWithGhCredentials_OverridesAmbientGhToken(t *testing.T) {
+	resetGhCredentialProvider(t)
+	t.Setenv("GH_TOKEN", "ambient-gh-token-should-be-overridden")
+	t.Setenv("GITHUB_TOKEN", "ambient-github-token-should-be-overridden")
+	SetGhCredentialProvider(func(ctx context.Context) (string, error) {
+		return testutil.FakeGitHubToken, nil
+	})
+
+	cmd := exec.CommandContext(context.Background(), "gh", "issue", "view", "1")
+	withGhCredentials(context.Background(), cmd)
+
+	if got := envValue(cmd.Env, "GH_TOKEN"); got != testutil.FakeGitHubToken {
+		t.Errorf("GH_TOKEN = %q, want %q (ambient value must be overridden by minted token)", got, testutil.FakeGitHubToken)
+	}
+	if got := envValue(cmd.Env, "GITHUB_TOKEN"); got != testutil.FakeGitHubToken {
+		t.Errorf("GITHUB_TOKEN = %q, want %q (ambient value must be overridden by minted token)", got, testutil.FakeGitHubToken)
 	}
 }
 
@@ -105,6 +137,74 @@ func TestWithGhCredentials_EmptyTokenFallsBackToAmbientEnv(t *testing.T) {
 
 	if cmd.Env != nil {
 		t.Errorf("cmd.Env = %v, want nil (empty token should degrade to ambient environment)", cmd.Env)
+	}
+}
+
+// resetGhMintFailureState clears the package-level mint-failure dedup state
+// so tests don't leak into each other (GH-4753).
+func resetGhMintFailureState(t *testing.T) {
+	t.Helper()
+	ghMintFailureMu.Lock()
+	ghMintFailureLast = ""
+	ghMintFailureMu.Unlock()
+	t.Cleanup(func() {
+		ghMintFailureMu.Lock()
+		ghMintFailureLast = ""
+		ghMintFailureMu.Unlock()
+	})
+}
+
+// TestLogGhMintFailure_DedupsByReason verifies the ERROR log fires on state
+// change (a new/different failure reason) but not on a repeat of the same
+// reason — the non-spammy behavior GH-4753 requires so a persistent mint
+// failure doesn't flood logs on every `gh` CLI invocation.
+func TestLogGhMintFailure_DedupsByReason(t *testing.T) {
+	resetGhMintFailureState(t)
+
+	logGhMintFailure(errors.New("mint failed: 401"))
+	if got := ghMintFailureLast; got != "mint failed: 401" {
+		t.Fatalf("ghMintFailureLast = %q, want %q after first failure", got, "mint failed: 401")
+	}
+
+	// Same reason again — dedup state must not change (this is the
+	// non-spammy guarantee; the log call itself is idempotent to invoke).
+	logGhMintFailure(errors.New("mint failed: 401"))
+	if got := ghMintFailureLast; got != "mint failed: 401" {
+		t.Fatalf("ghMintFailureLast = %q, want unchanged %q on repeat failure", got, "mint failed: 401")
+	}
+
+	// Different reason — state must change, i.e. this failure logs again.
+	logGhMintFailure(errors.New("mint failed: installation suspended"))
+	if got := ghMintFailureLast; got != "mint failed: installation suspended" {
+		t.Fatalf("ghMintFailureLast = %q, want %q after distinct failure", got, "mint failed: installation suspended")
+	}
+}
+
+// TestWithGhCredentials_ResetsMintFailureStateOnSuccess verifies a
+// subsequent successful mint clears the dedup state, so if the same failure
+// reason recurs later it logs again instead of staying silently deduped
+// forever.
+func TestWithGhCredentials_ResetsMintFailureStateOnSuccess(t *testing.T) {
+	resetGhCredentialProvider(t)
+	resetGhMintFailureState(t)
+
+	failing := true
+	SetGhCredentialProvider(func(ctx context.Context) (string, error) {
+		if failing {
+			return "", errors.New("mint failed: 401")
+		}
+		return testutil.FakeGitHubToken, nil
+	})
+
+	withGhCredentials(context.Background(), exec.CommandContext(context.Background(), "gh", "issue", "view", "1"))
+	if got := ghMintFailureLast; got != "mint failed: 401" {
+		t.Fatalf("ghMintFailureLast = %q, want %q after failure", got, "mint failed: 401")
+	}
+
+	failing = false
+	withGhCredentials(context.Background(), exec.CommandContext(context.Background(), "gh", "issue", "view", "1"))
+	if got := ghMintFailureLast; got != "" {
+		t.Fatalf("ghMintFailureLast = %q, want empty after a successful mint", got)
 	}
 }
 

--- a/internal/executor/git_credentials.go
+++ b/internal/executor/git_credentials.go
@@ -3,10 +3,13 @@ package executor
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sync"
+
+	"github.com/qf-studio/pilot/internal/logging"
 )
 
 // GitTokenProvider returns a currently-valid GitHub token to authenticate
@@ -54,23 +57,56 @@ func withGitCredentials(ctx context.Context, cmd *exec.Cmd) *exec.Cmd {
 	}
 	token, err := provider(ctx)
 	if err != nil || token == "" {
-		// Mint failure is already logged loudly by the provider (see
-		// mintGitHubAppToken / resolveGitHubToken in cmd/pilot); falling
-		// back to the ambient environment here lets a transient mint
-		// failure degrade to the pre-GH-4743 behavior instead of breaking
-		// every push/fetch outright.
+		// GH-4753: the provider closure installed in cmd/pilot calls
+		// mintGitHubAppToken directly, bypassing resolveGitHubToken — the
+		// only site that used to log mint failures loudly — so without this
+		// call a mint failure here degraded silently to the ambient
+		// GITHUB_TOKEN env/gh-CLI credential helper, indefinitely, with no
+		// signal. logGitMintFailure logs at ERROR on state change (not
+		// per-call) so a persistent failure doesn't flood logs on every git
+		// push/fetch while still alerting loudly the moment it starts.
+		logGitMintFailure(err)
 		return cmd
 	}
 	askpass, askpassErr := gitAskpassHelperPath()
 	if askpassErr != nil {
 		return cmd
 	}
+	gitMintFailureMu.Lock()
+	gitMintFailureLast = ""
+	gitMintFailureMu.Unlock()
 	cmd.Env = append(os.Environ(),
 		"GIT_ASKPASS="+askpass,
 		"PILOT_GIT_TOKEN="+token,
 		"GIT_TERMINAL_PROMPT=0",
 	)
 	return cmd
+}
+
+var (
+	gitMintFailureMu   sync.Mutex
+	gitMintFailureLast string
+)
+
+// logGitMintFailure logs a git credential mint failure at ERROR, once per
+// distinct failure reason (GH-4753) — see the comment in withGitCredentials
+// for why this call site, and not resolveGitHubToken, is the only place a
+// mint failure on this leg gets logged at all.
+func logGitMintFailure(err error) {
+	reason := "empty token"
+	if err != nil {
+		reason = err.Error()
+	}
+	gitMintFailureMu.Lock()
+	defer gitMintFailureMu.Unlock()
+	if gitMintFailureLast == reason {
+		return
+	}
+	gitMintFailureLast = reason
+	logging.WithComponent("github-auth").Error(
+		"github app installation token mint failed for git push/fetch — falling back to ambient GITHUB_TOKEN env/gh-CLI credential helper",
+		slog.String("reason", reason),
+	)
 }
 
 // gitAskpassScript is the content of the GIT_ASKPASS helper. It contains no

--- a/internal/executor/git_credentials_test.go
+++ b/internal/executor/git_credentials_test.go
@@ -87,6 +87,71 @@ func TestWithGitCredentials_EmptyTokenFallsBackToAmbientEnv(t *testing.T) {
 	}
 }
 
+// resetGitMintFailureState clears the package-level mint-failure dedup
+// state so tests don't leak into each other (GH-4753).
+func resetGitMintFailureState(t *testing.T) {
+	t.Helper()
+	gitMintFailureMu.Lock()
+	gitMintFailureLast = ""
+	gitMintFailureMu.Unlock()
+	t.Cleanup(func() {
+		gitMintFailureMu.Lock()
+		gitMintFailureLast = ""
+		gitMintFailureMu.Unlock()
+	})
+}
+
+// TestLogGitMintFailure_DedupsByReason verifies the ERROR log fires on state
+// change (a new/different failure reason) but not on a repeat of the same
+// reason — the non-spammy behavior GH-4753 requires so a persistent mint
+// failure doesn't flood logs on every git push/fetch.
+func TestLogGitMintFailure_DedupsByReason(t *testing.T) {
+	resetGitMintFailureState(t)
+
+	logGitMintFailure(errors.New("mint failed: 401"))
+	if got := gitMintFailureLast; got != "mint failed: 401" {
+		t.Fatalf("gitMintFailureLast = %q, want %q after first failure", got, "mint failed: 401")
+	}
+
+	logGitMintFailure(errors.New("mint failed: 401"))
+	if got := gitMintFailureLast; got != "mint failed: 401" {
+		t.Fatalf("gitMintFailureLast = %q, want unchanged %q on repeat failure", got, "mint failed: 401")
+	}
+
+	logGitMintFailure(errors.New("mint failed: installation suspended"))
+	if got := gitMintFailureLast; got != "mint failed: installation suspended" {
+		t.Fatalf("gitMintFailureLast = %q, want %q after distinct failure", got, "mint failed: installation suspended")
+	}
+}
+
+// TestWithGitCredentials_ResetsMintFailureStateOnSuccess verifies a
+// subsequent successful mint clears the dedup state, so if the same failure
+// reason recurs later it logs again instead of staying silently deduped
+// forever.
+func TestWithGitCredentials_ResetsMintFailureStateOnSuccess(t *testing.T) {
+	resetGitCredentialProvider(t)
+	resetGitMintFailureState(t)
+
+	failing := true
+	SetGitCredentialProvider(func(ctx context.Context) (string, error) {
+		if failing {
+			return "", errors.New("mint failed: 401")
+		}
+		return testutil.FakeGitHubToken, nil
+	})
+
+	withGitCredentials(context.Background(), exec.CommandContext(context.Background(), "git", "fetch"))
+	if got := gitMintFailureLast; got != "mint failed: 401" {
+		t.Fatalf("gitMintFailureLast = %q, want %q after failure", got, "mint failed: 401")
+	}
+
+	failing = false
+	withGitCredentials(context.Background(), exec.CommandContext(context.Background(), "git", "fetch"))
+	if got := gitMintFailureLast; got != "" {
+		t.Fatalf("gitMintFailureLast = %q, want empty after a successful mint", got)
+	}
+}
+
 func TestGitAskpassHelperPath_ScriptContainsNoSecret(t *testing.T) {
 	path, err := gitAskpassHelperPath()
 	if err != nil {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4753.

Closes #4753

## Changes

GitHub Issue GH-4753: fix(executor): gh credential injection — GH_TOKEN precedence + loud mint-failure fallback (PR#4750 review)

## Problem

Post-merge review of PR#4750 (GH-4746) found two defects in the gh/git credential-injection seam that can make the App cutover silently ineffective.

1. **`GH_TOKEN` precedence hole** — `withGhCredentials` (`internal/executor/gh_credentials.go:67`) appends only `GITHUB_TOKEN`, but gh CLI resolves `GH_TOKEN` with *higher* precedence. The child env inherits the daemon's full environment via `os.Environ()`, so an ambient `GH_TOKEN` silently wins over the minted App token — every gh write keeps riding the OAuth PAT while app auth looks active, with zero signal.
2. **Silent mint-failure fallback** — the comment at `gh_credentials.go:60-65` claims "mint failure is already logged loudly by the provider", but the installed provider closure (`cmd/pilot/main.go:1747-1749`) calls `mintGitHubAppToken` directly, bypassing the only loud log site (`resolveGitHubToken`, `main.go:190-195`), and `withGhCredentials` swallows the error. Expired/revoked App key → indefinite silent degradation to the ambient PAT. The identical latent defect exists on the git leg: `internal/executor/git_credentials.go:56-62` + `main.go:1744-1746` (inherited from PR#4745).

## Acceptance

1. `withGhCredentials` sets BOTH `GITHUB_TOKEN` and `GH_TOKEN` to the minted token.
2. Mint failure in the provider closure (or at the fallback site) logs at ERROR with enough context to alert on — both the gh and git legs. Keep it non-spammy (log on state change or rate-limited — implementer's choice, document it). Fix the stale comment.
3. New test: ambient `GH_TOKEN`/`GITHUB_TOKEN` in the parent env are overridden by the injected values (the `envValue` last-wins helper exists in `gh_credentials_test.go`; nothing exercises ambient collision today).
4. `make build` / `make test` / `make lint` green.

## Scope fence

No changes to token minting/caching (`apptoken.go` lifecycle hardening is a separate issue) · no changes to Claude Code session subprocess env (`backend_claudecode.go:663` ambient gh auth is a separate, explicit scope decision).

**This task must NOT be decomposed — implement as a single PR.** <!-- pilot:no-decompose -->