### PR TITLE
fix(approval): propagate typed decision errors through Controller state writer

### DIFF
--- a/internal/approval/manager.go
+++ b/internal/approval/manager.go
@@ -416,10 +416,18 @@ func (m *Manager) NotifyMerged(ctx context.Context, requestID, shortSHA string) 
 // It persists the decision via the state writer (if configured) and cancels
 // any background goroutine waiting on this request. Safe to call from
 // handler callbacks (e.g. Telegram button taps).
+//
+// GH-4777: waiter cleanup (the pending-map delete + CancelFn below) must run
+// even when the writer rejects the decision (e.g. memory.ErrApprovalAlreadyDecided
+// from a lost race) — the writer error is still returned to the caller, but a
+// race LOSER must not leave its channel button armed or its background
+// goroutine alive just because the write itself failed. Previously this
+// early-returned on writer error, before cleanup ever ran (PR#4767 review).
 func (m *Manager) RecordDecision(ctx context.Context, requestID string, decision Decision, by string) error {
+	var writerErr error
 	if m.stateWriter != nil {
 		if err := m.stateWriter.SetApprovalDecision(ctx, requestID, string(decision), by); err != nil {
-			return fmt.Errorf("record decision: %w", err)
+			writerErr = fmt.Errorf("record decision: %w", err)
 		}
 	}
 
@@ -433,11 +441,19 @@ func (m *Manager) RecordDecision(ctx context.Context, requestID string, decision
 	if exists {
 		// Cancel the background goroutine waiting on the handler response.
 		pr.CancelFn()
-		m.log.Info("approval decision recorded",
-			slog.String("request_id", requestID),
-			slog.String("decision", string(decision)),
-			slog.String("by", by))
+		if writerErr != nil {
+			m.log.Info("approval decision race lost — waiter cleaned up without applying decision",
+				slog.String("request_id", requestID),
+				slog.String("decision", string(decision)),
+				slog.String("by", by),
+				slog.Any("error", writerErr))
+		} else {
+			m.log.Info("approval decision recorded",
+				slog.String("request_id", requestID),
+				slog.String("decision", string(decision)),
+				slog.String("by", by))
+		}
 	}
 
-	return nil
+	return writerErr
 }

--- a/internal/approval/manager_test.go
+++ b/internal/approval/manager_test.go
@@ -607,6 +607,64 @@ func TestManager_RecordDecision_NoWriter_NoError(t *testing.T) {
 	}
 }
 
