### PR TITLE
GH-4757: fix(approval): decision integrity — atomic already-decided guard + unlinked-request handling (PR#4752 review)

### DIFF
--- a/internal/approval/manager_test.go
+++ b/internal/approval/manager_test.go
@@ -13,13 +13,14 @@ import (
 type mockPRStateWriter struct {
 	mu    sync.Mutex
 	calls []struct{ requestID, decision, by string }
+	err   error // returned by SetApprovalDecision, if non-nil
 }
 
 func (w *mockPRStateWriter) SetApprovalDecision(_ context.Context, requestID, decision, by string) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.calls = append(w.calls, struct{ requestID, decision, by string }{requestID, decision, by})
-	return nil
+	return w.err
 }
 
 func (w *mockPRStateWriter) getCalls() []struct{ requestID, decision, by string } {
@@ -512,6 +513,22 @@ func TestManager_RecordDecision_PersistsViaWriter(t *testing.T) {
 	}
 	if calls[0].by != "user123" {
 		t.Errorf("expected user123, got %s", calls[0].by)
+	}
+}
+
+// TestManager_RecordDecision_PropagatesWriterError verifies RecordDecision
+// wraps (rather than swallows) an error from the state writer, so a typed
+// sentinel like memory.ErrApprovalAlreadyDecided survives errors.Is() all
+// the way up to the HTTP handler (GH-4757).
+func TestManager_RecordDecision_PropagatesWriterError(t *testing.T) {
+	m := NewManager(nil)
+	sentinel := errors.New("already decided sentinel")
+	writer := &mockPRStateWriter{err: sentinel}
+	m.WithStateWriter(writer)
+
+	err := m.RecordDecision(context.Background(), "req-conflict", DecisionApproved, "user123")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected wrapped sentinel error, got %v", err)
 	}
 }
 

