### PR TITLE
GH-4774: feat(autopilot): ProjectApprovalOverride — per-project require_approval + approval_source

### DIFF
--- a/.agent/tasks/gh-4774.md
+++ b/.agent/tasks/gh-4774.md
@@ -1,0 +1,47 @@
+# GH-4774
+
+**Created:** 2026-08-07
+
+## Problem
+
+GitHub Issue GH-4774: feat(autopilot): ProjectApprovalOverride — per-project require_approval + approval_source
+
+## Problem
+
+`RequireApproval` and `ApprovalSource` resolve globally (per-environment) for every controller (`internal/autopilot/types.go:46-65`, read sites `controller.go:2163` and `:2787`), while controllers are already **per-repo** (`autopilotControllers` map, `cmd/pilot/main.go:1907-2065`) and each knows its repo + project path. The operator needs per-project resolution: a personal project routes approval asks to Telegram, a work project to Slack, and gating strictness set per project. This is config plumbing following an established pattern, not architecture.
+
+## Context (verified 2026-08-06, origin/main)
+
+- **Copy-pattern exists 3×**: `ProjectCIChecksOverride` (`internal/autopilot/types.go:281-308`), `ProjectReleaseConfig`, per-project quality. The 4-part shape: `ProjectConfig` field (`internal/config/config.go:246-284`) → override struct in `autopilot/types.go` → `WithXOverride` ControllerOption (`controller.go:347-360` idiom) → resolution in `NewController`.
+- **Critical caveat**: unlike CIChecks (consumed once at construction), BOTH approval reads are per-tick — store resolved values on the controller (the `resolvedReleaseCfg` idiom, `controller.go:477-481`); do NOT rely on a construction-time shallow cfg copy, and never mutate the shared `cfg.Orchestrator.Autopilot` (hazard documented at `controller.go:699-716`).
+- Resolution order: project override > env (`EffectiveApprovalSource`, `types.go:416-427`) > global. Empty/nil fields inherit (all-pointer struct, `ProjectReleaseConfig` style).
+- **Escalation-gate interplay verified**: size-floor/scope-drift escalations funnel into the same `submitAsyncApprovalRequest` (`controller.go:2790`) where `PreferredChannel` is built — once that reads the resolved per-project source, gate-triggered asks route per-project with zero extra work.
+- **Wire at ALL THREE construction sites**: default repo `cmd/pilot/main.go:1983-1991`, projects loop `:2013-2051`, AND the gateway-mode single-controller path `:835` (which today skips even the CIChecks overlay — fix the approval wiring only; the CIChecks asymmetry is a separately filed backlog item, do not fold it in).
+- Validation slot: `internal/config/config.go:996-1010` (index-addressed, `projects[%d].approval...`). Example YAML slot: `configs/pilot.example.yaml:491-528` next to the `release:`/`quality:` overlay examples.
+- Health checks (`internal/health/health.go:923-942`): extend the require_approval/pre_merge deadlock check to iterate project overrides; ADD a check that each effective `approval_source` maps to a handler the current mode registers (webhook mode registers only Slack — `internal/pilot/pilot.go:248-269` — this check turns that per-tick hard error into a boot-time diagnostic).
+
+## Acceptance
+
+1. `ProjectApprovalOverride { RequireApproval *bool; ApprovalSource *ApprovalSource }` (yaml `require_approval`, `approval_source`) on `ProjectConfig` as `approval`; nil/omitted fields inherit env/global.
+2. `WithApprovalOverride` ControllerOption; resolved once in `NewController` into controller fields; read sites `controller.go:2163` + `:2787` switch to the resolved values.
+3. Wired at all three construction sites incl. gateway mode.
+4. Validation: `approval_source` ∈ registered-channel names (accept the `github-review` alias per TASK-454's normalization).
+5. Health: per-project deadlock variant + effective-source-has-registered-handler check.
+6. Example YAML block documenting the per-project `approval:` overlay.
+7. Tests: two-project config (telegram/slack) resolves gating + channel independently · escalation-gate ask on the slack project carries `PreferredChannel: slack` · gateway-mode controller honors the override · health check fires on unregistered source · no-override config byte-identical behavior (regression guard).
+8. `make build` / `make test` / `make lint` green.
+
+## Scope fence
+
+No per-project *destinations* (chat_id/slack channel — needs a `Destination` field on Request; backlog) · no changes to escalation gates themselves · no approval-package changes beyond what resolution requires (routing fidelity is TASK-454) · no config flip (operator step, roadmap B5) · config remains static-at-boot (restart semantics documented; `Reload()` has zero callers).
+
+**This task must NOT be decomposed — implement as a single PR.** <!-- pilot:no-decompose -->
+
+## Refs
+
+- Roadmap: `.agent/system/approval-architecture-roadmap.md` (leg B3 — merges after TASK-454 on the lane)
+- Research pass 2026-08-06 (per-project config dimension, 11-point hook map)
+- Pitfall on flip day: `.agent/knowledge/memories/pitfalls/require-approval-flip-doesnt-release-held-prs.md`
+
+## Acceptance Criteria
+

--- a/cmd/pilot/github_sdk_bridge.go
+++ b/cmd/pilot/github_sdk_bridge.go
@@ -72,3 +72,20 @@ func projectBoardControllerOpts(apGHClient *githubSDK.Client, cfg *config.Config
 
 	return opts
 }
+
+// projectApprovalControllerOpts resolves repoFullName's projects[] entry
+// (GH-4774) and, if it sets an approval: overlay, returns the
+// WithApprovalOverride ControllerOption for it. Returns nil when the repo
+// isn't in projects[] or has no approval overlay — callers append the
+// (possibly empty) result to their option slice unconditionally, mirroring
+// projectBoardControllerOpts above. Shared by all three controller
+// construction sites in main.go (default repo, projects loop, gateway mode)
+// so gateway mode can no longer silently skip this overlay the way it used
+// to before GH-4774.
+func projectApprovalControllerOpts(cfg *config.Config, repoFullName string) []autopilot.ControllerOption {
+	proj := cfg.FindProjectByRepo(repoFullName)
+	if proj == nil || proj.Approval == nil {
+		return nil
+	}
+	return []autopilot.ControllerOption{autopilot.WithApprovalOverride(proj.Approval)}
+}

--- a/cmd/pilot/github_sdk_bridge_test.go
+++ b/cmd/pilot/github_sdk_bridge_test.go
@@ -6,6 +6,7 @@ import (
 	githubSDK "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 
 	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/autopilot"
 	"github.com/qf-studio/pilot/internal/config"
 )
 
@@ -74,4 +75,85 @@ func TestProjectBoardControllerOpts(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestProjectApprovalControllerOpts_GH4774 covers GH-4774: all three
+// autopilot controller construction sites (default repo, projects loop, and
+// — critically, since it used to be skipped entirely — gateway mode) resolve
+// the per-project approval overlay through this one shared helper, so
+// testing it here stands in for exercising every call site including the
+// gateway-mode one that isn't otherwise unit-testable in isolation (it's
+// wired inline inside main()'s gateway startup branch).
+func TestProjectApprovalControllerOpts_GH4774(t *testing.T) {
+	requireApprovalFalse := false
+	requireApprovalTrue := true
+
+	cfg := &config.Config{
+		Adapters: &config.AdaptersConfig{
+			GitHub: &github.Config{Repo: "acme/default"},
+		},
+		Projects: []*config.ProjectConfig{
+			{
+				Name:   "personal",
+				Path:   "/personal",
+				GitHub: &config.ProjectGitHubConfig{Owner: "acme", Repo: "personal"},
+				Approval: &autopilot.ProjectApprovalOverride{
+					RequireApproval: &requireApprovalFalse,
+					ApprovalSource:  autopilot.ApprovalSourceTelegram,
+				},
+			},
+			{
+				Name:   "work",
+				Path:   "/work",
+				GitHub: &config.ProjectGitHubConfig{Owner: "acme", Repo: "work"},
+				Approval: &autopilot.ProjectApprovalOverride{
+					RequireApproval: &requireApprovalTrue,
+					ApprovalSource:  autopilot.ApprovalSourceSlack,
+				},
+			},
+			ghProj("no-override", "acme", "no-override", "/no"),
+		},
+	}
+
+	t.Run("repo with no projects[] entry gets no option", func(t *testing.T) {
+		got := projectApprovalControllerOpts(cfg, "acme/default")
+		if len(got) != 0 {
+			t.Errorf("len = %d, want 0", len(got))
+		}
+	})
+
+	t.Run("project with no approval override gets no option", func(t *testing.T) {
+		got := projectApprovalControllerOpts(cfg, "acme/no-override")
+		if len(got) != 0 {
+			t.Errorf("len = %d, want 0", len(got))
+		}
+	})
+
+	t.Run("personal project resolves to telegram + require_approval=false", func(t *testing.T) {
+		got := projectApprovalControllerOpts(cfg, "acme/personal")
+		if len(got) != 1 {
+			t.Fatalf("len = %d, want 1", len(got))
+		}
+		c := autopilot.NewController(autopilot.DefaultConfig(), nil, nil, "acme", "personal", got...)
+		if c.ResolvedRequireApproval() {
+			t.Error("ResolvedRequireApproval() = true, want false (project override)")
+		}
+		if got := c.ResolvedApprovalSource(); got != autopilot.ApprovalSourceTelegram {
+			t.Errorf("ResolvedApprovalSource() = %q, want %q", got, autopilot.ApprovalSourceTelegram)
+		}
+	})
+
+	t.Run("work project resolves to slack + require_approval=true independently of the personal project", func(t *testing.T) {
+		got := projectApprovalControllerOpts(cfg, "acme/work")
+		if len(got) != 1 {
+			t.Fatalf("len = %d, want 1", len(got))
+		}
+		c := autopilot.NewController(autopilot.DefaultConfig(), nil, nil, "acme", "work", got...)
+		if !c.ResolvedRequireApproval() {
+			t.Error("ResolvedRequireApproval() = false, want true (project override)")
+		}
+		if got := c.ResolvedApprovalSource(); got != autopilot.ApprovalSourceSlack {
+			t.Errorf("ResolvedApprovalSource() = %q, want %q", got, autopilot.ApprovalSourceSlack)
+		}
+	})
 }

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -835,6 +835,13 @@ Examples:
 							if proj := cfg.FindProjectByRepo(cfg.Adapters.GitHub.Repo); proj != nil && proj.Release != nil {
 								gwBoardOpts = append(gwBoardOpts, autopilot.WithReleaseOverride(proj.Release))
 							}
+							// GH-4774: apply the per-project approval overlay (require_approval /
+							// approval_source) when configured; nil is a no-op (inherits
+							// env/global). This gateway-mode single-controller path previously
+							// skipped this overlay entirely (it also still skips the separate
+							// CIChecks overlay — tracked as its own backlog item, not folded in
+							// here).
+							gwBoardOpts = append(gwBoardOpts, projectApprovalControllerOpts(cfg, cfg.Adapters.GitHub.Repo)...)
 							gwAutopilotController = autopilot.NewController(
 								cfg.Orchestrator.Autopilot,
 								apGHClient,
@@ -1990,6 +1997,10 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 							ctrlOpts = append(ctrlOpts, autopilot.WithCIChecksOverride(proj.CIChecks))
 						}
 					}
+					// GH-4774: apply the per-project approval overlay (require_approval /
+					// approval_source) when configured; nil is a no-op (inherits
+					// env/global).
+					ctrlOpts = append(ctrlOpts, projectApprovalControllerOpts(cfg, cfg.Adapters.GitHub.Repo)...)
 					controller := autopilot.NewController(
 						cfg.Orchestrator.Autopilot,
 						apGHClient,
@@ -2050,6 +2061,12 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				if proj.CIChecks != nil {
 					ctrlOpts = append(ctrlOpts, autopilot.WithCIChecksOverride(proj.CIChecks))
 				}
+				// GH-4774: apply the per-project approval overlay (require_approval /
+				// approval_source) when configured; nil is a no-op (inherits
+				// env/global) — unlike Release, there's no "opt-in" warning here
+				// since inheriting the shared approval policy was always the
+				// pre-existing behavior.
+				ctrlOpts = append(ctrlOpts, projectApprovalControllerOpts(cfg, repoFullName)...)
 				controller := autopilot.NewController(
 					cfg.Orchestrator.Autopilot,
 					apGHClient,

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -565,6 +565,30 @@ projects:
   #                     # (Homebrew tap). Repos with GoReleaser must stay workflow.
   #     tag_human_merges: true  # also tag this project's human-authored merges (GH-3928)
   #
+  # Per-project approval overlay (GH-4774) - overrides the env/global
+  # require_approval + approval_source above for this project only. Nil/unset
+  # fields inherit from the resolved env/global approval config, matching the
+  # release overlay's semantics. Motivating case: a personal project routes
+  # merge approval to Telegram while a work project on the same daemon routes
+  # to Slack, and/or gates merges more or less strictly than the shared
+  # environment default.
+  # - name: "personal-project"
+  #   path: "/path/to/personal-project"
+  #   github:
+  #     owner: "aleks"
+  #     repo: "personal-project"
+  #   approval:
+  #     require_approval: false   # merge without a human tap even if the env requires it
+  #     approval_source: "telegram"
+  # - name: "work-project"
+  #   path: "/path/to/work-project"
+  #   github:
+  #     owner: "qf-studio"
+  #     repo: "work-project"
+  #   approval:
+  #     require_approval: true
+  #     approval_source: "slack"  # telegram, slack, or github-review
+  #
   # on_schedule example (GH-3993): batch everything merged since the last tag
   # into one release train, cut every Friday at 21:00 in Europe/Berlin.
   # - name: some-product

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -359,6 +359,17 @@ func WithCIChecksOverride(o *ProjectCIChecksOverride) ControllerOption {
 	}
 }
 
+// WithApprovalOverride wires a per-project require_approval/approval_source
+// overlay (GH-4774) for this controller's repo. Nil is a no-op. Must be
+// applied before NewController resolves c.resolvedRequireApproval /
+// c.resolvedApprovalSource — see the options loop at the top of
+// NewController.
+func WithApprovalOverride(o *ProjectApprovalOverride) ControllerOption {
+	return func(c *Controller) {
+		c.projectApproval = o
+	}
+}
+
 // WithRateBudget wires the shared, process-wide GitHub rate-limit budget
 // tracker (GH-4391). All controllers in a multi-repo daemon share ONE
 // tracker — GitHub's primary rate limit is pooled per authenticated user
@@ -467,6 +478,24 @@ type Controller struct {
 	// Config.RequiredChecks / Config.CIChecks, same as before this option
 	// existed. Applied once during NewController, before c.ciMonitor is built.
 	projectCIChecks *ProjectCIChecksOverride
+
+	// projectApproval is the per-project require_approval/approval_source
+	// overlay (GH-4774), wired via WithApprovalOverride. Nil = no
+	// project-level override. Consulted once during NewController to compute
+	// resolvedRequireApproval/resolvedApprovalSource below.
+	projectApproval *ProjectApprovalOverride
+
+	// resolvedRequireApproval and resolvedApprovalSource are the effective
+	// approval gating settings computed once in NewController: env wins over
+	// global, then projectApproval (if any) is overlaid on top (GH-4774).
+	// Unlike projectCIChecks (folded into a one-time CIMonitor construction),
+	// the read sites for these — handleCIPassed's merge gate and
+	// submitAsyncApprovalRequest's PreferredChannel — run on every tick a PR
+	// sits in StageAwaitApproval, so they read these cached fields directly
+	// rather than re-deriving from c.config + c.projectApproval each time
+	// (mirroring the resolvedReleaseCfg idiom).
+	resolvedRequireApproval bool
+	resolvedApprovalSource  ApprovalSource
 
 	// resolvedReleaseCfg is the effective release config computed once in
 	// NewController: env-scoped config wins over global, then projectRelease
@@ -766,7 +795,54 @@ func NewController(cfg *Config, ghClient *github.Client, approvalMgr *approval.M
 		c.deployer = NewDeployer(ghClient, owner, repo, env.PostMerge)
 	}
 
+	// GH-4774: resolve the effective approval gating + channel once — env wins
+	// over global (ResolvedEnvOrDefault/EffectiveApprovalSource), then the
+	// per-project overlay (if any) wins over that. The read sites
+	// (handleCIPassed's merge gate, submitAsyncApprovalRequest's
+	// PreferredChannel, alertApprovalSubmitFailureOnce) are evaluated on every
+	// tick a PR sits in StageAwaitApproval, so caching the resolved values here
+	// (mirroring resolvedReleaseCfg above) avoids re-deriving them from
+	// c.config + c.projectApproval on every poll.
+	c.resolvedRequireApproval = cfg.ResolvedEnvOrDefault().RequireApproval
+	c.resolvedApprovalSource = cfg.EffectiveApprovalSource()
+	if c.projectApproval != nil {
+		if c.projectApproval.RequireApproval != nil {
+			c.resolvedRequireApproval = *c.projectApproval.RequireApproval
+		}
+		if c.projectApproval.ApprovalSource != "" {
+			c.resolvedApprovalSource = c.projectApproval.ApprovalSource
+		}
+	}
+
 	return c
+}
+
+// ResolvedRequireApproval returns the effective require_approval gate this
+// controller was constructed with (env/global, overlaid by
+// WithApprovalOverride if any) — exported for callers like cmd/pilot's
+// controller-construction wiring tests that need to verify a per-project
+// approval overlay actually took effect without reaching into unexported
+// fields (GH-4774).
+func (c *Controller) ResolvedRequireApproval() bool {
+	return c.resolvedRequireApproval
+}
+
+// ResolvedApprovalSource returns the effective approval channel this
+// controller was constructed with (env/global, overlaid by
+// WithApprovalOverride if any). See ResolvedRequireApproval (GH-4774).
+func (c *Controller) ResolvedApprovalSource() ApprovalSource {
+	return c.resolvedApprovalSource
+}
+
+// requireApprovalSourceLabel names the config path that produced
+// c.resolvedRequireApproval, for use in EscalationReason / log text so an
+// operator can tell whether a merge-gate ask came from the per-project
+// override or the shared environment default (GH-4774).
+func (c *Controller) requireApprovalSourceLabel() string {
+	if c.projectApproval != nil && c.projectApproval.RequireApproval != nil {
+		return fmt.Sprintf("projects[%s/%s].approval.require_approval=true", c.owner, c.repo)
+	}
+	return fmt.Sprintf("environments.%s.require_approval=true", c.config.EnvironmentName())
 }
 
 // parentIssueRe extracts a parent issue number from a sub-issue body line like
@@ -1289,7 +1365,7 @@ func (c *Controller) alertApprovalSubmitFailureOnce(ctx context.Context, prState
 
 	msg := fmt.Sprintf(
 		"PR #%d (%s) approval request could not be delivered via the configured channel (%s): %s — it will not merge until a human intervenes",
-		prState.PRNumber, c.repoKey(), c.config.EffectiveApprovalSource(), submitErr,
+		prState.PRNumber, c.repoKey(), c.resolvedApprovalSource, submitErr,
 	)
 	c.log.Error("approval submit failed", "pr", prState.PRNumber, "error", submitErr)
 
@@ -1306,13 +1382,13 @@ func (c *Controller) alertApprovalSubmitFailureOnce(ctx context.Context, prState
 			Metadata: map[string]string{
 				"repo":            c.repoKey(),
 				"pr":              strconv.Itoa(prState.PRNumber),
-				"approval_source": string(c.config.EffectiveApprovalSource()),
+				"approval_source": string(c.resolvedApprovalSource),
 			},
 		})
 	}
 
 	comment := fmt.Sprintf("%s\n🚨 **Approval request undeliverable**\n\n@%s %s\n\nCheck the approval channel config (`approval_source: %s`) — the adapter/handler for it may not be registered or reachable. This PR is stuck in `awaiting_approval` until it's fixed.",
-		approvalFailedCommentMarker, c.owner, msg, c.config.EffectiveApprovalSource())
+		approvalFailedCommentMarker, c.owner, msg, c.resolvedApprovalSource)
 	if _, cerr := c.ghClient.AddPRComment(ctx, c.owner, c.repo, prState.PRNumber, comment); cerr != nil {
 		c.log.Warn("failed to post approval-submit-failed PR comment", "pr", prState.PRNumber, "error", cerr)
 	}