+// TestManager_RecordDecision_CleansUpPendingOnWriterError is the GH-4777
+// regression test for the "waiter cleanup skipped on error" bug (PR#4767
+// review, item 3): RecordDecision used to early-return on a writer error
+// (e.g. memory.ErrApprovalAlreadyDecided from a lost race) before ever
+// reaching the pending-map delete + CancelFn — leaving a race loser's channel
+// button armed and its background timeout goroutine alive. Cleanup must run
+// exactly once regardless of whether the write succeeded.
+func TestManager_RecordDecision_CleansUpPendingOnWriterError(t *testing.T) {
+	config := DefaultConfig()
+	config.Enabled = true
+	config.PreExecution.Enabled = true
+	config.PreExecution.Timeout = 10 * time.Second
+
+	m := NewManager(config)
+	sentinel := errors.New("already decided sentinel")
+	writer := &mockPRStateWriter{err: sentinel}
+	m.WithStateWriter(writer)
+
+	handler := &mockHandler{name: "test"} // never responds
+	m.RegisterHandler(handler)
+
+	req := &Request{
+		ID:        "race-loser-1",
+		TaskID:    "TASK-07",
+		Stage:     StagePreExecution,
+		CreatedAt: time.Now(),
+	}
+	_, err := m.SubmitApprovalRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+
+	time.Sleep(20 * time.Millisecond) // let the background goroutine start
+
+	pending := m.GetPendingRequests()
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending before RecordDecision, got %d", len(pending))
+	}
+
+	recErr := m.RecordDecision(context.Background(), req.ID, DecisionApproved, "loser")
+	if !errors.Is(recErr, sentinel) {
+		t.Fatalf("expected wrapped sentinel error, got %v", recErr)
+	}
+
+	// Cleanup must have happened despite the writer error.
+	pending = m.GetPendingRequests()
+	if len(pending) != 0 {
+		t.Errorf("expected 0 pending after RecordDecision (cleanup must run on error too), got %d", len(pending))
+	}
+
+	// Cleanup must be idempotent — a second call for the same requestID (e.g.
+	// a retried callback) must not panic or double-cancel.
+	recErr2 := m.RecordDecision(context.Background(), req.ID, DecisionApproved, "loser-retry")
+	if !errors.Is(recErr2, sentinel) {
+		t.Fatalf("expected wrapped sentinel error on retry, got %v", recErr2)
+	}
+}
+
 func TestManager_RecordDecision_CancelsPendingRequest(t *testing.T) {
 	config := DefaultConfig()
 	config.Enabled = true

--- a/internal/approval/slack.go
+++ b/internal/approval/slack.go
@@ -2,6 +2,7 @@ package approval
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -411,16 +412,35 @@ func (h *SlackHandler) HandleInteraction(ctx context.Context, actionID, value, u
 	// nothing is left waiting on pending.ResponseCh — the common case after a
 	// daemon restart, where Rehydrate reconstructs this entry with a fresh
 	// channel but no goroutine to read it (GH-4411, mirrors GH-3825).
+	//
+	// GH-4777: a click can lose the race to a concurrent HTTP POST (or the
+	// other channel) — RecordDecision then returns memory.ErrApprovalAlreadyDecided.
+	// The clicker must see "already decided", not a success card claiming
+	// their click won when it didn't (PR#4767 review).
+	raceLost := false
 	if h.recorder != nil {
 		if err := h.recorder.RecordDecision(ctx, requestID, decision, username); err != nil {
-			h.log.Warn("failed to record approval decision", slog.String("request_id", requestID), slog.Any("error", err))
+			if errors.Is(err, memory.ErrApprovalAlreadyDecided) {
+				raceLost = true
+				h.log.Info("approval decision race lost — another decider already recorded",
+					slog.String("request_id", requestID), slog.String("user", username))
+			} else {
+				h.log.Warn("failed to record approval decision", slog.String("request_id", requestID), slog.Any("error", err))
+			}
 		}
 	}
 
 	// Update message to show result
 	if pending.TS != "" {
-		blocks := h.buildResponseBlocks(pending.Request, decision, username)
-		text := h.formatResponseText(pending.Request, decision, username)
+		var blocks []interface{}
+		var text string
+		if raceLost {
+			blocks = h.buildAlreadyDecidedBlocks(pending.Request)
+			text = h.formatAlreadyDecidedText(pending.Request)
+		} else {
+			blocks = h.buildResponseBlocks(pending.Request, decision, username)
+			text = h.formatResponseText(pending.Request, decision, username)
+		}
 		if err := h.client.UpdateInteractiveMessage(ctx, pending.Channel, pending.TS, blocks, text); err != nil {
 			h.log.Warn("Failed to update response message", slog.Any("error", err))
 		}
@@ -591,6 +611,30 @@ func (h *SlackHandler) buildCancelledBlocks(req *Request) []interface{} {
 			},
 		},
 	}
+}
+
+// buildAlreadyDecidedBlocks creates Slack blocks for a click that lost the
+// decision race (GH-4777) — another decider (a concurrent HTTP POST, or the
+// same request answered through a different channel) already recorded the
+// outcome first.
+func (h *SlackHandler) buildAlreadyDecidedBlocks(req *Request) []interface{} {
+	text := fmt.Sprintf("⚠️ *ALREADY DECIDED*\n\n*Task:* `%s`\n*Title:* %s\n\n_Someone else already recorded a decision for this request._",
+		req.TaskID, req.Title)
+
+	return []interface{}{
+		SlackSectionBlock{
+			Type: "section",
+			Text: &SlackTextObject{
+				Type: "mrkdwn",
+				Text: text,
+			},
+		},
+	}
+}
+
+// formatAlreadyDecidedText creates fallback text for the already-decided race-loss message.
+func (h *SlackHandler) formatAlreadyDecidedText(req *Request) string {
+	return fmt.Sprintf("Task %s already decided by someone else", req.TaskID)
 }
 
 // buildExpiredBlocks creates Slack blocks for an expired request.

