### PR TITLE
GH-4778: fix(github): remaining in-tree static-token client sites + webhook-mode startup token validation (PR#4764 review)

### DIFF
--- a/.agent/tasks/gh-4778.md
+++ b/.agent/tasks/gh-4778.md
@@ -1,0 +1,29 @@
+# GH-4778
+
+**Created:** 2026-08-07
+
+## Problem
+
+GitHub Issue GH-4778: fix(github): remaining in-tree static-token client sites + webhook-mode startup token validation (PR#4764 review)
+
+## Problem
+
+Post-merge review of PR#4764 (GH-4755) confirmed the webhook-mode fix is correct, but found residual same-class defects in tree:
+
+1. **`cmd/pilot/main.go:2863`** — static `github.NewClient(token)` in `runPollingMode` is held past construction by `NewMergeWaiter` (`:3079`, daemon-lifetime merge-wait callback) and `NewCleaner` (`:3122`, periodic stale-label loop). Violates `newGitHubClient`'s own doc contract; frozen token 401s after App-token rotation. One-line swap to `newGitHubClient(cfg)`.
+2. **Test doesn't pin the load-bearing property** — `internal/pilot/github_client_test.go:75-90` asserts `p.githubClient == client` but never asserts `githubWH`/`githubNotify` (the actual consumers, `pilot.go:378-385`) captured the injected client. If option application moves back after adapter init, the regression returns and this test stays green. Also `gotAuth` (`:64-66`) is appended in handler goroutines without sync.
+3. **Webhook/gateway mode never validates the token at startup** — `validateGitHubToken` (`:2864`) and the GH-3769 preflight (`:2845-2846`) run only in `runPollingMode`. A dead App key in webhook mode fails silently at first use instead of loudly at boot.
+
+NOT in scope here (SDK-gated, tracked separately): `poller_github.go:228,478` and `main.go:2328-2331` hold static tokens in studio-sdk clients — the SDK has no TokenFunc API yet (sdk issue filed; pilot wiring leg follows the SDK release).
+
+## Acceptance
+
+1. Merge-waiter/cleaner client swapped to `newGitHubClient(cfg)`; no in-tree `github.NewClient(` construction whose result outlives the call remains (grep-assert in a test if cheap).
+2. Rotation test asserts the consumers (`githubWH`/`githubNotify`) hold the injected client; `gotAuth` access synchronized.
+3. Webhook/gateway mode runs startup token validation with the same loud-401 behavior as polling mode.
+4. `make build/test/lint` green.
+
+**This task must NOT be decomposed — implement as a single PR.** <!-- pilot:no-decompose -->
+
+## Acceptance Criteria
+

--- a/cmd/pilot/gh4778_test.go
+++ b/cmd/pilot/gh4778_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestPollingModeMergeWaiterCleanerClient_UsesTokenFunc is a GH-4778
+// regression test: the GitHub client that runPollingMode hands to
+// NewMergeWaiter (daemon-lifetime merge-wait callback) and NewCleaner
+// (periodic stale-label loop) must come from newGitHubClient(cfg) — which
+// re-resolves the token on every request and invalidates its cache on a 401
+// — not a static github.NewClient(token) built once and held for the rest
+// of the daemon's life. A frozen token here 401s after an App-token
+// rotation (same defect class as GH-4755/PR#4764, found in post-merge
+// review as PR#4764's residual case).
+func TestPollingModeMergeWaiterCleanerClient_UsesTokenFunc(t *testing.T) {
+	content, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	src := string(content)
+
+	if !strings.Contains(src, "client := newGitHubClient(cfg)") {
+		t.Error("runPollingMode must build the merge-waiter/cleaner GitHub client via newGitHubClient(cfg), " +
+			"not a static github.NewClient(token) held past construction")
+	}
+	if strings.Contains(src, "client := github.NewClient(token)") {
+		t.Error("runPollingMode must not construct its long-lived GitHub client via github.NewClient(token) — " +
+			"that freezes the token for the daemon's lifetime; use newGitHubClient(cfg) instead")
+	}
+}
+
+// TestGatewayModeGithubToken_ValidatedAtStartup is a GH-4778 regression
+// test: webhook/gateway mode (the `pilot start --linear`/`--jira`/no-flags
+// daemon path, as opposed to runPollingMode) must validate its GitHub token
+// at startup the same way runPollingMode does via validateGitHubToken —
+// otherwise a dead App key fails silently at first webhook delivery instead
+// of loudly at boot (GH-3769 preflight parity).
+func TestGatewayModeGithubToken_ValidatedAtStartup(t *testing.T) {
+	content, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	src := string(content)
+
+	const startMarker = "// Build Pilot options for gateway mode (GH-349)"
+	const endMarker = "// GH-392: Create shared infrastructure for polling adapters in gateway mode"
+
+	start := strings.Index(src, startMarker)
+	if start < 0 {
+		t.Fatalf("marker %q not found in main.go — gateway mode setup moved, update this test's markers", startMarker)
+	}
+	rest := src[start:]
+	end := strings.Index(rest, endMarker)
+	if end < 0 {
+		t.Fatalf("marker %q not found in main.go — gateway mode setup moved, update this test's markers", endMarker)
+	}
+	gatewaySetup := rest[:end]
+
+	if !strings.Contains(gatewaySetup, "pilot.WithGitHubClient(") {
+		t.Fatal("gateway mode must build a GitHub client and inject it via pilot.WithGitHubClient — this test's markers may be stale")
+	}
+	if !strings.Contains(gatewaySetup, "validateGitHubToken(") {
+		t.Error("gateway/webhook mode must call validateGitHubToken at startup, mirroring runPollingMode's GH-3769 preflight — " +
+			"a dead App key must surface as a loud 401 log line at boot, not fail silently on the first webhook")
+	}
+}

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -607,7 +607,20 @@ Examples:
 			// newGitHubClient. Pass the same kind of client in via an option so
 			// webhook mode re-resolves (and invalidates on 401) identically.
 			if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled {
-				pilotOpts = append(pilotOpts, pilot.WithGitHubClient(newGitHubClient(cfg)))
+				gwGithubClient := newGitHubClient(cfg)
+				pilotOpts = append(pilotOpts, pilot.WithGitHubClient(gwGithubClient))
+
+				// GH-4778: runPollingMode has always validated its GitHub token at
+				// startup (validateGitHubToken, GH-3769 preflight below) so a dead
+				// App key surfaces as a loud 401 log line before the first poll.
+				// Gateway/webhook mode built its client the same way but never ran
+				// this check, so a dead key here failed silently on the first
+				// inbound webhook instead. gwAlertsEngine isn't constructed yet at
+				// this point in gateway-mode setup (it's built further down, only
+				// inside the needsPollingInfra branch), so alerting isn't wired
+				// here — the loud startup log is what this closes.
+				_, gwTokenSource := resolveGitHubToken(cfg)
+				validateGitHubToken(context.Background(), gwGithubClient, gwTokenSource, nil)
 			}
 
 			// GH-392: Create shared infrastructure for polling adapters in gateway mode
@@ -2860,7 +2873,11 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		token, tokenSource := resolveGitHubToken(cfg)
 
 		if token != "" {
-			client := github.NewClient(token)
+			// GH-4778: use newGitHubClient(cfg) instead of github.NewClient(token) —
+			// this client is held past construction by the merge-waiter (daemon-lifetime
+			// merge-wait callback) and the stale-label cleaner (periodic loop), so a
+			// static token here would freeze and 401 after App-token rotation (GH-4755).
+			client := newGitHubClient(cfg)
 			validateGitHubToken(context.Background(), client, tokenSource, alertsEngine)
 			interval := cfg.Adapters.GitHub.Polling.Interval
 			if interval == 0 {

--- a/internal/adapters/github/notifier.go
+++ b/internal/adapters/github/notifier.go
@@ -20,6 +20,14 @@ func NewNotifier(client *Client, pilotLabel string) *Notifier {
 	}
 }
 
+// Client returns the GitHub client this notifier was constructed with.
+// GH-4778: exposed so callers (and regression tests) can pin which client
+// instance a Notifier is actually holding, rather than only checking the
+// value initially passed to the constructor that built it.
+func (n *Notifier) Client() *Client {
+	return n.client
+}
+
 // NotifyTaskStarted posts a comment and adds in-progress label
 func (n *Notifier) NotifyTaskStarted(ctx context.Context, owner, repo string, issueNum int, taskID string) error {
 	// Add in-progress label

--- a/internal/adapters/github/webhook.go
+++ b/internal/adapters/github/webhook.go
@@ -60,6 +60,14 @@ func (h *WebhookHandler) OnIssue(callback func(context.Context, *Issue, *Reposit
 	h.onIssue = callback
 }
 
+// Client returns the GitHub client this handler was constructed with.
+// GH-4778: exposed so callers (and regression tests) can pin which client
+// instance a WebhookHandler is actually holding, rather than only checking
+// the value initially passed to the constructor that built it.
+func (h *WebhookHandler) Client() *Client {
+	return h.client
+}
+
 // OnPRReview sets the callback for when a PR review event is received
 func (h *WebhookHandler) OnPRReview(callback PRReviewCallback) {
 	h.onPRReview = callback

--- a/internal/pilot/github_client_test.go
+++ b/internal/pilot/github_client_test.go
@@ -64,9 +64,12 @@ func newTestPilotConfig(t *testing.T, token string) *config.Config {
 // its lifetime — so an App-auth token rotation (or a 401) after that point
 // would never be picked up.
 func TestNew_WithGitHubClient_ResolvesTokenPerRequest(t *testing.T) {
+	var mu sync.Mutex
 	var gotAuth []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		gotAuth = append(gotAuth, r.Header.Get("Authorization"))
+		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"number":1}`))
 	}))
@@ -90,6 +93,25 @@ func TestNew_WithGitHubClient_ResolvesTokenPerRequest(t *testing.T) {
 		t.Fatal("New must keep the client supplied via WithGitHubClient instead of building its own from cfg.Adapters.GitHub.Token")
 	}
 
+	// GH-4778: p.githubClient matching is necessary but not sufficient — the
+	// actual consumers that make requests are githubWH and githubNotify
+	// (wired at pilot.go:378-385). Pin that they captured the same injected
+	// client too, so a regression that moves option application back after
+	// adapter init (discarding the injected client for these two) is caught
+	// even though p.githubClient itself would still look correct.
+	if p.githubWH == nil {
+		t.Fatal("New must initialize githubWH when the GitHub adapter is enabled")
+	}
+	if p.githubWH.Client() != client {
+		t.Fatal("githubWH must hold the client supplied via WithGitHubClient, not a client built from cfg.Adapters.GitHub.Token")
+	}
+	if p.githubNotify == nil {
+		t.Fatal("New must initialize githubNotify when the GitHub adapter is enabled")
+	}
+	if p.githubNotify.Client() != client {
+		t.Fatal("githubNotify must hold the client supplied via WithGitHubClient, not a client built from cfg.Adapters.GitHub.Token")
+	}
+
 	if _, err := p.githubClient.GetIssue(context.Background(), "owner", "repo", 1); err != nil {
 		t.Fatalf("GetIssue (pre-rotation) failed: %v", err)
 	}
@@ -103,14 +125,18 @@ func TestNew_WithGitHubClient_ResolvesTokenPerRequest(t *testing.T) {
 		t.Fatalf("GetIssue (post-rotation) failed: %v", err)
 	}
 
-	if len(gotAuth) != 2 {
-		t.Fatalf("expected 2 requests, got %d", len(gotAuth))
+	mu.Lock()
+	gotAuthCopy := append([]string(nil), gotAuth...)
+	mu.Unlock()
+
+	if len(gotAuthCopy) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(gotAuthCopy))
 	}
-	if gotAuth[0] != "Bearer token-v1" {
-		t.Errorf("first request Authorization = %q, want %q", gotAuth[0], "Bearer token-v1")
+	if gotAuthCopy[0] != "Bearer token-v1" {
+		t.Errorf("first request Authorization = %q, want %q", gotAuthCopy[0], "Bearer token-v1")
 	}
-	if gotAuth[1] != "Bearer token-v2" {
-		t.Errorf("second request Authorization = %q (stale boot-time token), want %q — webhook-mode Pilot's client did not pick up the rotated token", gotAuth[1], "Bearer token-v2")
+	if gotAuthCopy[1] != "Bearer token-v2" {
+		t.Errorf("second request Authorization = %q (stale boot-time token), want %q — webhook-mode Pilot's client did not pick up the rotated token", gotAuthCopy[1], "Bearer token-v2")
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4778.

Closes #4778

## Changes

GitHub Issue GH-4778: fix(github): remaining in-tree static-token client sites + webhook-mode startup token validation (PR#4764 review)

## Problem

Post-merge review of PR#4764 (GH-4755) confirmed the webhook-mode fix is correct, but found residual same-class defects in tree:

1. **`cmd/pilot/main.go:2863`** — static `github.NewClient(token)` in `runPollingMode` is held past construction by `NewMergeWaiter` (`:3079`, daemon-lifetime merge-wait callback) and `NewCleaner` (`:3122`, periodic stale-label loop). Violates `newGitHubClient`'s own doc contract; frozen token 401s after App-token rotation. One-line swap to `newGitHubClient(cfg)`.
2. **Test doesn't pin the load-bearing property** — `internal/pilot/github_client_test.go:75-90` asserts `p.githubClient == client` but never asserts `githubWH`/`githubNotify` (the actual consumers, `pilot.go:378-385`) captured the injected client. If option application moves back after adapter init, the regression returns and this test stays green. Also `gotAuth` (`:64-66`) is appended in handler goroutines without sync.
3. **Webhook/gateway mode never validates the token at startup** — `validateGitHubToken` (`:2864`) and the GH-3769 preflight (`:2845-2846`) run only in `runPollingMode`. A dead App key in webhook mode fails silently at first use instead of loudly at boot.

NOT in scope here (SDK-gated, tracked separately): `poller_github.go:228,478` and `main.go:2328-2331` hold static tokens in studio-sdk clients — the SDK has no TokenFunc API yet (sdk issue filed; pilot wiring leg follows the SDK release).

## Acceptance

1. Merge-waiter/cleaner client swapped to `newGitHubClient(cfg)`; no in-tree `github.NewClient(` construction whose result outlives the call remains (grep-assert in a test if cheap).
2. Rotation test asserts the consumers (`githubWH`/`githubNotify`) hold the injected client; `gotAuth` access synchronized.
3. Webhook/gateway mode runs startup token validation with the same loud-401 behavior as polling mode.
4. `make build/test/lint` green.

**This task must NOT be decomposed — implement as a single PR.** <!-- pilot:no-decompose -->