### PR TITLE
fix(autopilot): dedupe CI check-runs by name to latest attempt (GH-4781)

### DIFF
--- a/.agent/tasks/gh-4781.md
+++ b/.agent/tasks/gh-4781.md
@@ -1,0 +1,41 @@
+# GH-4781
+
+**Created:** 2026-08-07
+
+## Problem
+
+GitHub Issue GH-4781: fix(autopilot): CI aggregation counts superseded check-runs — a re-run PR is closed on stale failures
+
+## Problem
+
+When a SHA has more than one workflow run, autopilot aggregates check-runs across **all** of them instead of taking the latest per check name — so superseded failures still count and the PR is closed despite CI now being green.
+
+Observed live 2026-08-07 while recovering PR#4770 (closed during the 08-06 Actions outage). Branch was restored at the original SHA `8cc1186`, which triggered a fresh workflow run; the fresh run passed. Daemon log:
+
+```
+10:44:17 msg="CI checks discovered" pr=4770 checks="[Check Secret Patterns Box Scripts (ShellCheck + tests) lint Knowledge Graph Drift Gate test Check Argument-Discarding Mocks lint Check Argument-Discarding Mocks Box Scripts (ShellCheck + tests) Knowledge Graph Drift Gate Check Secret Patterns test]"
+10:44:17 level=WARN msg="CI failed" pr=4770 sha=8cc1186
+10:44:31 msg="closed failed PR" pr=4770 fix_issue=4775
+10:45:01 msg="deleted branch on PR removal" branch=pilot/GH-4756 pr=4770
+```
+
+Every check name appears **twice** — the outage-era run (failed) and the fresh run (passing). GitHub retains check-runs from superseded runs for the same SHA; `ListCheckRuns` returns them all.
+
+Impact beyond this incident: any recovery or retry that produces a second workflow run for one SHA is doomed — the PR gets closed on the old failure regardless of the new result. This silently undermines re-run-based recovery paths generally.
+
+## Acceptance
+
+1. Check-run aggregation dedupes by check **name**, keeping only the most recent attempt (highest check-run id, or latest `started_at`/`completed_at` — pick one and document why). Applies to `aggregateStatus`/`checkRequiredChecks`/`checkAutoDiscoveredRuns`/`checkAllRuns` and to every evidence-gathering function (`GetFailedChecks`, `GetFailedCheckLogsByCheck`, `GetFailedCheckExcerpts`) so status and evidence agree.
+2. If the GitHub API exposes a cheaper correct filter (e.g. `filter=latest` on the check-runs endpoint), prefer it and note the choice in the PR description.
+3. The "CI checks discovered" log line reports the deduped set (a duplicated name in that line is the tell — it should be impossible after this).
+4. Tests: seeded check-run list with an old failed attempt + a new passing attempt for the same name → aggregate is success, evidence gathering returns nothing; reversed order (old pass, new fail) → failure with the new attempt's evidence; single-attempt behavior unchanged.
+5. `make build` / `make test` / `make lint` green.
+
+## Scope fence
+
+No changes to `required_checks` scoping or the debounce (`hasFailure && !hasPending`) · classification work belongs to #4779 · breaker work to #4780.
+
+**This task must NOT be decomposed — implement as a single PR.** <!-- pilot:no-decompose -->
+
+## Acceptance Criteria
+

--- a/internal/autopilot/ci_monitor.go
+++ b/internal/autopilot/ci_monitor.go
@@ -184,13 +184,74 @@ func (m *CIMonitor) WaitForCI(ctx context.Context, sha string) (CIStatus, error)
 	}
 }
 
