### PR TITLE
GH-4754: fix(github): TokenSource lifecycle hardening — 401 invalidation, serve-stale-within-margin, single-flight mint (PR#4751 review)

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -232,14 +232,38 @@ func githubTokenFunc(cfg *config.Config) github.TokenFunc {
 	}
 }
 
+// invalidateGitHubAppToken returns a callback that discards the cached
+// GitHub App installation token, if App auth is configured, so the next
+// resolveGitHubToken call re-mints instead of replaying a token GitHub has
+// already revoked (GH-4754: a 401 on an App-minted token means the App
+// private key rotated or the installation was suspended/reinstalled — the
+// old token is dead regardless of what TokenSource's cached expiresAt
+// says). Returns nil when App auth isn't configured for cfg — there is
+// nothing App-sourced to invalidate, and a 401 in that case came from a
+// different credential entirely (config/env/gh-CLI), which this ticket
+// doesn't change the handling of.
+func invalidateGitHubAppToken(cfg *config.Config) func() {
+	if cfg == nil || cfg.Adapters == nil || cfg.Adapters.GitHub == nil || cfg.Adapters.GitHub.App == nil {
+		return nil
+	}
+	appCfg := cfg.Adapters.GitHub.App
+	return func() {
+		if source, err := ghAppTokenCache.get(appCfg); err == nil {
+			source.Invalidate()
+		}
+	}
+}
+
 // newGitHubClient builds an in-tree GitHub client whose token is re-resolved
-// on every request via githubTokenFunc (GH-4747). Use this instead of
+// on every request via githubTokenFunc (GH-4747) and whose cached App token
+// is invalidated on a 401 so the automatic single retry re-mints instead of
+// replaying a revoked token (GH-4754). Use this instead of
 // github.NewClient(token) for anything held past the call that constructs
 // it — a client built once from a static string keeps that string forever,
 // which is exactly the bug this ticket fixes for the daemon's long-lived
 // clients.
 func newGitHubClient(cfg *config.Config) *github.Client {
-	return github.NewClientWithTokenFunc(githubTokenFunc(cfg))
+	return github.NewClientWithTokenFuncAndInvalidate(githubTokenFunc(cfg), invalidateGitHubAppToken(cfg))
 }
 
 // validateGitHubToken makes one authenticated API call to confirm the

--- a/internal/adapters/github/apptoken.go
+++ b/internal/adapters/github/apptoken.go
@@ -12,10 +12,13 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"sync"
 	"time"
