### PR TITLE
GH-4773: feat(approval): project identity on approval records — Request.Project, approval_pending.project, GET surface

### DIFF
--- a/internal/approval/slack.go
+++ b/internal/approval/slack.go
@@ -169,6 +169,7 @@ func (h *SlackHandler) Rehydrate(ctx context.Context) error {
 			Metadata:         row.Metadata,
 			Approvers:        row.Approvers,
 			PreferredChannel: row.PreferredChannel,
+			Project:          row.Project,
 			CreatedAt:        row.CreatedAt,
 			ExpiresAt:        row.ExpiresAt,
 		}
@@ -293,6 +294,7 @@ func (h *SlackHandler) SendApprovalRequest(ctx context.Context, req *Request) (<
 			Metadata:         req.Metadata,
 			Approvers:        req.Approvers,
 			PreferredChannel: req.PreferredChannel,
+			Project:          req.Project,
 			CreatedAt:        req.CreatedAt,
 			ExpiresAt:        req.ExpiresAt,
 		}

--- a/internal/approval/slack_test.go
+++ b/internal/approval/slack_test.go
@@ -356,6 +356,31 @@ func TestSlackHandler_WithStore_PersistOnSend(t *testing.T) {
 	}
 }
 
+// TestSlackHandler_WithStore_PersistsProject is the GH-4773 round-trip
+// regression test: SendApprovalRequest must copy req.Project onto the
+// persisted memory.PendingApproval row.
+func TestSlackHandler_WithStore_PersistsProject(t *testing.T) {
+	client := &mockSlackClient{}
+	store := newMockPendingStore()
+	handler := NewSlackHandler(client, "#approvals").WithStore(store)
+
+	req := &Request{
+		ID: "persist-project-1", TaskID: "T-1", Stage: StagePreMerge,
+		Title: "Test", Project: "/home/user/projects/pilot", ExpiresAt: time.Now().Add(time.Hour),
+	}
+	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	row := store.get("persist-project-1")
+	if row == nil {
+		t.Fatal("expected row to be stored")
+	}
+	if row.Project != "/home/user/projects/pilot" {
+		t.Errorf("row.Project = %q, want /home/user/projects/pilot", row.Project)
+	}
+}
+
 func TestSlackHandler_WithStore_DeleteOnInteraction(t *testing.T) {
 	client := &mockSlackClient{}
 	store := newMockPendingStore()

--- a/internal/approval/telegram.go
+++ b/internal/approval/telegram.go
@@ -225,6 +225,7 @@ func (h *TelegramHandler) Rehydrate(ctx context.Context) error {
 			Metadata:         row.Metadata,
 			Approvers:        row.Approvers,
 			PreferredChannel: row.PreferredChannel,
+			Project:          row.Project,
 			CreatedAt:        row.CreatedAt,
 			ExpiresAt:        row.ExpiresAt,
 		}
@@ -405,6 +406,7 @@ func (h *TelegramHandler) SendApprovalRequest(ctx context.Context, req *Request)
 			Metadata:         req.Metadata,
 			Approvers:        req.Approvers,
 			PreferredChannel: req.PreferredChannel,
+			Project:          req.Project,
 			CreatedAt:        req.CreatedAt,
 			ExpiresAt:        req.ExpiresAt,
 		}

--- a/internal/approval/telegram_test.go
+++ b/internal/approval/telegram_test.go
@@ -1306,6 +1306,31 @@ func TestTelegramHandler_WithStore_PersistOnSend(t *testing.T) {
 	}
 }
 
