### PR TITLE
GH-4779: fix(autopilot): structural infra-failure classification — stop string-matching outage prose, never close a PR on zero evidence

### DIFF
--- a/.agent/knowledge/memories/pitfalls/ci-infra-failure-misclassified-as-code.md
+++ b/.agent/knowledge/memories/pitfalls/ci-infra-failure-misclassified-as-code.md
@@ -61,6 +61,20 @@ repick counter — which hit the hard cap (5) and put GH-4526 into
    → [#4531](https://github.com/qf-studio/pilot/issues/4531) — classify from
    job logs, bounded `rerun-failed-jobs` (2 per head SHA), `failure_class`
    dimension on CI/PR-failure metrics so outages stop polluting baselines.
+5. **2026-08-06 recurrence:** TASK-418's classifier was still four hardcoded
+   log-prose substrings — a GitHub Actions outage with new wording ("Failed
+   to resolve action download info. Error: Service Unavailable") matched
+   none of them and closed a correct PR (#4770) again. GH-4779 replaced
+   prose-first classification with structural signals evaluated *before* any
+   log text is read (synthetic-step name, zero repo-defined steps executed,
+   `startup_failure`/`stale` conclusion — see `isStructuralInfra` in
+   `internal/autopilot/failure_class.go`), and closed the companion gap where
+   `classifyPRFailure(nil)` used to fall back to `FailureClassCode`: zero
+   gathered evidence now classifies `FailureClassUnknown` and routes to
+   `escalateAndHold`, never `ClosePullRequest`. New outage prose can no
+   longer cause a blind close — only a genuinely unrecognized *and*
+   structurally-ambiguous shape falls through to the (still prose-based)
+   fail-safe default of code.
 
 Related: [[claim-lost-drops-count-toward-hard-cap]] and
 [[hard-cap-rearm-in-memory-gate]] (same class: non-code failures consuming an

--- a/.agent/tasks/archive/gh-4779.md
+++ b/.agent/tasks/archive/gh-4779.md
@@ -1,0 +1,58 @@
+# GH-4779
+
+**Created:** 2026-08-07
+
+## Problem
+
+GitHub Issue GH-4779: fix(autopilot): structural infra-failure classification — stop string-matching outage prose, never close a PR on zero evidence
+
+## Problem
+
+On 2026-08-06 a GitHub Actions outage made every job fail at the synthetic `Set up job` step with *"Failed to resolve action download info. Error: Service Unavailable"* — repo code never ran. Autopilot classified this as a **code** failure and took irreversible action: closed a correct PR (#4770), spawned fix work, burned a GH-4756 retry, escalated GH-4771 to `pilot-needs-human`. The operator had to stop the daemon manually.
+
+The infra-classification machinery already exists (TASK-418, v2.246.0, built after the GH-4526 429/504 incident) — it did not fire because `classifyCheckFailure` (`internal/autopilot/failure_class.go:66-89`) matches **four hardcoded log substrings**:
+
+```go
+hasInfraSignature := (strings.Contains(logs, "Failed to download action") && strings.Contains(logs, "429")) ||
+	(strings.Contains(logs, "##[error]Failed to run:") && strings.Contains(logs, "Unexpected HTTP response: 5")) ||
+	strings.Contains(logs, "##[error]The runner has received a shutdown signal") ||
+	strings.Contains(logs, "lost communication with the server")
+```
+
+This outage's prose matches none of them ("resolve action download info" ≠ "download action"; no `429`; "Service Unavailable" has no digits for the `5xx` matcher). **Adding a fifth string is not the fix** — every future outage has new prose. The classification must rest on structural facts, and the destructive path must require positive evidence.
+
+## Context (verified 2026-08-06, origin/main)
+
+- `mapCheckStatus` (`internal/autopilot/ci_monitor.go:580-599`) recognizes only 6 conclusions (`success`/`failure`/`cancelled`/`timed_out`/`skipped`/`neutral`). **`startup_failure`, `stale`, `action_required` fall to `default: CIPending`** — a completed check with those conclusions reads as forever-pending until the CI wait timeout. They are also absent from the studio-sdk constant list (use local literals; do not block on an SDK release).
+- **Live bug that amplifies outages**: `GetFailedChecks` (`ci_monitor.go:666-683`), `GetFailedCheckLogsByCheck` (`:792-833`) and `GetFailedCheckExcerpts` (`:848-871`) all filter `run.Conclusion != ConclusionFailure` — literal `"failure"` only — while `mapCheckStatus` maps `cancelled`/`timed_out` to the same `CIFailure`. Such a PR yields **zero evidence**, and `classifyPRFailure(nil)` returns `FailureClassCode` (`failure_class.go:156-158`) → destructive path with an empty fix issue. Outages produce `cancelled`/`timed_out` in bulk.
+- **Unused structural data already fetched**: `JobStep{Name, Status, Conclusion, StartedAt, CompletedAt}` (`internal/adapters/github/jobs.go:17-25`) via `GetWorkflowJob`. Nothing inspects step *names*. GitHub's synthetic setup steps (`Set up job`, `Set up runner`, `Complete job`) bracket repo-defined steps — a job whose failing step is synthetic never ran repo code.
+- `isJobsNeverStartedInfra` (`failure_class.go:100-142`, GH-4591) already has the right *shape* (structural: `StepsKnown && StepsCount == 0`) but is scoped to billing-refusal.
+- Existing infra path when classification succeeds: `maybeRetryInfraFailure` → `rerunInfraFailures` → `RerunFailedJobs` (`controller.go:2437-2512`), budget `maxInfraRerunBudget = 2` per head SHA, persisted on `PRState`. No delay before the rerun fires.
+- Irreversible sites: `ClosePullRequest` at `controller.go:2273` (iteration limit) and `:2399` (after fix-issue creation). Non-destructive rung: `escalateAndHold` (`:4938`).
+
+## Acceptance
+
+1. **Structural signals** added to the classifier, evaluated BEFORE prose matching (prose stays as a supplementary signal, not the basis):
+   - Failing step is a GitHub synthetic step (`Set up job` / `Set up runner` / `Complete job`, case-insensitive) → `FailureClassInfra`.
+   - Job completed with zero repo-defined steps executed (extend the existing `StepsKnown`/`StepsCount` logic beyond billing).
+   - Check-run conclusion is `startup_failure` or `stale` → `FailureClassInfra` (these are never code failures).
+2. **Conclusion coverage**: `mapCheckStatus` handles `startup_failure`, `stale`, `action_required` explicitly (no silent `CIPending` fallthrough); document the mapping for each in a comment.
+3. **Evidence-filter fix**: the three evidence-gathering functions include every conclusion that `mapCheckStatus` treats as `CIFailure` (`failure`, `cancelled`, `timed_out`, plus new infra ones) so classification never runs blind. Regression test asserting parity between "what counts as CIFailure" and "what evidence gathering collects" — a table both sides read, so they cannot drift again.
+4. **THE INVARIANT — never close on zero evidence**: when the aggregate says `CIFailure` but evidence gathering returns nothing (logs unfetchable, no matching check-runs), classify `FailureClassUnknown` (new) and take the NON-destructive path: `escalateAndHold` (or the infra rerun path if budget remains) — never `ClosePullRequest`, never a fix issue. `FailureClassCode` must require positive evidence of a repo-code failure.
+5. Metrics/logging: record the classification and which signal produced it (structural-step / conclusion / prose / zero-evidence) so the next incident is diagnosable from logs alone.
+6. Tests: table-driven over captured fixtures incl. **this incident's shape** (failing step `Set up job`, "Service Unavailable" text, conclusion `failure`) → must classify infra; `cancelled`-conclusion PR → evidence non-empty; zero-evidence → `Unknown` + no close; genuine test failure → still `FailureClassCode` and destructive path intact (no regression in the common case).
+7. `make build` / `make test` / `make lint` green.
+
+## Scope fence
+
+No changes to the rerun budget or its semantics · no daemon-level breaker (that is the sibling task, TASK-458 — this task provides the classification signal it consumes) · no studio-sdk changes (use local conclusion literals) · no changes to the dedup guards in `feedback_loop.go`.
+
+**This task must NOT be decomposed — implement as a single PR.** <!-- pilot:no-decompose -->
+
+## Refs
+
+- Incident 2026-08-06 (GitHub Actions outage): PR#4770 closed wrongly, GH-4771 escalated, daemon stopped manually ~50 min in
+- Prior art: `.agent/tasks/archive/TASK-418-ci-infra-failure-classification.md` (the mechanism this task makes structural), pitfall `ci-infra-failure-misclassified-as-code.md` (signature set now stale), `.agent/tasks/archive/TASK-421-repick-counter-counts-non-failures.md` (dispatcher-level sibling classifier — same `failure_class` vocabulary, keep them consistent)
+
+## Acceptance Criteria
+

--- a/internal/autopilot/ci_failure_excerpt.go
+++ b/internal/autopilot/ci_failure_excerpt.go
@@ -71,6 +71,29 @@ func resolveFailingStep(steps []ghadapter.JobStep) (ghadapter.JobStep, bool) {
 	return ghadapter.JobStep{}, false
 }
 
+// repoStepsExecuted returns the count of non-synthetic (repo-defined) steps
+// in steps that GitHub actually recorded an outcome for (non-empty
+// Conclusion) — GH-4779 structural signal: a job that died during GitHub's
+// own setup/teardown (isSyntheticStepName) before reaching any step the
+// workflow itself defines has this at 0, even when the raw step array is
+// non-empty (synthetic entries still populate it). Kept independent from
+// resolveFailingStep above — a step-name match on the failing step is
+// stronger evidence (the failing step is known), while this count also
+// catches a hard runner death with no single step-level conclusion recorded
+// at all.
+func repoStepsExecuted(steps []ghadapter.JobStep) int {
+	n := 0
+	for _, s := range steps {
+		if isSyntheticStepName(s.Name) {
+			continue
+		}
+		if s.Conclusion != "" {
+			n++
+		}
+	}
+	return n
+}
+
 // sliceLogByStepWindow returns the lines of jobLog whose leading timestamp
 // falls within [step.StartedAt, step.CompletedAt]. This slices a job's
 // combined raw log down to one step's output without depending on GitHub

--- a/internal/autopilot/ci_monitor.go
+++ b/internal/autopilot/ci_monitor.go
@@ -576,20 +576,70 @@ func (m *CIMonitor) aggregateStatus(statuses map[string]CIStatus) CIStatus {
 	return CISuccess
 }
 
+// ciFailureConclusions is every GitHub check-run conclusion mapCheckStatus
+// treats as CIFailure (GH-4779). mapCheckStatus and the evidence-gathering
+// functions below (GetFailedChecks, GetFailedCheckLogs,
+// GetFailedCheckLogsByCheck, GetFailedCheckExcerpts) all read this single
+// table via isCIFailureConclusion instead of separately hardcoding
+// "conclusion != failure" — that drift is exactly what amplified the
+// 2026-08-06 outage: mapCheckStatus already treated cancelled/timed_out as
+// CIFailure, but every evidence-gathering function only ever matched the
+// literal "failure" string, so a bulk cancelled/timed_out outage produced an
+// aggregate CIFailure with zero gathered evidence, and classifyPRFailure
+// defaulted the resulting empty check list to a destructive classification.
+// Documented per-conclusion:
+//   - failure: the job ran and a step failed — the common case.
+//   - cancelled: the run was aborted (manually, or cascade-cancelled by a
+//     failing sibling) before completing normally.
+//   - timed_out: the job hit a configured time limit.
+//   - startup_failure: the job failed to even start (GH-4779) — GitHub-side,
+//     never a code failure.
+//   - stale: GitHub gave up tracking the check run's status (GH-4779) —
+//     GitHub-side, never a code failure.
+//   - action_required: GitHub is waiting on a human (e.g. first-time
+//     contributor workflow approval) — not a code failure, but also not
+//     something a CIPending wait will ever resolve on its own; routed into
+//     evidence gathering/classification like any other failure so it lands
+//     on the non-destructive escalate-and-hold path (FailureClassUnknown,
+//     since no job ever ran to produce evidence) rather than blocking
+//     forever.
+var ciFailureConclusions = map[string]bool{
+	github.ConclusionFailure:        true,
+	github.ConclusionCancelled:      true,
+	github.ConclusionTimedOut:       true,
+	conclusionStartupFailure:        true,
+	conclusionStale:                 true,
+	github.ConclusionActionRequired: true,
+}
+
+// isCIFailureConclusion reports whether conclusion is one mapCheckStatus
+// treats as CIFailure — the single source of truth shared with the
+// evidence-gathering functions (GH-4779; see ciFailureConclusions).
+func isCIFailureConclusion(conclusion string) bool {
+	return ciFailureConclusions[conclusion]
+}
+
 // mapCheckStatus maps GitHub check status to CIStatus.
 func (m *CIMonitor) mapCheckStatus(status, conclusion string) CIStatus {
 	switch status {
 	case github.CheckRunQueued, github.CheckRunInProgress:
 		return CIRunning
 	case github.CheckRunCompleted:
-		switch conclusion {
-		case github.ConclusionSuccess:
+		switch {
+		case conclusion == github.ConclusionSuccess:
 			return CISuccess
-		case github.ConclusionFailure, github.ConclusionCancelled, github.ConclusionTimedOut:
-			return CIFailure
-		case github.ConclusionSkipped, github.ConclusionNeutral:
+		case conclusion == github.ConclusionSkipped || conclusion == github.ConclusionNeutral:
 			// Skipped/neutral checks don't block
 			return CISuccess
+		case isCIFailureConclusion(conclusion):
+			// GH-4779: covers failure/cancelled/timed_out plus
+			// startup_failure/stale/action_required — see
+			// ciFailureConclusions for the documented reasoning behind each.
+			// None of these fall through to CIPending: a completed check
+			// with one of these conclusions will never change on its own,
+			// so waiting forever is worse than routing it into
+			// classifyPRFailure/escalateAndHold.
+			return CIFailure
 		default:
 			return CIPending
 		}
@@ -671,7 +721,7 @@ func (m *CIMonitor) GetFailedChecks(ctx context.Context, sha string) ([]string, 
 
 	var failed []string
 	for _, run := range checkRuns.CheckRuns {
-		if run.Conclusion != github.ConclusionFailure {
+		if !isCIFailureConclusion(run.Conclusion) {
 			continue
 		}
 		if !m.isScopedCheck(run.Name) {
@@ -713,7 +763,7 @@ func (m *CIMonitor) GetFailedCheckLogs(ctx context.Context, sha string, maxLen i
 
 	var combined strings.Builder
 	for _, run := range checkRuns.CheckRuns {
-		if run.Conclusion != github.ConclusionFailure {
+		if !isCIFailureConclusion(run.Conclusion) {
 			continue
 		}
 		if !m.isScopedCheck(run.Name) {
@@ -775,6 +825,27 @@ type FailedCheckLog struct {
 	// zero steps".
 	StepsKnown bool
 	StepsCount int
+	// FailingStepName is the name of the step resolveFailingStep actually
+	// resolved as the job's failing step, or "" when unresolved (GH-4779) —
+	// structural classification signal 1: a job whose failing step is one of
+	// GitHub's own synthetic setup/teardown steps (isSyntheticStepName) never
+	// reached any repo-defined code, regardless of what the log prose says.
+	// Only populated when StepsKnown.
+	FailingStepName string
+	// RepoStepsExecuted is the count of non-synthetic (repo-defined) steps
+	// GitHub recorded an outcome for (GH-4779 structural classification
+	// signal 2, see repoStepsExecuted) — 0 alongside StepsKnown means the job
+	// died during GitHub's own setup/teardown before running any of the
+	// workflow's own steps, even if StepsCount itself is non-zero (synthetic
+	// steps still populate the raw array). Only meaningful when StepsKnown.
+	RepoStepsExecuted int
+	// Conclusion is the check run's own top-level GitHub conclusion (e.g.
+	// "cancelled", "startup_failure", "stale") — GH-4779 structural
+	// classification signal 3: startup_failure/stale are never genuine code
+	// failures regardless of log content, since GitHub emits them when the
+	// job died for reasons outside the workflow's own steps. Always
+	// populated from the ListCheckRuns response — no extra API call.
+	Conclusion string
 }
 
 // GetFailedCheckLogsByCheck fetches raw job logs for each failed, in-scope
@@ -798,7 +869,7 @@ func (m *CIMonitor) GetFailedCheckLogsByCheck(ctx context.Context, sha string) [
 
 	var results []FailedCheckLog
 	for _, run := range checkRuns.CheckRuns {
-		if run.Conclusion != github.ConclusionFailure {
+		if !isCIFailureConclusion(run.Conclusion) {
 			continue
 		}
 		if !m.isScopedCheck(run.Name) {
@@ -814,7 +885,7 @@ func (m *CIMonitor) GetFailedCheckLogsByCheck(ctx context.Context, sha string) [
 			)
 		}
 
-		entry := FailedCheckLog{CheckName: run.Name, JobID: run.ID, Logs: logs}
+		entry := FailedCheckLog{CheckName: run.Name, JobID: run.ID, Logs: logs, Conclusion: run.Conclusion}
 		if run.Output != nil {
 			entry.AnnotationText = strings.TrimSpace(run.Output.Summary + "\n" + run.Output.Text)
 		}
@@ -825,6 +896,10 @@ func (m *CIMonitor) GetFailedCheckLogsByCheck(ctx context.Context, sha string) [
 			} else {
 				entry.StepsKnown = true
 				entry.StepsCount = len(job.Steps)
+				entry.RepoStepsExecuted = repoStepsExecuted(job.Steps)
+				if step, found := resolveFailingStep(job.Steps); found {
+					entry.FailingStepName = step.Name
+				}
 			}
 		}
 		results = append(results, entry)
@@ -854,7 +929,7 @@ func (m *CIMonitor) GetFailedCheckExcerpts(ctx context.Context, sha string) stri
 
 	var excerpts []FailingStepExcerpt
 	for _, run := range checkRuns.CheckRuns {
-		if run.Conclusion != github.ConclusionFailure {
+		if !isCIFailureConclusion(run.Conclusion) {
 			continue
 		}
 		if !m.isScopedCheck(run.Name) {

--- a/internal/autopilot/ci_monitor_test.go
+++ b/internal/autopilot/ci_monitor_test.go
@@ -392,6 +392,23 @@ func TestCIMonitor_GetFailedChecks(t *testing.T) {
 			wantFailed: nil,
 			wantErr:    false,
 		},
+		{
+			// GH-4779 acceptance criterion #6: a cancelled-conclusion check
+			// (mapCheckStatus's completed-cancelled case has always been
+			// CIFailure) must still be gathered as evidence here — this is
+			// the parity the evidence-filter fix guarantees, so a PR whose
+			// only failed check was cancelled (e.g. GitHub aborted a sibling
+			// job after another one in the same run failed) never falls
+			// through to the zero-evidence FailureClassUnknown path for want
+			// of a filter that simply forgot about "cancelled".
+			name: "cancelled conclusion is gathered as evidence",
+			checkRuns: []github.CheckRun{
+				{Name: "build", Conclusion: github.ConclusionSuccess},
+				{Name: "integration", Conclusion: github.ConclusionCancelled},
+			},
+			wantFailed: []string{"integration"},
+			wantErr:    false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -535,6 +552,14 @@ func TestCIMonitor_MapCheckStatus(t *testing.T) {
 		{"completed timed_out", github.CheckRunCompleted, github.ConclusionTimedOut, CIFailure},
 		{"completed skipped", github.CheckRunCompleted, github.ConclusionSkipped, CISuccess},
 		{"completed neutral", github.CheckRunCompleted, github.ConclusionNeutral, CISuccess},
+		// GH-4779: startup_failure/stale (studio-sdk doesn't vendor these
+		// yet, hence the local literals) and action_required must all be
+		// explicit CIFailure cases, not fall through to the CIPending
+		// default — a job that never started or went stale is a completed
+		// failure, not something still in flight.
+		{"completed startup_failure", github.CheckRunCompleted, conclusionStartupFailure, CIFailure},
+		{"completed stale", github.CheckRunCompleted, conclusionStale, CIFailure},
+		{"completed action_required", github.CheckRunCompleted, github.ConclusionActionRequired, CIFailure},
 		{"completed unknown", github.CheckRunCompleted, "unknown", CIPending},
 		{"unknown status", "unknown", "", CIPending},
 	}
@@ -548,6 +573,42 @@ func TestCIMonitor_MapCheckStatus(t *testing.T) {
 			got := monitor.mapCheckStatus(tt.status, tt.conclusion)
 			if got != tt.want {
 				t.Errorf("mapCheckStatus(%s, %s) = %s, want %s", tt.status, tt.conclusion, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCIMonitor_MapCheckStatus_FailureConclusionParity is GH-4779's explicit
+// anti-drift guard for acceptance criterion #3: every conclusion that
+// mapCheckStatus treats as a completed CIFailure must also be a conclusion
+// the evidence-gathering functions (GetFailedChecks, GetFailedCheckLogsByCheck,
+// GetFailedCheckExcerpts) collect via isCIFailureConclusion — both sides now
+// read the same ciFailureConclusions table, so this test would catch any
+// future edit that updates one without the other.
+func TestCIMonitor_MapCheckStatus_FailureConclusionParity(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+	monitor := NewCIMonitor(ghClient, "owner", "repo", cfg)
+
+	allConclusions := []string{
+		github.ConclusionSuccess,
+		github.ConclusionFailure,
+		github.ConclusionCancelled,
+		github.ConclusionTimedOut,
+		github.ConclusionSkipped,
+		github.ConclusionNeutral,
+		github.ConclusionActionRequired,
+		conclusionStartupFailure,
+		conclusionStale,
+	}
+
+	for _, conclusion := range allConclusions {
+		t.Run(conclusion, func(t *testing.T) {
+			mappedFailure := monitor.mapCheckStatus(github.CheckRunCompleted, conclusion) == CIFailure
+			gatheredAsEvidence := isCIFailureConclusion(conclusion)
+			if mappedFailure != gatheredAsEvidence {
+				t.Errorf("conclusion %q: mapCheckStatus treats as CIFailure=%v but isCIFailureConclusion=%v — the two must agree or evidence gathering can silently miss a check the aggregate already counted as failed",
+					conclusion, mappedFailure, gatheredAsEvidence)
 			}
 		})
 	}
@@ -1882,6 +1943,46 @@ func TestCIMonitor_GetFailedCheckLogsByCheck(t *testing.T) {
 		}
 		if results[0].CheckName != "lint" {
 			t.Errorf("CheckName = %q, want lint", results[0].CheckName)
+		}
+	})
+
+	// GH-4779 acceptance criterion #6: a cancelled-conclusion check must
+	// still produce a non-empty evidence entry (with Conclusion populated),
+	// not be silently dropped by the same stale-filter bug the structural
+	// fix targets — cancelled is one of mapCheckStatus's CIFailure
+	// conclusions.
+	t.Run("cancelled conclusion is gathered with Conclusion populated", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/repos/owner/repo/commits/abc123/check-runs":
+				resp := github.CheckRunsResponse{
+					TotalCount: 1,
+					CheckRuns: []github.CheckRun{
+						{ID: 100, Name: "integration", Status: "completed", Conclusion: "cancelled"},
+					},
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(resp)
+			case "/repos/owner/repo/actions/jobs/100/logs":
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("a sibling job in this run failed, so GitHub cancelled this one"))
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+		cfg := DefaultConfig()
+		monitor := NewCIMonitor(ghClient, "owner", "repo", cfg)
+
+		results := monitor.GetFailedCheckLogsByCheck(context.Background(), "abc123")
+
+		if len(results) != 1 {
+			t.Fatalf("len(results) = %d, want 1 (cancelled conclusion must be gathered as evidence)", len(results))
+		}
+		if results[0].Conclusion != "cancelled" {
+			t.Errorf("Conclusion = %q, want %q", results[0].Conclusion, "cancelled")
 		}
 	})
 }

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2227,11 +2227,38 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 	// exhaustion) folded into prState.Error if this falls through anyway.
 	perCheckLogs := c.ciMonitor.GetFailedCheckLogsByCheck(ctx, prState.HeadSHA)
 	failureClass := classifyPRFailure(perCheckLogs)
+	c.logCIFailureClassification(prState, perCheckLogs, failureClass)
 	if failureClass == FailureClassInfraBilling {
 		c.alertBillingRefusalOnce(perCheckLogs)
 	}
 	infraNote, retried := c.maybeRetryInfraFailure(ctx, prState, perCheckLogs, failureClass)
 	if retried {
+		return nil
+	}
+
+	// GH-4779 THE INVARIANT: a CIFailure aggregate with zero gathered
+	// evidence must never fall through to the destructive fix-issue/close
+	// path below. classifyPRFailure only returns FailureClassUnknown when
+	// perCheckLogs came back empty despite CI's own aggregate status already
+	// being CIFailure to reach handleCIFailed at all — the check-runs list
+	// API call itself failed, or no in-scope check run actually carried a
+	// CIFailure-mapped conclusion. maybeRetryInfraFailure above already gave
+	// this the same infra-rerun chance as a classified infra failure (its
+	// gate now also admits FailureClassUnknown); reaching here means that
+	// path found nothing to rerun (there is no job ID to resolve when there
+	// is no evidence), so hold for a human instead of closing a PR autopilot
+	// never actually looked at.
+	if failureClass == FailureClassUnknown {
+		failedChecks, err := c.ciMonitor.GetFailedChecks(ctx, prState.HeadSHA)
+		if err != nil {
+			c.log.Warn("failed to get failed checks for zero-evidence escalation", "pr", prState.PRNumber, "error", err)
+		}
+		comment := fmt.Sprintf("CI reported failure, but no evidence could be gathered from any check run to classify it — holding this PR for manual review instead of closing it blind.%s %s",
+			infraNote, ciFailedChecksSummary(failedChecks))
+		c.escalateAndHold(ctx, prState, "CI failure with zero gathered evidence", []string{labelNeedsHuman}, comment)
+		c.metrics.RecordPRFailed()
+		c.metrics.RecordPRFailedClass(failureClass)
+		c.recordCIFailVerdict(failureClass)
 		return nil
 	}
 
@@ -2442,8 +2469,17 @@ const maxInfraRerunBudget = 2
 // through to the fix-issue path. When retried is false, note carries an
 // optional human-readable reason (currently only set on budget exhaustion)
 // to fold into the eventual prState.Error.
+//
+// GH-4779: the gate also admits FailureClassUnknown (zero gathered
+// evidence), giving it the same infra-rerun chance an actual infra
+// classification gets, on the same budget (scope fence: no change to the
+// budget or its semantics). In practice this is a no-op for Unknown —
+// classifyPRFailure only returns it when checks is empty, so
+// rerunInfraFailures below has no job IDs to resolve and falls through with
+// retried=false — but it costs nothing to try, and it means a future signal
+// that lets Unknown carry partial evidence doesn't need this gate revisited.
 func (c *Controller) maybeRetryInfraFailure(ctx context.Context, prState *PRState, checks []FailedCheckLog, class FailureClass) (note string, retried bool) {
-	if !class.IsInfra() || c.stepLogClient == nil {
+	if (!class.IsInfra() && class != FailureClassUnknown) || c.stepLogClient == nil {
 		return "", false
 	}
 
@@ -2512,18 +2548,47 @@ func (c *Controller) rerunInfraFailures(ctx context.Context, prState *PRState, c
 }
 
 // recordCIFailVerdict records the terminal CI-run verdict metric for a
-// non-retried failure (GH-4533): "fail" preserves the pre-GH-4533 meaning
-// for genuine code failures and any other non-infra fallthrough (e.g. a
-// mixed infra+code signal across checks), while "infra_fail" is reserved for
-// the budget-exhausted infra path so dashboards can distinguish "gave up
-// retrying a flaky runner" from "an actual code failure" without CIRuns
-// ["fail"] silently absorbing both.
+// non-retried failure (GH-4533, extended GH-4779): "fail" preserves the
+// pre-GH-4533 meaning for genuine code failures and any other non-infra
+// fallthrough (e.g. a mixed infra+code signal across checks), "infra_fail" is
+// reserved for the budget-exhausted infra path so dashboards can distinguish
+// "gave up retrying a flaky runner" from "an actual code failure" without
+// CIRuns["fail"] silently absorbing both, and "unknown_evidence" is reserved
+// for the zero-evidence escalate-and-hold path so it never gets folded into
+// "fail" either — a CI failure autopilot never actually looked at is a
+// different diagnosable condition than a genuine code failure.
 func (c *Controller) recordCIFailVerdict(class FailureClass) {
-	if class.IsInfra() {
+	switch {
+	case class == FailureClassUnknown:
+		c.metrics.RecordCIRun("unknown_evidence")
+	case class.IsInfra():
 		c.metrics.RecordCIRun("infra_fail")
+	default:
+		c.metrics.RecordCIRun("fail")
+	}
+}
+
+// logCIFailureClassification logs, per gathered failed check, which
+// classification signal fired and the resulting class (GH-4779) — in
+// addition to the single aggregate verdict already folded into
+// prState.Error/metrics elsewhere, so a future incident whose log prose
+// doesn't match any known signature is still diagnosable from logs alone,
+// without re-deriving classifyCheckFailureFull's decision by hand.
+func (c *Controller) logCIFailureClassification(prState *PRState, checks []FailedCheckLog, aggregate FailureClass) {
+	if len(checks) == 0 {
+		c.log.Warn("CI failure classification: zero evidence gathered",
+			"pr", prState.PRNumber, "sha", ShortSHA(prState.HeadSHA), "class", aggregate)
 		return
 	}
-	c.metrics.RecordCIRun("fail")
+	for _, chk := range checks {
+		class, signal := classifyCheckFailureFull(chk)
+		c.log.Info("CI failure classification",
+			"pr", prState.PRNumber, "sha", ShortSHA(prState.HeadSHA),
+			"check", chk.CheckName, "conclusion", chk.Conclusion,
+			"failing_step", chk.FailingStepName, "class", class, "signal", signal,
+			"aggregate", aggregate,
+		)
+	}
 }
 
 // handleReviewRequested processes a PR that received "changes requested" review feedback.

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -2886,6 +2886,205 @@ func TestHandleCIFailed_InfraFailure_BudgetResetOnNewSHA(t *testing.T) {
 	}
 }
 
+// TestHandleCIFailed_StructuralOutageReplay_AutoRetries replays the
+// 2026-08-06 GitHub Actions outage (pilot#4779) end-to-end through
+// handleCIFailed: every job died at GitHub's own synthetic "Set up job" step
+// with log prose ("Failed to resolve action download info. Error: Service
+// Unavailable") that matches none of TASK-418's four hardcoded infra
+// signatures, and the check-run conclusion is the ordinary "failure" — not
+// one of the newer startup_failure/stale conclusions. Before GH-4779 this
+// fell through to classifyCheckFailure's prose fallback and classified code,
+// which is exactly what closed the real PR #4770. The structural signal
+// (isStructuralInfra: RepoStepsExecuted==0) must classify infra and
+// auto-retry instead.
+func TestHandleCIFailed_StructuralOutageReplay_AutoRetries(t *testing.T) {
+	rerunCalled := false
+	issueCreated := false
+	prClosed := false
+
+	const outageLog = `##[error]Failed to resolve action download info. Error: Service Unavailable`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/outagesha1/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{ID: 200, Name: "build", Status: "completed", Conclusion: "failure"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/actions/jobs/200/logs":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(outageLog))
+		case r.URL.Path == "/repos/owner/repo/actions/jobs/200":
+			w.WriteHeader(http.StatusOK)
+			// The job died during GitHub's own synthetic "Set up job" step —
+			// no repo-defined step ever ran.
+			_ = json.NewEncoder(w).Encode(ghadapter.WorkflowJob{
+				ID: 200, RunID: 600, Name: "build", Status: "completed",
+				Steps: []ghadapter.JobStep{
+					{Name: "Set up job", Status: "completed", Conclusion: "failure", Number: 1},
+				},
+			})
+		case r.URL.Path == "/repos/owner/repo/actions/runs/600/rerun-failed-jobs" && r.Method == http.MethodPost:
+			rerunCalled = true
+			w.WriteHeader(http.StatusCreated)
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			issueCreated = true
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, github.Issue{Number: 950}))
+		case r.URL.Path == "/repos/owner/repo/pulls/60" && r.Method == http.MethodPatch:
+			prClosed = true
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	stepClient := ghadapter.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithStepLogClient(stepClient))
+
+	prState := &PRState{
+		PRNumber: 60,
+		HeadSHA:  "outagesha1",
+		Stage:    StageCIFailed,
+	}
+
+	if err := c.handleCIFailed(context.Background(), prState); err != nil {
+		t.Fatalf("handleCIFailed returned unexpected error: %v", err)
+	}
+
+	if !rerunCalled {
+		t.Error("expected RerunFailedJobs to be called for the structurally-classified outage")
+	}
+	if issueCreated {
+		t.Error("no fix issue should be created for a structural-infra outage with retry budget remaining")
+	}
+	if prClosed {
+		t.Error("PR must not be closed on a structural-infra auto-retry")
+	}
+	if prState.Stage != StageWaitingCI {
+		t.Errorf("Stage = %s, want %s", prState.Stage, StageWaitingCI)
+	}
+
+	snap := c.metrics.Snapshot()
+	if got := snap.CIRuns["infra_retry"]; got != 1 {
+		t.Errorf("CIRuns[infra_retry] = %d, want 1", got)
+	}
+	if got := snap.CIRuns["fail"]; got != 0 {
+		t.Errorf("CIRuns[fail] = %d, want 0 (not a terminal fail)", got)
+	}
+}
+
+// TestHandleCIFailed_ZeroEvidence_EscalatesInsteadOfClosing covers GH-4779's
+// THE INVARIANT: CI's own aggregate reported CIFailure (that's the only way
+// handleCIFailed is reached), but evidence gathering came back with nothing
+// — the check-runs list is empty. This is precisely the gap that let the
+// pre-GH-4779 fail-unsafe default (classifyPRFailure(nil) == FailureClassCode)
+// close a PR and spawn a fix issue with nothing to point at. handleCIFailed
+// must classify FailureClassUnknown and route to escalateAndHold: never
+// ClosePullRequest, never a spawned fix issue, never a self-close marker.
+func TestHandleCIFailed_ZeroEvidence_EscalatesInsteadOfClosing(t *testing.T) {
+	issueCreated := false
+	prClosed := false
+	branchDeleted := false
+	var labelsAdded []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/zeroevidence1/check-runs":
+			// No check runs at all — the classic shape of a check-runs list
+			// call that raced GitHub's own status propagation, or otherwise
+			// returned nothing despite CI's aggregate already reporting
+			// failure.
+			resp := github.CheckRunsResponse{TotalCount: 0, CheckRuns: []github.CheckRun{}}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			issueCreated = true
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, github.Issue{Number: 951}))
+		case r.URL.Path == "/repos/owner/repo/pulls/61" && r.Method == http.MethodPatch:
+			prClosed = true
+			w.WriteHeader(http.StatusOK)
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/git/refs/heads/") && r.Method == http.MethodDelete:
+			branchDeleted = true
+			w.WriteHeader(http.StatusOK)
+		case strings.Contains(r.URL.Path, "/labels") && r.Method == http.MethodPost:
+			var body map[string][]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			labelsAdded = append(labelsAdded, body["labels"]...)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Label{})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:    61,
+		IssueNumber: 32,
+		HeadSHA:     "zeroevidence1",
+		Stage:       StageCIFailed,
+	}
+
+	if err := c.handleCIFailed(context.Background(), prState); err != nil {
+		t.Fatalf("handleCIFailed returned unexpected error: %v", err)
+	}
+
+	if issueCreated {
+		t.Error("no fix issue should be spawned when there is zero evidence to point it at")
+	}
+	if prClosed {
+		t.Error("PR must NOT be closed on zero gathered evidence — THE INVARIANT (GH-4779)")
+	}
+	if branchDeleted {
+		t.Error("branch must NOT be deleted when the PR is held via escalateAndHold")
+	}
+	if c.consumeSelfClosedMarker(61) {
+		t.Error("escalateAndHold must never stamp a self-close marker — the PR was never closed")
+	}
+	if prState.Stage != StageFailed {
+		t.Errorf("Stage = %s, want %s", prState.Stage, StageFailed)
+	}
+	if prState.Error != "CI failure with zero gathered evidence" {
+		t.Errorf("Error = %q, want %q", prState.Error, "CI failure with zero gathered evidence")
+	}
+	found := false
+	for _, l := range labelsAdded {
+		if l == labelNeedsHuman {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected pilot-needs-human label on the issue, got labels: %v", labelsAdded)
+	}
+
+	snap := c.metrics.Snapshot()
+	if got := snap.CIRuns["unknown_evidence"]; got != 1 {
+		t.Errorf("CIRuns[unknown_evidence] = %d, want 1", got)
+	}
+	if got := snap.PRFailureClasses["unknown"]; got != 1 {
+		t.Errorf("PRFailureClasses[unknown] = %d, want 1", got)
+	}
+}
+
 // TestHandleCIFailed_RealCodeFailure_StillHitsFixIssuePath is a regression
 // guard (GH-4533): a genuine code failure (real errcheck annotation in the
 // job log) must be unaffected by the new classify-first path — still
@@ -10464,6 +10663,14 @@ func TestController_handleCIFailed_BoardSync_IterationLimit(t *testing.T) {
 				case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/issues/"):
 					// Return an issue body with iteration counter at the limit.
 					_, _ = fmt.Fprintf(w, `{"number":10,"body":"<!-- autopilot-meta iteration:%d -->"}`, 3)
+				case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/check-runs"):
+					// GH-4779: a genuine code failure, so classifyPRFailure sees positive
+					// evidence (FailureClassCode) rather than short-circuiting into the
+					// zero-evidence escalateAndHold path — this test exercises the
+					// iteration-limit board sync, not the zero-evidence guard.
+					_, _ = fmt.Fprintf(w, `{"total_count":1,"check_runs":[{"id":200,"name":"test","status":"completed","conclusion":"failure"}]}`)
+				case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/actions/jobs/200/logs"):
+					_, _ = w.Write([]byte("--- FAIL: TestSomething\nassertion failed: expected true, got false"))
 				case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/pulls/"):
 					w.WriteHeader(http.StatusNoContent)
 				default:
@@ -10529,7 +10736,13 @@ func TestController_handleCIFailed_BoardSync_Regression_NormalPath(t *testing.T)
 		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/check-runs"):
 			_, _ = w.Write([]byte(`[]`))
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/check-runs"):
-			_, _ = fmt.Fprintf(w, `{"check_runs":[]}`)
+			// GH-4779: a genuine code failure, so classifyPRFailure sees positive
+			// evidence (FailureClassCode) rather than short-circuiting into the
+			// zero-evidence escalateAndHold path — this test exercises the normal
+			// CI-fail board sync, not the zero-evidence guard.
+			_, _ = fmt.Fprintf(w, `{"total_count":1,"check_runs":[{"id":300,"name":"test","status":"completed","conclusion":"failure"}]}`)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/actions/jobs/300/logs"):
+			_, _ = w.Write([]byte("--- FAIL: TestSomething\nassertion failed: expected true, got false"))
 		case r.Method == http.MethodDelete:
 			w.WriteHeader(http.StatusNoContent)
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls/"):

--- a/internal/autopilot/failure_class.go
+++ b/internal/autopilot/failure_class.go
@@ -32,6 +32,19 @@ const (
 	// can name billing specifically instead of folding it into the generic
 	// runner-infra count.
 	FailureClassInfraBilling FailureClass = "infra_billing"
+	// FailureClassUnknown is GH-4779's zero-evidence guard: classifyPRFailure
+	// returns this — never FailureClassCode — when the CI aggregate already
+	// reported CIFailure but per-check evidence gathering came back with
+	// nothing to classify (the check-runs list API call itself failed, or no
+	// in-scope check run's conclusion actually matched what the aggregate
+	// used to decide CIFailure). This used to silently default to
+	// FailureClassCode, which is how the 2026-08-06 GitHub Actions outage
+	// closed a correct PR (#4770) on logs autopilot never actually looked
+	// at. FailureClassCode must require positive evidence of a genuine
+	// repo-code failure; FailureClassUnknown is the honest "we don't know"
+	// verdict, and callers must route it to a non-destructive hold
+	// (escalateAndHold), never ClosePullRequest or a spawned fix issue.
+	FailureClassUnknown FailureClass = "unknown"
 )
 
 // IsInfra reports whether c is any infra-family classification — safe to
@@ -119,46 +132,157 @@ func isJobsNeverStartedInfra(chk FailedCheckLog) bool {
 	return chk.StepsKnown && chk.StepsCount == 0
 }
 
-// classifyCheckFailureFull is classifyCheckFailure extended with GH-4591's
-// jobs-never-started billing-refusal shape, which classifyCheckFailure alone
-// cannot see since it only has the (empty) job log to work from.
+// conclusionStartupFailure and conclusionStale are GitHub Actions check-run
+// conclusions absent from studio-sdk's Conclusion* constants (studio-sdk
+// vendors only success/failure/neutral/cancelled/timed_out/action_required/
+// skipped as of this writing — GH-4779) — declared here as local literals
+// per the task's scope fence rather than blocking on an SDK release. Both
+// are GitHub-side signals, never a genuine code failure:
+//   - startup_failure: the job failed to even start (workflow/runner
+//     provisioning problem on GitHub's side) — no repo code ever ran.
+//   - stale: GitHub gave up trying to get a final status update for the
+//     check run (e.g. a runner or webhook delivery died mid-run) and marked
+//     it stale rather than leave it pending forever.
+const (
+	conclusionStartupFailure = "startup_failure"
+	conclusionStale          = "stale"
+)
+
+// syntheticStepNames are the setup/teardown steps GitHub Actions injects
+// into every job's step list, bracketing the repo-defined steps a workflow
+// actually specifies (GH-4779). A job whose failing step is one of these
+// died during GitHub's own provisioning/teardown — it never reached any
+// step the repo defines, regardless of what the log prose says.
+var syntheticStepNames = map[string]bool{
+	"set up job":    true,
+	"set up runner": true,
+	"complete job":  true,
+}
+
+// isSyntheticStepName reports whether name is one of GitHub's synthetic
+// setup/teardown step names, case-insensitively. An empty name (failing step
+// unresolved, e.g. no StepLogClient configured) is never synthetic.
+func isSyntheticStepName(name string) bool {
+	return syntheticStepNames[strings.ToLower(strings.TrimSpace(name))]
+}
+
+// isStructuralInfra reports whether chk carries a structural fact —
+// independent of log wording — that definitively marks it as CI
+// infrastructure trouble rather than a genuine code failure (GH-4779,
+// evaluated in classifyCheckFailureFull before any prose-signature
+// matching):
+//  1. the failing step GitHub actually resolved is one of its own synthetic
+//     setup/teardown steps (FailingStepName), or
+//  2. the job's step breakdown is known and zero repo-defined
+//     (non-synthetic) steps ever executed — broader than
+//     isJobsNeverStartedInfra's raw StepsCount==0 check, which only catches
+//     a job with an empty step array altogether; this also catches a job
+//     that got as far as GitHub's synthetic "Set up job" step and then died
+//     before reaching anything the workflow itself defines, or
+//  3. the check run's own top-level conclusion is startup_failure or stale
+//     — GitHub-only outcomes that never represent a repo-code failure.
 //
-// A real compiler/lint annotation in the log is checked first and, if
-// present, wins outright — exactly like classifyCheckFailure's own
-// realAnnotationRe override — because it is definitive proof the job
-// actually started and ran far enough to hit real source code, regardless of
-// what StepsCount/AnnotationText happen to report (e.g. an incomplete jobs-
-// API response). Only once that's ruled out does the billing-refusal check
-// run: a job that never started is unambiguously not-code regardless of what
-// an empty/near-empty log happens to contain otherwise.
-func classifyCheckFailureFull(chk FailedCheckLog) FailureClass {
+// This is the fix for the 2026-08-06 GitHub Actions outage (pilot#4779):
+// TASK-418's four hardcoded log-prose signatures matched none of that
+// incident's wording ("resolve action download info" / "Service
+// Unavailable"), but the job's failing step was GitHub's own synthetic "Set
+// up job" — a structural fact no amount of new prose signatures can keep up
+// with across future incidents.
+func isStructuralInfra(chk FailedCheckLog) bool {
+	if isSyntheticStepName(chk.FailingStepName) {
+		return true
+	}
+	if chk.StepsKnown && chk.RepoStepsExecuted == 0 {
+		return true
+	}
+	if chk.Conclusion == conclusionStartupFailure || chk.Conclusion == conclusionStale {
+		return true
+	}
+	return false
+}
+
+// classificationSignal names which detection tier produced a
+// classifyCheckFailureFull verdict (GH-4779) — logged by handleCIFailed so a
+// future incident is diagnosable from logs alone without re-deriving the
+// decision by hand.
+type classificationSignal string
+
+const (
+	signalRealAnnotation classificationSignal = "real_annotation" // definitive code evidence, wins outright
+	signalBilling        classificationSignal = "billing"         // GH-4591 jobs-never-started shape
+	signalStructural     classificationSignal = "structural"      // GH-4779 synthetic step / zero repo steps / startup_failure|stale
+	signalProse          classificationSignal = "prose"           // TASK-418's legacy hardcoded log signatures
+	signalNone           classificationSignal = "none"            // no positive signal either way; fail-safe code
+)
+
+// classifyCheckFailureFull is classifyCheckFailure extended with GH-4591's
+// jobs-never-started billing-refusal shape and GH-4779's structural signals,
+// which classifyCheckFailure alone cannot see since it only has the (often
+// empty, for these shapes) job log to work from. Also returns which signal
+// tier produced the verdict, purely for diagnostic logging.
+//
+// Evaluation order:
+//  1. A real compiler/lint annotation in the log wins outright — definitive
+//     proof the job actually started and ran far enough to hit real source
+//     code, regardless of what any other signal reports (e.g. an
+//     incomplete/stale jobs-API response reading StepsCount/RepoStepsExecuted
+//     as 0). This mirrors classifyCheckFailure's own realAnnotationRe
+//     override.
+//  2. GH-4591's billing-refusal shape (isJobsNeverStartedInfra) — checked
+//     ahead of the more general structural signals below so a genuine
+//     billing refusal keeps reporting the specific FailureClassInfraBilling
+//     rather than being swallowed by the generic zero-repo-steps signal,
+//     which would also match it.
+//  3. GH-4779's structural signals (isStructuralInfra) — synthetic failing
+//     step, zero repo-defined steps executed, or a startup_failure/stale
+//     conclusion. None of these depend on log wording.
+//  4. classifyCheckFailure's legacy log-prose signature matching, as the
+//     last resort fallback.
+func classifyCheckFailureFull(chk FailedCheckLog) (FailureClass, classificationSignal) {
 	if realAnnotationRe.MatchString(chk.Logs) {
-		return classifyCheckFailure(chk.Logs)
+		return classifyCheckFailure(chk.Logs), signalRealAnnotation
 	}
 	if isJobsNeverStartedInfra(chk) {
-		return FailureClassInfraBilling
+		return FailureClassInfraBilling, signalBilling
 	}
-	return classifyCheckFailure(chk.Logs)
+	if isStructuralInfra(chk) {
+		return FailureClassInfra, signalStructural
+	}
+	class := classifyCheckFailure(chk.Logs)
+	if class == FailureClassInfra {
+		return class, signalProse
+	}
+	return class, signalNone
 }
 
 // classifyPRFailure aggregates classifyCheckFailureFull across every scoped
-// failed check on a SHA (GH-4533, extended by GH-4591): an infra-family
-// classification (FailureClassInfra or FailureClassInfraBilling) only when
-// there is at least one failed check and every single one of them
-// classifies infra-family; FailureClassCode otherwise — covering zero failed
-// checks, a pure code failure, and a mix of infra and code failures across
-// different checks. Fail-safe by construction: a mixed signal never allows
-// an auto-retry. When every check is infra-family and at least one is
-// specifically a billing refusal, the aggregate reports
-// FailureClassInfraBilling (the more actionable, specific signal) rather
-// than the generic FailureClassInfra.
+// failed check on a SHA (GH-4533, extended by GH-4591 and GH-4779): an
+// infra-family classification (FailureClassInfra or FailureClassInfraBilling)
+// only when there is at least one failed check and every single one of them
+// classifies infra-family; FailureClassCode when at least one check is a
+// genuine code failure — a mixed signal never allows an auto-retry, fail-safe
+// by construction.
+//
+// FailureClassUnknown (GH-4779) is the zero-evidence case: no failed checks
+// were gathered at all, even though the caller only reaches classifyPRFailure
+// after CI's own aggregate status already reported CIFailure. That gap means
+// evidence gathering itself came back empty — the check-runs list API call
+// failed, or no in-scope check run's conclusion matched what the aggregate
+// used to decide CIFailure — not that CI actually passed. Returning
+// FailureClassCode here (the pre-GH-4779 behavior) let a PR be closed and a
+// fix issue spawned with literally nothing to point at; FailureClassUnknown
+// forces callers onto the non-destructive escalate-and-hold path instead.
+//
+// When every check is infra-family and at least one is specifically a
+// billing refusal, the aggregate reports FailureClassInfraBilling (the more
+// actionable, specific signal) rather than the generic FailureClassInfra.
 func classifyPRFailure(checks []FailedCheckLog) FailureClass {
 	if len(checks) == 0 {
-		return FailureClassCode
+		return FailureClassUnknown
 	}
 	sawBilling := false
 	for _, chk := range checks {
-		class := classifyCheckFailureFull(chk)
+		class, _ := classifyCheckFailureFull(chk)
 		if !class.IsInfra() {
 			return FailureClassCode
 		}

--- a/internal/autopilot/failure_class_test.go
+++ b/internal/autopilot/failure_class_test.go
@@ -112,9 +112,14 @@ func TestClassifyPRFailure_TableDriven(t *testing.T) {
 		want   FailureClass
 	}{
 		{
-			name:   "no failed checks is code",
+			// GH-4779: zero gathered evidence must never fall back to
+			// FailureClassCode — that's the exact gap that let the
+			// 2026-08-06 outage close a correct PR (#4770) with nothing to
+			// point at. FailureClassUnknown routes callers to the
+			// non-destructive escalate-and-hold path instead.
+			name:   "no failed checks is unknown (zero evidence)",
 			checks: nil,
-			want:   FailureClassCode,
+			want:   FailureClassUnknown,
 		},
 		{
 			name: "all checks infra",
@@ -292,6 +297,115 @@ func TestClassifyPRFailure_JobsNeverStarted_TableDriven(t *testing.T) {
 			}
 			if got.IsInfra() != (tt.want != FailureClassCode) {
 				t.Errorf("IsInfra() = %v inconsistent with want %q", got.IsInfra(), tt.want)
+			}
+		})
+	}
+}
+
+// TestClassifyCheckFailureFull_StructuralSignals is GH-4779's core regression
+// suite: structural, non-prose signals must classify infra even when the log
+// text matches none of TASK-418's four hardcoded signatures — the exact gap
+// that let the 2026-08-06 GitHub Actions outage misclassify PR #4770 as a
+// code failure.
+func TestClassifyCheckFailureFull_StructuralSignals(t *testing.T) {
+	tests := []struct {
+		name       string
+		chk        FailedCheckLog
+		wantClass  FailureClass
+		wantSignal classificationSignal
+	}{
+		{
+			// The 2026-08-06 incident's exact shape: the failing step is
+			// GitHub's own synthetic "Set up job", the log prose is
+			// "Failed to resolve action download info. Error: Service
+			// Unavailable" (none of TASK-418's four signatures), and the
+			// conclusion is the ordinary "failure" — not one of the newer
+			// startup_failure/stale conclusions. Structural step-name
+			// evidence alone must be enough.
+			name: "2026-08-06 outage replay: synthetic Set up job step, unrecognized prose, conclusion failure",
+			chk: FailedCheckLog{
+				CheckName:       "build",
+				JobID:           1,
+				Conclusion:      "failure",
+				FailingStepName: "Set up job",
+				// StepsCount=1 (only the synthetic "Set up job" step ever
+				// ran) deliberately keeps this fixture out of
+				// isJobsNeverStartedInfra's StepsCount==0 billing-refusal
+				// check — that shape is for jobs with an empty step array
+				// altogether. This incident's job got as far as GitHub's own
+				// synthetic step and died there, which is exactly the
+				// broader isStructuralInfra RepoStepsExecuted==0 signal.
+				StepsKnown:        true,
+				StepsCount:        1,
+				RepoStepsExecuted: 0,
+				Logs:              "##[error]Failed to resolve action download info. Error: Service Unavailable",
+			},
+			wantClass:  FailureClassInfra,
+			wantSignal: signalStructural,
+		},
+		{
+			name: "zero repo-defined steps executed, failing step unresolved",
+			chk: FailedCheckLog{
+				CheckName:         "test",
+				JobID:             2,
+				Conclusion:        "failure",
+				StepsKnown:        true,
+				StepsCount:        2, // both synthetic ("Set up job", "Complete job"); no repo step ran
+				RepoStepsExecuted: 0,
+				Logs:              "some unrecognized runner-provisioning error",
+			},
+			wantClass:  FailureClassInfra,
+			wantSignal: signalStructural,
+		},
+		{
+			name: "conclusion startup_failure with no useful logs",
+			chk: FailedCheckLog{
+				CheckName:  "lint",
+				JobID:      3,
+				Conclusion: conclusionStartupFailure,
+			},
+			wantClass:  FailureClassInfra,
+			wantSignal: signalStructural,
+		},
+		{
+			name: "conclusion stale with no useful logs",
+			chk: FailedCheckLog{
+				CheckName:  "e2e",
+				JobID:      4,
+				Conclusion: conclusionStale,
+			},
+			wantClass:  FailureClassInfra,
+			wantSignal: signalStructural,
+		},
+		{
+			// A repo-defined step actually ran and executed steps are
+			// non-zero, so a structural signal must not fire even though
+			// the conclusion is "failure" and the log is unrecognized —
+			// falls through to the fail-safe prose default of code.
+			name: "repo steps executed, unrecognized log, conclusion failure classifies code",
+			chk: FailedCheckLog{
+				CheckName:         "test",
+				JobID:             5,
+				Conclusion:        "failure",
+				FailingStepName:   "go test ./...",
+				StepsKnown:        true,
+				StepsCount:        4,
+				RepoStepsExecuted: 3,
+				Logs:              "--- FAIL: TestSomething\nassertion failed",
+			},
+			wantClass:  FailureClassCode,
+			wantSignal: signalNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotClass, gotSignal := classifyCheckFailureFull(tt.chk)
+			if gotClass != tt.wantClass {
+				t.Errorf("classifyCheckFailureFull() class = %q, want %q", gotClass, tt.wantClass)
+			}
+			if gotSignal != tt.wantSignal {
+				t.Errorf("classifyCheckFailureFull() signal = %q, want %q", gotSignal, tt.wantSignal)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4779.

Closes #4779

## Changes

GitHub Issue GH-4779: fix(autopilot): structural infra-failure classification — stop string-matching outage prose, never close a PR on zero evidence

## Problem

On 2026-08-06 a GitHub Actions outage made every job fail at the synthetic `Set up job` step with *"Failed to resolve action download info. Error: Service Unavailable"* — repo code never ran. Autopilot classified this as a **code** failure and took irreversible action: closed a correct PR (#4770), spawned fix work, burned a GH-4756 retry, escalated GH-4771 to `pilot-needs-human`. The operator had to stop the daemon manually.

The infra-classification machinery already exists (TASK-418, v2.246.0, built after the GH-4526 429/504 incident) — it did not fire because `classifyCheckFailure` (`internal/autopilot/failure_class.go:66-89`) matches **four hardcoded log substrings**:

```go
hasInfraSignature := (strings.Contains(logs, "Failed to download action") && strings.Contains(logs, "429")) ||
	(strings.Contains(logs, "##[error]Failed to run:") && strings.Contains(logs, "Unexpected HTTP response: 5")) ||
	strings.Contains(logs, "##[error]The runner has received a shutdown signal") ||
	strings.Contains(logs, "lost communication with the server")
```

This outage's prose matches none of them ("resolve action download info" ≠ "download action"; no `429`; "Service Unavailable" has no digits for the `5xx` matcher). **Adding a fifth string is not the fix** — every future outage has new prose. The classification must rest on structural facts, and the destructive path must require positive evidence.

## Context (verified 2026-08-06, origin/main)

- `mapCheckStatus` (`internal/autopilot/ci_monitor.go:580-599`) recognizes only 6 conclusions (`success`/`failure`/`cancelled`/`timed_out`/`skipped`/`neutral`). **`startup_failure`, `stale`, `action_required` fall to `default: CIPending`** — a completed check with those conclusions reads as forever-pending until the CI wait timeout. They are also absent from the studio-sdk constant list (use local literals; do not block on an SDK release).
- **Live bug that amplifies outages**: `GetFailedChecks` (`ci_monitor.go:666-683`), `GetFailedCheckLogsByCheck` (`:792-833`) and `GetFailedCheckExcerpts` (`:848-871`) all filter `run.Conclusion != ConclusionFailure` — literal `"failure"` only — while `mapCheckStatus` maps `cancelled`/`timed_out` to the same `CIFailure`. Such a PR yields **zero evidence**, and `classifyPRFailure(nil)` returns `FailureClassCode` (`failure_class.go:156-158`) → destructive path with an empty fix issue. Outages produce `cancelled`/`timed_out` in bulk.
- **Unused structural data already fetched**: `JobStep{Name, Status, Conclusion, StartedAt, CompletedAt}` (`internal/adapters/github/jobs.go:17-25`) via `GetWorkflowJob`. Nothing inspects step *names*. GitHub's synthetic setup steps (`Set up job`, `Set up runner`, `Complete job`) bracket repo-defined steps — a job whose failing step is synthetic never ran repo code.
- `isJobsNeverStartedInfra` (`failure_class.go:100-142`, GH-4591) already has the right *shape* (structural: `StepsKnown && StepsCount == 0`) but is scoped to billing-refusal.
- Existing infra path when classification succeeds: `maybeRetryInfraFailure` → `rerunInfraFailures` → `RerunFailedJobs` (`controller.go:2437-2512`), budget `maxInfraRerunBudget = 2` per head SHA, persisted on `PRState`. No delay before the rerun fires.
- Irreversible sites: `ClosePullRequest` at `controller.go:2273` (iteration limit) and `:2399` (after fix-issue creation). Non-destructive rung: `escalateAndHold` (`:4938`).

## Acceptance

1. **Structural signals** added to the classifier, evaluated BEFORE prose matching (prose stays as a supplementary signal, not the basis):
   - Failing step is a GitHub synthetic step (`Set up job` / `Set up runner` / `Complete job`, case-insensitive) → `FailureClassInfra`.
   - Job completed with zero repo-defined steps executed (extend the existing `StepsKnown`/`StepsCount` logic beyond billing).
   - Check-run conclusion is `startup_failure` or `stale` → `FailureClassInfra` (these are never code failures).
2. **Conclusion coverage**: `mapCheckStatus` handles `startup_failure`, `stale`, `action_required` explicitly (no silent `CIPending` fallthrough); document the mapping for each in a comment.
3. **Evidence-filter fix**: the three evidence-gathering functions include every conclusion that `mapCheckStatus` treats as `CIFailure` (`failure`, `cancelled`, `timed_out`, plus new infra ones) so classification never runs blind. Regression test asserting parity between "what counts as CIFailure" and "what evidence gathering collects" — a table both sides read, so they cannot drift again.
4. **THE INVARIANT — never close on zero evidence**: when the aggregate says `CIFailure` but evidence gathering returns nothing (logs unfetchable, no matching check-runs), classify `FailureClassUnknown` (new) and take the NON-destructive path: `escalateAndHold` (or the infra rerun path if budget remains) — never `ClosePullRequest`, never a fix issue. `FailureClassCode` must require positive evidence of a repo-code failure.
5. Metrics/logging: record the classification and which signal produced it (structural-step / conclusion / prose / zero-evidence) so the next incident is diagnosable from logs alone.
6. Tests: table-driven over captured fixtures incl. **this incident's shape** (failing step `Set up job`, "Service Unavailable" text, conclusion `failure`) → must classify infra; `cancelled`-conclusion PR → evidence non-empty; zero-evidence → `Unknown` + no close; genuine test failure → still `FailureClassCode` and destructive path intact (no regression in the common case).
7. `make build` / `make test` / `make lint` green.

## Scope fence

No changes to the rerun budget or its semantics · no daemon-level breaker (that is the sibling task, TASK-458 — this task provides the classification signal it consumes) · no studio-sdk changes (use local conclusion literals) · no changes to the dedup guards in `feedback_loop.go`.

**This task must NOT be decomposed — implement as a single PR.** <!-- pilot:no-decompose -->

## Refs

- Incident 2026-08-06 (GitHub Actions outage): PR#4770 closed wrongly, GH-4771 escalated, daemon stopped manually ~50 min in
- Prior art: `.agent/tasks/archive/TASK-418-ci-infra-failure-classification.md` (the mechanism this task makes structural), pitfall `ci-infra-failure-misclassified-as-code.md` (signature set now stale), `.agent/tasks/archive/TASK-421-repick-counter-counts-non-failures.md` (dispatcher-level sibling classifier — same `failure_class` vocabulary, keep them consistent)