+
+	"github.com/qf-studio/pilot/internal/logging"
 )
 
 const (
@@ -34,6 +37,20 @@ const (
 	// documented guidance, to tolerate clock drift between this host and
 	// GitHub's servers.
 	appJWTClockSkew = 60 * time.Second
+
+	// mintRetryBackoff is how long TokenSource waits after a failed mint
+	// attempt before allowing another network call. Callers arriving within
+	// this window of a failure are answered immediately from the cached
+	// error instead of each dialing GitHub and paying the mint HTTP timeout
+	// (GH-4754 acceptance #3: mint-outage serialization collapsed
+	// process-wide GitHub throughput to ~4 req/min when every caller queued
+	// behind TokenSource.mu and each paid up to the 15s mint timeout).
+	mintRetryBackoff = 10 * time.Second
+
+	// mintFailureLogInterval throttles mint-failure log lines so a sustained
+	// outage produces one line per interval instead of one per caller
+	// (GH-4754 acceptance #3: "ERROR logs rate-limited").
+	mintFailureLogInterval = 60 * time.Second
 )
 
 // TokenSource mints, caches, and proactively refreshes a GitHub App
@@ -49,6 +66,26 @@ type TokenSource struct {
 	mu        sync.Mutex
 	token     string
 	expiresAt time.Time
+
+	// mint-outage coordination (GH-4754): inFlight lets concurrent callers
+	// share a single in-progress mint HTTP call instead of each dialing
+	// GitHub; lastMintErr/lastMintAt implement the post-failure backoff so a
+	// caller arriving shortly after a failure is answered from the cached
+	// error rather than paying the mint timeout again; lastLogAt throttles
+	// the mint-failure log line to at most one per mintFailureLogInterval.
+	inFlight    *mintCall
+	lastMintErr error
+	lastMintAt  time.Time
+	lastLogAt   time.Time
+}
+
+// mintCall represents one in-flight (or just-completed) mint HTTP call
+// shared by every TokenSource.Token caller that arrives while it is running.
+type mintCall struct {
+	done      chan struct{}
+	token     string
+	expiresAt time.Time
+	err       error
 }
 
 // NewTokenSource builds a TokenSource from an AppConfig, reading and parsing
@@ -117,21 +154,124 @@ func parseRSAPrivateKey(pemBytes []byte) (*rsa.PrivateKey, error) {
 // installationTokenRefreshMargin of expiring. Never logs the token or the
 // signing JWT — callers must do the same (GH-4743: zero token material in
 // logs/argv).
+//
+// GH-4754: a mint failure while the cached token is still within the
+// refresh margin (but not yet actually expired) serves the still-valid
+// cached token with a WARN log instead of erroring — an error here used to
+// make resolveGitHubToken silently fail over to a different credential
+// identity (config PAT/env/gh-CLI) on every request during a transient mint
+// blip, flapping between rate pools and actor identities. A mint failure
+// with nothing valid cached (empty, or actually past expiresAt) still
+// returns the error.
 func (ts *TokenSource) Token(ctx context.Context) (string, error) {
 	ts.mu.Lock()
-	defer ts.mu.Unlock()
-
 	if ts.token != "" && time.Until(ts.expiresAt) > installationTokenRefreshMargin {
-		return ts.token, nil
+		tok := ts.token
+		ts.mu.Unlock()
+		return tok, nil
 	}
+	stillValid := ts.token != "" && time.Until(ts.expiresAt) > 0
+	cachedToken := ts.token
+	cachedExpiresAt := ts.expiresAt
+	ts.mu.Unlock()
+
+	token, expiresAt, err := ts.mintOnce(ctx)
+	if err == nil {
+		ts.mu.Lock()
+		ts.token = token
+		ts.expiresAt = expiresAt
+		ts.mu.Unlock()
+		return token, nil
+	}
+
+	if ts.shouldLog() {
+		log := logging.WithComponent("github-auth").With(
+			slog.Int64("app_id", ts.appID),
+			slog.Int64("installation_id", ts.installationID),
+			slog.Any("error", err),
+		)
+		if stillValid {
+			log.Warn("github app installation token refresh failed within the refresh margin — serving cached token",
+				slog.Time("cached_expires_at", cachedExpiresAt))
+		} else {
+			log.Error("github app installation token mint failed")
+		}
+	}
+
+	if stillValid {
+		return cachedToken, nil
+	}
+	return "", err
+}
+
+// shouldLog reports whether a mint-failure log line should be emitted now,
+// throttling to at most one per mintFailureLogInterval so a sustained outage
+// (or many concurrent callers each hitting a fresh Token() failure) doesn't
+// flood the log with one line per caller (GH-4754 acceptance #3).
+func (ts *TokenSource) shouldLog() bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	if time.Since(ts.lastLogAt) < mintFailureLogInterval {
+		return false
+	}
+	ts.lastLogAt = time.Now()
+	return true
+}
+
+// Invalidate discards the cached token so the next Token() call re-mints
+// unconditionally, regardless of the cached expiry. Callers use this when
+// GitHub answers a request with 401 even though TokenSource still considers
+// the token valid — evidence GitHub revoked it early (App private-key
+// rotation, installation suspend/reinstall). Without this, Token() would
+// keep serving the revoked token verbatim until its cached expiresAt, up to
+// ~55 minutes of hard 401s (GH-4754 acceptance #1).
+func (ts *TokenSource) Invalidate() {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	ts.token = ""
+	ts.expiresAt = time.Time{}
+}
+
+// mintOnce performs a single-flight mint: concurrent callers arriving while
+// a mint HTTP call is already in progress share its result instead of each
+// dialing GitHub, and a caller arriving within mintRetryBackoff of the last
+// completed *failure* is answered immediately from that cached error
+// without making a network call at all. Together these keep a mint outage
+// from serializing every GitHub request behind repeated 15s mint timeouts
+// (GH-4754 acceptance #3).
+func (ts *TokenSource) mintOnce(ctx context.Context) (string, time.Time, error) {
+	ts.mu.Lock()
+	if ts.inFlight != nil {
+		call := ts.inFlight
+		ts.mu.Unlock()
+		select {
+		case <-call.done:
+			return call.token, call.expiresAt, call.err
+		case <-ctx.Done():
+			return "", time.Time{}, ctx.Err()
+		}
+	}
+	if ts.lastMintErr != nil && time.Since(ts.lastMintAt) < mintRetryBackoff {
+		err := ts.lastMintErr
+		ts.mu.Unlock()
+		return "", time.Time{}, err
+	}
+	call := &mintCall{done: make(chan struct{})}
+	ts.inFlight = call
+	ts.mu.Unlock()
 
 	token, expiresAt, err := ts.mint(ctx)
-	if err != nil {
-		return "", err
-	}
-	ts.token = token
-	ts.expiresAt = expiresAt
-	return token, nil
+
+	ts.mu.Lock()
+	ts.inFlight = nil
+	ts.lastMintAt = time.Now()
+	ts.lastMintErr = err
+	ts.mu.Unlock()
+
+	call.token, call.expiresAt, call.err = token, expiresAt, err
+	close(call.done)
+
+	return token, expiresAt, err
 }
 
 // mintResponse is the body of POST /app/installations/{id}/access_tokens.

--- a/internal/adapters/github/apptoken_test.go
+++ b/internal/adapters/github/apptoken_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -182,6 +183,178 @@ func TestTokenSource_Token_MintFailure(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "401") {
 		t.Errorf("error %q does not surface the mint HTTP status", err.Error())
+	}
+}
+
+// TestTokenSource_Invalidate_ForcesRemint is the GH-4754 acceptance #1
+// regression test: a caller that learns (via a 401 on an otherwise-still-
+// cached token) that GitHub revoked the token early must be able to force
+// TokenSource to re-mint on the very next Token() call, even though the
+// cached token's expiresAt says it's still fine.
+func TestTokenSource_Invalidate_ForcesRemint(t *testing.T) {
+	var mintCount int64
+	server := fakeTokenServer(t, time.Hour, &mintCount)
+	defer server.Close()
+
+	ts, err := NewTokenSourceWithBaseURL(testAppConfig(t), server.URL)
+	if err != nil {
+		t.Fatalf("NewTokenSourceWithBaseURL() error = %v", err)
+	}
+
+	ctx := context.Background()
+	tok1, err := ts.Token(ctx)
+	if err != nil {
+		t.Fatalf("first Token() error = %v", err)
+	}
+
+	ts.Invalidate()
+
+	tok2, err := ts.Token(ctx)
+	if err != nil {
+		t.Fatalf("Token() after Invalidate() error = %v", err)
+	}
+	if tok2 == tok1 {
+		t.Errorf("Token() after Invalidate() = %q, same as pre-invalidate token %q — want a fresh mint", tok2, tok1)
+	}
+	if got := atomic.LoadInt64(&mintCount); got != 2 {
+		t.Errorf("mint endpoint hit %d times, want 2 (Invalidate() must force a re-mint despite the cached token's expiresAt being an hour out)", got)
+	}
+}
+
+// TestTokenSource_Token_ServesStaleWithinMarginOnMintFailure is the GH-4754
+// acceptance #2 regression test: a proactive refresh attempted inside the
+// refresh margin that fails must not error (which used to make
+// resolveGitHubToken silently fail over to a different credential identity
+// on every request) — it must keep serving the still-valid cached token.
+func TestTokenSource_Token_ServesStaleWithinMarginOnMintFailure(t *testing.T) {
+	var mintCount int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt64(&mintCount, 1)
+		if n == 1 {
+			// First mint succeeds but with an expiry inside the refresh
+			// margin, so the very next Token() call attempts a proactive
+			// refresh rather than serving straight from cache.
+			resp := mintResponse{
+				Token:     "test-installation-token-1",
+				ExpiresAt: time.Now().Add(2 * time.Minute),
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		// Every subsequent mint (the proactive refresh) fails.
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"message":"mint temporarily unavailable"}`))
+	}))
+	defer server.Close()
+
+	ts, err := NewTokenSourceWithBaseURL(testAppConfig(t), server.URL)
+	if err != nil {
+		t.Fatalf("NewTokenSourceWithBaseURL() error = %v", err)
+	}
+
+	ctx := context.Background()
+	tok1, err := ts.Token(ctx)
+	if err != nil {
+		t.Fatalf("first Token() error = %v", err)
+	}
+
+	tok2, err := ts.Token(ctx)
+	if err != nil {
+		t.Fatalf("Token() error = %v, want nil — a refresh-margin mint failure must serve the still-valid cached token instead of erroring", err)
+	}
+	if tok2 != tok1 {
+		t.Errorf("Token() = %q, want the still-valid cached token %q served despite the refresh failure", tok2, tok1)
+	}
+}
+
+// TestTokenSource_Token_MintOutageBackoff is the GH-4754 acceptance #3
+// regression test: once a mint attempt has failed, a caller arriving shortly
+// after must be answered from the cached failure instead of dialing GitHub
+// (and paying the mint HTTP timeout) again — otherwise a sustained outage
+// serializes every caller behind repeated full-timeout network calls.
+func TestTokenSource_Token_MintOutageBackoff(t *testing.T) {
+	var mintCount int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&mintCount, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"message":"server error"}`))
+	}))
+	defer server.Close()
+
+	ts, err := NewTokenSourceWithBaseURL(testAppConfig(t), server.URL)
+	if err != nil {
+		t.Fatalf("NewTokenSourceWithBaseURL() error = %v", err)
+	}
+
+	ctx := context.Background()
+	if _, err := ts.Token(ctx); err == nil {
+		t.Fatal("first Token() = nil error, want error from mint failure")
+	}
+	if _, err := ts.Token(ctx); err == nil {
+		t.Fatal("second Token() = nil error, want the cached failure surfaced again")
+	}
+
+	if got := atomic.LoadInt64(&mintCount); got != 1 {
+		t.Errorf("mint endpoint hit %d times for 2 calls inside the backoff window, want 1 (second call must be answered from the cached failure, not dial the network again)", got)
+	}
+}
+
+// TestTokenSource_Token_SingleFlightMint is the GH-4754 acceptance #3
+// regression test for the concurrent-caller half of mint-outage
+// serialization: N callers arriving while a mint is already in flight must
+// share that one in-flight attempt (and its result) rather than each
+// dialing GitHub independently.
+func TestTokenSource_Token_SingleFlightMint(t *testing.T) {
+	var mintCount int64
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&mintCount, 1)
+		<-release // hold the response so every concurrent caller has time to queue up behind the single in-flight mint
+		resp := mintResponse{
+			Token:     "test-installation-token-shared",
+			ExpiresAt: time.Now().Add(time.Hour),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	ts, err := NewTokenSourceWithBaseURL(testAppConfig(t), server.URL)
+	if err != nil {
+		t.Fatalf("NewTokenSourceWithBaseURL() error = %v", err)
+	}
+
+	const n = 5
+	var wg sync.WaitGroup
+	tokens := make([]string, n)
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			tokens[i], errs[i] = ts.Token(context.Background())
+		}(i)
+	}
+
+	// Give every goroutine a chance to reach mintOnce and queue behind the
+	// single in-flight call before letting the mint response through.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("Token() [%d] error = %v", i, err)
+		}
+		if tokens[i] != tokens[0] {
+			t.Errorf("Token() [%d] = %q, want shared result %q across all concurrent callers", i, tokens[i], tokens[0])
+		}
+	}
+	if got := atomic.LoadInt64(&mintCount); got != 1 {
+		t.Errorf("mint endpoint hit %d times for %d concurrent callers, want 1 (single-flight)", got, n)
 	}
 }
 