--- a/internal/gateway/approvals.go
+++ b/internal/gateway/approvals.go
@@ -1,7 +1,9 @@
 package gateway
 
 import (
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -126,6 +128,19 @@ func (s *Server) handleApprovals(w http.ResponseWriter, r *http.Request) {
 // Also deletes the persisted approval_pending row, mirroring the channel handlers'
 // own decision path (they own that store via WithStore(); Manager does not), so a
 // later Rehydrate() doesn't re-notify a request already decided over HTTP.
+//
+// Decision integrity (GH-4757 / PR#4752 review): Store.SetApprovalDecision now
+// guards its UPDATE atomically (AND approval_decision = ''), so two racing
+// decisions — two concurrent POSTs, or a POST racing a Telegram/Slack button
+// tap — can never both win. The loser's RecordDecision call returns
+// memory.ErrApprovalAlreadyDecided; this handler turns that into 409 rather
+// than silently overwriting the winner's decision (both used to get 200).
+// A pending row with no execution linkage (SetApprovalRequestID is
+// best-effort — see memory.Store.SetApprovalRequestID) makes RecordDecision
+// return sql.ErrNoRows; that is aligned with Telegram/Slack channel semantics
+// (they treat this as warn-only and still resolve the request — see
+// internal/approval/telegram.go:507, slack.go:391) instead of the previous
+// 500 that left the pending row undecidable forever over HTTP.
 func (s *Server) handleApprovalDecision(w http.ResponseWriter, r *http.Request) {
 	requestID := r.PathValue("requestId")
 	if requestID == "" {
@@ -186,7 +201,31 @@ func (s *Server) handleApprovalDecision(w http.ResponseWriter, r *http.Request) 
 	}
 
 	now := time.Now()
-	if err := recorder.RecordDecision(r.Context(), requestID, decision, body.By); err != nil {
+	recErr := recorder.RecordDecision(r.Context(), requestID, decision, body.By)
+	switch {
+	case recErr == nil:
+		// Recorded successfully — fall through to cleanup + 200 below.
+	case errors.Is(recErr, memory.ErrApprovalAlreadyDecided):
+		// Lost the race: the atomic guard in Store.SetApprovalDecision
+		// rejected this write because another decider (a concurrent POST, or
+		// a Telegram/Slack button tap) already recorded a decision first —
+		// the recorded value never flips. Clean up the now-stale pending row
+		// (idempotent if the winner already did) and report the conflict.
+		if delErr := store.DeletePendingApproval(requestID); delErr != nil {
+			logging.WithComponent("gateway").Warn("failed to delete persisted approval after losing decision race",
+				slog.String("request_id", requestID), slog.Any("error", delErr))
+		}
+		http.Error(w, "approval already decided", http.StatusConflict)
+		return
+	case errors.Is(recErr, sql.ErrNoRows):
+		// Unlinked request: no execution row carries this approval_request_id
+		// (SetApprovalRequestID never landed the linkage), so there is
+		// nothing to persist a decision onto. Warn and still resolve the
+		// request — matching how Telegram/Slack treat this exact failure —
+		// rather than 500ing forever with no channel button left to clear it.
+		logging.WithComponent("gateway").Warn("HTTP decision on unlinked approval request — resolving without execution persistence",
+			slog.String("request_id", requestID), slog.String("decision", body.Decision), slog.String("by", body.By))
+	default:
 		http.Error(w, "failed to record decision", http.StatusInternalServerError)
 		return
 	}

--- a/internal/gateway/approvals_test.go
+++ b/internal/gateway/approvals_test.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -386,6 +387,74 @@ func TestHandleApprovalDecision_RecordDecisionError_500(t *testing.T) {
 	// Cleanup must not run if the recorder itself failed.
 	if len(store.deletedApprovalIDs) != 0 {
 		t.Errorf("DeletePendingApproval should not run after a RecordDecision error, got %v", store.deletedApprovalIDs)
+	}
+}
+
+// TestHandleApprovalDecision_RaceLoss_409 simulates the loser of a decision
+// race: the request is still listed pending (findPendingApproval succeeds),
+// but by the time RecordDecision runs, Store.SetApprovalDecision's atomic
+// guard has already rejected the write because another decider won first.
+// The handler must surface 409 (not the previous last-writer-wins 200) and
+// still clean up the now-stale pending row (GH-4757 acceptance criterion 1).
+func TestHandleApprovalDecision_RaceLoss_409(t *testing.T) {
+	now := time.Now()
+	store := &mockDashboardStore{
+		pendingApprovals: []*memory.PendingApproval{
+			{ID: "req-race", TaskID: "GH-10", CreatedAt: now, ExpiresAt: now.Add(time.Hour)},
+		},
+	}
+	rec := &fakeDecisionRecorder{err: memory.ErrApprovalAlreadyDecided}
+	s := decisionServer(store, rec)
+
+	body := bytes.NewBufferString(`{"decision":"approve","by":"alice"}`)
+	req := httpTestRequestWithPathValue(t, http.MethodPost, "/api/v1/approvals/req-race/decision", body, "requestId", "req-race")
+	w := newTestResponseRecorder()
+	s.handleApprovalDecision(w, req)
+
+	if w.status != http.StatusConflict {
+		t.Errorf("status = %d, want 409 (body=%s)", w.status, w.body.String())
+	}
+	if len(store.deletedApprovalIDs) != 1 || store.deletedApprovalIDs[0] != "req-race" {
+		t.Errorf("DeletePendingApproval calls = %v, want [req-race] (stale pending row must still be cleaned up)", store.deletedApprovalIDs)
+	}
+}
+
+// TestHandleApprovalDecision_UnlinkedRequest_ResolvesInsteadOf500 covers the
+// second integrity gap: a pending row with no execution linkage (
+// SetApprovalRequestID never ran) makes Store.SetApprovalDecision return
+// sql.ErrNoRows. The handler must align with Telegram/Slack channel
+// semantics — warn-log and still resolve the request — instead of the
+// previous 500 that left the row undecidable forever over HTTP
+// (GH-4757 acceptance criterion 2).
+func TestHandleApprovalDecision_UnlinkedRequest_ResolvesInsteadOf500(t *testing.T) {
+	now := time.Now()
+	store := &mockDashboardStore{
+		pendingApprovals: []*memory.PendingApproval{
+			{ID: "req-unlinked", TaskID: "GH-11", CreatedAt: now, ExpiresAt: now.Add(time.Hour)},
+		},
+		// No execByApprovalReqID entry for "req-unlinked" — mirrors GET
+		// listing it with executionId: null.
+	}
+	rec := &fakeDecisionRecorder{err: sql.ErrNoRows}
+	s := decisionServer(store, rec)
+
+	body := bytes.NewBufferString(`{"decision":"reject","by":"bob"}`)
+	req := httpTestRequestWithPathValue(t, http.MethodPost, "/api/v1/approvals/req-unlinked/decision", body, "requestId", "req-unlinked")
+	w := newTestResponseRecorder()
+	s.handleApprovalDecision(w, req)
+
+	if w.status != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", w.status, w.body.String())
+	}
+	if len(store.deletedApprovalIDs) != 1 || store.deletedApprovalIDs[0] != "req-unlinked" {
+		t.Errorf("DeletePendingApproval calls = %v, want [req-unlinked]", store.deletedApprovalIDs)
+	}
+	var resp decisionResponseBody
+	if err := json.Unmarshal(w.body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.RequestID != "req-unlinked" || resp.Decision != "reject" || resp.By != "bob" {
+		t.Errorf("unexpected response body: %+v", resp)
 	}
 }
 

--- a/internal/memory/pr_state_test.go
+++ b/internal/memory/pr_state_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 )
@@ -173,5 +174,96 @@ func TestGetExecutionByApprovalRequestID_EmptyRequestID(t *testing.T) {
 
 	if _, err := s.GetExecutionByApprovalRequestID(""); !errors.Is(err, sql.ErrNoRows) {
 		t.Errorf("expected sql.ErrNoRows for empty requestID, got %v", err)
+	}
+}
+
+// TestSetApprovalDecision_AlreadyDecided_Guard verifies the atomic
+// `AND approval_decision = ''` guard: a second decision on an
+// already-decided row must not overwrite the first, and must return the
+// typed ErrApprovalAlreadyDecided rather than sql.ErrNoRows (GH-4757).
+func TestSetApprovalDecision_AlreadyDecided_Guard(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+
+	const execID = "exec-guard-1"
+	const reqID = "req-guard-1"
+	seedExecution(t, s, execID, reqID)
+
+	if err := s.SetApprovalDecision(context.Background(), reqID, "approved", "alice"); err != nil {
+		t.Fatalf("first SetApprovalDecision: %v", err)
+	}
+
+	err := s.SetApprovalDecision(context.Background(), reqID, "rejected", "mallory")
+	if !errors.Is(err, ErrApprovalAlreadyDecided) {
+		t.Fatalf("second SetApprovalDecision: got %v, want ErrApprovalAlreadyDecided", err)
+	}
+
+	exec, getErr := s.GetExecution(execID)
+	if getErr != nil {
+		t.Fatalf("GetExecution: %v", getErr)
+	}
+	if exec.ApprovalDecision != "approved" {
+		t.Errorf("ApprovalDecision flipped: got %q, want %q (first writer must win)", exec.ApprovalDecision, "approved")
+	}
+	if exec.ApprovalDecisionBy != "alice" {
+		t.Errorf("ApprovalDecisionBy flipped: got %q, want %q", exec.ApprovalDecisionBy, "alice")
+	}
+}
+
+// TestSetApprovalDecision_ConcurrentRace verifies that of two goroutines
+// racing to decide the same request, exactly one succeeds and the other gets
+// ErrApprovalAlreadyDecided — and the persisted decision matches whichever
+// one actually won, never a blend or a silent overwrite (GH-4757 acceptance
+// criterion 1).
+func TestSetApprovalDecision_ConcurrentRace(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+
+	const execID = "exec-race-1"
+	const reqID = "req-race-1"
+	seedExecution(t, s, execID, reqID)
+
+	var wg sync.WaitGroup
+	results := make([]error, 2)
+	deciders := []string{"approved", "rejected"}
+	by := []string{"alice", "bob"}
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx] = s.SetApprovalDecision(context.Background(), reqID, deciders[idx], by[idx])
+		}(i)
+	}
+	wg.Wait()
+
+	var nilCount, alreadyDecidedCount int
+	for _, err := range results {
+		switch {
+		case err == nil:
+			nilCount++
+		case errors.Is(err, ErrApprovalAlreadyDecided):
+			alreadyDecidedCount++
+		default:
+			t.Fatalf("unexpected error from racing SetApprovalDecision: %v", err)
+		}
+	}
+	if nilCount != 1 || alreadyDecidedCount != 1 {
+		t.Fatalf("got %d winners and %d already-decided, want exactly 1 and 1", nilCount, alreadyDecidedCount)
+	}
+
+	exec, err := s.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	// The recorded decision must match exactly one of the two racing writes
+	// — never empty, never a mix of the two.
+	if exec.ApprovalDecision != "approved" && exec.ApprovalDecision != "rejected" {
+		t.Fatalf("ApprovalDecision = %q, want either approved or rejected", exec.ApprovalDecision)
+	}
+	if results[0] == nil && exec.ApprovalDecision != "approved" {
+		t.Errorf("goroutine 0 won but recorded decision is %q, want approved", exec.ApprovalDecision)
+	}
+	if results[1] == nil && exec.ApprovalDecision != "rejected" {
+		t.Errorf("goroutine 1 won but recorded decision is %q, want rejected", exec.ApprovalDecision)
 	}
 }

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1466,9 +1466,23 @@ func (s *Store) TerminateNonTerminalExecutionAsSuperseded(taskID, projectPath, r
 	})
 }
 