@@ -2160,10 +2236,10 @@ func (c *Controller) handleCIPassed(ctx context.Context, prState *PRState) error
 		return nil
 	}
 
-	if c.config.ResolvedEnvOrDefault().RequireApproval {
+	if c.resolvedRequireApproval {
 		c.log.Info("awaiting approval before merge", "pr", prState.PRNumber)
 		prState.Stage = StageAwaitApproval
-		prState.EscalationReason = fmt.Sprintf("environments.%s.require_approval=true", c.config.EnvironmentName())
+		prState.EscalationReason = c.requireApprovalSourceLabel()
 
 		// Notify approval required
 		if c.notifier != nil {
@@ -2727,7 +2803,7 @@ func (c *Controller) submitAsyncApprovalRequest(ctx context.Context, prState *PR
 		// defense-in-depth gate did the escalating — observed on PR #3559.
 		reason := prState.EscalationReason
 		if reason == "" {
-			reason = fmt.Sprintf("environments.%s.require_approval=true", c.config.EnvironmentName())
+			reason = c.requireApprovalSourceLabel()
 		}
 		// GH-4596: a gate demanding approval with no approval channel wired is a
 		// config gap, not a PR failure — nothing about the PR's code is wrong.
@@ -2784,7 +2860,7 @@ func (c *Controller) submitAsyncApprovalRequest(ctx context.Context, prState *PR
 		// Before this, PreferredChannel was never set on this path, so
 		// Manager.SubmitApprovalRequest always fell through to whichever
 		// handler happened to win Go's map iteration order.
-		PreferredChannel: string(c.config.EffectiveApprovalSource()),
+		PreferredChannel: string(c.resolvedApprovalSource),
 	}
 
 	requestID, err := c.approvalMgr.SubmitApprovalRequest(ctx, req)

--- a/internal/autopilot/gh4774_project_approval_override_test.go
+++ b/internal/autopilot/gh4774_project_approval_override_test.go
@@ -1,0 +1,156 @@
+package autopilot
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/approval"
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// namedCapturingApprovalHandler is a capturing approval.Handler with a
+// configurable Name(), so a test can register both a "telegram" and a
+// "slack" handler on the same approval.Manager and verify
+// Request.PreferredChannel actually routed to the right one instead of
+// relying on Go's map iteration order (GH-4380/GH-4774).
+type namedCapturingApprovalHandler struct {
+	name string
+	sent []*approval.Request
+}
+
+func (m *namedCapturingApprovalHandler) Name() string { return m.name }
+
+func (m *namedCapturingApprovalHandler) SendApprovalRequest(_ context.Context, req *approval.Request) (<-chan *approval.Response, error) {
+	m.sent = append(m.sent, req)
+	return make(chan *approval.Response, 1), nil
+}
+
+func (m *namedCapturingApprovalHandler) CancelRequest(context.Context, string) error { return nil }
+
+// TestController_ProjectApprovalOverride_GatingIndependent_GH4774 is the
+// GH-4774 acceptance test for gating independence: two controllers share the
+// SAME global *Config (mirroring cmd/pilot/main.go threading
+// cfg.Orchestrator.Autopilot by pointer into every repo's controller) — the
+// active environment (prod) requires approval for everyone by default. A
+// "personal" project overlays require_approval: false and must merge
+// straight through; a "work" project has no require_approval override (only
+// an approval_source override) and must still escalate, proving the two
+// controllers' gating decisions are resolved independently rather than one
+// overlay leaking onto the other's shared *Config (the exact class of bug
+// GH-4478's shallow-copy discipline exists to avoid).
+func TestController_ProjectApprovalOverride_GatingIndependent_GH4774(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Small, no linked issue — neither size-floor nor scope-drift gates fire,
+		// isolating the assertion to the require_approval resolution itself.
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	cfg := DefaultConfig()
+	cfg.Environment = EnvProd // built-in prod default: RequireApproval=true
+
+	requireApprovalFalse := false
+	personal := NewController(cfg, ghClient, nil, "acme", "personal",
+		WithApprovalOverride(&ProjectApprovalOverride{RequireApproval: &requireApprovalFalse}))
+	work := NewController(cfg, ghClient, nil, "acme", "work",
+		WithApprovalOverride(&ProjectApprovalOverride{ApprovalSource: ApprovalSourceSlack}))
+
+	personalPR := &PRState{PRNumber: 1, PRTitle: "fix: small change", Stage: StageCIPassed}
+	if err := personal.handleCIPassed(context.Background(), personalPR); err != nil {
+		t.Fatalf("personal handleCIPassed error: %v", err)
+	}
+	if personalPR.Stage != StageMerging {
+		t.Errorf("personal project stage = %s, want %s — its require_approval: false override must bypass the env's require_approval=true default", personalPR.Stage, StageMerging)
+	}
+
+	workPR := &PRState{PRNumber: 2, PRTitle: "fix: small change", Stage: StageCIPassed}
+	if err := work.handleCIPassed(context.Background(), workPR); err != nil {
+		t.Fatalf("work handleCIPassed error: %v", err)
+	}
+	if workPR.Stage != StageAwaitApproval {
+		t.Errorf("work project stage = %s, want %s — it has no require_approval override, so it must still inherit the env's require_approval=true", workPR.Stage, StageAwaitApproval)
+	}
+
+	// Confirm the resolved fields themselves, not just the stage transition.
+	if personal.ResolvedRequireApproval() {
+		t.Error("personal.ResolvedRequireApproval() = true, want false")
+	}
+	if !work.ResolvedRequireApproval() {
+		t.Error("work.ResolvedRequireApproval() = false, want true (inherited from env)")
+	}
+}
+
+// TestController_ProjectApprovalOverride_ChannelRouting_GH4774 is the
+// GH-4774 acceptance test for channel routing: a project's approval_source
+// override must set Request.PreferredChannel to that project's channel, not
+// the global/env default, and a daemon with both Telegram and Slack handlers
+// registered must route to the right one.
+func TestController_ProjectApprovalOverride_ChannelRouting_GH4774(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+
+	cfg := DefaultConfig()
+	cfg.Environment = EnvProd
+	cfg.ApprovalSource = ApprovalSourceTelegram // global/env default channel
+
+	mgr := asyncApprovalManager()
+	tgHandler := &namedCapturingApprovalHandler{name: "telegram"}
+	slackHandler := &namedCapturingApprovalHandler{name: "slack"}
+	mgr.RegisterHandler(tgHandler)
+	mgr.RegisterHandler(slackHandler)
+
+	work := NewController(cfg, ghClient, mgr, "acme", "work",
+		WithApprovalOverride(&ProjectApprovalOverride{ApprovalSource: ApprovalSourceSlack}))
+
+	work.mu.Lock()
+	work.activePRs[42] = &PRState{
+		PRNumber:    42,
+		PRURL:       "https://github.com/acme/work/pull/42",
+		PRTitle:     "feat: something",
+		IssueNumber: 10,
+		Stage:       StageAwaitApproval,
+	}
+	work.mu.Unlock()
+
+	if err := work.ProcessPR(context.Background(), 42, nil); err != nil {
+		t.Fatalf("ProcessPR error: %v", err)
+	}
+
+	if len(slackHandler.sent) != 1 {
+		t.Fatalf("slack handler received %d requests, want 1", len(slackHandler.sent))
+	}
+	if len(tgHandler.sent) != 0 {
+		t.Fatalf("telegram handler received %d requests, want 0 — the project's approval_source: slack override must not fall back to the global telegram default", len(tgHandler.sent))
+	}
+	if got, want := slackHandler.sent[0].PreferredChannel, "slack"; got != want {
+		t.Errorf("PreferredChannel = %q, want %q", got, want)
+	}
+}
+
+// TestController_ProjectApprovalOverride_NilIsRegressionSafe_GH4774 is the
+// regression guard from the acceptance criteria: a controller constructed
+// with no WithApprovalOverride (nil projectApproval, i.e. every config that
+// predates GH-4774) must resolve to exactly the same require_approval /
+// approval_source values cfg.ResolvedEnvOrDefault().RequireApproval and
+// cfg.EffectiveApprovalSource() would have produced directly — byte-identical
+// behavior for every existing config.
+func TestController_ProjectApprovalOverride_NilIsRegressionSafe_GH4774(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvProd
+	cfg.ApprovalSource = ApprovalSourceSlack
+
+	c := NewController(cfg, ghClient, nil, "acme", "no-override")
+
+	if got, want := c.ResolvedRequireApproval(), cfg.ResolvedEnvOrDefault().RequireApproval; got != want {
+		t.Errorf("ResolvedRequireApproval() = %v, want %v (cfg.ResolvedEnvOrDefault().RequireApproval, unchanged pre-GH-4774 behavior)", got, want)
+	}
+	if got, want := c.ResolvedApprovalSource(), cfg.EffectiveApprovalSource(); got != want {
+		t.Errorf("ResolvedApprovalSource() = %q, want %q (cfg.EffectiveApprovalSource(), unchanged pre-GH-4774 behavior)", got, want)
+	}
+}

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -305,6 +305,35 @@ type ProjectCIChecksOverride struct {
 	CIChecks *CIChecksConfig `yaml:"ci_checks,omitempty"`
 }
 
+// ProjectApprovalOverride lets a per-project controller override the
+// env/global RequireApproval + ApprovalSource for merge-gate approval
+// requests (GH-4774). Nil fields inherit — resolution order is project
+// override > active environment (EnvironmentConfig.RequireApproval /
+// EffectiveApprovalSource) > global Config.ApprovalSource, mirroring the
+// ProjectCIChecksOverride/ProjectReleaseConfig overlay pattern. Motivating
+// case: a personal project should route approval asks to Telegram while a
+// work project on the same daemon routes to Slack, and/or gates merges more
+// or less strictly than the shared environment default.
+//
+// Unlike ProjectCIChecksOverride (folded into a shallow Config copy once at
+// CIMonitor construction), the two read sites this overlay feeds
+// (handleCIPassed's RequireApproval check and submitAsyncApprovalRequest's
+// PreferredChannel) are evaluated on every tick a PR sits in
+// StageAwaitApproval — so NewController resolves this overlay once into
+// plain Controller fields (resolvedRequireApproval/resolvedApprovalSource,
+// mirroring the resolvedReleaseCfg idiom) rather than leaving per-tick
+// callers to re-derive it from cfg + this overlay themselves.
+type ProjectApprovalOverride struct {
+	// RequireApproval overrides the active environment's RequireApproval for
+	// this project. Nil inherits.
+	RequireApproval *bool `yaml:"require_approval,omitempty"`
+
+	// ApprovalSource overrides EffectiveApprovalSource() for this project.
+	// Empty inherits. Accepts the same values as the global/env
+	// approval_source field (telegram, slack, github-review).
+	ApprovalSource ApprovalSource `yaml:"approval_source,omitempty"`
+}
+
 // defaultEnvironments returns built-in environment configs matching legacy behavior.
 func defaultEnvironments() map[string]*EnvironmentConfig {
 	return map[string]*EnvironmentConfig{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -274,6 +274,15 @@ type ProjectConfig struct {
 	// only flips CISuccess when a live run's name matches an allowlisted name).
 	// Unset fields inherit from the global config.
 	CIChecks *autopilot.ProjectCIChecksOverride `yaml:"ci_checks,omitempty"`
+	// Approval overlays the global/environment require_approval gate and
+	// approval_source channel for this project (GH-4774). Without it, every
+	// project controller shares Config.Orchestrator.Autopilot's single
+	// env/global approval policy — fine when one team owns every project on
+	// the daemon, but a personal project alongside a work project may want
+	// merges gated differently and/or routed to a different approval channel
+	// (e.g. Telegram vs. Slack). Unset fields inherit from the
+	// env/global config.
+	Approval *autopilot.ProjectApprovalOverride `yaml:"approval,omitempty"`
 	// Canary marks this project as a synthetic sandbox (e.g. the TASK-379 V8
 	// canary workflow) rather than real work (GH-4240). Executions dispatched
 	// for a canary project are still fully persisted and event-logged — the
@@ -863,6 +872,19 @@ var validReleasePublishValues = map[string]bool{
 	"":         true, // Empty inherits the default (workflow)
 }
 
+// validApprovalSourceValues are the accepted values for a project's
+// approval.approval_source overlay (GH-4774). Mirrors the same three
+// channels EffectiveApprovalSource() recognizes at the global/env level
+// (internal/autopilot/types.go), including the "github-review" alias that
+// internal/approval/channel.go's normalizeChannelName maps onto the
+// GitHubHandler's registered "github" name (TASK-454/GH-4772).
+var validApprovalSourceValues = map[string]bool{
+	"":              true, // Empty inherits env/global
+	"telegram":      true,
+	"slack":         true,
+	"github-review": true,
+}
+
 // validReleaseTriggerValues are the accepted values for release.trigger,
 // checked at the global, per-environment, and per-project overlay levels
 // (GH-3989).
@@ -995,16 +1017,25 @@ func (c *Config) Validate() error {
 
 	// GH-3930: Validate release.publish enum on each project's release overlay.
 	// GH-3989: Validate release.trigger + schedule/schedule_timezone alongside.
+	// GH-4774: Validate approval.approval_source enum on each project's
+	// approval overlay, independently of whether a release overlay is set.
 	for i, p := range c.Projects {
-		if p == nil || p.Release == nil {
+		if p == nil {
 			continue
 		}
-		if !validReleasePublishValues[p.Release.Publish] {
-			return fmt.Errorf("projects[%d].release.publish must be \"workflow\", \"api\", or \"tag_only\", got %q", i, p.Release.Publish)
+		if p.Release != nil {
+			if !validReleasePublishValues[p.Release.Publish] {
+				return fmt.Errorf("projects[%d].release.publish must be \"workflow\", \"api\", or \"tag_only\", got %q", i, p.Release.Publish)
+			}
+			projectPath := fmt.Sprintf("projects[%d].release", i)
+			if err := validateReleaseTriggerFields(projectPath, p.Release.Trigger, p.Release.Schedule, p.Release.ScheduleTimezone); err != nil {
+				return err
+			}
 		}
-		projectPath := fmt.Sprintf("projects[%d].release", i)
-		if err := validateReleaseTriggerFields(projectPath, p.Release.Trigger, p.Release.Schedule, p.Release.ScheduleTimezone); err != nil {
-			return err
+		if p.Approval != nil {
+			if !validApprovalSourceValues[string(p.Approval.ApprovalSource)] {
+				return fmt.Errorf("projects[%d].approval.approval_source must be \"\", \"telegram\", \"slack\", or \"github-review\", got %q", i, p.Approval.ApprovalSource)
+			}
 		}
 	}
 

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -607,6 +607,100 @@ func TestConfig_Validate_DashboardStatsWindowDays(t *testing.T) {
 	}
 }
 
+// GH-4774: Validate approval.approval_source enum on a project's approval
+// overlay, independently of whether that project also sets a release
+// overlay (the two overlays used to share one loop that `continue`d whenever
+// Release was nil).
+func TestConfig_Validate_ProjectApprovalSource(t *testing.T) {
+	tests := []struct {
+		name      string
+		buildCfg  func() *Config
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "nil approval overlay is valid",
+			buildCfg: func() *Config {
+				return baseValidConfig()
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty approval_source inherits and is valid",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Projects[0].Approval = &autopilot.ProjectApprovalOverride{}
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "telegram is valid",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Projects[0].Approval = &autopilot.ProjectApprovalOverride{ApprovalSource: autopilot.ApprovalSourceTelegram}
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "slack is valid",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Projects[0].Approval = &autopilot.ProjectApprovalOverride{ApprovalSource: autopilot.ApprovalSourceSlack}
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "github-review alias is valid (TASK-454/GH-4772)",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Projects[0].Approval = &autopilot.ProjectApprovalOverride{ApprovalSource: autopilot.ApprovalSourceGitHubReview}
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "unknown approval_source is rejected",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Projects[0].Approval = &autopilot.ProjectApprovalOverride{ApprovalSource: "bogus"}
+				return cfg
+			},
+			wantErr:   true,
+			errSubstr: `projects[0].approval.approval_source must be "", "telegram", "slack", or "github-review"`,
+		},
+		{
+			name: "approval overlay validated even when no release overlay is set on the same project",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Projects[0].Release = nil
+				cfg.Projects[0].Approval = &autopilot.ProjectApprovalOverride{ApprovalSource: "bogus"}
+				return cfg
+			},
+			wantErr:   true,
+			errSubstr: `projects[0].approval.approval_source must be`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.buildCfg()
+			err := cfg.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errSubstr)
+				} else if !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("expected error containing %q, got %q", tt.errSubstr, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 // GH-3930: Validate release.publish enum at the global, per-environment, and
 // per-project overlay levels.
 func TestConfig_Validate_ReleasePublish(t *testing.T) {

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/qf-studio/pilot/internal/adapters/slack"
 	"github.com/qf-studio/pilot/internal/adapters/telegram"
+	"github.com/qf-studio/pilot/internal/autopilot"
 	"github.com/qf-studio/pilot/internal/config"
 	"github.com/qf-studio/pilot/internal/health/verify"
 	"github.com/qf-studio/pilot/internal/upgrade"
@@ -759,6 +760,45 @@ func TelegramApprovalStranding(cfg *config.Config) string {
 	return "approval channel telegram is send-only in this configuration — approvals will strand"
 }
 
+// normalizeApprovalChannelName maps an ApprovalSource config value onto the
+// approval.Handler name it will actually be looked up by. Duplicates
+// internal/approval/channel.go's unexported normalizeChannelName — that
+// package can't be imported here without an import cycle risk (health
+// intentionally stays a leaf consumer of config/autopilot), so the single
+// alias this project has ever needed ("github-review" -> "github", added for
+// TASK-454/GH-4772) is re-derived locally. Every other value already matches
+// its handler's Name() (telegram/slack), so it passes through unchanged.
+func normalizeApprovalChannelName(source autopilot.ApprovalSource) string {
+	if source == autopilot.ApprovalSourceGitHubReview {
+		return "github"
+	}
+	return string(source)
+}
+
+// registeredApprovalChannels reports which approval.Handler names will
+// actually be registered at boot, mirroring the exact conditions
+// cmd/pilot/main.go gates each handler's construction on (GH-4774). Kept in
+// sync manually — there is no single source of truth to derive this from
+// without exporting main.go's wiring, which is out of scope here.
+func registeredApprovalChannels(cfg *config.Config) map[string]bool {
+	registered := map[string]bool{}
+	if cfg == nil || cfg.Adapters == nil {
+		return registered
+	}
+	if tg := cfg.Adapters.Telegram; tg != nil && tg.Enabled && tg.BotToken != "" &&
+		(tg.Approval == nil || tg.Approval.Enabled) {
+		registered["telegram"] = true
+	}
+	if sl := cfg.Adapters.Slack; sl != nil && sl.Enabled && sl.BotToken != "" &&
+		sl.Approval != nil && sl.Approval.Enabled {
+		registered["slack"] = true
+	}
+	if gh := cfg.Adapters.GitHub; gh != nil && gh.Approval != nil && gh.Approval.Enabled {
+		registered["github"] = true
+	}
+	return registered
+}
+
 // checkConfig validates configuration
 func checkConfig(cfg *config.Config) []ConfigCheck {
 	checks := []ConfigCheck{}
@@ -937,6 +977,65 @@ func checkConfig(cfg *config.Config) []ConfigCheck {
 					Fix:     "Set approval.enabled: true + approval.pre_merge.enabled: true + add an approver, or set require_approval: false for the environment",
 				})
 				break // one diagnostic per run is enough
+			}
+		}
+	}
+
+	// GH-4774: same deadlock class as above, but for a project's own
+	// approval.require_approval override — ProjectApprovalOverride wins over
+	// the env default (see Controller.resolvedRequireApproval in
+	// internal/autopilot), so a project can force require_approval=true (and
+	// deadlock) even in an environment whose own require_approval is false,
+	// which the env-keyed loop above can't see.
+	if cfg.Orchestrator != nil && cfg.Orchestrator.Autopilot != nil {
+		preMergeEnabled := cfg.Approval != nil &&
+			cfg.Approval.Enabled &&
+			cfg.Approval.PreMerge != nil &&
+			cfg.Approval.PreMerge.Enabled
+		if !preMergeEnabled {
+			for _, p := range cfg.Projects {
+				if p == nil || p.Approval == nil || p.Approval.RequireApproval == nil || !*p.Approval.RequireApproval {
+					continue
+				}
+				checks = append(checks, ConfigCheck{
+					Name:    "approval-misconfig",
+					Status:  StatusError,
+					Message: fmt.Sprintf("project %q has approval.require_approval=true but approval.pre_merge.enabled=false → all its PRs will deadlock until enabled or the override is removed", p.Name),
+					Fix:     "Set approval.enabled: true + approval.pre_merge.enabled: true + add an approver, or remove/flip this project's approval.require_approval override",
+				})
+			}
+		}
+	}
+
+	// GH-4774: verify every effective approval_source (global/env default plus
+	// every project's own override) resolves to a handler that will actually
+	// be registered at boot. Without this, the failure mode only surfaces at
+	// runtime as approval.Manager.SubmitApprovalRequest's hard error (GH-4380)
+	// the first time a PR reaches StageAwaitApproval.
+	if cfg.Orchestrator != nil && cfg.Orchestrator.Autopilot != nil {
+		registered := registeredApprovalChannels(cfg)
+		apCfg := cfg.Orchestrator.Autopilot
+		defaultSource := normalizeApprovalChannelName(apCfg.EffectiveApprovalSource())
+		if !registered[defaultSource] {
+			checks = append(checks, ConfigCheck{
+				Name:    "approval-source-unregistered",
+				Status:  StatusError,
+				Message: fmt.Sprintf("approval_source resolves to %q but no handler for it will be registered at boot — approval requests will hard-fail once a PR reaches awaiting_approval", defaultSource),
+				Fix:     "Enable the matching adapter (adapters.telegram/slack.enabled + bot_token, or adapters.github.approval.enabled) or change approval_source",
+			})
+		}
+		for _, p := range cfg.Projects {
+			if p == nil || p.Approval == nil || p.Approval.ApprovalSource == "" {
+				continue
+			}
+			source := normalizeApprovalChannelName(p.Approval.ApprovalSource)
+			if !registered[source] {
+				checks = append(checks, ConfigCheck{
+					Name:    "approval-source-unregistered",
+					Status:  StatusError,
+					Message: fmt.Sprintf("project %q sets approval.approval_source: %q, which resolves to %q, but no handler for it will be registered at boot", p.Name, p.Approval.ApprovalSource, source),
+					Fix:     "Enable the matching adapter (adapters.telegram/slack.enabled + bot_token, or adapters.github.approval.enabled) for this project's approval_source, or change the override",
+				})
 			}
 		}
 	}

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -1019,6 +1019,180 @@ func TestCheckConfig_ApprovalMisconfig_NotReported_WhenPreMergeEnabled(t *testin
 }
 
 // ---------------------------------------------------------------------------
+// Per-project approval overlay doctor checks (GH-4774)
+// ---------------------------------------------------------------------------
+
+// projectApprovalOverlayConfig returns a base config with autopilot defaults
+// (env=stage, require_approval=false at the env level, approval_source=telegram
+// globally) plus one project entry whose approval overlay the caller can
+// mutate. Mirrors telegramStrandingConfig's "start from a known-good base,
+// mutate one field" style.
+func projectApprovalOverlayConfig(t *testing.T) *config.Config {
+	t.Helper()
+	cfg := config.DefaultConfig()
+	cfg.Orchestrator.Autopilot = autopilot.DefaultConfig()
+	// autopilot.DefaultConfig()'s built-in Environments map includes
+	// "prod": {RequireApproval: true}, which would otherwise trip the
+	// pre-existing env-keyed approval-misconfig check (it scans every entry
+	// in the map, not just the active environment) and mask the
+	// project-scoped assertions these tests care about.
+	cfg.Orchestrator.Autopilot.Environments = map[string]*autopilot.EnvironmentConfig{
+		"stage": {RequireApproval: false},
+	}
+	cfg.Projects = []*config.ProjectConfig{
+		{
+			Name:   "work",
+			Path:   "/work",
+			GitHub: &config.ProjectGitHubConfig{Owner: "acme", Repo: "work"},
+		},
+	}
+	return cfg
+}
+
+func TestCheckConfig_ApprovalMisconfig_Project_Detected(t *testing.T) {
+	// project overlay sets require_approval=true but approval.pre_merge is
+	// disabled (and the env itself doesn't require approval) → the env-keyed
+	// loop can't see this, so the project-keyed loop must catch it.
+	cfg := projectApprovalOverlayConfig(t)
+	requireApprovalTrue := true
+	cfg.Projects[0].Approval = &autopilot.ProjectApprovalOverride{RequireApproval: &requireApprovalTrue}
+	approvalCfg := approval.DefaultConfig()
+	approvalCfg.Enabled = false
+	cfg.Approval = approvalCfg
+
+	checks := checkConfig(cfg)
+	found := findConfigCheck(checks, "approval-misconfig")
+	if found == nil {
+		t.Fatal("expected 'approval-misconfig' check to appear in ConfigChecks")
+	}
+	if found.Status != StatusError {
+		t.Errorf("approval-misconfig status = %v, want StatusError", found.Status)
+	}
+	if !strings.Contains(found.Message, "work") {
+		t.Errorf("approval-misconfig message should mention project name, got: %s", found.Message)
+	}
+}
+
+func TestCheckConfig_ApprovalMisconfig_Project_NotReported_WhenPreMergeEnabled(t *testing.T) {
+	cfg := projectApprovalOverlayConfig(t)
+	requireApprovalTrue := true
+	cfg.Projects[0].Approval = &autopilot.ProjectApprovalOverride{RequireApproval: &requireApprovalTrue}
+	approvalCfg := approval.DefaultConfig()
+	approvalCfg.Enabled = true
+	approvalCfg.PreMerge = &approval.StageConfig{Enabled: true}
+	cfg.Approval = approvalCfg
+
+	checks := checkConfig(cfg)
+	if found := findConfigCheck(checks, "approval-misconfig"); found != nil {
+		t.Errorf("unexpected approval-misconfig check when pre_merge is enabled: %+v", found)
+	}
+}
+
+func TestCheckConfig_ApprovalMisconfig_Project_NotReported_WhenNoOverrideOrFalse(t *testing.T) {
+	approvalCfg := approval.DefaultConfig()
+	approvalCfg.Enabled = false
+
+	requireApprovalFalse := false
+	tests := []struct {
+		name     string
+		approval *autopilot.ProjectApprovalOverride
+	}{
+		{"nil overlay", nil},
+		{"overlay with require_approval=false", &autopilot.ProjectApprovalOverride{RequireApproval: &requireApprovalFalse}},
+		{"overlay with only approval_source set", &autopilot.ProjectApprovalOverride{ApprovalSource: autopilot.ApprovalSourceTelegram}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := projectApprovalOverlayConfig(t)
+			cfg.Projects[0].Approval = tt.approval
+			cfg.Approval = approvalCfg
+
+			checks := checkConfig(cfg)
+			if found := findConfigCheck(checks, "approval-misconfig"); found != nil {
+				t.Errorf("unexpected approval-misconfig check: %+v", found)
+			}
+		})
+	}
+}
+
+func TestCheckConfig_ApprovalSourceUnregistered_Default_Detected(t *testing.T) {
+	// Default approval_source is telegram (autopilot.DefaultConfig), but no
+	// adapter is configured to register a "telegram" handler at boot.
+	cfg := projectApprovalOverlayConfig(t)
+
+	checks := checkConfig(cfg)
+	found := findConfigCheck(checks, "approval-source-unregistered")
+	if found == nil {
+		t.Fatal("expected 'approval-source-unregistered' check to appear in ConfigChecks")
+	}
+	if found.Status != StatusError {
+		t.Errorf("approval-source-unregistered status = %v, want StatusError", found.Status)
+	}
+	if !strings.Contains(found.Message, "telegram") {
+		t.Errorf("approval-source-unregistered message should mention the unregistered source, got: %s", found.Message)
+	}
+}
+
+func TestCheckConfig_ApprovalSourceUnregistered_Default_NotReported_WhenRegistered(t *testing.T) {
+	cfg := projectApprovalOverlayConfig(t)
+	cfg.Adapters.Telegram = &telegram.Config{Enabled: true, BotToken: "test-bot-token"}
+
+	checks := checkConfig(cfg)
+	if found := findConfigCheck(checks, "approval-source-unregistered"); found != nil {
+		t.Errorf("unexpected approval-source-unregistered check when telegram is registered: %+v", found)
+	}
+}
+
+func TestCheckConfig_ApprovalSourceUnregistered_Project_Detected(t *testing.T) {
+	// Project overrides approval_source: slack, but no slack adapter/approval
+	// channel is registered — this must be flagged independently of the
+	// (registered) global telegram default.
+	cfg := projectApprovalOverlayConfig(t)
+	cfg.Adapters.Telegram = &telegram.Config{Enabled: true, BotToken: "test-bot-token"}
+	cfg.Projects[0].Approval = &autopilot.ProjectApprovalOverride{ApprovalSource: autopilot.ApprovalSourceSlack}
+
+	checks := checkConfig(cfg)
+	found := findConfigCheck(checks, "approval-source-unregistered")
+	if found == nil {
+		t.Fatal("expected 'approval-source-unregistered' check to appear in ConfigChecks")
+	}
+	if !strings.Contains(found.Message, "work") || !strings.Contains(found.Message, "slack") {
+		t.Errorf("approval-source-unregistered message should mention project name and source, got: %s", found.Message)
+	}
+}
+
+func TestCheckConfig_ApprovalSourceUnregistered_Project_NotReported_WhenRegistered(t *testing.T) {
+	cfg := projectApprovalOverlayConfig(t)
+	cfg.Adapters.Telegram = &telegram.Config{Enabled: true, BotToken: "test-bot-token"}
+	cfg.Adapters.Slack = &slack.Config{
+		Enabled:  true,
+		BotToken: "test-slack-bot-token",
+		Approval: &slack.ApprovalConfig{Enabled: true},
+	}
+	cfg.Projects[0].Approval = &autopilot.ProjectApprovalOverride{ApprovalSource: autopilot.ApprovalSourceSlack}
+
+	checks := checkConfig(cfg)
+	if found := findConfigCheck(checks, "approval-source-unregistered"); found != nil {
+		t.Errorf("unexpected approval-source-unregistered check when slack is registered: %+v", found)
+	}
+}
+
+func TestCheckConfig_ApprovalSourceUnregistered_GitHubReviewAlias_Registered(t *testing.T) {
+	// "github-review" must normalize to the "github" handler name
+	// (TASK-454/GH-4772) before the registered-handlers lookup, not be
+	// treated as its own literal, unregistered channel name.
+	cfg := projectApprovalOverlayConfig(t)
+	cfg.Adapters.Telegram = &telegram.Config{Enabled: true, BotToken: "test-bot-token"}
+	cfg.Adapters.GitHub.Approval = &github.ApprovalConfig{Enabled: true}
+	cfg.Projects[0].Approval = &autopilot.ProjectApprovalOverride{ApprovalSource: autopilot.ApprovalSourceGitHubReview}
+
+	checks := checkConfig(cfg)
+	if found := findConfigCheck(checks, "approval-source-unregistered"); found != nil {
+		t.Errorf("unexpected approval-source-unregistered check for registered github-review alias: %+v", found)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // checkBrewTapHealth
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4774.

Closes #4774

## Changes

GitHub Issue GH-4774: feat(autopilot): ProjectApprovalOverride — per-project require_approval + approval_source

## Problem

`RequireApproval` and `ApprovalSource` resolve globally (per-environment) for every controller (`internal/autopilot/types.go:46-65`, read sites `controller.go:2163` and `:2787`), while controllers are already **per-repo** (`autopilotControllers` map, `cmd/pilot/main.go:1907-2065`) and each knows its repo + project path. The operator needs per-project resolution: a personal project routes approval asks to Telegram, a work project to Slack, and gating strictness set per project. This is config plumbing following an established pattern, not architecture.

## Context (verified 2026-08-06, origin/main)

- **Copy-pattern exists 3×**: `ProjectCIChecksOverride` (`internal/autopilot/types.go:281-308`), `ProjectReleaseConfig`, per-project quality. The 4-part shape: `ProjectConfig` field (`internal/config/config.go:246-284`) → override struct in `autopilot/types.go` → `WithXOverride` ControllerOption (`controller.go:347-360` idiom) → resolution in `NewController`.
- **Critical caveat**: unlike CIChecks (consumed once at construction), BOTH approval reads are per-tick — store resolved values on the controller (the `resolvedReleaseCfg` idiom, `controller.go:477-481`); do NOT rely on a construction-time shallow cfg copy, and never mutate the shared `cfg.Orchestrator.Autopilot` (hazard documented at `controller.go:699-716`).
- Resolution order: project override > env (`EffectiveApprovalSource`, `types.go:416-427`) > global. Empty/nil fields inherit (all-pointer struct, `ProjectReleaseConfig` style).
- **Escalation-gate interplay verified**: size-floor/scope-drift escalations funnel into the same `submitAsyncApprovalRequest` (`controller.go:2790`) where `PreferredChannel` is built — once that reads the resolved per-project source, gate-triggered asks route per-project with zero extra work.
- **Wire at ALL THREE construction sites**: default repo `cmd/pilot/main.go:1983-1991`, projects loop `:2013-2051`, AND the gateway-mode single-controller path `:835` (which today skips even the CIChecks overlay — fix the approval wiring only; the CIChecks asymmetry is a separately filed backlog item, do not fold it in).
- Validation slot: `internal/config/config.go:996-1010` (index-addressed, `projects[%d].approval...`). Example YAML slot: `configs/pilot.example.yaml:491-528` next to the `release:`/`quality:` overlay examples.
- Health checks (`internal/health/health.go:923-942`): extend the require_approval/pre_merge deadlock check to iterate project overrides; ADD a check that each effective `approval_source` maps to a handler the current mode registers (webhook mode registers only Slack — `internal/pilot/pilot.go:248-269` — this check turns that per-tick hard error into a boot-time diagnostic).

## Acceptance

1. `ProjectApprovalOverride { RequireApproval *bool; ApprovalSource *ApprovalSource }` (yaml `require_approval`, `approval_source`) on `ProjectConfig` as `approval`; nil/omitted fields inherit env/global.
2. `WithApprovalOverride` ControllerOption; resolved once in `NewController` into controller fields; read sites `controller.go:2163` + `:2787` switch to the resolved values.
3. Wired at all three construction sites incl. gateway mode.
4. Validation: `approval_source` ∈ registered-channel names (accept the `github-review` alias per TASK-454's normalization).
5. Health: per-project deadlock variant + effective-source-has-registered-handler check.
6. Example YAML block documenting the per-project `approval:` overlay.
7. Tests: two-project config (telegram/slack) resolves gating + channel independently · escalation-gate ask on the slack project carries `PreferredChannel: slack` · gateway-mode controller honors the override · health check fires on unregistered source · no-override config byte-identical behavior (regression guard).
8. `make build` / `make test` / `make lint` green.

## Scope fence

No per-project *destinations* (chat_id/slack channel — needs a `Destination` field on Request; backlog) · no changes to escalation gates themselves · no approval-package changes beyond what resolution requires (routing fidelity is TASK-454) · no config flip (operator step, roadmap B5) · config remains static-at-boot (restart semantics documented; `Reload()` has zero callers).

**This task must NOT be decomposed — implement as a single PR.** <!-- pilot:no-decompose -->

## Refs

- Roadmap: `.agent/system/approval-architecture-roadmap.md` (leg B3 — merges after TASK-454 on the lane)
- Research pass 2026-08-06 (per-project config dimension, 11-point hook map)
- Pitfall on flip day: `.agent/knowledge/memories/pitfalls/require-approval-flip-doesnt-release-held-prs.md`