--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -140,10 +141,11 @@ func StaticToken(token string) TokenFunc {
 
 // Client is a GitHub API client
 type Client struct {
-	tokenFunc  TokenFunc
-	httpClient *http.Client
-	baseURL    string       // For testing - defaults to githubAPIURL
-	retryOpts  RetryOptions // Retry config for doRequest; overridable in tests
+	tokenFunc       TokenFunc
+	invalidateToken func() // optional; see NewClientWithTokenFuncAndInvalidate
+	httpClient      *http.Client
+	baseURL         string       // For testing - defaults to githubAPIURL
+	retryOpts       RetryOptions // Retry config for doRequest; overridable in tests
 }
 
 // NewClient creates a new GitHub client with a fixed token, resolved once at
@@ -176,6 +178,22 @@ func NewClientWithTokenFuncAndBaseURL(fn TokenFunc, baseURL string) *Client {
 	return newClient(fn, baseURL, RetryOptions{MaxRetries: 0})
 }
 
+// NewClientWithTokenFuncAndInvalidate is NewClientWithTokenFunc plus an
+// invalidate callback the Client calls when GitHub answers a request with
+// 401 (GH-4754): the credential fn resolves may have been revoked early
+// (App private-key rotation, installation suspend/reinstall) and would
+// otherwise keep being served verbatim by fn — which only reacts to its own
+// cached expiry, not to GitHub's live verdict — until that cache naturally
+// expires. invalidate discards it so the single retry this triggers
+// re-resolves through fn with a fresh mint. Pass nil when fn has nothing to
+// invalidate (static tokens, PAT/env/gh-CLI fallbacks), in which case a 401
+// behaves exactly as before this ticket: no retry.
+func NewClientWithTokenFuncAndInvalidate(fn TokenFunc, invalidate func()) *Client {
+	c := newClient(fn, githubAPIURL, DefaultRetryOptions())
+	c.invalidateToken = invalidate
+	return c
+}
+
 func newClient(fn TokenFunc, baseURL string, retryOpts RetryOptions) *Client {
 	return &Client{
 		tokenFunc: fn,
@@ -197,6 +215,28 @@ func (c *Client) resolveToken(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("resolve github token: %w", err)
 	}
 	return token, nil
+}
+
+// doWithAuthRetry runs op and, if it terminates with an *AuthError (401) and
+// the Client has an invalidate callback wired, discards the cached
+// credential and runs op exactly one more time so the retry resolves a
+// freshly minted token instead of replaying the same revoked one (GH-4754).
+// Every request path — REST via doRequest, GraphQL via executeGraphQLCore,
+// and the raw job-logs request in GetJobLogs — routes its single HTTP
+// attempt (or its own internal WithRetryVoid loop, which already treats 401
+// as non-retryable and returns immediately) through this so a 401 gets
+// exactly one auth-retry regardless of entry point.
+func (c *Client) doWithAuthRetry(op func() error) error {
+	err := op()
+	if c.invalidateToken == nil {
+		return err
+	}
+	var authErr *AuthError
+	if !errors.As(err, &authErr) {
+		return err
+	}
+	c.invalidateToken()
+	return op()
 }
 
 // Issue represents a GitHub issue
@@ -265,75 +305,77 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body interf
 		}
 	}
 