+// ErrApprovalAlreadyDecided is returned by SetApprovalDecision when the
+// execution row linked to requestID already carries a non-empty
+// approval_decision. Distinguished from sql.ErrNoRows (no linked row at
+// all — an unlinked/unknown request) so callers can tell "already decided"
+// (409) apart from "nothing to decide" (GH-4757 / PR#4752 review).
+var ErrApprovalAlreadyDecided = errors.New("approval already decided")
+
 // SetApprovalDecision records an approval decision on the execution linked to requestID.
 // It sets approval_decision, approval_decision_at, and approval_decision_by on the row
-// whose approval_request_id matches. Returns sql.ErrNoRows if no matching row is found.
+// whose approval_request_id matches. The UPDATE is guarded by
+// `AND approval_decision = ''` so two racing callers (e.g. a POST racing a
+// Telegram/Slack button tap, or two concurrent POSTs) can never both win: only
+// the first writer's UPDATE matches a row, the second affects zero rows and
+// gets ErrApprovalAlreadyDecided rather than silently overwriting the first
+// decision (GH-4757 / PR#4752 review — previously unguarded, last writer won).
+// Returns sql.ErrNoRows if no row is linked to requestID at all (unlinked
+// request — SetApprovalRequestID is best-effort and may never have run).
 func (s *Store) SetApprovalDecision(ctx context.Context, requestID string, decision string, by string) error {
 	if requestID == "" {
 		return sql.ErrNoRows
@@ -1479,7 +1493,7 @@ func (s *Store) SetApprovalDecision(ctx context.Context, requestID string, decis
 			SET approval_decision    = ?,
 			    approval_decision_at = CURRENT_TIMESTAMP,
 			    approval_decision_by = ?
-			WHERE approval_request_id = ?
+			WHERE approval_request_id = ? AND COALESCE(approval_decision, '') = ''
 		`, decision, by, requestID)
 		if err != nil {
 			return fmt.Errorf("SetApprovalDecision: %w", err)
@@ -1488,10 +1502,29 @@ func (s *Store) SetApprovalDecision(ctx context.Context, requestID string, decis
 		if err != nil {
 			return fmt.Errorf("SetApprovalDecision rows affected: %w", err)
 		}
-		if rows == 0 {
-			return sql.ErrNoRows
+		if rows > 0 {
+			return nil
 		}
-		return nil
+
+		// Zero rows: either no row is linked to requestID (unlinked request),
+		// or a row is linked but the guard just rejected it because it's
+		// already decided. Distinguish with a follow-up read.
+		var existingDecision string
+		checkErr := s.db.QueryRowContext(ctx, `
+			SELECT COALESCE(approval_decision, '') FROM executions
+			WHERE approval_request_id = ?
+			ORDER BY created_at DESC LIMIT 1
+		`, requestID).Scan(&existingDecision)
+		if checkErr != nil {
+			if errors.Is(checkErr, sql.ErrNoRows) {
+				return sql.ErrNoRows
+			}
+			return fmt.Errorf("SetApprovalDecision existence check: %w", checkErr)
+		}
+		if existingDecision != "" {
+			return ErrApprovalAlreadyDecided
+		}
+		return sql.ErrNoRows
 	})
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4757.

Closes #4757

## Changes

GitHub Issue GH-4757: fix(approval): decision integrity — atomic already-decided guard + unlinked-request handling (PR#4752 review)

## Problem

Post-merge review of PR#4752 found two integrity gaps in the HTTP decision path:

1. **TOCTOU double-decide** — `handleApprovalDecision` (`internal/gateway/approvals.go:129`) is check-then-act (`findPendingApproval` → `RecordDecision` → `DeletePendingApproval`), and `Store.SetApprovalDecision` (`internal/memory/store.go:1472`) has no already-decided guard: two concurrent POSTs, or a POST racing a Telegram/Slack button tap, both pass the pending check and the last writer silently overwrites — an approve→reject flip is possible after autopilot may already have consumed "approved". Both callers get 200.
2. **Unlinked requests are undecidable over HTTP** — `SetApprovalRequestID` is best-effort, so a pending row can lack an `executions` match. GET lists it (`executionId: null`); POST → `RecordDecision` → `sql.ErrNoRows` → 500 "failed to record decision", pending row never cleaned — a console will show a pending approval that 500s on every click, forever; only a channel button can clear it. Telegram diverges: it treats `RecordDecision` failure as warn-only (`internal/approval/telegram.go:507`) and still resolves the request.

## Acceptance

1. `SetApprovalDecision` guards atomically (`AND approval_decision = ''`) and reports rows-affected; zero rows → typed already-decided error → handler returns 409. Concurrency test: two racing decisions → exactly one 200 and one 409; the recorded value never flips.
2. HTTP decision on an unlinked request aligns with channel semantics: warn-log, resolve/clean the pending request, no 500. Decide and document the exact response (the console maps it — pilot-console#109 currently maps upstream 500 → 502).
3. Slack/Telegram flows unchanged; a channel tap racing an HTTP POST also resolves to exactly one winner.
4. `make build` / `make test` / `make lint` green.

## Scope fence

No API-shape changes to the 200 response · no approval-policy changes · no console-repo changes.

**This task must NOT be decomposed — implement as a single PR.** <!-- pilot:no-decompose -->