--- a/internal/approval/slack_test.go
+++ b/internal/approval/slack_test.go
@@ -13,6 +13,18 @@ type mockSlackClient struct {
 	lastMessage *SlackInteractiveMessage
 	response    *SlackPostMessageResponse
 	updateError error
+
+	// updateCalls records every UpdateInteractiveMessage invocation so tests
+	// can assert on the text/blocks a race-loss vs. a real decision produces
+	// (GH-4777).
+	updateCalls []mockSlackUpdateCall
+}
+
+type mockSlackUpdateCall struct {
+	Channel string
+	TS      string
+	Blocks  []interface{}
+	Text    string
 }
 
 func (m *mockSlackClient) PostInteractiveMessage(ctx context.Context, msg *SlackInteractiveMessage) (*SlackPostMessageResponse, error) {
@@ -28,6 +40,7 @@ func (m *mockSlackClient) PostInteractiveMessage(ctx context.Context, msg *Slack
 }
 
 func (m *mockSlackClient) UpdateInteractiveMessage(ctx context.Context, channel, ts string, blocks []interface{}, text string) error {
+	m.updateCalls = append(m.updateCalls, mockSlackUpdateCall{Channel: channel, TS: ts, Blocks: blocks, Text: text})
 	return m.updateError
 }
 
@@ -644,6 +657,40 @@ func TestSlackHandler_PruneExpired_RemovesExpiredAndDeletesFromStore(t *testing.
 		}
 	case <-time.After(time.Second):
 		t.Error("timeout waiting for response channel to resolve")
+	}
+}
+
+// TestSlackHandler_HandleInteraction_RaceLoss_ShowsAlreadyDecided is the
+// GH-4777 regression test (PR#4767 review, item 4): a click that loses the
+// decision race — RecordDecision returns memory.ErrApprovalAlreadyDecided
+// because another decider (a concurrent HTTP POST, or the same request
+// answered via Telegram) already recorded the outcome first — must update
+// the message with an "already decided" card, never a success card claiming
+// this click's decision won.
+func TestSlackHandler_HandleInteraction_RaceLoss_ShowsAlreadyDecided(t *testing.T) {
+	client := &mockSlackClient{}
+	recorder := &mockDecisionRecorder{err: memory.ErrApprovalAlreadyDecided}
+	handler := NewSlackHandler(client, "#approvals").WithDecisionRecorder(recorder)
+
+	req := &Request{ID: "req-race-loss", TaskID: "T-Race", Stage: StagePreMerge, Title: "Test", ExpiresAt: time.Now().Add(time.Hour)}
+	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	handled := handler.HandleInteraction(context.Background(), "approve", "approve:req-race-loss", "U1", "loser", "")
+	if !handled {
+		t.Fatal("expected interaction to still be handled on a lost race")
+	}
+
+	if len(client.updateCalls) != 1 {
+		t.Fatalf("expected 1 message update, got %d", len(client.updateCalls))
+	}
+	got := client.updateCalls[0]
+	if !containsString(got.Text, "already decided") {
+		t.Errorf("update text = %q, want it to mention already decided", got.Text)
+	}
+	if containsString(got.Text, "approved") {
+		t.Errorf("update text = %q, must not claim the race-losing decision was applied", got.Text)
 	}
 }
 