-	return WithRetryVoid(ctx, func() error {
-		var bodyReader io.Reader
-		if bodyBytes != nil {
-			bodyReader = bytes.NewReader(bodyBytes)
-		}
-
-		req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
-		if err != nil {
-			return fmt.Errorf("failed to create request: %w", err)
-		}
-
-		token, err := c.resolveToken(ctx)
-		if err != nil {
-			return err
-		}
-		req.Header.Set("Accept", "application/vnd.github+json")
-		req.Header.Set("Authorization", "Bearer "+token)
-		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-		if bodyBytes != nil {
-			req.Header.Set("Content-Type", "application/json")
-		}
-
-		resp, err := c.httpClient.Do(req)
-		if err != nil {
-			return fmt.Errorf("failed to execute request: %w", err)
-		}
-		defer func() { _ = resp.Body.Close() }()
-
-		respBody, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("failed to read response: %w", err)
-		}
-
-		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			msg := string(respBody)
-			if resp.StatusCode == http.StatusUnauthorized {
-				return &AuthError{Message: msg}
+	return c.doWithAuthRetry(func() error {
+		return WithRetryVoid(ctx, func() error {
+			var bodyReader io.Reader
+			if bodyBytes != nil {
+				bodyReader = bytes.NewReader(bodyBytes)
 			}
-			if resp.StatusCode == http.StatusTooManyRequests {
-				return &RateLimitError{
-					StatusCode: http.StatusTooManyRequests,
-					RetryAfter: parseRetryAfterHeader(resp.Header),
-					Message:    msg,
+
+			req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
+			if err != nil {
+				return fmt.Errorf("failed to create request: %w", err)
+			}
+
+			token, err := c.resolveToken(ctx)
+			if err != nil {
+				return err
+			}
+			req.Header.Set("Accept", "application/vnd.github+json")
+			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+			if bodyBytes != nil {
+				req.Header.Set("Content-Type", "application/json")
+			}
+
+			resp, err := c.httpClient.Do(req)
+			if err != nil {
+				return fmt.Errorf("failed to execute request: %w", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			respBody, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return fmt.Errorf("failed to read response: %w", err)
+			}
+
+			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+				msg := string(respBody)
+				if resp.StatusCode == http.StatusUnauthorized {
+					return &AuthError{Message: msg}
 				}
-			}
-			if resp.StatusCode == http.StatusForbidden {
-				msgLower := strings.ToLower(msg)
-				isRateLimit := resp.Header.Get("X-RateLimit-Remaining") == "0" ||
-					strings.Contains(msgLower, "secondary rate limit") ||
-					strings.Contains(msgLower, "rate limit exceeded")
-				if isRateLimit {
+				if resp.StatusCode == http.StatusTooManyRequests {
 					return &RateLimitError{
-						StatusCode: http.StatusForbidden,
+						StatusCode: http.StatusTooManyRequests,
 						RetryAfter: parseRetryAfterHeader(resp.Header),
 						Message:    msg,
 					}
 				}
+				if resp.StatusCode == http.StatusForbidden {
+					msgLower := strings.ToLower(msg)
+					isRateLimit := resp.Header.Get("X-RateLimit-Remaining") == "0" ||
+						strings.Contains(msgLower, "secondary rate limit") ||
+						strings.Contains(msgLower, "rate limit exceeded")
+					if isRateLimit {
+						return &RateLimitError{
+							StatusCode: http.StatusForbidden,
+							RetryAfter: parseRetryAfterHeader(resp.Header),
+							Message:    msg,
+						}
+					}
+				}
+				return fmt.Errorf("API error (status %d): %s", resp.StatusCode, msg)
 			}
-			return fmt.Errorf("API error (status %d): %s", resp.StatusCode, msg)
-		}
 
-		if result != nil && len(respBody) > 0 {
-			if err := json.Unmarshal(respBody, result); err != nil {
-				return fmt.Errorf("failed to parse response: %w", err)
+			if result != nil && len(respBody) > 0 {
+				if err := json.Unmarshal(respBody, result); err != nil {
+					return fmt.Errorf("failed to parse response: %w", err)
+				}
 			}
-		}
 
-		return nil
-	}, c.retryOpts)
+			return nil
+		}, c.retryOpts)
+	})
 }
 
 // GetIssue fetches an issue by owner, repo, and number
@@ -826,6 +868,24 @@ func (c *Client) CompareStatus(ctx context.Context, owner, repo, base, head stri
 func (c *Client) GetJobLogs(ctx context.Context, owner, repo string, jobID int64) (string, error) {
 	path := fmt.Sprintf("/repos/%s/%s/actions/jobs/%d/logs", owner, repo, jobID)
 
+	var logs string
+	err := c.doWithAuthRetry(func() error {
+		body, err := c.getJobLogsOnce(ctx, path)
+		if err != nil {
+			return err
+		}
+		logs = body
+		return nil
+	})
+	return logs, err
+}
+
+// getJobLogsOnce performs a single, non-retried GetJobLogs request. Split
+// out so GetJobLogs can wrap it in doWithAuthRetry (GH-4754): a 401 here
+// means the App-minted token behind c.tokenFunc was revoked early, and
+// without the wrapper's invalidate-and-retry-once this endpoint would keep
+// resending the same revoked token every poll until it naturally expired.
+func (c *Client) getJobLogsOnce(ctx context.Context, path string) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
@@ -845,13 +905,16 @@ func (c *Client) GetJobLogs(ctx context.Context, owner, repo string, jobID int64
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", fmt.Errorf("API error (status %d) fetching job logs", resp.StatusCode)
-	}
-
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("failed to read log response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return "", &AuthError{Message: string(body)}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("API error (status %d) fetching job logs", resp.StatusCode)
 	}
 
 	return string(body), nil
@@ -1041,80 +1104,85 @@ func (c *Client) executeGraphQLCore(ctx context.Context, query string, variables
 
 	endpoint := c.baseURL + "/graphql"
 
-	return WithRetryVoid(ctx, func() error {
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(bodyBytes))
-		if err != nil {
-			return fmt.Errorf("create graphql request: %w", err)
-		}
-		token, err := c.resolveToken(ctx)
-		if err != nil {
-			return err
-		}
-		req.Header.Set("Authorization", "Bearer "+token)
-		req.Header.Set("Content-Type", "application/json")
+	return c.doWithAuthRetry(func() error {
+		return WithRetryVoid(ctx, func() error {
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(bodyBytes))
+			if err != nil {
+				return fmt.Errorf("create graphql request: %w", err)
+			}
+			token, err := c.resolveToken(ctx)
+			if err != nil {
+				return err
+			}
+			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("Content-Type", "application/json")
 
-		resp, err := c.httpClient.Do(req)
-		if err != nil {
-			return fmt.Errorf("graphql request failed: %w", err)
-		}
-		defer func() { _ = resp.Body.Close() }()
+			resp, err := c.httpClient.Do(req)
+			if err != nil {
+				return fmt.Errorf("graphql request failed: %w", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
 
-		respBody, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("read graphql response: %w", err)
-		}
+			respBody, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return fmt.Errorf("read graphql response: %w", err)
+			}
 
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("graphql API error (status %d): %s", resp.StatusCode, string(respBody))
-		}
+			if resp.StatusCode == http.StatusUnauthorized {
+				return &AuthError{Message: string(respBody)}
+			}
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("graphql API error (status %d): %s", resp.StatusCode, string(respBody))
+			}
 
-		var gqlResp GraphQLResponse
-		if err := json.Unmarshal(respBody, &gqlResp); err != nil {
-			return fmt.Errorf("parse graphql response: %w", err)
-		}
+			var gqlResp GraphQLResponse
+			if err := json.Unmarshal(respBody, &gqlResp); err != nil {
+				return fmt.Errorf("parse graphql response: %w", err)
+			}
 
-		if len(gqlResp.Errors) > 0 {
-			// TASK-357 (board low): aggregate ALL errors (message + type + path), not
-			// just Errors[0]. GitHub Projects V2 frequently returns several per-node
-			// errors at once, and surfacing only the first made board flows hard to
-			// diagnose.
-			//
-			// In tolerant mode: if all errors are NOT_FOUND/FORBIDDEN, unmarshal
-			// the good data and return *PartialGraphQLError. Any non-tolerable error
-			// (including mixed tolerable+fatal) makes the whole response fatal.
-			if tolerant {
-				allTolerable := true
-				for _, ge := range gqlResp.Errors {
-					if !isTolerable(ge.Type) {
-						allTolerable = false
-						break
-					}
-				}
-				if allTolerable {
-					if result != nil && len(gqlResp.Data) > 0 {
-						if err := json.Unmarshal(gqlResp.Data, result); err != nil {
-							return fmt.Errorf("unmarshal graphql data: %w", err)
+			if len(gqlResp.Errors) > 0 {
+				// TASK-357 (board low): aggregate ALL errors (message + type + path), not
+				// just Errors[0]. GitHub Projects V2 frequently returns several per-node
+				// errors at once, and surfacing only the first made board flows hard to
+				// diagnose.
+				//
+				// In tolerant mode: if all errors are NOT_FOUND/FORBIDDEN, unmarshal
+				// the good data and return *PartialGraphQLError. Any non-tolerable error
+				// (including mixed tolerable+fatal) makes the whole response fatal.
+				if tolerant {
+					allTolerable := true
+					for _, ge := range gqlResp.Errors {
+						if !isTolerable(ge.Type) {
+							allTolerable = false
+							break
 						}
 					}
-					return &PartialGraphQLError{Errors: gqlResp.Errors}
+					if allTolerable {
+						if result != nil && len(gqlResp.Data) > 0 {
+							if err := json.Unmarshal(gqlResp.Data, result); err != nil {
+								return fmt.Errorf("unmarshal graphql data: %w", err)
+							}
+						}
+						return &PartialGraphQLError{Errors: gqlResp.Errors}
+					}
+				}
+
+				msgs := make([]string, len(gqlResp.Errors))
+				for i, ge := range gqlResp.Errors {
+					msgs[i] = ge.String()
+				}
+				return fmt.Errorf("graphql error: %s", strings.Join(msgs, "; "))
+			}
+
+			if result != nil && len(gqlResp.Data) > 0 {
+				if err := json.Unmarshal(gqlResp.Data, result); err != nil {
+					return fmt.Errorf("unmarshal graphql data: %w", err)
 				}
 			}
 
-			msgs := make([]string, len(gqlResp.Errors))
-			for i, ge := range gqlResp.Errors {
-				msgs[i] = ge.String()
-			}
-			return fmt.Errorf("graphql error: %s", strings.Join(msgs, "; "))
-		}
-
-		if result != nil && len(gqlResp.Data) > 0 {
-			if err := json.Unmarshal(gqlResp.Data, result); err != nil {
-				return fmt.Errorf("unmarshal graphql data: %w", err)
-			}
-		}
-
-		return nil
-	}, c.retryOpts)
+			return nil
+		}, c.retryOpts)
+	})
 }
 
 // SearchPRsForIssue returns all PRs that reference the given issue number using the

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -2658,7 +2658,7 @@ func TestExecuteGraphQL(t *testing.T) {
 			statusCode:  http.StatusUnauthorized,
 			response:    `{"message":"Bad credentials"}`,
 			wantErr:     true,
-			errContains: "graphql API error (status 401)",
+			errContains: "API error (status 401)",
 		},
 		{
 			name:       "nil result ignores data",

--- a/internal/adapters/github/token_func_test.go
+++ b/internal/adapters/github/token_func_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // rotatingTokenSource is a fake TokenFunc that starts out returning current
@@ -141,5 +142,297 @@ func TestClient_TokenFunc_ErrorPropagates(t *testing.T) {
 	}
 	if !errors.Is(err, wantErr) {
 		t.Errorf("expected error to wrap %v, got %v", wantErr, err)
+	}
+}
+
+// TestClient_TokenFunc_ResolvesPerRequest_GraphQL is the GraphQL-path
+// counterpart of TestClient_TokenFunc_ResolvesPerRequest — token_func_test.go
+// previously only exercised token rotation through the REST GetIssue path,
+// leaving executeGraphQLCore's independent resolveToken call unverified
+// (GH-4754 acceptance #4).
+func TestClient_TokenFunc_ResolvesPerRequest_GraphQL(t *testing.T) {
+	var gotAuth []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = append(gotAuth, r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"ok":true}}`))
+	}))
+	defer server.Close()
+
+	source := newRotatingTokenSource("token-v1")
+	client := NewClientWithTokenFuncAndBaseURL(source.TokenFunc(), server.URL)
+
+	var result struct {
+		OK bool `json:"ok"`
+	}
+	if err := client.ExecuteGraphQL(context.Background(), "query{}", nil, &result); err != nil {
+		t.Fatalf("ExecuteGraphQL (pre-rotation) failed: %v", err)
+	}
+
+	source.set("token-v2")
+
+	if err := client.ExecuteGraphQL(context.Background(), "query{}", nil, &result); err != nil {
+		t.Fatalf("ExecuteGraphQL (post-rotation) failed: %v", err)
+	}
+
+	if len(gotAuth) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(gotAuth))
+	}
+	if gotAuth[0] != "Bearer token-v1" {
+		t.Errorf("first request Authorization = %q, want %q", gotAuth[0], "Bearer token-v1")
+	}
+	if gotAuth[1] != "Bearer token-v2" {
+		t.Errorf("second request Authorization = %q (stale boot-time token), want %q — GraphQL token rotation did not propagate", gotAuth[1], "Bearer token-v2")
+	}
+}
+
+// TestClient_TokenFunc_ResolvesPerRequest_GetJobLogs is the GetJobLogs
+// counterpart of TestClient_TokenFunc_ResolvesPerRequest — GetJobLogs builds
+// its request by hand (it predates doRequest's shared retry path) with its
+// own resolveToken call, so it needs its own rotation coverage
+// (GH-4754 acceptance #4).
+func TestClient_TokenFunc_ResolvesPerRequest_GetJobLogs(t *testing.T) {
+	var gotAuth []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = append(gotAuth, r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("log line 1\nlog line 2\n"))
+	}))
+	defer server.Close()
+
+	source := newRotatingTokenSource("token-v1")
+	client := NewClientWithTokenFuncAndBaseURL(source.TokenFunc(), server.URL)
+
+	if _, err := client.GetJobLogs(context.Background(), "owner", "repo", 42); err != nil {
+		t.Fatalf("GetJobLogs (pre-rotation) failed: %v", err)
+	}
+
+	source.set("token-v2")
+
+	if _, err := client.GetJobLogs(context.Background(), "owner", "repo", 42); err != nil {
+		t.Fatalf("GetJobLogs (post-rotation) failed: %v", err)
+	}
+
+	if len(gotAuth) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(gotAuth))
+	}
+	if gotAuth[0] != "Bearer token-v1" {
+		t.Errorf("first request Authorization = %q, want %q", gotAuth[0], "Bearer token-v1")
+	}
+	if gotAuth[1] != "Bearer token-v2" {
+		t.Errorf("second request Authorization = %q (stale boot-time token), want %q — GetJobLogs token rotation did not propagate", gotAuth[1], "Bearer token-v2")
+	}
+}
+
+// TestClient_TokenFunc_RotatesBetweenRetryAttempts covers the gap the ticket
+// calls out explicitly: WithRetryVoid's internal backoff loop re-runs the
+// whole request closure (including resolveToken) on each attempt, so a
+// token that rotates out from under a client mid-retry (e.g. a proactive
+// TokenSource refresh landing between a transient 503 and its retry) must
+// be picked up on attempt 2, not replay attempt 1's now-stale value
+// (GH-4754 acceptance #4: "rotation between retry attempts 1 and 2").
+func TestClient_TokenFunc_RotatesBetweenRetryAttempts(t *testing.T) {
+	var gotAuth []string
+	source := newRotatingTokenSource("token-v1")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = append(gotAuth, r.Header.Get("Authorization"))
+		if len(gotAuth) == 1 {
+			// Rotate the credential right as attempt 1 fails transiently —
+			// attempt 2 (fired by WithRetryVoid after backoff) must resolve
+			// the token fresh rather than replaying attempt 1's header.
+			source.set("token-v2")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"number":1}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithTokenFuncAndBaseURL(source.TokenFunc(), server.URL)
+	client.retryOpts = RetryOptions{MaxRetries: 1, BaseDelay: time.Millisecond, MaxDelay: time.Millisecond}
+
+	if _, err := client.GetIssue(context.Background(), "owner", "repo", 1); err != nil {
+		t.Fatalf("GetIssue() error = %v, want the retry to succeed on attempt 2 with the rotated token", err)
+	}
+
+	if len(gotAuth) != 2 {
+		t.Fatalf("expected 2 attempts (1 transient failure + 1 retry), got %d", len(gotAuth))
+	}
+	if gotAuth[0] != "Bearer token-v1" {
+		t.Errorf("attempt 1 Authorization = %q, want %q", gotAuth[0], "Bearer token-v1")
+	}
+	if gotAuth[1] != "Bearer token-v2" {
+		t.Errorf("attempt 2 Authorization = %q, want %q — retry replayed attempt 1's token instead of re-resolving", gotAuth[1], "Bearer token-v2")
+	}
+}
+
+// invalidatingRotatingTokenSource models the real TokenSource + Client
+// wiring from apptoken.go/client.go: it serves a stale token until
+// Invalidate() is called, then serves a fresh one — letting these tests
+// exercise Client.doWithAuthRetry's 401-invalidate-and-retry-once behavior
+// (GH-4754 acceptance #1) without spinning up a real GitHub App mint
+// server.
+type invalidatingRotatingTokenSource struct {
+	mu          sync.Mutex
+	stale       string
+	fresh       string
+	invalidated bool
+}
+
+func (r *invalidatingRotatingTokenSource) TokenFunc() TokenFunc {
+	return func(ctx context.Context) (string, error) {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		if r.invalidated {
+			return r.fresh, nil
+		}
+		return r.stale, nil
+	}
+}
+
+func (r *invalidatingRotatingTokenSource) Invalidate() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.invalidated = true
+}
+
+// newInvalidatingTestClient builds a Client wired exactly like
+// newGitHubClient in cmd/pilot/main.go — a TokenFunc plus an invalidate
+// callback — pointed at a test server, for exercising the 401
+// invalidate-and-retry-once path added in GH-4754.
+func newInvalidatingTestClient(source *invalidatingRotatingTokenSource, baseURL string) *Client {
+	c := newClient(source.TokenFunc(), baseURL, RetryOptions{MaxRetries: 0})
+	c.invalidateToken = source.Invalidate
+	return c
+}
+
+// TestClient_401InvalidatesAndRetriesOnce_REST is the GH-4754 acceptance #1
+// regression test for the REST path: a 401 on the stale token must
+// invalidate it and retry exactly once with the fresh token, succeeding
+// transparently to the caller instead of surfacing the 401.
+func TestClient_401InvalidatesAndRetriesOnce_REST(t *testing.T) {
+	const stale, fresh = "token-stale", "token-fresh"
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		if r.Header.Get("Authorization") != "Bearer "+fresh {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"number":1}`))
+	}))
+	defer server.Close()
+
+	source := &invalidatingRotatingTokenSource{stale: stale, fresh: fresh}
+	client := newInvalidatingTestClient(source, server.URL)
+
+	issue, err := client.GetIssue(context.Background(), "owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("GetIssue() error = %v, want automatic recovery via invalidate-and-retry", err)
+	}
+	if issue.Number != 1 {
+		t.Errorf("GetIssue() = %+v, want Number=1", issue)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Errorf("server hit %d times, want 2 (initial 401 + one auth-retry)", got)
+	}
+}
+
+// TestClient_401InvalidatesAndRetriesOnce_GraphQL is the GraphQL-path
+// counterpart of TestClient_401InvalidatesAndRetriesOnce_REST.
+func TestClient_401InvalidatesAndRetriesOnce_GraphQL(t *testing.T) {
+	const stale, fresh = "token-stale", "token-fresh"
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		if r.Header.Get("Authorization") != "Bearer "+fresh {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"ok":true}}`))
+	}))
+	defer server.Close()
+
+	source := &invalidatingRotatingTokenSource{stale: stale, fresh: fresh}
+	client := newInvalidatingTestClient(source, server.URL)
+
+	var result struct {
+		OK bool `json:"ok"`
+	}
+	if err := client.ExecuteGraphQL(context.Background(), "query{}", nil, &result); err != nil {
+		t.Fatalf("ExecuteGraphQL() error = %v, want automatic recovery via invalidate-and-retry", err)
+	}
+	if !result.OK {
+		t.Errorf("ExecuteGraphQL() result = %+v, want OK=true", result)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Errorf("server hit %d times, want 2 (initial 401 + one auth-retry)", got)
+	}
+}
+
+// TestClient_401InvalidatesAndRetriesOnce_GetJobLogs is the GetJobLogs-path
+// counterpart of TestClient_401InvalidatesAndRetriesOnce_REST.
+func TestClient_401InvalidatesAndRetriesOnce_GetJobLogs(t *testing.T) {
+	const stale, fresh = "token-stale", "token-fresh"
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		if r.Header.Get("Authorization") != "Bearer "+fresh {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("log line 1\n"))
+	}))
+	defer server.Close()
+
+	source := &invalidatingRotatingTokenSource{stale: stale, fresh: fresh}
+	client := newInvalidatingTestClient(source, server.URL)
+
+	logs, err := client.GetJobLogs(context.Background(), "owner", "repo", 42)
+	if err != nil {
+		t.Fatalf("GetJobLogs() error = %v, want automatic recovery via invalidate-and-retry", err)
+	}
+	if logs != "log line 1\n" {
+		t.Errorf("GetJobLogs() = %q, want %q", logs, "log line 1\n")
+	}
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Errorf("server hit %d times, want 2 (initial 401 + one auth-retry)", got)
+	}
+}
+
+// TestClient_401WithoutInvalidator_NoRetry guards the opt-in nature of the
+// invalidate-and-retry path: a Client built without an invalidate callback
+// (NewClientWithTokenFunc / NewClientWithTokenFuncAndBaseURL — every
+// call site except the App-auth-aware newGitHubClient) must behave exactly
+// as before GH-4754: a single 401, no retry.
+func TestClient_401WithoutInvalidator_NoRetry(t *testing.T) {
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithTokenFuncAndBaseURL(StaticToken("token"), server.URL)
+
+	_, err := client.GetIssue(context.Background(), "owner", "repo", 1)
+	if err == nil {
+		t.Fatal("expected AuthError, got nil")
+	}
+	var authErr *AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected *AuthError, got %T: %v", err, err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("server hit %d times, want 1 (no invalidate callback wired, so no auth-retry)", got)
 	}
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4754.

Closes #4754

## Changes

GitHub Issue GH-4754: fix(github): TokenSource lifecycle hardening — 401 invalidation, serve-stale-within-margin, single-flight mint (PR#4751 review)

## Problem

Post-merge review of PR#4751 (GH-4747) confirmed per-request resolution works (token re-resolved inside the retry closure, -race clean), but `TokenSource` (`internal/adapters/github/apptoken.go`) has three lifecycle gaps that turn recoverable auth events into outages under App auth:

1. **No 401-invalidation feedback** (`apptoken.go:120-135`): nothing discards a token GitHub revoked early (App private-key rotation, installation suspend/reinstall); `Token()` serves it until `expiresAt` and `doRequest` treats 401 as non-retryable → up to ~55 min of hard 401s, recoverable only by restart.
2. **Refresh-margin identity flapping** (`apptoken.go:124-131`): inside the 5-min refresh margin, a failed mint returns error even though the cached token is still valid; `resolveGitHubToken` (`cmd/pilot/main.go:196-205`) then silently fails over to a different identity (config PAT/env/gh-CLI) per-request — traffic flips between App and PAT identity (different rate pools, different actor attribution) during transient mint blips, or errors every request when no fallback exists.
3. **Mint-outage serialization** (`main.go:184-195` + `apptoken.go:121`): with the cached token expired during a mint outage, every request serializes behind `TokenSource.mu`, each paying up to the 15s mint timeout and emitting an ERROR → process-wide GitHub throughput collapses to ~4 req/min and floods logs.

## Acceptance

1. A 401 on an App-minted token invalidates the cache and retries the request once with a fresh mint (REST, GraphQL, and `GetJobLogs` paths).
2. Within the refresh margin, mint failure serves the still-valid cached token (WARN log) — no error, no identity fallback.
3. Mint is single-flight with backoff: concurrent callers during an outage share one in-flight attempt; failures answer promptly from shared state instead of each caller paying the full timeout; ERROR logs rate-limited.
4. Rotation tests extended beyond REST `GetIssue`: GraphQL path, `GetJobLogs`, and rotation between retry attempts 1 and 2 (`token_func_test.go` gap).
5. `make build` / `make test` / `make lint` green; `-race` clean.

## Scope fence

No changes to the resolution-chain ordering in `resolveGitHubToken` · webhook-mode client migration is a separate issue · studio-sdk clients out of scope.

**This task must NOT be decomposed — implement as a single PR.** <!-- pilot:no-decompose -->