+// TestTelegramHandler_WithStore_PersistsProject is the GH-4773 round-trip
+// regression test: SendApprovalRequest must copy req.Project onto the
+// persisted memory.PendingApproval row.
+func TestTelegramHandler_WithStore_PersistsProject(t *testing.T) {
+	client := &mockTelegramClient{}
+	store := newMockPendingStore()
+	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+
+	req := &Request{
+		ID: "persist-project-1", TaskID: "T-1", Stage: StagePreMerge,
+		Title: "Test", Project: "/home/user/projects/pilot", ExpiresAt: time.Now().Add(time.Hour),
+	}
+	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	row := store.get("persist-project-1")
+	if row == nil {
+		t.Fatal("expected row to be stored")
+	}
+	if row.Project != "/home/user/projects/pilot" {
+		t.Errorf("row.Project = %q, want /home/user/projects/pilot", row.Project)
+	}
+}
+
 func TestTelegramHandler_WithStore_DeleteOnCallback(t *testing.T) {
 	client := &mockTelegramClient{}
 	store := newMockPendingStore()

--- a/internal/approval/types.go
+++ b/internal/approval/types.go
@@ -42,6 +42,15 @@ type Request struct {
 	Approvers        []string               // Required approvers (user IDs, handles)
 	PreferredChannel string                 `json:",omitempty"` // Preferred approval channel (e.g., "telegram", "slack"); falls back to first-available only when unset. When set but not registered, SubmitApprovalRequest fails with a named error instead of silently picking another handler (GH-4380).
 
+	// Project is the canonicalized project path this request was submitted
+	// for (memory.CanonicalizeProjectPath — the #4297 cross-project collision
+	// lesson: scoping keys on canonicalized paths). Set by the caller
+	// (autopilot.Controller, which owns c.projectPath) at submit time; the
+	// approval package only carries it through to persistence. Empty for
+	// requests submitted with no project context (e.g. tests, single-project
+	// setups predating GH-4773). GH-4773.
+	Project string
+
 	// ReleasePlan is a human-readable, pre-rendered description of what happens
 	// after this request is approved (e.g. "Will release immediately after
 	// merge." or "Rides the next release train: 2026-07-11 16:00 CET."),

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2785,6 +2785,10 @@ func (c *Controller) submitAsyncApprovalRequest(ctx context.Context, prState *PR
 		// Manager.SubmitApprovalRequest always fell through to whichever
 		// handler happened to win Go's map iteration order.
 		PreferredChannel: string(c.config.EffectiveApprovalSource()),
+		// GH-4773: canonicalize c.projectPath the same way the store keys its
+		// own scoping (the #4297 cross-project collision lesson) so the
+		// persisted row and any later scoped lookup agree on the same string.
+		Project: memory.CanonicalizeProjectPath(c.projectPath),
 	}
 
 	requestID, err := c.approvalMgr.SubmitApprovalRequest(ctx, req)

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -8916,6 +8916,49 @@ func TestController_SubmitAsyncApprovalRequest_SetsReleasePlan(t *testing.T) {
 	}
 }
 
+// TestController_SubmitAsyncApprovalRequest_SetsProject is the GH-4773
+// regression test: submitAsyncApprovalRequest must populate the outbound
+// approval.Request's Project field from the controller's own c.projectPath
+// (set via WithProjectPath), canonicalized the same way memory.Store keys
+// its own scoping (the #4297 lesson) — so the persisted approval_pending row
+// carries project identity even though the approval package itself never
+// computes a project path.
+func TestController_SubmitAsyncApprovalRequest_SetsProject(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvProd
+
+	mgr := asyncApprovalManager()
+	handler := &mockCapturingApprovalHandler{}
+	mgr.RegisterHandler(handler)
+
+	c := NewController(cfg, ghClient, mgr, "owner", "repo", WithProjectPath("/proj/pilot"))
+
+	c.mu.Lock()
+	c.activePRs[42] = &PRState{
+		PRNumber:    42,
+		PRURL:       "https://github.com/owner/repo/pull/42",
+		PRTitle:     "feat: something",
+		IssueNumber: 10,
+		Stage:       StageAwaitApproval,
+	}
+	c.mu.Unlock()
+
+	if err := c.ProcessPR(context.Background(), 42, nil); err != nil {
+		t.Fatalf("tick error: %v", err)
+	}
+
+	if len(handler.sent) != 1 {
+		t.Fatalf("expected 1 approval request sent, got %d", len(handler.sent))
+	}
+	// "/proj/pilot" doesn't exist on the test filesystem, so
+	// CanonicalizeProjectPath falls back to filepath.Clean (EvalSymlinks
+	// fails) — the canonicalized form here is just the cleaned input.
+	if got, want := handler.sent[0].Project, memory.CanonicalizeProjectPath("/proj/pilot"); got != want {
+		t.Errorf("Project = %q, want %q", got, want)
+	}
+}
+
 // TestController_AwaitApproval_StaysInStageUntilDecision verifies that the
 // non-blocking handleAwaitApproval submits a request on the first tick and
 // stays in StageAwaitApproval until a decision is recorded.

--- a/internal/gateway/approvals.go
+++ b/internal/gateway/approvals.go
@@ -30,12 +30,16 @@ func (s *Server) SetDecisionRecorder(r approval.DecisionRecorder) {
 // PRNumber, and PRUrl are nullable: the approval_pending row (source of the pending
 // list) has no execution linkage until SetApprovalRequestID runs, and that call is
 // best-effort (see memory.Store.SetApprovalRequestID), so the join can legitimately
-// miss.
+// miss. Project (GH-4773) is distinct from ProjectPath: it comes directly off the
+// approval_pending row's own `project` column (the submitter's canonicalized project
+// path), not the executions join, so it's populated even when the join misses. Also
+// nullable — empty/pre-migration rows carry no project.
 type approvalResponse struct {
 	RequestID   string    `json:"requestId"`
 	ExecutionID *string   `json:"executionId"`
 	TaskID      string    `json:"taskId"`
 	ProjectPath *string   `json:"projectPath"`
+	Project     *string   `json:"project"`
 	PRNumber    *int      `json:"prNumber"`
 	PRUrl       *string   `json:"prUrl"`
 	RequestedAt time.Time `json:"requestedAt"`
@@ -78,6 +82,15 @@ func (s *Server) handleApprovals(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// GH-4773: canonicalize the scope filter the same way the row's own
+	// `project` column was canonicalized at submit time (memory.
+	// CanonicalizeProjectPath, the #4297 lesson), so the column comparison
+	// below is robust regardless of how dashboardProjectPath was sourced.
+	scopedProject := ""
+	if projectPath != "" {
+		scopedProject = memory.CanonicalizeProjectPath(projectPath)
+	}
+
 	now := time.Now()
 	out := make([]approvalResponse, 0, len(rows))
 	for _, row := range rows {
@@ -90,10 +103,18 @@ func (s *Server) handleApprovals(w http.ResponseWriter, r *http.Request) {
 			TaskID:      row.TaskID,
 			RequestedAt: row.CreatedAt,
 		}
+		if row.Project != "" {
+			proj := row.Project
+			resp.Project = &proj
+		}
 
 		exec, execErr := store.GetExecutionByApprovalRequestID(row.ID)
 		if execErr == nil && exec != nil {
-			if projectPath != "" && exec.ProjectPath != projectPath {
+			// GH-4773: prefer the row's own project column when it matches the
+			// scope — it's a direct, non-best-effort attribution — but fall
+			// back to the join-based check for legacy rows with no project
+			// column (row.Project == ""), preserving today's behavior exactly.
+			if projectPath != "" && exec.ProjectPath != projectPath && row.Project != scopedProject {
 				continue
 			}
 			execID := exec.ID
@@ -108,10 +129,15 @@ func (s *Server) handleApprovals(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		} else if projectPath != "" {
-			// Can't attribute this request to the scoped project (no execution
-			// linkage yet, or the lookup failed) — exclude rather than leak a
-			// possibly cross-project pending approval.
-			continue
+			// No execution linkage. GH-4773: previously this always excluded
+			// the row (PR#4752 finding — scoped mode dropped it entirely).
+			// Now include it when the row's own project column matches the
+			// scope directly, since that attribution doesn't depend on the
+			// best-effort executions join. Legacy rows with no project column
+			// keep the prior exclude-on-unjoinable behavior.
+			if row.Project == "" || row.Project != scopedProject {
+				continue
+			}
 		}
 
 		out = append(out, resp)

--- a/internal/gateway/approvals_test.go
+++ b/internal/gateway/approvals_test.go
@@ -154,6 +154,99 @@ func TestHandleApprovals_ProjectScoped_ExcludesUnjoinable(t *testing.T) {
 	}
 }
 
+// TestHandleApprovals_ProjectScoped_UnjoinableRowIncludedViaProjectColumn is
+// the GH-4773 regression test for the PR#4752 finding: a row with no
+// execution linkage (join misses) must still be included under project
+// scoping when its own `project` column matches the scope, instead of being
+// dropped entirely.
+func TestHandleApprovals_ProjectScoped_UnjoinableRowIncludedViaProjectColumn(t *testing.T) {
+	now := time.Now()
+	store := &mockDashboardStore{
+		pendingApprovals: []*memory.PendingApproval{
+			{ID: "req-attributed", TaskID: "GH-6", Project: "/tmp/proj-a", CreatedAt: now, ExpiresAt: now.Add(time.Hour)},
+		},
+	}
+	s := newTestServerWithDashboard(store)
+	s.dashboardProjectPath = "/tmp/proj-a"
+
+	req := httpTestRequest(t, http.MethodGet, "/api/v1/approvals", nil)
+	w := newTestResponseRecorder()
+	s.handleApprovals(w, req)
+
+	var got []approvalResponse
+	if err := json.Unmarshal(w.body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got) != 1 || got[0].RequestID != "req-attributed" {
+		t.Fatalf("got = %+v, want only req-attributed (included via project column)", got)
+	}
+	if got[0].Project == nil || *got[0].Project != "/tmp/proj-a" {
+		t.Errorf("Project = %v, want /tmp/proj-a", got[0].Project)
+	}
+	if got[0].ExecutionID != nil {
+		t.Errorf("ExecutionID = %v, want nil (no execution linkage)", got[0].ExecutionID)
+	}
+}
+
+// TestHandleApprovals_ProjectScoped_ProjectColumnMismatchExcluded verifies a
+// row whose own project column names a different project than the scope is
+// still excluded, even with no execution linkage to contradict it.
+func TestHandleApprovals_ProjectScoped_ProjectColumnMismatchExcluded(t *testing.T) {
+	now := time.Now()
+	store := &mockDashboardStore{
+		pendingApprovals: []*memory.PendingApproval{
+			{ID: "req-other", TaskID: "GH-7", Project: "/tmp/proj-b", CreatedAt: now, ExpiresAt: now.Add(time.Hour)},
+		},
+	}
+	s := newTestServerWithDashboard(store)
+	s.dashboardProjectPath = "/tmp/proj-a"
+
+	req := httpTestRequest(t, http.MethodGet, "/api/v1/approvals", nil)
+	w := newTestResponseRecorder()
+	s.handleApprovals(w, req)
+
+	var got []approvalResponse
+	if err := json.Unmarshal(w.body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("len(got) = %d, want 0 (project column names a different project)", len(got))
+	}
+}
+
+// TestHandleApprovals_UnscopedMode_EmitsProjectField verifies the GET
+// response carries the new `project` JSON field (from approval_pending's own
+// column) even when the gateway is not project-scoped.
+func TestHandleApprovals_UnscopedMode_EmitsProjectField(t *testing.T) {
+	now := time.Now()
+	store := &mockDashboardStore{
+		pendingApprovals: []*memory.PendingApproval{
+			{ID: "req-1", TaskID: "GH-1", Project: "/tmp/proj-a", CreatedAt: now, ExpiresAt: now.Add(time.Hour)},
+			{ID: "req-2", TaskID: "GH-2", CreatedAt: now, ExpiresAt: now.Add(time.Hour)}, // legacy, no project
+		},
+	}
+	s := newTestServerWithDashboard(store)
+
+	req := httpTestRequest(t, http.MethodGet, "/api/v1/approvals", nil)
+	w := newTestResponseRecorder()
+	s.handleApprovals(w, req)
+
+	var got []approvalResponse
+	if err := json.Unmarshal(w.body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	byID := make(map[string]approvalResponse, len(got))
+	for _, r := range got {
+		byID[r.RequestID] = r
+	}
+	if p := byID["req-1"].Project; p == nil || *p != "/tmp/proj-a" {
+		t.Errorf("req-1.Project = %v, want /tmp/proj-a", p)
+	}
+	if p := byID["req-2"].Project; p != nil {
+		t.Errorf("req-2.Project = %v, want nil (legacy row)", p)
+	}
+}
+
 func TestHandleApprovals_StoreNil_503(t *testing.T) {
 	s := NewServer(&Config{Host: "127.0.0.1", Port: 0})
 

--- a/internal/memory/approval_store.go
+++ b/internal/memory/approval_store.go
@@ -22,6 +22,11 @@ type PendingApproval struct {
 	PreferredChannel string
 	CreatedAt        time.Time
 	ExpiresAt        time.Time
+
+	// Project is the canonicalized project path this request was submitted
+	// for (approval.Request.Project — GH-4773). Empty for pre-migration rows
+	// and requests submitted with no project context.
+	Project string
 }
 
 // InsertPendingApproval persists a new pending approval record.
@@ -45,8 +50,8 @@ func (s *Store) InsertPendingApproval(a *PendingApproval) error {
 	return s.withRetry("InsertPendingApproval", func() error {
 		_, err := s.db.Exec(`
 			INSERT INTO approval_pending
-				(id, task_id, stage, title, description, metadata, approvers, preferred_channel, created_at, expires_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				(id, task_id, stage, title, description, metadata, approvers, preferred_channel, project, created_at, expires_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			ON CONFLICT(id) DO UPDATE SET
 				task_id           = excluded.task_id,
 				stage             = excluded.stage,
@@ -55,10 +60,11 @@ func (s *Store) InsertPendingApproval(a *PendingApproval) error {
 				metadata          = excluded.metadata,
 				approvers         = excluded.approvers,
 				preferred_channel = excluded.preferred_channel,
+				project           = excluded.project,
 				expires_at        = excluded.expires_at
 		`,
 			a.ID, a.TaskID, a.Stage, a.Title, a.Description,
-			string(metaJSON), string(approversJSON), a.PreferredChannel,
+			string(metaJSON), string(approversJSON), a.PreferredChannel, a.Project,
 			a.CreatedAt, a.ExpiresAt,
 		)
 		return err
@@ -79,6 +85,7 @@ func (s *Store) LoadPendingApprovals() ([]*PendingApproval, error) {
 		SELECT id, task_id, stage, title,
 			COALESCE(description, ''), COALESCE(metadata, ''),
 			COALESCE(approvers, ''), COALESCE(preferred_channel, ''),
+			COALESCE(project, ''),
 			created_at, expires_at
 		FROM approval_pending
 		ORDER BY created_at ASC
@@ -181,7 +188,7 @@ func scanPendingApproval(row interface {
 	var metaJSON, approversJSON string
 	if err := row.Scan(
 		&a.ID, &a.TaskID, &a.Stage, &a.Title, &a.Description,
-		&metaJSON, &approversJSON, &a.PreferredChannel,
+		&metaJSON, &approversJSON, &a.PreferredChannel, &a.Project,
 		&a.CreatedAt, &a.ExpiresAt,
 	); err != nil {
 		return nil, err

--- a/internal/memory/approval_store_test.go
+++ b/internal/memory/approval_store_test.go
@@ -80,6 +80,97 @@ func TestInsertAndLoadPendingApproval(t *testing.T) {
 	}
 }
 
+// TestInsertAndLoadPendingApproval_Project is the GH-4773 round-trip
+// regression test: a row's Project column must survive insert -> load
+// unchanged, and a legacy row that never set Project must load back as "".
+func TestInsertAndLoadPendingApproval_Project(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	a := &PendingApproval{
+		ID:        "req-project",
+		TaskID:    "GH-700",
+		Stage:     "pre_merge",
+		Title:     "Approve merge",
+		Project:   "/home/user/projects/pilot",
+		CreatedAt: now,
+		ExpiresAt: now.Add(24 * time.Hour),
+	}
+	legacy := &PendingApproval{
+		ID:        "req-legacy",
+		TaskID:    "GH-701",
+		Stage:     "pre_merge",
+		Title:     "Approve merge (pre-GH-4773)",
+		CreatedAt: now,
+		ExpiresAt: now.Add(24 * time.Hour),
+	}
+	if err := s.InsertPendingApproval(a); err != nil {
+		t.Fatalf("InsertPendingApproval: %v", err)
+	}
+	if err := s.InsertPendingApproval(legacy); err != nil {
+		t.Fatalf("InsertPendingApproval (legacy): %v", err)
+	}
+
+	all, err := s.LoadPendingApprovals()
+	if err != nil {
+		t.Fatalf("LoadPendingApprovals: %v", err)
+	}
+	byID := make(map[string]*PendingApproval, len(all))
+	for _, row := range all {
+		byID[row.ID] = row
+	}
+
+	if got := byID["req-project"]; got == nil || got.Project != "/home/user/projects/pilot" {
+		t.Errorf("req-project.Project = %v, want /home/user/projects/pilot", got)
+	}
+	if got := byID["req-legacy"]; got == nil || got.Project != "" {
+		t.Errorf("req-legacy.Project = %q, want empty (no backfill)", got.Project)
+	}
+}
+
+// TestApprovalPendingProjectColumn_MigrationIdempotent verifies that
+// re-opening the store (which re-runs the full migrations list, including
+// the GH-4773 `ALTER TABLE approval_pending ADD COLUMN project`) against an
+// existing DB tolerates the already-added column and preserves rows written
+// before the reopen.
+func TestApprovalPendingProjectColumn_MigrationIdempotent(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pilot-approval-migration-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store1, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore (first open): %v", err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := store1.InsertPendingApproval(&PendingApproval{
+		ID: "pre-reopen", TaskID: "GH-702", Stage: "pre_merge", Title: "t",
+		Project: "/proj/a", CreatedAt: now, ExpiresAt: now.Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("InsertPendingApproval: %v", err)
+	}
+	_ = store1.Close()
+
+	// Re-open: migration must run the ALTER TABLE statement idempotently
+	// (the runner tolerates "duplicate column" per store.go's migration loop).
+	store2, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore (second open, post-migration): %v", err)
+	}
+	defer func() { _ = store2.Close() }()
+
+	all, err := store2.LoadPendingApprovals()
+	if err != nil {
+		t.Fatalf("LoadPendingApprovals after reopen: %v", err)
+	}
+	if len(all) != 1 || all[0].Project != "/proj/a" {
+		t.Fatalf("post-reopen rows = %+v, want 1 row with Project=/proj/a", all)
+	}
+}
+
 func TestInsertPendingApproval_Upsert(t *testing.T) {
 	s, cleanup := newTestStore(t)
 	defer cleanup()

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -451,6 +451,15 @@ func (s *Store) migrate() error {
 		// reasoning exactly but for a different prior-claim status. See
 		// Dispatcher.priorClaimWasInfra.
 		`ALTER TABLE repick_backoff ADD COLUMN infra_drops INTEGER NOT NULL DEFAULT 0`,
+		// GH-4773: project identity on approval records. The gateway approvals
+		// surface (PR#4752) attributed rows only via the best-effort
+		// executions.approval_request_id join and dropped unlinked rows
+		// entirely in project-scoped mode; persisting the submitter's
+		// canonicalized project path directly on the row lets scoped GET
+		// /api/v1/approvals include those rows without depending on the join.
+		// Empty-string default keeps pre-migration rows attributing via the
+		// join exactly as before (no backfill — they expire within 24h).
+		`ALTER TABLE approval_pending ADD COLUMN project TEXT DEFAULT ''`,
 	}
 
 	for _, migration := range migrations {
@@ -3035,6 +3044,16 @@ func canonicalizeProjectPath(projectPath string) string {
 		return resolved
 	}
 	return cleaned
+}
+
+// CanonicalizeProjectPath is the exported form of canonicalizeProjectPath,
+// for callers outside this package that need to key on the same
+// canonicalized project path this store uses internally — e.g.
+// approval.Request.Project, set by autopilot.Controller at approval-submit
+// time so the persisted row and this store's own scoping keys agree
+// (GH-4773).
+func CanonicalizeProjectPath(projectPath string) string {
+	return canonicalizeProjectPath(projectPath)
 }
 
 // ClaimExecution atomically claims (task_id, project_path, generation) for


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4773.

Closes #4773

## Changes

GitHub Issue GH-4773: feat(approval): project identity on approval records — Request.Project, approval_pending.project, GET surface

## Problem

Approval records carry no project identity: `approval.Request` (`internal/approval/types.go:32-55`) has no project field and `approval_pending` (`internal/memory/store.go:341-352`) no project column. Consequences today: the gateway approvals surface (PR#4752) attributes rows only via the best-effort `executions.approval_request_id` join and **drops unlinked rows entirely in project-scoped mode** (`internal/gateway/approvals.go:92-113`); the console approval mirror (console#109, in flight) inherits that degraded attribution; and per-project routing (roadmap leg B3) has no persisted project on the record.

## Context (verified 2026-08-06, origin/main)

- Sole production submit site: `submitAsyncApprovalRequest` (`internal/autopilot/controller.go:2772-2790`) — the controller already knows its project: `c.projectPath` (wired via `WithProjectPath`, `cmd/pilot/main.go:1979` default repo, `:2023` projects loop).
- Canonicalize the path before persisting (the #4297 cross-project collision lesson: project scoping keys on canonicalized paths).
- Migration idiom: append `ALTER TABLE approval_pending ADD COLUMN project TEXT DEFAULT ''` to the migrations list — the runner tolerates duplicate-column re-runs (`internal/memory/store.go:459-462`).
- Row write sites (post-TASK-454 rebase): handler inserts at `internal/approval/telegram.go:371-383` and `slack.go:265-277`; `memory.PendingApproval` struct at `internal/memory/approval_store.go:13-24`.
- GET surface: `handleApprovals` (`internal/gateway/approvals.go:62`) — response DTO gains `project`; scoped filtering prefers the column when non-empty, keeping the executions join as fallback for pre-migration rows. This FIXES the scoped-mode row-dropping for rows that have a project but no execution linkage.
- Coordination: console#109's ingest consumes this GET — the new field is additive JSON; a coordination note is posted on console#109 (done by the dispatcher, not this task).

## Acceptance

1. `Request.Project` populated (canonicalized `c.projectPath`) at the submit site; both handlers copy it into the row; `PendingApproval.Project` round-trips through insert/load.
2. Migration appended per the store idiom; idempotent on second boot.
3. GET `/api/v1/approvals` emits `project` (JSON `project`, nullable/omitted when empty). Scoped mode: rows with a matching `project` column are included even when the executions join misses; empty-project legacy rows keep today's join-based behavior exactly.
4. Tests: submit→insert→GET carries project · legacy empty-project row still attributes via join · scoped filtering by column · migration idempotency (existing `store_test.go` seeding patterns).
5. `make build` / `make test` / `make lint` green.

## Scope fence

No routing/gating changes (leg B3) · no console-repo changes · no changes to the POST decision path · no backfill of existing rows (they expire within 24h anyway) · rebase on TASK-454 if it is in flight (same handler functions).

**This task must NOT be decomposed — implement as a single PR.** <!-- pilot:no-decompose -->

## Refs

- Roadmap: `.agent/system/approval-architecture-roadmap.md` (leg B2 — unblocks console#109 attribution)
- PR#4752 post-merge review (scoped-mode row-dropping finding)