### PR TITLE
fix(approval): channel-routing fidelity — rehydrate/sweep scoping, Slack destination parity, github-review alias

### DIFF
--- a/internal/approval/channel.go
+++ b/internal/approval/channel.go
@@ -1,0 +1,79 @@
+package approval
+
+// This file is the single normalization point for approval channel names in
+// this package (GH-4772). Everything that compares a persisted/requested
+// channel string against a registered Handler.Name() — Manager's dispatch
+// lookup, each handler's Rehydrate, and the expiry sweep's channel scoping —
+// goes through normalizeChannelName/ownsChannel so the alias table and the
+// legacy-row ownership rule are defined exactly once.
+
+// defaultChannelName is the approval channel that claims pending-approval
+// rows persisted with an empty preferred_channel: rows written before
+// PreferredChannel existed (pre-GH-4380), or by any future caller that
+// leaves it unset. Exactly one handler must own these rows, or Rehydrate/the
+// expiry sweep double-process (or silently strand) them once more than one
+// channel handler is registered (GH-4772).
+//
+// Hardcoded to "telegram" rather than read from the autopilot-level
+// `approval_source` default (autopilot.ApprovalSourceTelegram,
+// internal/autopilot/types.go) because this package cannot import autopilot
+// — autopilot already imports approval (e.g. controller.go's
+// `PreferredChannel: string(c.config.EffectiveApprovalSource())`), so the
+// reverse import would cycle. Telegram was the only approval channel before
+// Slack existed (GH-4411) and before PreferredChannel existed (GH-4380), so
+// every empty-preferred_channel row in a live database predates Slack
+// entirely — Telegram is the correct legacy owner in practice, not just by
+// convention.
+const defaultChannelName = "telegram"
+
+// githubReviewAlias is the autopilot-level ApprovalSource config value for
+// GitHub PR-review approvals (autopilot.ApprovalSourceGitHubReview =
+// "github-review", internal/autopilot/types.go:36). This package's own
+// handler for that channel is registered under Name() == "github"
+// (GitHubHandler.Name, github.go:62-64) — the two names diverged when the
+// GitHub handler was added without an alias, so a request configured with
+// `approval_source: github-review` always hit Manager's preferred-channel
+// hard error (GH-4380 semantics preserved: unregistered/unresolvable
+// channels still fail loudly, never a silent fallback).
+const githubReviewAlias = "github-review"
+
+// knownChannelNames lists every channel name a Handler in this package can
+// be registered under (i.e. every Handler.Name() value), used to scope the
+// expiry sweep's orphan fallback (see ownedChannels / PruneExpired). The
+// raw config alias is included too so a row persisted with the unnormalized
+// "github-review" string is never mistaken for an orphan. Update this list
+// when a new Handler type is added.
+var knownChannelNames = []string{"telegram", "slack", "github", githubReviewAlias}
+
+// normalizeChannelName maps a channel name as it appears on a Request or a
+// persisted PendingApproval row to the name its serving Handler is
+// registered under. Every value other than the github-review alias passes
+// through unchanged.
+func normalizeChannelName(name string) string {
+	if name == githubReviewAlias {
+		return "github"
+	}
+	return name
+}
+
+// ownsChannel reports whether the handler registered as handlerName should
+// treat a row/request carrying preferredChannel as its own: either the
+// (normalized) channel matches directly, or the row predates per-request
+// channel routing (empty PreferredChannel) and handlerName is the default
+// legacy claimant (GH-4772).
+func ownsChannel(handlerName, preferredChannel string) bool {
+	if preferredChannel == "" {
+		return handlerName == defaultChannelName
+	}
+	return normalizeChannelName(preferredChannel) == handlerName
+}
+
+// ownedChannels returns the set of preferred_channel values a channel-scoped
+// store sweep (PrunePendingApprovals) should delete for handlerName: its own
+// name, plus "" (empty/legacy) when handlerName is the default claimant.
+func ownedChannels(handlerName string) []string {
+	if handlerName == defaultChannelName {
+		return []string{handlerName, ""}
+	}
+	return []string{handlerName}
+}

