### PR TITLE
GH-4755: fix(pilot): webhook-mode Pilot holds a static daemon-lifetime GitHub client (PR#4751 review)

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -599,6 +599,17 @@ Examples:
 				pilotOpts = append(pilotOpts, pilot.WithDashboardFS(dashboardFS))
 			}
 
+			// GH-4755: webhook-mode Pilot's GitHub client was built once from
+			// github.NewClient(cfg.Adapters.GitHub.Token) inside pilot.New and
+			// held for the daemon's lifetime — bypassing the per-request
+			// token-resolution chain (App auth / env / gh-CLI fallback,
+			// GH-4747) that every polling-mode client already goes through via
+			// newGitHubClient. Pass the same kind of client in via an option so
+			// webhook mode re-resolves (and invalidates on 401) identically.
+			if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled {
+				pilotOpts = append(pilotOpts, pilot.WithGitHubClient(newGitHubClient(cfg)))
+			}
+
 			// GH-392: Create shared infrastructure for polling adapters in gateway mode
 			// This allows GitHub polling to work alongside Linear/Jira webhooks
 			telegramFlagSet := cmd.Flags().Changed("telegram")

--- a/internal/pilot/github_client_test.go
+++ b/internal/pilot/github_client_test.go
@@ -1,0 +1,134 @@
+package pilot
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/config"
+)
+
+// rotatingGitHubToken is a minimal TokenFunc source for exercising
+// per-request token resolution against a webhook-mode Pilot instance,
+// mirroring internal/adapters/github/token_func_test.go's
+// rotatingTokenSource.
+type rotatingGitHubToken struct {
+	mu      sync.Mutex
+	current string
+}
+
+func (r *rotatingGitHubToken) tokenFunc() github.TokenFunc {
+	return func(ctx context.Context) (string, error) {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		return r.current, nil
+	}
+}
+
+func (r *rotatingGitHubToken) set(token string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.current = token
+}
+
+// newTestPilotConfig returns a minimal, GitHub-enabled config pointed at a
+// temp memory dir, suitable for New() in these tests.
+func newTestPilotConfig(t *testing.T, token string) *config.Config {
+	t.Helper()
+	tempDir, err := os.MkdirTemp("", "pilot-github-client-test")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+
+	cfg := config.DefaultConfig()
+	cfg.Memory.Path = tempDir
+	cfg.Adapters.GitHub.Enabled = true
+	cfg.Adapters.GitHub.Token = token
+	return cfg
+}
+
+// TestNew_WithGitHubClient_ResolvesTokenPerRequest is the GH-4755 regression
+// test: webhook-mode Pilot (built via New, exactly as cmd/pilot's
+// gateway/webhook mode does) must keep resolving its GitHub token
+// per-request through whatever client the caller injects via
+// WithGitHubClient, instead of freezing whatever cfg.Adapters.GitHub.Token
+// held at construction time. Before this fix, New unconditionally built
+// github.NewClient(cfg.Adapters.GitHub.Token) regardless of options,
+// discarding any token-func-based client cmd/pilot's newGitHubClient would
+// have supplied and locking the daemon to a single static credential for
+// its lifetime — so an App-auth token rotation (or a 401) after that point
+// would never be picked up.
+func TestNew_WithGitHubClient_ResolvesTokenPerRequest(t *testing.T) {
+	var gotAuth []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = append(gotAuth, r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"number":1}`))
+	}))
+	defer server.Close()
+
+	source := &rotatingGitHubToken{current: "token-v1"}
+	client := github.NewClientWithTokenFuncAndBaseURL(source.tokenFunc(), server.URL)
+
+	// The static config token must NOT win over the injected client — if it
+	// does, New rebuilt its own client from this value instead of keeping
+	// the one passed via WithGitHubClient.
+	cfg := newTestPilotConfig(t, "boot-time-static-token")
+
+	p, err := New(cfg, WithGitHubClient(client))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = p.Stop() }()
+
+	if p.githubClient != client {
+		t.Fatal("New must keep the client supplied via WithGitHubClient instead of building its own from cfg.Adapters.GitHub.Token")
+	}
+
+	if _, err := p.githubClient.GetIssue(context.Background(), "owner", "repo", 1); err != nil {
+		t.Fatalf("GetIssue (pre-rotation) failed: %v", err)
+	}
+
+	// Simulate a mid-daemon-lifetime rotation (GitHub App token refresh, gh-CLI
+	// re-auth, ...) — the Pilot instance is never rebuilt, exactly like the
+	// live daemon.
+	source.set("token-v2")
+
+	if _, err := p.githubClient.GetIssue(context.Background(), "owner", "repo", 1); err != nil {
+		t.Fatalf("GetIssue (post-rotation) failed: %v", err)
+	}
+
+	if len(gotAuth) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(gotAuth))
+	}
+	if gotAuth[0] != "Bearer token-v1" {
+		t.Errorf("first request Authorization = %q, want %q", gotAuth[0], "Bearer token-v1")
+	}
+	if gotAuth[1] != "Bearer token-v2" {
+		t.Errorf("second request Authorization = %q (stale boot-time token), want %q — webhook-mode Pilot's client did not pick up the rotated token", gotAuth[1], "Bearer token-v2")
+	}
+}
+
+// TestNew_WithoutGitHubClient_FallsBackToStaticToken guards the fallback
+// path for direct New() callers that don't supply WithGitHubClient (e.g.
+// other existing tests in this package/cmd/pilot) — New must still build a
+// usable client from cfg.Adapters.GitHub.Token so their behavior is
+// unchanged by this fix.
+func TestNew_WithoutGitHubClient_FallsBackToStaticToken(t *testing.T) {
+	cfg := newTestPilotConfig(t, "static-token")
+
+	p, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = p.Stop() }()
+
+	if p.githubClient == nil {
+		t.Fatal("New must build a fallback GitHub client from cfg.Adapters.GitHub.Token when no WithGitHubClient option is supplied")
+	}
+}

--- a/internal/pilot/pilot.go
+++ b/internal/pilot/pilot.go
@@ -184,6 +184,21 @@ func WithDashboardFS(fsys fs.FS) Option {
 	}
 }
 
+// WithGitHubClient overrides the GitHub client New would otherwise build
+// internally from a static cfg.Adapters.GitHub.Token (GH-4755). Webhook-mode
+// Pilot held that static client for the daemon's lifetime, bypassing the
+// per-request token-resolution chain (GitHub App auth / env / gh-CLI
+// fallback, plus 401-triggered re-mint) that cmd/pilot's newGitHubClient
+// already gives every polling-mode client (GH-4747/GH-4754). Passing a
+// client built the same way in here means webhook mode's githubWH/
+// githubNotify resolve tokens identically instead of freezing the boot-time
+// value. Must be applied before New's GitHub adapter init block runs.
+func WithGitHubClient(client *github.Client) Option {
+	return func(p *Pilot) {
+		p.githubClient = client
+	}
+}
+
 // New creates a new Pilot instance
 func New(cfg *config.Config, opts ...Option) (*Pilot, error) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -193,6 +208,17 @@ func New(cfg *config.Config, opts ...Option) (*Pilot, error) {
 		ctx:         ctx,
 		cancel:      cancel,
 		linearTasks: make(map[string]linearTaskInfo),
+	}
+
+	// GH-4755: apply functional options before any adapter init block runs
+	// (not just before return, as previously) so WithGitHubClient can supply
+	// a per-request-resolving client before the GitHub adapter block below
+	// decides whether it needs to build its own static fallback. The other
+	// options (WithDashboardFS, WithTeamsService, WithTelegramHandler, ...)
+	// only set fields consumed later in New or by callers after it returns,
+	// so applying them this early changes nothing for them.
+	for _, opt := range opts {
+		opt(p)
 	}
 
 	// Initialize memory store
@@ -341,7 +367,14 @@ func New(cfg *config.Config, opts ...Option) (*Pilot, error) {
 
 	// Initialize GitHub adapter if enabled
 	if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled {
-		p.githubClient = github.NewClient(cfg.Adapters.GitHub.Token)
+		// GH-4755: WithGitHubClient (applied above, before this block) already
+		// supplies a client whose token resolves per-request through the same
+		// chain as polling mode. Only fall back to a static
+		// github.NewClient(token) — frozen at construction time — when no
+		// caller passed one in (e.g. direct pilot.New callers in tests).
+		if p.githubClient == nil {
+			p.githubClient = github.NewClient(cfg.Adapters.GitHub.Token)
+		}
 		p.githubWH = github.NewWebhookHandler(
 			p.githubClient,
 			cfg.Adapters.GitHub.WebhookSecret,
@@ -588,10 +621,8 @@ func New(cfg *config.Config, opts ...Option) (*Pilot, error) {
 			slog.String("path", "/webhooks/slack/interactions"))
 	}
 
-	// Apply functional options (GH-349)
-	for _, opt := range opts {
-		opt(p)
-	}
+	// Functional options were already applied at the top of New (GH-4755),
+	// before the adapter init blocks above ran.
 
 	// Set embedded dashboard frontend on gateway if available (GH-1612)
 	if p.dashboardFS != nil {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4755.

Closes #4755

## Changes

GitHub Issue GH-4755: fix(pilot): webhook-mode Pilot holds a static daemon-lifetime GitHub client (PR#4751 review)

## Problem

`internal/pilot/pilot.go:344` (constructed at `cmd/pilot/main.go:1088`) builds `github.NewClient(cfg.Adapters.GitHub.Token)` once and holds it for the daemon's lifetime — webhook/orchestrator mode bypasses the entire per-request resolution chain shipped in PR#4751 (config token only: no App auth, no env, no gh-CLI fallback). Under App auth, `pilot start` in webhook mode runs unauthenticated or 401s after the first token rotation. Not cutover-blocking today only because the founder box runs polling mode; it violates PR#4751's acceptance ("all long-lived client construction sites") for that mode.

## Acceptance

1. Webhook-mode Pilot's client resolves tokens per-request through the same chain as polling mode (`newGitHubClient(cfg)` / `githubTokenFunc` pattern).
2. Test covering token rotation mid-lifetime for this construction site.
3. `make build` / `make test` / `make lint` green.

## Scope fence

No changes to polling-mode clients · no TokenSource-internal changes (separate issue).

**This task must NOT be decomposed — implement as a single PR.** <!-- pilot:no-decompose -->