+// listLatestCheckRuns fetches check-runs for sha and dedupes them down to the
+// most recent attempt per check name (GH-4781). Every status/evidence call
+// site below must go through this rather than calling
+// m.ghClient.ListCheckRuns directly — see latestCheckRunsByName for why a
+// SHA can carry more than one check-run per name and how "most recent" is
+// decided.
+func (m *CIMonitor) listLatestCheckRuns(ctx context.Context, sha string) (*github.CheckRunsResponse, error) {
+	checkRuns, err := m.ghClient.ListCheckRuns(ctx, m.owner, m.repo, sha)
+	if err != nil {
+		return nil, err
+	}
+	deduped := latestCheckRunsByName(checkRuns.CheckRuns)
+	return &github.CheckRunsResponse{TotalCount: len(deduped), CheckRuns: deduped}, nil
+}
+
+// latestCheckRunsByName dedupes runs down to one entry per check Name,
+// keeping only the most recent attempt (GH-4781).
+//
+// Why this is needed at all: GitHub retains check-runs from every check
+// suite that has ever reported for a SHA. A recovery/retry that produces a
+// second workflow run for the same SHA (e.g. restoring a branch after an
+// Actions outage, or a manual re-run) creates a NEW check suite rather than
+// replacing the old one, so ListCheckRuns returns one entry per (check
+// name, check suite) pair — the same check name appears once per attempt.
+// Observed live 2026-08-07 (GH-4781): PR#4770's outage-era run failed, a
+// recovery run at the same SHA passed, and every check name showed up
+// twice in the aggregate — the stale failure still counted and the PR was
+// closed despite the fresh run being green. The Checks API's own
+// filter=latest query parameter does not fix this: per GitHub's docs it
+// dedupes re-requested runs within a single check suite, not across
+// separate check suites for the same SHA, so it would not have prevented
+// this incident even if the vendored client passed it. Deduping here,
+// after the fetch, is correct regardless of what filter the API applies.
+//
+// Keyed on check-run ID rather than started_at/completed_at: GitHub
+// assigns check-run IDs monotonically increasing at creation time, and ID
+// is always populated (unlike StartedAt/CompletedAt, which are empty for
+// queued/in_progress runs — comparing empty timestamps would make an
+// in-flight rerun lose to a completed stale attempt it should supersede).
+func latestCheckRunsByName(runs []github.CheckRun) []github.CheckRun {
+	latest := make(map[string]github.CheckRun, len(runs))
+	order := make([]string, 0, len(runs))
+	for _, run := range runs {
+		existing, ok := latest[run.Name]
+		if !ok {
+			order = append(order, run.Name)
+			latest[run.Name] = run
+			continue
+		}
+		if run.ID > existing.ID {
+			latest[run.Name] = run
+		}
+	}
+	deduped := make([]github.CheckRun, 0, len(order))
+	for _, name := range order {
+		deduped = append(deduped, latest[name])
+	}
+	return deduped
+}
+
 // checkStatus gets current CI status for a SHA.
 // skipGrace, when true, bypasses the no-CI discovery grace period entirely
 // (see checkAutoDiscoveredRuns) for callers that already know CI resolved
 // once for this SHA earlier in the PR lifecycle.
 func (m *CIMonitor) checkStatus(ctx context.Context, sha string, skipGrace bool) (CIStatus, error) {
-	// Get check runs (GitHub Actions)
-	checkRuns, err := m.ghClient.ListCheckRuns(ctx, m.owner, m.repo, sha)
+	// Get check runs (GitHub Actions), deduped to the latest attempt per
+	// check name (GH-4781).
+	checkRuns, err := m.listLatestCheckRuns(ctx, sha)
 	if err != nil {
 		return CIPending, err
 	}
@@ -339,7 +400,7 @@ func (m *CIMonitor) ProbeRequiredCheckCoverage(ctx context.Context, sha string) 
 	if len(m.requiredChecks) == 0 {
 		return nil, nil, false, nil
 	}
-	checkRuns, err := m.ghClient.ListCheckRuns(ctx, m.owner, m.repo, sha)
+	checkRuns, err := m.listLatestCheckRuns(ctx, sha)
 	if err != nil {
 		return nil, nil, false, err
 	}
@@ -714,7 +775,7 @@ func (m *CIMonitor) GetCIStatus(ctx context.Context, sha string) (CIStatus, erro
 // Exclude-matched checks (e.g. an always-on scheduled canary) are dropped so
 // fix-issue bodies don't attribute an unrelated failure to this SHA's CI.
 func (m *CIMonitor) GetFailedChecks(ctx context.Context, sha string) ([]string, error) {
-	checkRuns, err := m.ghClient.ListCheckRuns(ctx, m.owner, m.repo, sha)
+	checkRuns, err := m.listLatestCheckRuns(ctx, sha)
 	if err != nil {
 		return nil, err
 	}
@@ -755,7 +816,7 @@ func (m *CIMonitor) isScopedCheck(name string) bool {
 // Logs are truncated to maxLen total characters to keep issues readable.
 // GH-1567: Include actual CI error output in fix issues.
 func (m *CIMonitor) GetFailedCheckLogs(ctx context.Context, sha string, maxLen int) string {
-	checkRuns, err := m.ghClient.ListCheckRuns(ctx, m.owner, m.repo, sha)
+	checkRuns, err := m.listLatestCheckRuns(ctx, sha)
 	if err != nil {
 		m.log.Warn("failed to list check runs for log fetch", "sha", ShortSHA(sha), "error", err)
 		return ""
@@ -861,7 +922,7 @@ type FailedCheckLog struct {
 // check classifies infra", and classifyCheckFailure already treats empty
 // logs as FailureClassCode (fail-safe).
 func (m *CIMonitor) GetFailedCheckLogsByCheck(ctx context.Context, sha string) []FailedCheckLog {
-	checkRuns, err := m.ghClient.ListCheckRuns(ctx, m.owner, m.repo, sha)
+	checkRuns, err := m.listLatestCheckRuns(ctx, sha)
 	if err != nil {
 		m.log.Warn("failed to list check runs for per-check log fetch", "sha", ShortSHA(sha), "error", err)
 		return nil
@@ -921,7 +982,7 @@ func (m *CIMonitor) GetFailedCheckLogsByCheck(ctx context.Context, sha string) [
 // GH-4415 continuation (4444/4446/4449/4453) bounce at preflight with
 // "provide only runner setup information".
 func (m *CIMonitor) GetFailedCheckExcerpts(ctx context.Context, sha string) string {
-	checkRuns, err := m.ghClient.ListCheckRuns(ctx, m.owner, m.repo, sha)
+	checkRuns, err := m.listLatestCheckRuns(ctx, sha)
 	if err != nil {
 		m.log.Warn("failed to list check runs for excerpt fetch", "sha", ShortSHA(sha), "error", err)
 		return ""
@@ -1008,7 +1069,7 @@ func (m *CIMonitor) buildFailingStepExcerpt(ctx context.Context, run github.Chec
 // test-evidence gate (GH-4329) needs to see the test job's own passing output
 // to tell a rigorous run from one that silently skipped everything.
 func (m *CIMonitor) GetCheckLogs(ctx context.Context, sha string, maxLen int) string {
-	checkRuns, err := m.ghClient.ListCheckRuns(ctx, m.owner, m.repo, sha)
+	checkRuns, err := m.listLatestCheckRuns(ctx, sha)
 	if err != nil {
 		m.log.Warn("failed to list check runs for log fetch", "sha", ShortSHA(sha), "error", err)
 		return ""
@@ -1053,7 +1114,7 @@ func (m *CIMonitor) GetCheckLogs(ctx context.Context, sha string, maxLen int) st
 
 // GetCheckStatus returns the current status of a specific check by name.
 func (m *CIMonitor) GetCheckStatus(ctx context.Context, sha, checkName string) (CIStatus, error) {
-	checkRuns, err := m.ghClient.ListCheckRuns(ctx, m.owner, m.repo, sha)
+	checkRuns, err := m.listLatestCheckRuns(ctx, sha)
 	if err != nil {
 		return CIPending, err
 	}

--- a/internal/autopilot/ci_monitor_test.go
+++ b/internal/autopilot/ci_monitor_test.go
@@ -2094,6 +2094,348 @@ func TestCIMonitor_GetFailedCheckLogsByCheck_JobsNeverStarted(t *testing.T) {
 	})
 }
 
+// TestLatestCheckRunsByName is the unit test for the GH-4781 dedup helper:
+// a SHA carrying more than one check-run per name (a rerun/recovery workflow
+// creates a new check suite rather than replacing the old one) must collapse
+// to exactly one entry per name — the one with the highest check-run ID,
+// regardless of the order runs appear in the API response.
+func TestLatestCheckRunsByName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []github.CheckRun
+		want []github.CheckRun
+	}{
+		{
+			name: "old failed attempt then new passing attempt for same name",
+			in: []github.CheckRun{
+				{ID: 100, Name: "test", Conclusion: github.ConclusionFailure},
+				{ID: 200, Name: "test", Conclusion: github.ConclusionSuccess},
+			},
+			want: []github.CheckRun{
+				{ID: 200, Name: "test", Conclusion: github.ConclusionSuccess},
+			},
+		},
+		{
+			name: "old passing attempt then new failing attempt for same name (reversed)",
+			in: []github.CheckRun{
+				{ID: 100, Name: "test", Conclusion: github.ConclusionSuccess},
+				{ID: 200, Name: "test", Conclusion: github.ConclusionFailure},
+			},
+			want: []github.CheckRun{
+				{ID: 200, Name: "test", Conclusion: github.ConclusionFailure},
+			},
+		},
+		{
+			name: "newest attempt appears first in the API response",
+			in: []github.CheckRun{
+				{ID: 200, Name: "test", Conclusion: github.ConclusionSuccess},
+				{ID: 100, Name: "test", Conclusion: github.ConclusionFailure},
+			},
+			want: []github.CheckRun{
+				{ID: 200, Name: "test", Conclusion: github.ConclusionSuccess},
+			},
+		},
+		{
+			name: "single attempt per name is unchanged",
+			in: []github.CheckRun{
+				{ID: 1, Name: "build", Conclusion: github.ConclusionSuccess},
+				{ID: 2, Name: "lint", Conclusion: github.ConclusionFailure},
+			},
+			want: []github.CheckRun{
+				{ID: 1, Name: "build", Conclusion: github.ConclusionSuccess},
+				{ID: 2, Name: "lint", Conclusion: github.ConclusionFailure},
+			},
+		},
+		{
+			name: "three attempts for one name keeps only the highest id",
+			in: []github.CheckRun{
+				{ID: 300, Name: "test", Conclusion: github.ConclusionFailure},
+				{ID: 100, Name: "test", Conclusion: github.ConclusionFailure},
+				{ID: 200, Name: "test", Conclusion: github.ConclusionSuccess},
+			},
+			want: []github.CheckRun{
+				{ID: 300, Name: "test", Conclusion: github.ConclusionFailure},
+			},
+		},
+		{
+			name: "empty input",
+			in:   []github.CheckRun{},
+			want: []github.CheckRun{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := latestCheckRunsByName(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("latestCheckRunsByName() = %+v, want %+v", got, tt.want)
+			}
+			for i, run := range got {
+				if run.ID != tt.want[i].ID || run.Name != tt.want[i].Name || run.Conclusion != tt.want[i].Conclusion {
+					t.Errorf("latestCheckRunsByName()[%d] = %+v, want %+v", i, run, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestCIMonitor_CheckCI_DedupesSupersededCheckRuns is the GH-4781 regression
+// test: a SHA with an old (superseded) attempt and a new attempt for the
+// same check name must aggregate on the new attempt only, across every
+// status-aggregation mode (checkRequiredChecks, checkAutoDiscoveredRuns,
+// checkAllRuns). Reproduces the PR#4770 incident — an outage-era failed run
+// plus a fresh passing run for the same SHA must resolve to CISuccess, not
+// CIFailure on the stale attempt.
+func TestCIMonitor_CheckCI_DedupesSupersededCheckRuns(t *testing.T) {
+	type mode struct {
+		name      string
+		configure func(cfg *Config)
+		checkRuns func(oldConclusion, newConclusion string) []github.CheckRun
+	}
+
+	modes := []mode{
+		{
+			name: "checkRequiredChecks (required-checks allowlist)",
+			configure: func(cfg *Config) {
+				cfg.RequiredChecks = []string{"test"}
+				cfg.CIChecks = nil
+			},
+			checkRuns: func(oldC, newC string) []github.CheckRun {
+				return []github.CheckRun{
+					{ID: 100, Name: "test", Status: github.CheckRunCompleted, Conclusion: oldC},
+					{ID: 200, Name: "test", Status: github.CheckRunCompleted, Conclusion: newC},
+				}
+			},
+		},
+		{
+			name: "checkAutoDiscoveredRuns (auto mode, no required checks)",
+			configure: func(cfg *Config) {
+				cfg.RequiredChecks = nil
+				cfg.CIChecks = &CIChecksConfig{Mode: "auto", DiscoveryGracePeriod: 50 * time.Millisecond}
+			},
+			checkRuns: func(oldC, newC string) []github.CheckRun {
+				return []github.CheckRun{
+					{ID: 100, Name: "test", Status: github.CheckRunCompleted, Conclusion: oldC},
+					{ID: 200, Name: "test", Status: github.CheckRunCompleted, Conclusion: newC},
+				}
+			},
+		},
+		{
+			name: "checkAllRuns (manual mode, no required checks)",
+			configure: func(cfg *Config) {
+				cfg.RequiredChecks = nil
+				cfg.CIChecks = &CIChecksConfig{Mode: "manual"}
+			},
+			checkRuns: func(oldC, newC string) []github.CheckRun {
+				return []github.CheckRun{
+					{ID: 100, Name: "test", Status: github.CheckRunCompleted, Conclusion: oldC},
+					{ID: 200, Name: "test", Status: github.CheckRunCompleted, Conclusion: newC},
+				}
+			},
+		},
+	}
+
+	for _, m := range modes {
+		t.Run(m.name, func(t *testing.T) {
+			t.Run("old failure, new success -> CISuccess", func(t *testing.T) {
+				runs := m.checkRuns(github.ConclusionFailure, github.ConclusionSuccess)
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					resp := github.CheckRunsResponse{TotalCount: len(runs), CheckRuns: runs}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(resp)
+				}))
+				defer server.Close()
+
+				ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+				cfg := DefaultConfig()
+				m.configure(cfg)
+				monitor := NewCIMonitor(ghClient, "owner", "repo", cfg)
+
+				status, err := monitor.CheckCI(context.Background(), "abc1234")
+				if err != nil {
+					t.Fatalf("CheckCI() error = %v", err)
+				}
+				if status != CISuccess {
+					t.Errorf("CheckCI() with old failure + new success = %s, want %s (stale failure must not count)", status, CISuccess)
+				}
+			})
+
+			t.Run("old success, new failure -> CIFailure", func(t *testing.T) {
+				runs := m.checkRuns(github.ConclusionSuccess, github.ConclusionFailure)
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					resp := github.CheckRunsResponse{TotalCount: len(runs), CheckRuns: runs}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(resp)
+				}))
+				defer server.Close()
+
+				ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+				cfg := DefaultConfig()
+				m.configure(cfg)
+				monitor := NewCIMonitor(ghClient, "owner", "repo", cfg)
+
+				status, err := monitor.CheckCI(context.Background(), "abc1234")
+				if err != nil {
+					t.Fatalf("CheckCI() error = %v", err)
+				}
+				if status != CIFailure {
+					t.Errorf("CheckCI() with old success + new failure = %s, want %s (new attempt's failure must count)", status, CIFailure)
+				}
+			})
+		})
+	}
+}
+
+// TestCIMonitor_GetFailedChecks_DedupesSupersededAttempts verifies evidence
+// gathering agrees with status aggregation (GH-4781 acceptance #1): when the
+// latest attempt for a check name passed, GetFailedChecks must not report it
+// even though an older, superseded attempt for the same name failed; when
+// the latest attempt failed, it must be reported exactly once.
+func TestCIMonitor_GetFailedChecks_DedupesSupersededAttempts(t *testing.T) {
+	t.Run("old failure superseded by new success yields no evidence", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			resp := github.CheckRunsResponse{
+				TotalCount: 2,
+				CheckRuns: []github.CheckRun{
+					{ID: 100, Name: "test", Status: github.CheckRunCompleted, Conclusion: github.ConclusionFailure},
+					{ID: 200, Name: "test", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+		monitor := NewCIMonitor(ghClient, "owner", "repo", DefaultConfig())
+
+		failed, err := monitor.GetFailedChecks(context.Background(), "abc1234")
+		if err != nil {
+			t.Fatalf("GetFailedChecks() error = %v", err)
+		}
+		if len(failed) != 0 {
+			t.Errorf("GetFailedChecks() = %v, want empty (stale failure must not be gathered as evidence)", failed)
+		}
+	})
+
+	t.Run("old success superseded by new failure yields the new attempt as evidence", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			resp := github.CheckRunsResponse{
+				TotalCount: 2,
+				CheckRuns: []github.CheckRun{
+					{ID: 100, Name: "test", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+					{ID: 200, Name: "test", Status: github.CheckRunCompleted, Conclusion: github.ConclusionFailure},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+		monitor := NewCIMonitor(ghClient, "owner", "repo", DefaultConfig())
+
+		failed, err := monitor.GetFailedChecks(context.Background(), "abc1234")
+		if err != nil {
+			t.Fatalf("GetFailedChecks() error = %v", err)
+		}
+		if len(failed) != 1 || failed[0] != "test" {
+			t.Errorf("GetFailedChecks() = %v, want [test] exactly once", failed)
+		}
+	})
+}
+
+// TestCIMonitor_GetFailedCheckLogsByCheck_DedupesSupersededAttempts verifies
+// that per-check evidence gathering (GH-4533's classifier input) fetches
+// logs from the NEW attempt's job ID, not the stale one — and never returns
+// two entries for the same check name.
+func TestCIMonitor_GetFailedCheckLogsByCheck_DedupesSupersededAttempts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/commits/abc1234/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 2,
+				CheckRuns: []github.CheckRun{
+					{ID: 100, Name: "test", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+					{ID: 200, Name: "test", Status: github.CheckRunCompleted, Conclusion: github.ConclusionFailure},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/repos/owner/repo/actions/jobs/100/logs":
+			// Stale attempt's log must never be consulted.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("stale outage-era log"))
+		case "/repos/owner/repo/actions/jobs/200/logs":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("fresh failure log"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	monitor := NewCIMonitor(ghClient, "owner", "repo", DefaultConfig())
+
+	results := monitor.GetFailedCheckLogsByCheck(context.Background(), "abc1234")
+
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1 (one entry per check name, not one per attempt)", len(results))
+	}
+	if results[0].JobID != 200 {
+		t.Errorf("results[0].JobID = %d, want 200 (the new attempt's job ID)", results[0].JobID)
+	}
+	if results[0].Logs != "fresh failure log" {
+		t.Errorf("results[0].Logs = %q, want the new attempt's log, not the stale one", results[0].Logs)
+	}
+}
+
+// TestCIMonitor_GetDiscoveredChecks_DedupesSupersededNames is the regression
+// test for the "CI checks discovered" log line (GH-4781 acceptance #3): a
+// duplicated name in that line was the tell that superseded check-runs were
+// still being aggregated. Once discovery goes through the dedup, a SHA
+// carrying two attempts of the same check name must record that name once.
+func TestCIMonitor_GetDiscoveredChecks_DedupesSupersededNames(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := github.CheckRunsResponse{
+			TotalCount: 3,
+			CheckRuns: []github.CheckRun{
+				{ID: 100, Name: "test", Status: github.CheckRunCompleted, Conclusion: github.ConclusionFailure},
+				{ID: 101, Name: "lint", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+				{ID: 200, Name: "test", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+			},
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.RequiredChecks = nil
+	cfg.CIChecks = &CIChecksConfig{Mode: "auto", DiscoveryGracePeriod: 50 * time.Millisecond}
+	monitor := NewCIMonitor(ghClient, "owner", "repo", cfg)
+
+	if _, err := monitor.CheckCI(context.Background(), "abc1234"); err != nil {
+		t.Fatalf("CheckCI() error = %v", err)
+	}
+
+	discovered := monitor.GetDiscoveredChecks("abc1234")
+	seen := make(map[string]int)
+	for _, name := range discovered {
+		seen[name]++
+	}
+	for name, count := range seen {
+		if count > 1 {
+			t.Errorf("discovered check %q reported %d times, want 1 (duplicate name is the GH-4781 tell)", name, count)
+		}
+	}
+	if len(discovered) != 2 {
+		t.Errorf("GetDiscoveredChecks() = %v, want 2 unique names (test, lint)", discovered)
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
 }


### PR DESCRIPTION
## Summary

- Fixes GH-4781: autopilot was aggregating check-runs across **all** workflow runs for a SHA instead of the latest per check name, so a stale failed attempt from a superseded run kept counting even after a fresh run passed. This closed PR#4770 on 2026-08-06 outage residue despite the recovery run being green.
- Routes every `ListCheckRuns` call site in `ci_monitor.go` through a new `listLatestCheckRuns` wrapper (backed by `latestCheckRunsByName`) that collapses to one entry per check name, keeping the highest check-run ID — IDs are monotonically increasing and always populated, unlike `started_at`/`completed_at` which are empty for queued/in_progress runs.
- Covers status aggregation (`checkStatus` → `checkRequiredChecks`/`checkAllRuns`/`checkAutoDiscoveredRuns`/`aggregateStatus`) and every evidence-gathering function (`GetFailedChecks`, `GetFailedCheckLogsByCheck`, `GetFailedCheckExcerpts`, `GetFailedCheckLogs`, `GetCheckLogs`, `GetCheckStatus`, `ProbeRequiredCheckCoverage`) so status and evidence now agree. `HasAnyCIConfigured` is intentionally left on the raw list since it only checks `TotalCount > 0`, which dedup can't change.
- Did not use the Checks API's `filter=latest` query param: per GitHub's docs it dedupes re-requested runs within a single check suite, not across separate check suites for the same SHA — a recovery/retry run creates a new check suite, so `filter=latest` would not have prevented this incident.

## Test plan

- [x] `make build`
- [x] `go test ./internal/autopilot/...` — includes new `TestCIMonitor_CheckCI_DedupesSupersededCheckRuns` (old-fail/new-pass and old-pass/new-fail across all three status paths), `TestCIMonitor_GetFailedChecks_DedupesSupersededAttempts`, `TestCIMonitor_GetFailedCheckLogsByCheck_DedupesSupersededAttempts`, `TestCIMonitor_GetDiscoveredChecks_DedupesSupersededNames`
- [x] Existing single-attempt test suite unchanged/passing