--- a/internal/approval/channel_test.go
+++ b/internal/approval/channel_test.go
@@ -1,0 +1,150 @@
+package approval
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+func TestNormalizeChannelName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"github-review alias maps to github", "github-review", "github"},
+		{"telegram passes through", "telegram", "telegram"},
+		{"slack passes through", "slack", "slack"},
+		{"github passes through", "github", "github"},
+		{"empty passes through", "", ""},
+		{"unknown passes through unchanged", "webhook", "webhook"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeChannelName(tt.in); got != tt.want {
+				t.Errorf("normalizeChannelName(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOwnsChannel(t *testing.T) {
+	tests := []struct {
+		name             string
+		handlerName      string
+		preferredChannel string
+		want             bool
+	}{
+		{"telegram owns its own explicit rows", "telegram", "telegram", true},
+		{"telegram owns legacy empty rows", "telegram", "", true},
+		{"slack does not own legacy empty rows", "slack", "", false},
+		{"slack owns its own explicit rows", "slack", "slack", true},
+		{"github owns rows via the github-review alias", "github", "github-review", true},
+		{"telegram does not own slack rows", "telegram", "slack", false},
+		{"slack does not own telegram rows", "slack", "telegram", false},
+		{"telegram does not own unknown-channel rows", "telegram", "webhook", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ownsChannel(tt.handlerName, tt.preferredChannel); got != tt.want {
+				t.Errorf("ownsChannel(%q, %q) = %v, want %v", tt.handlerName, tt.preferredChannel, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOwnedChannels(t *testing.T) {
+	if got := ownedChannels("telegram"); len(got) != 2 || got[0] != "telegram" || got[1] != "" {
+		t.Errorf("ownedChannels(telegram) = %v, want [telegram \"\"]", got)
+	}
+	if got := ownedChannels("slack"); len(got) != 1 || got[0] != "slack" {
+		t.Errorf("ownedChannels(slack) = %v, want [slack]", got)
+	}
+}
+
+// TestRehydrate_MixedChannelScenario is the GH-4772 acceptance-criterion-5
+// regression test: it seeds one row per channel type — telegram, slack,
+// legacy (empty PreferredChannel), and an unknown/orphaned channel name —
+// and verifies that each handler's Rehydrate only ever claims the rows it
+// owns. The legacy row must be claimed by telegram (the documented default
+// legacy-channel owner) and the unknown-channel row must be claimed by
+// neither.
+func TestRehydrate_MixedChannelScenario(t *testing.T) {
+	store := newMockPendingStore()
+	future := time.Now().Add(time.Hour)
+
+	_ = store.InsertPendingApproval(&memory.PendingApproval{
+		ID: "row-telegram", TaskID: "T-telegram", Stage: "pre_merge",
+		Title: "Telegram row", PreferredChannel: "telegram", CreatedAt: time.Now(), ExpiresAt: future,
+	})
+	_ = store.InsertPendingApproval(&memory.PendingApproval{
+		ID: "row-slack", TaskID: "T-slack", Stage: "pre_merge",
+		Title: "Slack row", PreferredChannel: "slack", CreatedAt: time.Now(), ExpiresAt: future,
+	})
+	_ = store.InsertPendingApproval(&memory.PendingApproval{
+		ID: "row-legacy", TaskID: "T-legacy", Stage: "pre_merge",
+		Title: "Legacy row", PreferredChannel: "", CreatedAt: time.Now(), ExpiresAt: future,
+	})
+	_ = store.InsertPendingApproval(&memory.PendingApproval{
+		ID: "row-unknown", TaskID: "T-unknown", Stage: "pre_merge",
+		Title: "Unknown-channel row", PreferredChannel: "webhook", CreatedAt: time.Now(), ExpiresAt: future,
+	})
+
+	telegramHandler := NewTelegramHandler(&mockTelegramClient{}, "chat123").WithStore(store)
+	if err := telegramHandler.Rehydrate(context.Background()); err != nil {
+		t.Fatalf("telegram rehydrate: unexpected error: %v", err)
+	}
+
+	slackHandler := NewSlackHandler(&mockSlackClient{}, "#approvals").WithStore(store)
+	if err := slackHandler.Rehydrate(context.Background()); err != nil {
+		t.Fatalf("slack rehydrate: unexpected error: %v", err)
+	}
+
+	telegramHandler.mu.RLock()
+	_, tgGotTelegram := telegramHandler.pending["row-telegram"]
+	_, tgGotSlack := telegramHandler.pending["row-slack"]
+	_, tgGotLegacy := telegramHandler.pending["row-legacy"]
+	_, tgGotUnknown := telegramHandler.pending["row-unknown"]
+	telegramHandler.mu.RUnlock()
+
+	if !tgGotTelegram {
+		t.Error("expected telegram Rehydrate to claim its own row")
+	}
+	if tgGotSlack {
+		t.Error("expected telegram Rehydrate to skip the slack-owned row")
+	}
+	if !tgGotLegacy {
+		t.Error("expected telegram Rehydrate to claim the legacy empty-channel row (default owner)")
+	}
+	if tgGotUnknown {
+		t.Error("expected telegram Rehydrate to skip the unknown-channel row")
+	}
+
+	slackHandler.mu.RLock()
+	_, skGotTelegram := slackHandler.pending["row-telegram"]
+	_, skGotSlack := slackHandler.pending["row-slack"]
+	_, skGotLegacy := slackHandler.pending["row-legacy"]
+	_, skGotUnknown := slackHandler.pending["row-unknown"]
+	slackHandler.mu.RUnlock()
+
+	if skGotTelegram {
+		t.Error("expected slack Rehydrate to skip the telegram-owned row")
+	}
+	if !skGotSlack {
+		t.Error("expected slack Rehydrate to claim its own row")
+	}
+	if skGotLegacy {
+		t.Error("expected slack Rehydrate to skip the legacy empty-channel row (telegram-owned)")
+	}
+	if skGotUnknown {
+		t.Error("expected slack Rehydrate to skip the unknown-channel row")
+	}
+
+	// The unknown-channel row is claimed by neither handler; it's swept
+	// separately via PrunePendingApprovalsOutside once it expires.
+	if store.get("row-unknown") == nil {
+		t.Error("expected the unknown-channel row to still exist in the store, untouched")
+	}
+}

--- a/internal/approval/manager.go
+++ b/internal/approval/manager.go
@@ -248,7 +248,14 @@ func (m *Manager) SubmitApprovalRequest(ctx context.Context, req *Request) (stri
 	var handler Handler
 	preferredMissing := false
 	if req.PreferredChannel != "" {
-		if h, ok := m.handlers[req.PreferredChannel]; ok {
+		// GH-4772: normalize aliases (e.g. the autopilot config value
+		// "github-review" -> the GitHubHandler's registered Name()
+		// "github") before lookup, so an alias never hits the hard-error
+		// path below just because it doesn't literally match a handler's
+		// Name(). GH-4380 semantics are unchanged: a channel that's still
+		// unresolvable after normalization is a hard error, never a silent
+		// fallback.
+		if h, ok := m.handlers[normalizeChannelName(req.PreferredChannel)]; ok {
 			handler = h
 		} else {
 			preferredMissing = true

--- a/internal/approval/manager_test.go
+++ b/internal/approval/manager_test.go
@@ -377,6 +377,73 @@ func TestManager_SubmitApprovalRequest_PreferredChannelMissing_FailsExplicitly(t
 	}
 }
 
+// TestManager_SubmitApprovalRequest_GitHubReviewAlias verifies the GH-4772
+// fix: a request configured with PreferredChannel "github-review" (the
+// autopilot.ApprovalSourceGitHubReview config value,
+// internal/autopilot/types.go:36) resolves to the handler registered as
+// "github" (GitHubHandler.Name()) instead of hitting the preferredMissing
+// hard error just because the two names don't literally match.
+func TestManager_SubmitApprovalRequest_GitHubReviewAlias(t *testing.T) {
+	config := DefaultConfig()
+	config.Enabled = true
+	config.PreExecution.Enabled = true
+	config.PreExecution.Timeout = 5 * time.Second
+
+	m := NewManager(config)
+
+	github := &mockHandler{name: "github"}
+	m.RegisterHandler(github)
+
+	req := &Request{
+		ID:               "async-alias-1",
+		TaskID:           "TASK-01",
+		Stage:            StagePreExecution,
+		Title:            "Test task",
+		CreatedAt:        time.Now(),
+		PreferredChannel: "github-review",
+	}
+
+	if _, err := m.SubmitApprovalRequest(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(github.sentReqs) != 1 {
+		t.Errorf("expected 1 request sent to the github handler via the github-review alias, got %d", len(github.sentReqs))
+	}
+}
+
+// TestManager_SubmitApprovalRequest_UnresolvableChannelStillHardErrors
+// verifies GH-4380 semantics are preserved after adding the github-review
+// alias: a channel name that's still unresolvable after normalization must
+// still fail loudly, never silently fall back to another registered handler.
+func TestManager_SubmitApprovalRequest_UnresolvableChannelStillHardErrors(t *testing.T) {
+	config := DefaultConfig()
+	config.Enabled = true
+	config.PreExecution.Enabled = true
+	config.PreExecution.Timeout = 5 * time.Second
+
+	m := NewManager(config)
+
+	telegram := &mockHandler{name: "telegram"}
+	m.RegisterHandler(telegram)
+
+	req := &Request{
+		ID:               "async-alias-missing-1",
+		TaskID:           "TASK-01",
+		Stage:            StagePreExecution,
+		Title:            "Test task",
+		CreatedAt:        time.Now(),
+		PreferredChannel: "github-review",
+	}
+
+	_, err := m.SubmitApprovalRequest(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected an error when the aliased channel's target handler isn't registered, got nil")
+	}
+	if len(telegram.sentReqs) != 0 {
+		t.Errorf("expected no silent fallback to telegram handler, got %d requests", len(telegram.sentReqs))
+	}
+}
+
 // TestManager_SubmitApprovalRequest_NoPreferredChannel_FallsBackToFirstAvailable
 // preserves the pre-existing behavior for requests that don't specify a
 // PreferredChannel at all (e.g. legacy callers) — the fail-fast behavior only

--- a/internal/approval/slack.go
+++ b/internal/approval/slack.go
@@ -96,6 +96,20 @@ func (h *SlackHandler) Name() string {
 	return "slack"
 }
 
+// resolveChannel picks the Slack destination for req: the first approver
+// when it's set, otherwise the handler's own configured channel. This is
+// the single place that rule lives — SendApprovalRequest and Rehydrate both
+// call it, so the first send and any post-restart rehydrate never disagree
+// on where a given request's message lives (GH-4772; before this fix,
+// SendApprovalRequest used h.channel unconditionally while Rehydrate
+// honored Approvers[0]).
+func (h *SlackHandler) resolveChannel(req *Request) string {
+	if len(req.Approvers) > 0 && req.Approvers[0] != "" {
+		return req.Approvers[0]
+	}
+	return h.channel
+}
+
 // WithStore attaches a persistence store so pending approvals survive restarts.
 // Returns h to allow builder-style chaining after NewSlackHandler.
 func (h *SlackHandler) WithStore(store PendingApprovalStore) *SlackHandler {
@@ -134,6 +148,14 @@ func (h *SlackHandler) Rehydrate(ctx context.Context) error {
 	now := time.Now()
 	rehydrated := 0
 	for _, row := range rows {
+		// GH-4772: only rehydrate rows this handler actually owns — a row
+		// originally dispatched to Telegram (or any other channel) must not
+		// be re-armed here, and this handler must not delete an expired row
+		// it doesn't own out from under its owning handler's own sweep. See
+		// ownsChannel/defaultChannelName.
+		if !ownsChannel(h.Name(), row.PreferredChannel) {
+			continue
+		}
 		if row.ExpiresAt.Before(now) {
 			_ = h.store.DeletePendingApproval(row.ID)
 			continue
@@ -150,10 +172,7 @@ func (h *SlackHandler) Rehydrate(ctx context.Context) error {
 			CreatedAt:        row.CreatedAt,
 			ExpiresAt:        row.ExpiresAt,
 		}
-		channel := h.channel
-		if len(req.Approvers) > 0 && req.Approvers[0] != "" {
-			channel = req.Approvers[0]
-		}
+		channel := h.resolveChannel(req)
 		h.mu.Lock()
 		if _, exists := h.pending[req.ID]; !exists {
 			h.pending[req.ID] = &slackPending{
@@ -218,7 +237,10 @@ func (h *SlackHandler) PruneExpired(ctx context.Context) (int, error) {
 	}
 
 	if h.store != nil {
-		if _, err := h.store.PrunePendingApprovals(now); err != nil {
+		// GH-4772: scope the store-level sweep to rows this handler owns
+		// (see TelegramHandler.PruneExpired's matching comment). Slack is
+		// never the default channel, so it never runs the orphan fallback.
+		if _, err := h.store.PrunePendingApprovals(now, ownedChannels(h.Name())); err != nil {
 			return len(expired), fmt.Errorf("prune expired: sweep store: %w", err)
 		}
 	}
@@ -239,7 +261,7 @@ func (h *SlackHandler) SendApprovalRequest(ctx context.Context, req *Request) (<
 
 	// Create interactive message
 	msg := &SlackInteractiveMessage{
-		Channel: h.channel,
+		Channel: h.resolveChannel(req),
 		Text:    h.formatFallbackText(req), // Fallback for notifications
 		Blocks:  blocks,
 	}

--- a/internal/approval/slack_test.go
+++ b/internal/approval/slack_test.go
@@ -100,6 +100,60 @@ func TestSlackHandler_SendApprovalRequest(t *testing.T) {
 	}
 }
 
+// TestSlackHandler_SendApprovalRequest_RehydrateDestinationParity is the
+// GH-4772 regression test for bug (b): SendApprovalRequest must post to the
+// same destination that Rehydrate would resolve to for the same request
+// after a restart. Before the fix, SendApprovalRequest always used the
+// handler's configured default channel while Rehydrate honored
+// req.Approvers[0], so a per-request approver override took effect only on
+// rehydrate, silently retargeting the message after a daemon restart.
+func TestSlackHandler_SendApprovalRequest_RehydrateDestinationParity(t *testing.T) {
+	sendClient := &mockSlackClient{}
+	store := newMockPendingStore()
+	sendHandler := NewSlackHandler(sendClient, "#default-approvals").WithStore(store)
+
+	req := &Request{
+		ID:               "parity-1",
+		TaskID:           "TASK-01",
+		Stage:            StagePreMerge,
+		Title:            "Test PR",
+		Approvers:        []string{"#override-channel"},
+		PreferredChannel: "slack",
+		CreatedAt:        time.Now(),
+		ExpiresAt:        time.Now().Add(time.Hour),
+	}
+
+	if _, err := sendHandler.SendApprovalRequest(context.Background(), req); err != nil {
+		t.Fatalf("SendApprovalRequest: unexpected error: %v", err)
+	}
+	if sendClient.lastMessage == nil {
+		t.Fatal("expected message to be sent")
+	}
+	sentChannel := sendClient.lastMessage.Channel
+
+	// Simulate a restart: a fresh handler (same configured default channel)
+	// rehydrating the row that was just persisted by SendApprovalRequest.
+	rehydrateClient := &mockSlackClient{}
+	rehydrateHandler := NewSlackHandler(rehydrateClient, "#default-approvals").WithStore(store)
+	if err := rehydrateHandler.Rehydrate(context.Background()); err != nil {
+		t.Fatalf("Rehydrate: unexpected error: %v", err)
+	}
+
+	rehydrateHandler.mu.RLock()
+	pending, ok := rehydrateHandler.pending["parity-1"]
+	rehydrateHandler.mu.RUnlock()
+	if !ok {
+		t.Fatal("expected request to be rehydrated")
+	}
+
+	if sentChannel != pending.Channel {
+		t.Errorf("destination parity broken: SendApprovalRequest used %q, Rehydrate resolved %q", sentChannel, pending.Channel)
+	}
+	if pending.Channel != "#override-channel" {
+		t.Errorf("expected both to honor the approver override, got %q", pending.Channel)
+	}
+}
+
 func TestSlackHandler_HandleInteraction_Approve(t *testing.T) {
 	client := &mockSlackClient{}
 	handler := NewSlackHandler(client, "#approvals")
@@ -355,11 +409,11 @@ func TestSlackHandler_Rehydrate_RestoresNonExpired(t *testing.T) {
 	past := time.Now().Add(-time.Hour)
 	_ = store.InsertPendingApproval(&memory.PendingApproval{
 		ID: "live", TaskID: "T-live", Stage: "pre_merge",
-		Title: "Live", CreatedAt: time.Now(), ExpiresAt: future,
+		Title: "Live", PreferredChannel: "slack", CreatedAt: time.Now(), ExpiresAt: future,
 	})
 	_ = store.InsertPendingApproval(&memory.PendingApproval{
 		ID: "dead", TaskID: "T-dead", Stage: "pre_merge",
-		Title: "Dead", CreatedAt: time.Now(), ExpiresAt: past,
+		Title: "Dead", PreferredChannel: "slack", CreatedAt: time.Now(), ExpiresAt: past,
 	})
 
 	handler := NewSlackHandler(client, "#approvals").WithStore(store)
@@ -383,6 +437,49 @@ func TestSlackHandler_Rehydrate_RestoresNonExpired(t *testing.T) {
 	}
 }
 
+// TestSlackHandler_Rehydrate_SkipsOtherChannelRows is the GH-4772 regression
+// test: Rehydrate must not process (or delete) a row dispatched to another
+// channel — even an expired one, which the owning handler's own sweep still
+// needs to see so it can edit its message / record the timeout decision.
+func TestSlackHandler_Rehydrate_SkipsOtherChannelRows(t *testing.T) {
+	client := &mockSlackClient{}
+	store := newMockPendingStore()
+
+	future := time.Now().Add(time.Hour)
+	past := time.Now().Add(-time.Hour)
+	_ = store.InsertPendingApproval(&memory.PendingApproval{
+		ID: "tg-live", TaskID: "T-tg-live", Stage: "pre_merge",
+		Title: "Telegram live", PreferredChannel: "telegram", CreatedAt: time.Now(), ExpiresAt: future,
+	})
+	_ = store.InsertPendingApproval(&memory.PendingApproval{
+		ID: "tg-dead", TaskID: "T-tg-dead", Stage: "pre_merge",
+		Title: "Telegram dead", PreferredChannel: "telegram", CreatedAt: time.Now(), ExpiresAt: past,
+	})
+
+	handler := NewSlackHandler(client, "#approvals").WithStore(store)
+	if err := handler.Rehydrate(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	handler.mu.RLock()
+	_, gotLive := handler.pending["tg-live"]
+	_, gotDead := handler.pending["tg-dead"]
+	handler.mu.RUnlock()
+
+	if gotLive {
+		t.Error("expected slack Rehydrate to skip a telegram-owned row")
+	}
+	if gotDead {
+		t.Error("expected slack Rehydrate to skip a telegram-owned row")
+	}
+	if store.get("tg-live") == nil {
+		t.Error("expected telegram-owned live row to survive slack's Rehydrate untouched")
+	}
+	if store.get("tg-dead") == nil {
+		t.Error("expected slack Rehydrate to NOT delete an expired telegram-owned row — that's telegram's own sweep's job")
+	}
+}
+
 func TestSlackHandler_Rehydrate_NoStore(t *testing.T) {
 	client := &mockSlackClient{}
 	handler := NewSlackHandler(client, "#approvals")
@@ -402,12 +499,19 @@ func TestSlackHandler_Rehydrate_HonorsOldButtonRequestID(t *testing.T) {
 	store := newMockPendingStore()
 	_ = store.InsertPendingApproval(&memory.PendingApproval{
 		ID: "rehy-int", TaskID: "T-R", Stage: "pre_merge",
-		Title: "Rehydrated", CreatedAt: time.Now(), ExpiresAt: time.Now().Add(time.Hour),
+		Title: "Rehydrated", PreferredChannel: "slack", CreatedAt: time.Now(), ExpiresAt: time.Now().Add(time.Hour),
 	})
 
 	handler := NewSlackHandler(client, "#approvals").WithStore(store)
 	if err := handler.Rehydrate(context.Background()); err != nil {
 		t.Fatalf("rehydrate error: %v", err)
+	}
+
+	handler.mu.RLock()
+	_, gotPending := handler.pending["rehy-int"]
+	handler.mu.RUnlock()
+	if !gotPending {
+		t.Fatal("expected row to actually be rehydrated into pending before testing the button click")
 	}
 
 	// Simulate a click on the pre-restart message — its button value still
@@ -452,7 +556,7 @@ func TestSlackHandler_Rehydrate_InteractionRecordsDecisionDirectly(t *testing.T)
 	recorder := &mockDecisionRecorder{}
 	_ = store.InsertPendingApproval(&memory.PendingApproval{
 		ID: "rehy-rec", TaskID: "T-R2", Stage: "pre_merge",
-		Title: "Rehydrated", CreatedAt: time.Now(), ExpiresAt: time.Now().Add(time.Hour),
+		Title: "Rehydrated", PreferredChannel: "slack", CreatedAt: time.Now(), ExpiresAt: time.Now().Add(time.Hour),
 	})
 
 	handler := NewSlackHandler(client, "#approvals").WithStore(store).WithDecisionRecorder(recorder)

--- a/internal/approval/telegram.go
+++ b/internal/approval/telegram.go
@@ -19,7 +19,13 @@ type PendingApprovalStore interface {
 	InsertPendingApproval(*memory.PendingApproval) error
 	DeletePendingApproval(id string) error
 	LoadPendingApprovals() ([]*memory.PendingApproval, error)
-	PrunePendingApprovals(cutoff time.Time) (int64, error)
+	// PrunePendingApprovals channel-scopes the expiry sweep to `channels`
+	// (GH-4772) — see ownedChannels.
+	PrunePendingApprovals(cutoff time.Time, channels []string) (int64, error)
+	// PrunePendingApprovalsOutside sweeps rows whose channel matches none of
+	// `knownChannels` — the orphan fallback (GH-4772). Only the default
+	// channel handler should call this (see defaultChannelName).
+	PrunePendingApprovalsOutside(cutoff time.Time, knownChannels []string) (int64, error)
 }
 
 // TelegramClient defines the interface for Telegram operations
@@ -198,6 +204,14 @@ func (h *TelegramHandler) Rehydrate(ctx context.Context) error {
 	now := time.Now()
 	var newlyRehydrated []*telegramPending
 	for _, row := range rows {
+		// GH-4772: only rehydrate rows this handler actually owns — a row
+		// originally dispatched to Slack (or any other channel) must not
+		// get a duplicate Telegram prompt, and this handler must not delete
+		// an expired row it doesn't own out from under its owning handler's
+		// own sweep. See ownsChannel/defaultChannelName.
+		if !ownsChannel(h.Name(), row.PreferredChannel) {
+			continue
+		}
 		if row.ExpiresAt.Before(now) {
 			_ = h.store.DeletePendingApproval(row.ID)
 			continue
@@ -308,8 +322,22 @@ func (h *TelegramHandler) PruneExpired(ctx context.Context) (int, error) {
 	}
 
 	if h.store != nil {
-		if _, err := h.store.PrunePendingApprovals(now); err != nil {
+		// GH-4772: scope the store-level sweep to rows this handler owns
+		// (its own channel, plus legacy empty-channel rows when this is the
+		// default claimant) so it never deletes/decides another channel's
+		// expired row before that channel's own sweep runs.
+		if _, err := h.store.PrunePendingApprovals(now, ownedChannels(h.Name())); err != nil {
 			return len(expired), fmt.Errorf("prune expired: sweep store: %w", err)
+		}
+		// The default channel also sweeps orphaned rows — a preferred_channel
+		// that matches no handler this package knows about (removed from
+		// config, typo'd, etc.) — so such a row is never permanently
+		// unprunable. A full Manager-level orphan sweep is roadmap leg B4;
+		// this just keeps rows collectible until then.
+		if h.Name() == defaultChannelName {
+			if _, err := h.store.PrunePendingApprovalsOutside(now, knownChannelNames); err != nil {
+				return len(expired), fmt.Errorf("prune expired: sweep orphaned-channel rows: %w", err)
+			}
 		}
 	}
 

--- a/internal/approval/telegram_test.go
+++ b/internal/approval/telegram_test.go
@@ -1229,15 +1229,39 @@ func (s *mockPendingStore) LoadPendingApprovals() ([]*memory.PendingApproval, er
 	return out, nil
 }
 
-func (s *mockPendingStore) PrunePendingApprovals(cutoff time.Time) (int64, error) {
+func (s *mockPendingStore) PrunePendingApprovals(cutoff time.Time, channels []string) (int64, error) {
 	if s.pruneErr != nil {
 		return 0, s.pruneErr
+	}
+	owned := make(map[string]bool, len(channels))
+	for _, c := range channels {
+		owned[c] = true
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	var deleted int64
 	for id, r := range s.rows {
-		if r.ExpiresAt.Before(cutoff) {
+		if r.ExpiresAt.Before(cutoff) && owned[r.PreferredChannel] {
+			delete(s.rows, id)
+			deleted++
+		}
+	}
+	return deleted, nil
+}
+
+func (s *mockPendingStore) PrunePendingApprovalsOutside(cutoff time.Time, knownChannels []string) (int64, error) {
+	if s.pruneErr != nil {
+		return 0, s.pruneErr
+	}
+	known := make(map[string]bool, len(knownChannels))
+	for _, c := range knownChannels {
+		known[c] = true
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var deleted int64
+	for id, r := range s.rows {
+		if r.ExpiresAt.Before(cutoff) && !known[r.PreferredChannel] {
 			delete(s.rows, id)
 			deleted++
 		}

--- a/internal/memory/approval_store.go
+++ b/internal/memory/approval_store.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -98,17 +99,76 @@ func (s *Store) LoadPendingApprovals() ([]*PendingApproval, error) {
 	return out, rows.Err()
 }
 
-// PrunePendingApprovals deletes all approvals whose expires_at is before `cutoff`.
-// Returns the number of rows deleted.
-func (s *Store) PrunePendingApprovals(cutoff time.Time) (int64, error) {
+// PrunePendingApprovals deletes approvals whose expires_at is before
+// `cutoff` AND whose preferred_channel is one of `channels`. Channel-scoped
+// (GH-4772) so a handler's expiry sweep only ever deletes/decides rows it
+// owns — e.g. a Slack sweep must never delete a Telegram-dispatched row's
+// expiry before Telegram's own sweep gets to it. Callers pass "" in
+// `channels` to include legacy rows with no preferred_channel set. Returns
+// 0, nil for an empty `channels` (nothing to scope to, not "everything").
+func (s *Store) PrunePendingApprovals(cutoff time.Time, channels []string) (int64, error) {
+	if len(channels) == 0 {
+		return 0, nil
+	}
+	placeholders := make([]string, len(channels))
+	args := make([]interface{}, 0, len(channels)+1)
+	args = append(args, cutoff)
+	for i, c := range channels {
+		placeholders[i] = "?"
+		args = append(args, c)
+	}
+	query := fmt.Sprintf(
+		`DELETE FROM approval_pending WHERE expires_at < ? AND preferred_channel IN (%s)`,
+		strings.Join(placeholders, ","),
+	)
 	var result sql.Result
 	err := s.withRetry("PrunePendingApprovals", func() error {
 		var execErr error
-		result, execErr = s.db.Exec(`DELETE FROM approval_pending WHERE expires_at < ?`, cutoff)
+		result, execErr = s.db.Exec(query, args...)
 		return execErr
 	})
 	if err != nil {
 		return 0, fmt.Errorf("PrunePendingApprovals: %w", err)
+	}
+	return result.RowsAffected()
+}
+
+// PrunePendingApprovalsOutside deletes approvals whose expires_at is before
+// `cutoff` AND whose preferred_channel is NOT one of `knownChannels`. This
+// is the documented fallback for rows whose channel matches no registered
+// handler (a channel that was removed from config, a typo, etc.) — without
+// it such a row is never scoped to any handler's PrunePendingApprovals call
+// and becomes unprunable (GH-4772 acceptance 4). Callers should route this
+// through exactly one handler (the default legacy claimant) to avoid
+// multiple handlers racing to sweep the same orphaned rows; a full
+// Manager-level orphan sweep is roadmap leg B4. Returns 0, nil for an empty
+// `knownChannels` (matches "outside everything known", which is nothing to
+// exclude — same delete-all-expired shape as the pre-GH-4772 behavior).
+func (s *Store) PrunePendingApprovalsOutside(cutoff time.Time, knownChannels []string) (int64, error) {
+	var query string
+	args := make([]interface{}, 0, len(knownChannels)+1)
+	args = append(args, cutoff)
+	if len(knownChannels) == 0 {
+		query = `DELETE FROM approval_pending WHERE expires_at < ?`
+	} else {
+		placeholders := make([]string, len(knownChannels))
+		for i, c := range knownChannels {
+			placeholders[i] = "?"
+			args = append(args, c)
+		}
+		query = fmt.Sprintf(
+			`DELETE FROM approval_pending WHERE expires_at < ? AND preferred_channel NOT IN (%s)`,
+			strings.Join(placeholders, ","),
+		)
+	}
+	var result sql.Result
+	err := s.withRetry("PrunePendingApprovalsOutside", func() error {
+		var execErr error
+		result, execErr = s.db.Exec(query, args...)
+		return execErr
+	})
+	if err != nil {
+		return 0, fmt.Errorf("PrunePendingApprovalsOutside: %w", err)
 	}
 	return result.RowsAffected()
 }

--- a/internal/memory/approval_store_test.go
+++ b/internal/memory/approval_store_test.go
@@ -163,7 +163,7 @@ func TestPrunePendingApprovals(t *testing.T) {
 		t.Fatalf("insert active: %v", err)
 	}
 
-	deleted, err := s.PrunePendingApprovals(now)
+	deleted, err := s.PrunePendingApprovals(now, []string{""})
 	if err != nil {
 		t.Fatalf("PrunePendingApprovals: %v", err)
 	}
@@ -193,12 +193,131 @@ func TestPrunePendingApprovals_NoneExpired(t *testing.T) {
 		Title: "t", CreatedAt: now, ExpiresAt: now.Add(time.Hour),
 	})
 
-	deleted, err := s.PrunePendingApprovals(now.Add(-time.Minute))
+	deleted, err := s.PrunePendingApprovals(now.Add(-time.Minute), []string{""})
 	if err != nil {
 		t.Fatalf("PrunePendingApprovals: %v", err)
 	}
 	if deleted != 0 {
 		t.Errorf("expected 0 rows deleted, got %d", deleted)
+	}
+}
+
+// TestPrunePendingApprovals_ChannelScoped is the GH-4772 regression test:
+// PrunePendingApprovals must only delete expired rows whose preferred_channel
+// is in the caller's `channels` list — a Slack-scoped sweep must never touch
+// an expired Telegram row (and vice versa), because the owning handler still
+// needs to edit its message / record a timeout decision for it.
+func TestPrunePendingApprovals_ChannelScoped(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	past := now.Add(-2 * time.Hour)
+
+	for _, row := range []*PendingApproval{
+		{ID: "tg-exp", TaskID: "GH-700", Stage: "pre_merge", Title: "t", PreferredChannel: "telegram", CreatedAt: past, ExpiresAt: past.Add(time.Hour)},
+		{ID: "slack-exp", TaskID: "GH-701", Stage: "pre_merge", Title: "t", PreferredChannel: "slack", CreatedAt: past, ExpiresAt: past.Add(time.Hour)},
+		{ID: "legacy-exp", TaskID: "GH-702", Stage: "pre_merge", Title: "t", PreferredChannel: "", CreatedAt: past, ExpiresAt: past.Add(time.Hour)},
+	} {
+		if err := s.InsertPendingApproval(row); err != nil {
+			t.Fatalf("insert %s: %v", row.ID, err)
+		}
+	}
+
+	// A Slack-scoped sweep must only remove the slack row.
+	deleted, err := s.PrunePendingApprovals(now, []string{"slack"})
+	if err != nil {
+		t.Fatalf("PrunePendingApprovals: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("expected 1 row deleted by slack-scoped sweep, got %d", deleted)
+	}
+
+	all, err := s.LoadPendingApprovals()
+	if err != nil {
+		t.Fatalf("LoadPendingApprovals: %v", err)
+	}
+	remaining := make(map[string]bool, len(all))
+	for _, a := range all {
+		remaining[a.ID] = true
+	}
+	if !remaining["tg-exp"] {
+		t.Error("expected telegram row to survive a slack-scoped sweep")
+	}
+	if !remaining["legacy-exp"] {
+		t.Error("expected legacy (empty-channel) row to survive a slack-scoped sweep")
+	}
+	if remaining["slack-exp"] {
+		t.Error("expected slack row to be deleted by a slack-scoped sweep")
+	}
+
+	// A telegram+legacy-scoped sweep (the default channel's own scope)
+	// should then clean up both remaining rows.
+	deleted, err = s.PrunePendingApprovals(now, []string{"telegram", ""})
+	if err != nil {
+		t.Fatalf("PrunePendingApprovals: %v", err)
+	}
+	if deleted != 2 {
+		t.Fatalf("expected 2 rows deleted by telegram+legacy-scoped sweep, got %d", deleted)
+	}
+}
+
+// TestPrunePendingApprovals_EmptyChannelsIsNoop verifies the documented
+// "nothing to scope to" semantics: an empty channels slice deletes nothing,
+// rather than falling back to unscoped delete-everything.
+func TestPrunePendingApprovals_EmptyChannelsIsNoop(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	past := now.Add(-2 * time.Hour)
+	_ = s.InsertPendingApproval(&PendingApproval{
+		ID: "exp-noop", TaskID: "GH-703", Stage: "pre_merge", Title: "t",
+		PreferredChannel: "telegram", CreatedAt: past, ExpiresAt: past.Add(time.Hour),
+	})
+
+	deleted, err := s.PrunePendingApprovals(now, nil)
+	if err != nil {
+		t.Fatalf("PrunePendingApprovals: %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("expected 0 rows deleted with empty channels, got %d", deleted)
+	}
+}
+
+// TestPrunePendingApprovalsOutside_SweepsOrphanChannels is the GH-4772
+// fallback test: a row whose preferred_channel matches none of the known
+// handler names must still be prunable once expired.
+func TestPrunePendingApprovalsOutside_SweepsOrphanChannels(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	past := now.Add(-2 * time.Hour)
+
+	for _, row := range []*PendingApproval{
+		{ID: "orphan-exp", TaskID: "GH-704", Stage: "pre_merge", Title: "t", PreferredChannel: "unknown-channel", CreatedAt: past, ExpiresAt: past.Add(time.Hour)},
+		{ID: "tg-exp2", TaskID: "GH-705", Stage: "pre_merge", Title: "t", PreferredChannel: "telegram", CreatedAt: past, ExpiresAt: past.Add(time.Hour)},
+	} {
+		if err := s.InsertPendingApproval(row); err != nil {
+			t.Fatalf("insert %s: %v", row.ID, err)
+		}
+	}
+
+	deleted, err := s.PrunePendingApprovalsOutside(now, []string{"telegram", "slack", "github", "github-review"})
+	if err != nil {
+		t.Fatalf("PrunePendingApprovalsOutside: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("expected 1 orphaned row deleted, got %d", deleted)
+	}
+
+	all, err := s.LoadPendingApprovals()
+	if err != nil {
+		t.Fatalf("LoadPendingApprovals: %v", err)
+	}
+	if len(all) != 1 || all[0].ID != "tg-exp2" {
+		t.Errorf("expected only the known-channel row to remain, got %+v", all)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes GH-4772 — four channel-scoping defects in `internal/approval` that were blocking leg B3 (per-project channel routing) of the approval-architecture roadmap. Scope confined to `internal/approval` + `internal/memory/approval_store.go` per the task's scope fence; no controller/config surface changes, no new channels, GH-4380 hard-error semantics preserved.

- **Cross-channel rehydrate leak**: `TelegramHandler.Rehydrate` and `SlackHandler.Rehydrate` processed *every* persisted `approval_pending` row regardless of originating channel. Both now check ownership first via `ownsChannel` (new `internal/approval/channel.go`), with legacy rows (empty `preferred_channel`, predating GH-4380) claimed by Telegram as the documented default owner.
- **Slack destination asymmetry**: `SendApprovalRequest` used `h.channel` unconditionally while `Rehydrate` honored `req.Approvers[0]` — first-send and rehydrate could target different destinations for the same request. Both now share `SlackHandler.resolveChannel`.
- **`github-review` alias hard-error**: `autopilot.ApprovalSourceGitHubReview = "github-review"` had no route to the registered `"github"` handler, so it always hit Manager's hard error. `Manager.SubmitApprovalRequest` now normalizes the preferred channel via `normalizeChannelName` before the handler lookup; the original un-normalized value is preserved in the error message so a genuinely unresolvable channel still hard-errors (no silent fallback).
- **Channel-blind expiry sweep**: `PrunePendingApprovals` deleted all expired rows with no channel predicate, letting one channel's sweep delete another channel's expired rows before its owning handler could process them. It's now channel-scoped (`channels []string` param); a new `PrunePendingApprovalsOutside` fallback — run only by the default channel — sweeps rows whose channel matches no registered handler.

## Test plan

- [x] `internal/approval/channel_test.go` (new) — unit tests for `normalizeChannelName`/`ownsChannel`/`ownedChannels`, plus `TestRehydrate_MixedChannelScenario` covering telegram/slack/legacy-empty/unknown-channel rows in one store
- [x] `TestSlackHandler_Rehydrate_SkipsOtherChannelRows`, `TestSlackHandler_SendApprovalRequest_RehydrateDestinationParity` (new) — destination-parity and cross-channel-skip regressions
- [x] `TestManager_SubmitApprovalRequest_GitHubReviewAlias`, `TestManager_SubmitApprovalRequest_UnresolvableChannelStillHardErrors` (new)
- [x] `TestPrunePendingApprovals_ChannelScoped`, `TestPrunePendingApprovals_EmptyChannelsIsNoop`, `TestPrunePendingApprovalsOutside_SweepsOrphanChannels` (new)
- [x] `go test ./internal/approval/... ./internal/memory/...` — all green
- [x] `go test -race ./internal/approval/... ./internal/memory/...` — clean
- [x] `make build` — clean
- [x] `make test` (full suite) — all green
- [x] `golangci-lint run ./internal/approval/... ./internal/memory/...` — 0 issues