--- a/internal/approval/telegram.go
+++ b/internal/approval/telegram.go
@@ -2,6 +2,7 @@ package approval
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -533,17 +534,32 @@ func (h *TelegramHandler) HandleCallback(ctx context.Context, callbackID, data, 
 	// nothing is left waiting on pending.ResponseCh — the common case after a
 	// daemon restart, where Rehydrate reconstructs this entry with a fresh
 	// channel but no goroutine to read it (GH-3825).
+	//
+	// GH-4777: a tap can lose the race to a concurrent HTTP POST (or the
+	// other channel) — RecordDecision then returns memory.ErrApprovalAlreadyDecided.
+	// The tapper must see "already decided", not a success card claiming
+	// their tap won when it didn't (PR#4767 review).
+	raceLost := false
 	if h.recorder != nil {
 		if err := h.recorder.RecordDecision(ctx, requestID, decision, username); err != nil {
-			h.log.Warn("failed to record approval decision", slog.String("request_id", requestID), slog.Any("error", err))
+			if errors.Is(err, memory.ErrApprovalAlreadyDecided) {
+				raceLost = true
+				h.log.Info("approval decision race lost — another decider already recorded",
+					slog.String("request_id", requestID), slog.String("user", username))
+			} else {
+				h.log.Warn("failed to record approval decision", slog.String("request_id", requestID), slog.Any("error", err))
+			}
 		}
 	}
 
 	// Answer callback
 	var answerText string
-	if decision == DecisionApproved {
+	switch {
+	case raceLost:
+		answerText = "Already decided"
+	case decision == DecisionApproved:
 		answerText = "Approved!"
-	} else {
+	default:
 		answerText = "Rejected"
 	}
 	if err := h.client.AnswerCallback(ctx, callbackID, answerText); err != nil {
@@ -555,12 +571,15 @@ func (h *TelegramHandler) HandleCallback(ctx context.Context, callbackID, data, 
 	// the edit fails (or there is no live message to edit), so a recorded
 	// decision is never left with zero user feedback (GH-4164).
 	text := h.formatResponseMessage(pending.Request, decision, username)
+	if raceLost {
+		text = h.formatAlreadyDecidedMessage(pending.Request)
+	}
 	h.deliverResponseCard(ctx, pending.ChatID, pending.MessageID, text)
 
 	// Track the approved decision's chat/message so a later merge (autopilot
 	// calling NotifyMerged) can post a follow-up in the same chat. Only
-	// approved decisions ever reach a merge.
-	if decision == DecisionApproved {
+	// approved decisions that actually won the race ever reach a merge.
+	if decision == DecisionApproved && !raceLost {
 		h.mu.Lock()
 		h.resolved[requestID] = &telegramResolved{
 			Request:   pending.Request,
@@ -748,6 +767,14 @@ func (h *TelegramHandler) formatRehydratedMessage(req *Request) string {
 // formatCancelledMessage formats the message when request is cancelled
 func (h *TelegramHandler) formatCancelledMessage(req *Request) string {
 	return fmt.Sprintf("⏹ CANCELLED\n\nTask: %s\n%s\n\nApproval request was cancelled.", req.TaskID, req.Title)
+}
+
+// formatAlreadyDecidedMessage formats the message shown to a tapper who lost
+// the decision race (GH-4777) — another decider (a concurrent HTTP POST, or
+// the same request answered through a different channel) already recorded
+// the outcome first, so this tap must not claim success.
+func (h *TelegramHandler) formatAlreadyDecidedMessage(req *Request) string {
+	return fmt.Sprintf("⚠️ ALREADY DECIDED\n\nTask: %s\n%s\n\nSomeone else already recorded a decision for this request.", req.TaskID, req.Title)
 }
 
 // formatExpiredMessage formats the message when a request expires unanswered.

--- a/internal/approval/telegram_test.go
+++ b/internal/approval/telegram_test.go
@@ -1560,6 +1560,58 @@ func TestTelegramHandler_HandleCallback_RecorderErrorIsNonFatal(t *testing.T) {
 	}
 }
 
+// TestTelegramHandler_HandleCallback_RaceLoss_ShowsAlreadyDecided is the
+// GH-4777 regression test (PR#4767 review, item 4): a tap that loses the
+// decision race — RecordDecision returns memory.ErrApprovalAlreadyDecided
+// because another decider (a concurrent HTTP POST, or the same request
+// answered via Slack) already recorded the outcome first — must answer
+// "already decided" and edit the message accordingly, never a success card
+// claiming this tap's decision won.
+func TestTelegramHandler_HandleCallback_RaceLoss_ShowsAlreadyDecided(t *testing.T) {
+	client := &mockTelegramClient{}
+	recorder := &mockDecisionRecorder{err: memory.ErrApprovalAlreadyDecided}
+	handler := NewTelegramHandler(client, "chat123").WithDecisionRecorder(recorder)
+
+	req := &Request{ID: "req-race-loss", TaskID: "T-Race", Stage: StagePreMerge, Title: "Test", ExpiresAt: time.Now().Add(time.Hour)}
+	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	handled := handler.HandleCallback(context.Background(), "cb-race", "approve:req-race-loss", "u1", "loser")
+	if !handled {
+		t.Fatal("expected callback to still be handled on a lost race")
+	}
+
+	cbs := client.getAnsweredCallbacks()
+	if len(cbs) != 1 {
+		t.Fatalf("expected 1 answered callback, got %d", len(cbs))
+	}
+	if cbs[0].Text != "Already decided" {
+		t.Errorf("answer text = %q, want %q", cbs[0].Text, "Already decided")
+	}
+
+	edited := client.getEditedMessages()
+	if len(edited) != 1 {
+		t.Fatalf("expected 1 edited message, got %d", len(edited))
+	}
+	if !containsString(edited[0].Text, "ALREADY DECIDED") {
+		t.Errorf("edited message = %q, want it to mention ALREADY DECIDED", edited[0].Text)
+	}
+	if containsString(edited[0].Text, "APPROVED") {
+		t.Errorf("edited message = %q, must not claim the race-losing decision was applied", edited[0].Text)
+	}
+
+	// A race loser must never register a merge-follow-up target, even though
+	// its own decision was "approved" — only the winner's decision reaches a
+	// merge.
+	handler.mu.RLock()
+	_, resolved := handler.resolved["req-race-loss"]
+	handler.mu.RUnlock()
+	if resolved {
+		t.Error("race-losing decision must not be tracked in resolved (no merge follow-up for a loser)")
+	}
+}
+
 // containsString is a helper to check if a string contains a substring
 func containsString(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||

--- a/internal/autopilot/approval_decision_race_test.go
+++ b/internal/autopilot/approval_decision_race_test.go
@@ -1,0 +1,197 @@
+package autopilot
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/approval"
+	"github.com/qf-studio/pilot/internal/memory"
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestApproval_ProductionWiring_ConcurrentDecision_ExactlyOneWinner is the
+// GH-4777 acceptance test: two decisions race for the same approval request
+// through the PRODUCTION wiring — approval.Manager.RecordDecision calling
+// Controller.SetApprovalDecision (exactly the composition cmd/pilot/main.go
+// sets up via approvalMgr.WithStateWriter(controller)) backed by a real
+// memory.Store, not a test-only mock writer.
+//
+// Before this fix, Controller.SetApprovalDecision warn-logged and swallowed
+// every store error (including memory.ErrApprovalAlreadyDecided), so this
+// exact composition made the store's atomic race guard dead code in
+// production: both racing callers always got a nil error (the gateway's
+// equivalent of a 200), and prState.ApprovalDecision was last-writer-wins.
+//
+// This test asserts:
+//  1. Exactly one call returns nil (the gateway's 200) and exactly one
+//     returns an error wrapping memory.ErrApprovalAlreadyDecided (the
+//     gateway's 409).
+//  2. prState.ApprovalDecision (the actionable field autopilot's ProcessPR
+//     loop reads) matches the WINNER's decision — it never flips to the
+//     loser's value and is never a blend of both.
+//  3. The persisted executions row agrees with prState — the two never
+//     diverge.
+func TestApproval_ProductionWiring_ConcurrentDecision_ExactlyOneWinner(t *testing.T) {
+	const reqID = "req-gh4777-race"
+	const execID = "exec-gh4777-race"
+
+	tmpDir := t.TempDir()
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID:                execID,
+		TaskID:            "GH-4777",
+		ProjectPath:       "/tmp/gh4777-race",
+		Status:            "running",
+		ApprovalRequestID: reqID,
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+	mgr := approval.NewManager(nil)
+	c := NewController(cfg, ghClient, mgr, "owner", "repo")
+	c.memoryStore = store
+
+	// GH-2685-style production wiring: the controller is the Manager's state
+	// writer, exactly as cmd/pilot/main.go wires the single-controller daemon
+	// mode (approvalMgr.WithStateWriter(gwAutopilotController)).
+	mgr.WithStateWriter(c)
+
+	c.mu.Lock()
+	c.activePRs[55] = &PRState{
+		PRNumber:          55,
+		IssueNumber:       4777,
+		ApprovalRequestID: reqID,
+	}
+	c.mu.Unlock()
+
+	deciders := []struct {
+		decision approval.Decision
+		by       string
+	}{
+		{approval.DecisionApproved, "alice"},
+		{approval.DecisionRejected, "bob"},
+	}
+
+	results := make([]error, 2)
+	var wg sync.WaitGroup
+	for i := range deciders {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx] = mgr.RecordDecision(context.Background(), reqID, deciders[idx].decision, deciders[idx].by)
+		}(i)
+	}
+	wg.Wait()
+
+	var nilCount, alreadyDecidedCount int
+	var winnerIdx = -1
+	for i, err := range results {
+		switch {
+		case err == nil:
+			nilCount++
+			winnerIdx = i
+		case errors.Is(err, memory.ErrApprovalAlreadyDecided):
+			alreadyDecidedCount++
+		default:
+			t.Fatalf("unexpected error from racing RecordDecision: %v", err)
+		}
+	}
+	if nilCount != 1 || alreadyDecidedCount != 1 {
+		t.Fatalf("got %d winners (200) and %d already-decided (409), want exactly 1 and 1", nilCount, alreadyDecidedCount)
+	}
+
+	winnerDecision := string(deciders[winnerIdx].decision)
+
+	pr, ok := c.GetPRState(55)
+	if !ok {
+		t.Fatal("PR state not found")
+	}
+	if pr.ApprovalDecision != winnerDecision {
+		t.Errorf("prState.ApprovalDecision = %q, want winner's decision %q (must never flip to the loser's value)", pr.ApprovalDecision, winnerDecision)
+	}
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.ApprovalDecision != winnerDecision {
+		t.Errorf("persisted ApprovalDecision = %q, want winner's decision %q", exec.ApprovalDecision, winnerDecision)
+	}
+	if exec.ApprovalDecision != pr.ApprovalDecision {
+		t.Errorf("persisted decision %q diverges from in-memory PRState decision %q", exec.ApprovalDecision, pr.ApprovalDecision)
+	}
+}
+
+// TestApproval_ProductionWiring_MultiController_PropagatesAlreadyDecided
+// verifies the multi-repo composition (MultiControllerStateWriter, wired by
+// cmd/pilot/main.go when len(autopilotControllers) > 0) propagates the same
+// typed error a single-controller deployment does — a controller that
+// doesn't own requestID must not mask the error returned by the controller
+// that does.
+func TestApproval_ProductionWiring_MultiController_PropagatesAlreadyDecided(t *testing.T) {
+	const reqID = "req-gh4777-multi"
+	const execID = "exec-gh4777-multi"
+
+	tmpDir := t.TempDir()
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID:                execID,
+		TaskID:            "GH-4777",
+		ProjectPath:       "/tmp/gh4777-multi",
+		Status:            "running",
+		ApprovalRequestID: reqID,
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	mgr := approval.NewManager(nil)
+
+	// otherRepo doesn't own reqID's PR — it must fall through to noopRepo's
+	// controller without masking its result.
+	otherRepo := NewController(DefaultConfig(), ghClient, mgr, "owner", "other-repo")
+	owningRepo := NewController(DefaultConfig(), ghClient, mgr, "owner", "repo")
+	owningRepo.memoryStore = store
+
+	owningRepo.mu.Lock()
+	owningRepo.activePRs[56] = &PRState{
+		PRNumber:          56,
+		IssueNumber:       4778,
+		ApprovalRequestID: reqID,
+	}
+	owningRepo.mu.Unlock()
+
+	mgr.WithStateWriter(NewMultiControllerStateWriter(otherRepo, owningRepo))
+
+	if err := mgr.RecordDecision(context.Background(), reqID, approval.DecisionApproved, "alice"); err != nil {
+		t.Fatalf("first RecordDecision: %v", err)
+	}
+
+	err = mgr.RecordDecision(context.Background(), reqID, approval.DecisionRejected, "bob")
+	if !errors.Is(err, memory.ErrApprovalAlreadyDecided) {
+		t.Fatalf("second RecordDecision: got %v, want memory.ErrApprovalAlreadyDecided", err)
+	}
+
+	pr, ok := owningRepo.GetPRState(56)
+	if !ok {
+		t.Fatal("PR state not found")
+	}
+	if pr.ApprovalDecision != "approved" {
+		t.Errorf("prState.ApprovalDecision = %q, want %q (must never flip)", pr.ApprovalDecision, "approved")
+	}
+}

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2867,6 +2867,18 @@ func (c *Controller) applyApprovalDecision(prState *PRState) error {
 // PRState whose ApprovalRequestID matches and records the decision, then persists
 // via stateStore. Called by the approval.Manager's background goroutine when a
 // handler fires (e.g. Telegram button tap).
+//
+// GH-4777 (PR#4767 review): two callers can race for the same requestID — a
+// concurrent HTTP POST and a Telegram/Slack tap, or two concurrent POSTs.
+// memoryStore.SetApprovalDecision's atomic `AND approval_decision = ''` guard
+// is the arbiter: exactly one caller's write can ever return nil. The
+// actionable layer (pr.ApprovalDecision, what autopilot's ProcessPR loop
+// reads) is applied ONLY after that arbitration succeeds, so a race loser can
+// never flip PRState after the winner already advanced the stage — and the
+// loser's typed error (memory.ErrApprovalAlreadyDecided or sql.ErrNoRows) is
+// now returned instead of swallowed, so it survives errors.Is() all the way
+// up through Manager.RecordDecision to the gateway's 409 and the channel
+// handlers' race-loss branch.
 func (c *Controller) SetApprovalDecision(ctx context.Context, requestID string, decision string, by string) error {
 	if requestID == "" {
 		return nil
@@ -2889,31 +2901,63 @@ func (c *Controller) SetApprovalDecision(ctx context.Context, requestID string, 
 			pr.mu.Unlock()
 			continue
 		}
+		if pr.ApprovalDecision != "" {
+			// In-memory fast path for a no-store controller (see below): the
+			// pr.mu hold serializes concurrent callers for this PR, so a
+			// decision already applied means an earlier caller already won.
+			pr.mu.Unlock()
+			return memory.ErrApprovalAlreadyDecided
+		}
+		prNumber := pr.PRNumber
+		issueNumber := pr.IssueNumber
+
+		if c.memoryStore == nil {
+			// No backing store to arbitrate a race (e.g. some test wiring) —
+			// the pr.mu hold across this branch is the only guard, sufficient
+			// since it's the same in-process PRState object.
+			pr.ApprovalDecision = decision
+			if c.stateStore != nil {
+				_ = c.stateStore.SavePRState(c.repoKey(), pr)
+			}
+			pr.mu.Unlock()
+			c.log.Info("approval decision applied to PR state (no memory store)",
+				"pr", prNumber, "request_id", requestID,
+				"decision", decision, "by", by)
+			return nil
+		}
+		pr.mu.Unlock()
+
+		// memoryStore persistence is keyed by requestID, not by the live PRState
+		// fields, so it is safe (and required, for the atomic guard) to run it
+		// outside prState.mu.
+		merr := c.memoryStore.SetApprovalDecision(ctx, requestID, decision, by)
+		if merr != nil {
+			taskIDStr := fmt.Sprintf("GH-%d", issueNumber)
+			switch {
+			case errors.Is(merr, memory.ErrApprovalAlreadyDecided):
+				c.log.Warn("approval decision race lost — another decider already recorded",
+					"pr", prNumber, "task_id", taskIDStr, "request_id", requestID,
+					"op", "SetApprovalDecision", "decision", decision)
+			case errors.Is(merr, sql.ErrNoRows):
+				c.log.Warn("failed to persist approval decision to executions (no matching row)",
+					"pr", prNumber, "task_id", taskIDStr, "request_id", requestID,
+					"op", "SetApprovalDecision", "decision", decision, "error", merr)
+				c.metrics.RecordApprovalPersistMiss("decision")
+			default:
+				c.log.Warn("failed to persist approval decision to executions",
+					"pr", prNumber, "task_id", taskIDStr, "request_id", requestID,
+					"op", "SetApprovalDecision", "decision", decision, "error", merr)
+			}
+			return merr
+		}
+
+		pr.mu.Lock()
 		pr.ApprovalDecision = decision
 		if c.stateStore != nil {
 			_ = c.stateStore.SavePRState(c.repoKey(), pr)
 		}
-		prNumber := pr.PRNumber
-		issueNumber := pr.IssueNumber
 		pr.mu.Unlock()
 
-		// memoryStore persistence is keyed by requestID, not by the live PRState
-		// fields, so it is safe (and preferable) to run it outside prState.mu.
-		if c.memoryStore != nil {
-			if merr := c.memoryStore.SetApprovalDecision(ctx, requestID, decision, by); merr != nil {
-				taskIDStr := fmt.Sprintf("GH-%d", issueNumber)
-				if errors.Is(merr, sql.ErrNoRows) {
-					c.log.Warn("failed to persist approval decision to executions (no matching row)",
-						"pr", prNumber, "task_id", taskIDStr, "request_id", requestID,
-						"op", "SetApprovalDecision", "decision", decision, "error", merr)
-					c.metrics.RecordApprovalPersistMiss("decision")
-				} else {
-					c.log.Warn("failed to persist approval decision to executions",
-						"pr", prNumber, "task_id", taskIDStr, "request_id", requestID,
-						"op", "SetApprovalDecision", "decision", decision, "error", merr)
-				}
-			}
-		}
 		c.log.Info("approval decision applied to PR state",
 			"pr", prNumber, "request_id", requestID,
 			"decision", decision, "by", by)
@@ -6852,6 +6896,11 @@ func NewMultiControllerStateWriter(controllers ...*Controller) *MultiControllerS
 }
 
 // SetApprovalDecision implements approval.PRStateWriter by trying each controller.
+// GH-4777: Controller.SetApprovalDecision now returns the typed store error
+// (memory.ErrApprovalAlreadyDecided, sql.ErrNoRows) instead of swallowing it,
+// so the first controller that actually owns requestID's PR — success or
+// error — stops the loop here; a controller that doesn't own it always
+// returns nil ("not found"), so trying the next one is still safe.
 func (w *MultiControllerStateWriter) SetApprovalDecision(ctx context.Context, requestID string, decision string, by string) error {
 	for _, c := range w.controllers {
 		if err := c.SetApprovalDecision(ctx, requestID, decision, by); err != nil {

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -9425,6 +9426,12 @@ func TestController_ApprovalPersistMiss_RequestID(t *testing.T) {
 
 // TestController_ApprovalPersistMiss_Decision verifies that a sql.ErrNoRows from
 // SetApprovalDecision increments the decision miss counter via Controller.SetApprovalDecision.
+//
+// GH-4777: previously Controller.SetApprovalDecision swallowed this error and
+// returned nil — dead-code-ing the gateway's unlinked-request (still-200)
+// branch in production. It must now propagate sql.ErrNoRows so it survives
+// errors.Is() up through Manager.RecordDecision to the gateway handler, which
+// is the layer that actually decides to warn-and-resolve rather than fail.
 func TestController_ApprovalPersistMiss_Decision(t *testing.T) {
 	ghClient := github.NewClient(testutil.FakeGitHubToken)
 	c := NewController(DefaultConfig(), ghClient, approval.NewManager(nil), "owner", "repo")
@@ -9439,8 +9446,9 @@ func TestController_ApprovalPersistMiss_Decision(t *testing.T) {
 	c.mu.Unlock()
 
 	ctx := context.Background()
-	if err := c.SetApprovalDecision(ctx, "req-decision-miss", "approved", "bot"); err != nil {
-		t.Fatalf("SetApprovalDecision: %v", err)
+	err := c.SetApprovalDecision(ctx, "req-decision-miss", "approved", "bot")
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("SetApprovalDecision: got %v, want sql.ErrNoRows", err)
 	}
 
 	snap := c.metrics.Snapshot()


### PR DESCRIPTION
## Summary

Fixes GH-4777, a defect found in post-merge review of #4767 (GH-4757): the atomic already-decided guard at the store layer was dead code under production wiring.

- `Controller.SetApprovalDecision` warn-logged and swallowed every store error, including `memory.ErrApprovalAlreadyDecided` and `sql.ErrNoRows`. `Manager.RecordDecision` therefore never returned typed errors in production, so the gateway's 409 and channel "already decided" branches were only reachable in tests.
- In-memory `PRState.ApprovalDecision` was applied unconditionally (last-writer-wins), so two concurrent decisions could flip approve→reject at the actionable layer even though the DB's atomic guard already picked a winner.
- `Manager.RecordDecision` early-returned on writer error before waiter cleanup (pending-map delete + `CancelFn`), leaking the race loser's channel button/goroutine.
- Telegram/Slack handlers edited the message to the loser's decision on a lost race instead of showing "already decided".

### Fix

- `Controller.SetApprovalDecision` now guards `PRState` in-memory first (first decision wins, race losers get `ErrApprovalAlreadyDecided` without touching the store), then persists via the store and propagates the store's typed error instead of swallowing it. `MultiControllerStateWriter` forwards the same error unchanged.
- `Manager.RecordDecision` always runs waiter cleanup, regardless of whether the writer accepted or rejected the decision.
- Telegram/Slack handlers detect `ErrApprovalAlreadyDecided` and render an "already decided" message instead of a success edit.
- Added production-wiring race tests (`internal/autopilot/approval_decision_race_test.go`) using a real `memory.Store` and the exact `Manager.WithStateWriter(...)` composition `cmd/pilot/main.go` uses for both single-controller and multi-repo modes: exactly one 200 + one 409, and `PRState`/`executions` never diverge or flip to the loser's value.

No API-shape or approval-policy changes; unlinked-request semantics (HTTP 200 resolve on `sql.ErrNoRows`) are unchanged — only propagation/cleanup around the existing behavior.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full suite, all green)
- [x] `go test ./internal/approval/... ./internal/autopilot/... ./internal/gateway/... ./internal/memory/... -race -count=1` (clean)
- [x] New production-wiring race test run with `-race -count=20` during development (zero race reports)
- [x] `go vet ./...` clean; `gofmt -l` shows no new formatting issues introduced by this change