### PR TITLE
fix(poller): superseded/canceled executions no longer reported as failures (GH-4794)

### DIFF
--- a/cmd/pilot/handler_common.go
+++ b/cmd/pilot/handler_common.go
@@ -21,6 +21,7 @@ import (
 	"github.com/qf-studio/pilot/internal/dashboard"
 	"github.com/qf-studio/pilot/internal/executor"
 	"github.com/qf-studio/pilot/internal/logging"
+	"github.com/qf-studio/pilot/internal/memory"
 )
 
 // IssueInfo holds adapter-agnostic issue metadata passed to handleIssueGeneric.
@@ -45,6 +46,10 @@ type HandlerResult struct {
 	// Result carries the raw execution result for adapters that need rich metrics
 	// (e.g., GitHub uses it for the rich PR comment with token/cost/file stats).
 	Result *executor.ExecutionResult
+	// TerminalByDesign marks an execution that finished in a terminal-by-design
+	// status (superseded or canceled, see executor.IsTerminalByDesignStatus) —
+	// deliberately not carried out rather than genuinely failed (GH-4794).
+	TerminalByDesign bool
 }
 
 // IsDispatchGated reports whether this result's Error is (or wraps)
@@ -61,6 +66,17 @@ type HandlerResult struct {
 // that's actively being worked.
 func (hr *HandlerResult) IsDispatchGated() bool {
 	return hr != nil && errors.Is(hr.Error, executor.ErrDispatchGated)
+}
+
+// IsTerminalByDesign reports whether this execution finished in a
+// terminal-by-design status (superseded or canceled) rather than a genuine
+// completion or failure (GH-4794). Callers translating a HandlerResult into
+// a vendored-SDK sdkcore.IssueResult must consult this alongside
+// IsDispatchGated before forwarding Success=false with no PR/MR — and must
+// not emit a failure report/alert for it — since the work was deliberately
+// not carried out (issue closed, or operator-canceled), not botched.
+func (hr *HandlerResult) IsTerminalByDesign() bool {
+	return hr != nil && hr.TerminalByDesign
 }
 
 // HandlerDeps groups the shared infrastructure parameters every handler requires.
@@ -251,6 +267,11 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 	// side effects in steps 7-9, which intentionally treat this path as
 	// "nothing to wait for" rather than a failure.
 	var gatedDrop bool
+	// terminalByDesign marks an execution that finished superseded/canceled
+	// (GH-4794) — set below once WaitForExecution returns a terminal row —
+	// so steps 8/10 can suppress the false failure report/alert without
+	// touching the genuine-failure path.
+	var terminalByDesign bool
 
 	if deps.Dispatcher != nil {
 		execID, qErr := deps.Dispatcher.QueueTask(ctx, task)
@@ -330,18 +351,8 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 			exec, waitErr := deps.Dispatcher.WaitForExecution(ctx, execID, time.Second)
 			if waitErr != nil {
 				execErr = fmt.Errorf("failed waiting for execution: %w", waitErr)
-			} else if exec.Status == "failed" {
-				execErr = fmt.Errorf("execution failed: %s", execFailureMsg(exec.Error))
 			} else {
-				result = &executor.ExecutionResult{
-					TaskID:    task.ID,
-					Success:   exec.Status == "completed",
-					Output:    exec.Output,
-					Error:     exec.Error,
-					PRUrl:     exec.PRUrl,
-					CommitSHA: exec.CommitSHA,
-					Duration:  time.Duration(exec.DurationMs) * time.Millisecond,
-				}
+				result, execErr, terminalByDesign = classifyWaitedExecution(task.ID, exec)
 			}
 		}
 	} else {
@@ -363,40 +374,8 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 
 	// 8. Emit task completed/failed alert
 	if deps.AlertsEngine != nil {
-		if execErr != nil {
-			deps.AlertsEngine.ProcessEvent(alerts.Event{
-				Type:      alerts.EventTypeTaskFailed,
-				TaskID:    taskID,
-				TaskTitle: title,
-				Project:   projectPath,
-				Error:     execErr.Error(),
-				Timestamp: time.Now(),
-			})
-		} else if result != nil && result.Success {
-			metadata := map[string]string{}
-			if result.PRUrl != "" {
-				metadata["pr_url"] = result.PRUrl
-			}
-			if result.Duration > 0 {
-				metadata["duration"] = result.Duration.String()
-			}
-			deps.AlertsEngine.ProcessEvent(alerts.Event{
-				Type:      alerts.EventTypeTaskCompleted,
-				TaskID:    taskID,
-				TaskTitle: title,
-				Project:   projectPath,
-				Metadata:  metadata,
-				Timestamp: time.Now(),
-			})
-		} else if result != nil {
-			deps.AlertsEngine.ProcessEvent(alerts.Event{
-				Type:      alerts.EventTypeTaskFailed,
-				TaskID:    taskID,
-				TaskTitle: title,
-				Project:   projectPath,
-				Error:     result.Error,
-				Timestamp: time.Now(),
-			})
+		if ev := classifyResultAlert(taskID, title, projectPath, execErr, result, terminalByDesign); ev != nil {
+			deps.AlertsEngine.ProcessEvent(*ev)
 		}
 	}
 
@@ -421,10 +400,11 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 		hrErr = executor.ErrDispatchGated
 	}
 	hr := &HandlerResult{
-		Success:    execErr == nil && result != nil && result.Success,
-		BranchName: task.Branch,
-		Error:      hrErr,
-		Result:     result,
+		Success:          execErr == nil && result != nil && result.Success,
+		BranchName:       task.Branch,
+		Error:            hrErr,
+		Result:           result,
+		TerminalByDesign: terminalByDesign,
 	}
 	if result != nil {
 		if result.PRUrl != "" {
@@ -501,4 +481,84 @@ func execFailureMsg(execError string) string {
 		return "executor reported failure without providing an error message"
 	}
 	return execError
+}
+
+// classifyWaitedExecution turns a terminal execution row (as returned by
+// Dispatcher.WaitForExecution) into the (result, err, terminalByDesign)
+// triple handleIssueGeneric needs. GH-4794: a superseded or canceled
+// execution is the success path for "this work is no longer wanted" — it
+// must be reported as neither a completion nor a genuine failure, so callers
+// can suppress the failure alert/report and the vendored-SDK "no PR,
+// unmarking for retry" branch without touching the real-failure path
+// (exec.Status == "failed" is untouched below).
+func classifyWaitedExecution(taskID string, exec *memory.Execution) (result *executor.ExecutionResult, execErr error, terminalByDesign bool) {
+	if exec.Status == "failed" {
+		return nil, fmt.Errorf("execution failed: %s", execFailureMsg(exec.Error)), false
+	}
+	result = &executor.ExecutionResult{
+		TaskID:    taskID,
+		Success:   exec.Status == "completed",
+		Output:    exec.Output,
+		Error:     exec.Error,
+		PRUrl:     exec.PRUrl,
+		CommitSHA: exec.CommitSHA,
+		Duration:  time.Duration(exec.DurationMs) * time.Millisecond,
+	}
+	return result, nil, executor.IsTerminalByDesignStatus(exec.Status)
+}
+
+// classifyResultAlert decides which alerts.Event (if any) handleIssueGeneric's
+// step 8 should emit for a finished dispatch/execute attempt, given the
+// classification classifyWaitedExecution (or the direct-execute Runner path)
+// produced. Returns nil when no alert should fire.
+//
+// GH-4794: a terminal-by-design execution (superseded or canceled) is the
+// success path for "this work is no longer wanted" — it must not produce a
+// TaskFailed alert (it isn't a failure) or a TaskCompleted one (no PR/commit
+// exists), so the terminalByDesign case falls through to nil. A hard
+// execErr (queue/wait failure) always pages regardless of terminalByDesign,
+// since that's a pipeline failure, not a classified execution status.
+func classifyResultAlert(taskID, title, projectPath string, execErr error, result *executor.ExecutionResult, terminalByDesign bool) *alerts.Event {
+	now := time.Now()
+	switch {
+	case execErr != nil:
+		return &alerts.Event{
+			Type:      alerts.EventTypeTaskFailed,
+			TaskID:    taskID,
+			TaskTitle: title,
+			Project:   projectPath,
+			Error:     execErr.Error(),
+			Timestamp: now,
+		}
+	case result != nil && result.Success:
+		metadata := map[string]string{}
+		if result.PRUrl != "" {
+			metadata["pr_url"] = result.PRUrl
+		}
+		if result.Duration > 0 {
+			metadata["duration"] = result.Duration.String()
+		}
+		return &alerts.Event{
+			Type:      alerts.EventTypeTaskCompleted,
+			TaskID:    taskID,
+			TaskTitle: title,
+			Project:   projectPath,
+			Metadata:  metadata,
+			Timestamp: now,
+		}
+	case result != nil && !terminalByDesign:
+		// GH-4794: a superseded/canceled execution is the success path for
+		// "this work is no longer wanted", not a failure — don't page an
+		// operator for it.
+		return &alerts.Event{
+			Type:      alerts.EventTypeTaskFailed,
+			TaskID:    taskID,
+			TaskTitle: title,
+			Project:   projectPath,
+			Error:     result.Error,
+			Timestamp: now,
+		}
+	default:
+		return nil
+	}
 }

--- a/cmd/pilot/handler_common_test.go
+++ b/cmd/pilot/handler_common_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"errors"
 	"os"
+	osexec "os/exec"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	sdkcore "github.com/qf-studio/studio-sdk/sdk/core"
 
 	"github.com/qf-studio/pilot/internal/adapters/azuredevops"
 	"github.com/qf-studio/pilot/internal/adapters/github"
@@ -1006,4 +1009,303 @@ func TestHandleIssueGeneric_NilEnforcer(t *testing.T) {
 	}()
 
 	_, _ = handleIssueGeneric(context.Background(), deps, info, task)
+}
+
+// --- GH-4794: superseded/canceled executions must not be reported as
+// failures — the poller's post-execution classification must treat the
+// status vocabulary (executor.IsTerminalByDesignStatus) as the source of
+// truth rather than inferring failure from "no PR produced" ---
+
+// TestClassifyWaitedExecution_StatusVocabulary is the acceptance-criterion-1
+// regression test: classifyWaitedExecution (the step-6 classification
+// handleIssueGeneric applies to a terminal execution row) must distinguish
+// superseded/canceled (terminal-by-design, not a failure) from a genuine
+// "failed" status, and must leave "completed" behavior unchanged.
+func TestClassifyWaitedExecution_StatusVocabulary(t *testing.T) {
+	tests := []struct {
+		name             string
+		exec             *memory.Execution
+		wantErr          bool
+		wantTermByDesign bool
+		wantSuccess      bool
+	}{
+		{
+			name:             "superseded is terminal-by-design, not a failure",
+			exec:             &memory.Execution{TaskID: "GH-1", Status: "superseded"},
+			wantErr:          false,
+			wantTermByDesign: true,
+			wantSuccess:      false,
+		},
+		{
+			name:             "canceled is terminal-by-design, not a failure",
+			exec:             &memory.Execution{TaskID: "GH-1", Status: "canceled"},
+			wantErr:          false,
+			wantTermByDesign: true,
+			wantSuccess:      false,
+		},
+		{
+			name:             "failed is a genuine failure (regression guard)",
+			exec:             &memory.Execution{TaskID: "GH-1", Status: "failed", Error: "boom"},
+			wantErr:          true,
+			wantTermByDesign: false,
+		},
+		{
+			name:             "completed is unaffected",
+			exec:             &memory.Execution{TaskID: "GH-1", Status: "completed", PRUrl: "https://github.com/org/repo/pull/1"},
+			wantErr:          false,
+			wantTermByDesign: false,
+			wantSuccess:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err, terminalByDesign := classifyWaitedExecution(tt.exec.TaskID, tt.exec)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("classifyWaitedExecution() err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if terminalByDesign != tt.wantTermByDesign {
+				t.Errorf("terminalByDesign = %v, want %v", terminalByDesign, tt.wantTermByDesign)
+			}
+			if tt.wantErr {
+				if result != nil {
+					t.Errorf("expected nil result for a genuine failure, got %+v", result)
+				}
+				return
+			}
+			if result == nil {
+				t.Fatal("expected non-nil result for a non-failed status")
+			}
+			if result.Success != tt.wantSuccess {
+				t.Errorf("result.Success = %v, want %v", result.Success, tt.wantSuccess)
+			}
+		})
+	}
+}
+
+// TestClassifyResultAlert_TerminalByDesign_SuppressesFailureAlert is the
+// acceptance-criterion-1/3 regression test for the alert side: a
+// terminal-by-design result (superseded/canceled) must produce no alert at
+// all — neither TaskFailed nor TaskCompleted — while a genuine failure
+// (terminalByDesign=false) still produces TaskFailed unchanged, and a hard
+// execErr always produces TaskFailed regardless of terminalByDesign.
+func TestClassifyResultAlert_TerminalByDesign_SuppressesFailureAlert(t *testing.T) {
+	t.Run("superseded result: no alert", func(t *testing.T) {
+		result := &executor.ExecutionResult{TaskID: "GH-1", Success: false}
+		ev := classifyResultAlert("GH-1", "t", "/proj", nil, result, true)
+		if ev != nil {
+			t.Errorf("expected no alert for a terminal-by-design (superseded) result, got %+v", ev)
+		}
+	})
+
+	t.Run("canceled result: no alert", func(t *testing.T) {
+		result := &executor.ExecutionResult{TaskID: "GH-1", Success: false}
+		ev := classifyResultAlert("GH-1", "t", "/proj", nil, result, true)
+		if ev != nil {
+			t.Errorf("expected no alert for a terminal-by-design (canceled) result, got %+v", ev)
+		}
+	})
+
+	t.Run("genuine failure result: TaskFailed alert unchanged", func(t *testing.T) {
+		result := &executor.ExecutionResult{TaskID: "GH-1", Success: false, Error: "boom"}
+		ev := classifyResultAlert("GH-1", "t", "/proj", nil, result, false)
+		if ev == nil {
+			t.Fatal("expected a TaskFailed alert for a genuine (non-terminal-by-design) failure")
+		}
+		if ev.Type != alerts.EventTypeTaskFailed {
+			t.Errorf("expected EventTypeTaskFailed, got %v", ev.Type)
+		}
+		if ev.Error != "boom" {
+			t.Errorf("expected alert error %q, got %q", "boom", ev.Error)
+		}
+	})
+
+	t.Run("hard execErr: TaskFailed alert fires regardless of terminalByDesign", func(t *testing.T) {
+		ev := classifyResultAlert("GH-1", "t", "/proj", errors.New("queue failure"), nil, true)
+		if ev == nil {
+			t.Fatal("expected a TaskFailed alert for a hard dispatch/wait error")
+		}
+		if ev.Type != alerts.EventTypeTaskFailed {
+			t.Errorf("expected EventTypeTaskFailed, got %v", ev.Type)
+		}
+	})
+
+	t.Run("completed result: TaskCompleted alert unchanged", func(t *testing.T) {
+		result := &executor.ExecutionResult{TaskID: "GH-1", Success: true, PRUrl: "https://github.com/org/repo/pull/1"}
+		ev := classifyResultAlert("GH-1", "t", "/proj", nil, result, false)
+		if ev == nil {
+			t.Fatal("expected a TaskCompleted alert for a genuine success")
+		}
+		if ev.Type != alerts.EventTypeTaskCompleted {
+			t.Errorf("expected EventTypeTaskCompleted, got %v", ev.Type)
+		}
+	})
+}
+
+// TestHandlerResult_IsTerminalByDesign mirrors TestHandlerResult_IsDispatchGated
+// (poller_github_test.go) for the new GH-4794 field/method pair.
+func TestHandlerResult_IsTerminalByDesign(t *testing.T) {
+	terminal := &HandlerResult{TerminalByDesign: true}
+	if !terminal.IsTerminalByDesign() {
+		t.Error("expected IsTerminalByDesign() = true when TerminalByDesign is set")
+	}
+
+	notTerminal := &HandlerResult{TerminalByDesign: false}
+	if notTerminal.IsTerminalByDesign() {
+		t.Error("expected IsTerminalByDesign() = false when TerminalByDesign is unset")
+	}
+
+	var nilHR *HandlerResult
+	if nilHR.IsTerminalByDesign() {
+		t.Error("expected IsTerminalByDesign() = false for a nil HandlerResult")
+	}
+}
+
+// TestSDKTranslation_TerminalByDesign_DoesNotMislabelAsFailed drives the
+// exact Success translation formulas handlers.go now uses for github/gitlab
+// (`hr.Success || hr.IsDispatchGated() || hr.IsTerminalByDesign()`) and
+// azuredevops (`hr.Success || hr.IsTerminalByDesign()`) against a manufactured
+// terminal-by-design HandlerResult — mirroring
+// TestGithubSDKTranslation_LiveClaimStillRunning_DoesNotMislabelAsFailed's
+// approach of testing the translation formula directly since the real
+// handlers can't be driven end-to-end without live network/token access.
+// Success=false here would trip the vendored poller's "failed without PR,
+// unmarking for retry" branch on a closed/canceled issue (GH-4794's actual
+// incident).
+func TestSDKTranslation_TerminalByDesign_DoesNotMislabelAsFailed(t *testing.T) {
+	hr := &HandlerResult{Success: false, TerminalByDesign: true}
+
+	githubGitlabSuccess := hr.Success || hr.IsDispatchGated() || hr.IsTerminalByDesign()
+	if !githubGitlabSuccess {
+		t.Error("expected Success=true for a terminal-by-design result via the github/gitlab translation formula")
+	}
+
+	azureDevOpsSuccess := hr.Success || hr.IsTerminalByDesign()
+	if !azureDevOpsSuccess {
+		t.Error("expected Success=true for a terminal-by-design result via the azuredevops translation formula")
+	}
+}
+
+// fakeClosedIssueChecker reports every issue as closed with the
+// pilot-superseded label — used to drive the REAL dispatcher pickup-time
+// revalidation guard (GH-4656, dispatcher.go) into its supersede branch
+// without a live GitHub call.
+type fakeClosedIssueChecker struct{}
+
+func (fakeClosedIssueChecker) GetIssueState(_ context.Context, _, _ string, _ int) (executor.IssueState, error) {
+	return executor.IssueState{Closed: true, Labels: []string{"pilot-superseded"}}, nil
+}
+
+// TestHandleIssueGeneric_SupersededExecution_EndToEnd is the
+// acceptance-criterion-3 end-to-end regression test for GH-4794: drives the
+// REAL dispatcher (its actual GH-4656 pickup-time revalidation guard, not a
+// stub) for an issue that's closed before pickup, through handleIssueGeneric,
+// with a real AlertsEngine wired up. Confirms the whole pipeline —
+// dispatcher -> classifyWaitedExecution -> classifyResultAlert ->
+// HandlerResult.TerminalByDesign — agrees end to end: no TaskFailed alert
+// fires, and the sdkcore.IssueResult.Success translation formula (verbatim
+// from handlers.go) reports success, so the vendored poller's "failed
+// without PR, unmarking for retry" branch never fires for this closed issue.
+func TestHandleIssueGeneric_SupersededExecution_EndToEnd(t *testing.T) {
+	if _, err := osexec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	dir, err := os.MkdirTemp("", "pilot-gh4794-superseded-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := osexec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init")
+	runGit("config", "user.email", "test@pilot.local")
+	runGit("config", "user.name", "Pilot Test")
+	runGit("remote", "add", "origin", "https://github.com/gh4794-org/gh4794-repo.git")
+	if err := os.WriteFile(dir+"/README.md", []byte("# t\n"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	runGit("add", ".")
+	runGit("commit", "-m", "initial")
+
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	runner := executor.NewRunner()
+	runner.RegisterIssueStateChecker("github:gh4794-org/gh4794-repo", fakeClosedIssueChecker{})
+
+	d := executor.NewDispatcher(store, runner, nil)
+	if err := d.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(d.Stop)
+
+	config := &alerts.AlertConfig{
+		Enabled: true,
+		Channels: []alerts.ChannelConfig{
+			{Name: "test-channel", Type: "webhook", Enabled: true},
+		},
+		Rules: []alerts.AlertRule{
+			{
+				Name:     "task_failed",
+				Type:     alerts.AlertTypeTaskFailed,
+				Enabled:  true,
+				Severity: alerts.SeverityWarning,
+				Channels: []string{"test-channel"},
+				Cooldown: 0,
+			},
+		},
+	}
+	testCh := &testAlertChannel{}
+	alertDispatcher := alerts.NewDispatcher(config)
+	alertDispatcher.RegisterChannel(testCh)
+	engine := alerts.NewEngine(config, alerts.WithDispatcher(alertDispatcher))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := engine.Start(ctx); err != nil {
+		t.Fatalf("engine.Start: %v", err)
+	}
+
+	taskID := "GH-84001"
+	deps := HandlerDeps{Dispatcher: d, Monitor: executor.NewMonitor(), ProjectPath: dir, AlertsEngine: engine}
+	info := IssueInfo{TaskID: taskID, Title: "superseded e2e", Adapter: "github", LogMark: "▸"}
+	task := &executor.Task{ID: taskID, Title: "superseded e2e", Branch: "pilot/" + taskID, ProjectPath: dir, CreatePR: true}
+
+	hr, hErr := handleIssueGeneric(ctx, deps, info, task)
+	if hErr != nil {
+		t.Fatalf("expected nil error for a superseded execution, got: %v", hErr)
+	}
+	if !hr.IsTerminalByDesign() {
+		t.Error("expected hr.IsTerminalByDesign() = true for an issue closed before pickup")
+	}
+	if hr.Error != nil {
+		t.Errorf("expected nil hr.Error, got: %v", hr.Error)
+	}
+
+	// Give the async AlertsEngine.ProcessEvent a moment to settle before
+	// asserting nothing was dispatched.
+	time.Sleep(150 * time.Millisecond)
+	if got := testCh.count(); got != 0 {
+		t.Errorf("expected 0 alerts for a superseded execution (false operator alert, GH-4794), got %d", got)
+	}
+
+	// This is the exact formula handleGithubIssueEventSDK / handleGitlabIssueWithResult
+	// (cmd/pilot/handlers.go) use to build the sdkcore.IssueResult handed back to the poller.
+	issueResult := &sdkcore.IssueResult{
+		Success: hr.Success || hr.IsDispatchGated() || hr.IsTerminalByDesign(),
+	}
+	if !issueResult.Success {
+		t.Error("expected translated Success=true for a superseded execution — false would trip " +
+			"the vendored poller's 'failed without PR, unmarking for retry' branch on a closed issue")
+	}
 }

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -557,7 +557,7 @@ func handleGitlabIssueWithResult(ctx context.Context, cfg *config.Config, client
 	hr, execErr := handleIssueGeneric(ctx, deps, info, task)
 
 	issueResult := &sdkcore.IssueResult{
-		Success:    hr.Success || hr.IsDispatchGated(), // GH-4587: an admission-gate decline is not a genuine failure
+		Success:    hr.Success || hr.IsDispatchGated() || hr.IsTerminalByDesign(), // GH-4587/GH-4794: admission-gate declines and superseded/canceled executions are not genuine failures
 		BranchName: hr.BranchName,
 		PRNumber:   hr.PRNumber,
 		PRURL:      hr.PRURL,
@@ -606,7 +606,9 @@ func handleGitlabIssueWithResult(ctx context.Context, cfg *config.Config, client
 				)
 			}
 		}
-	} else if hr.Result != nil {
+	} else if hr.Result != nil && !hr.IsTerminalByDesign() {
+		// GH-4794: a superseded/canceled execution is the success path for
+		// "this work is no longer wanted" — don't post a failure note for it.
 		note := fmt.Sprintf("❌ Pilot execution failed\n\nError: %s\nDuration: %s", hr.Result.Error, hr.Result.Duration)
 		if _, err := client.AddIssueNote(ctx, issueIID, note); err != nil {
 			logging.WithComponent("gitlab").Warn("Failed to add failure note",
@@ -670,7 +672,7 @@ func handleAzureDevOpsIssueWithResult(ctx context.Context, cfg *config.Config, e
 	hr, execErr := handleIssueGeneric(ctx, deps, info, task)
 
 	issueResult := &sdkcore.IssueResult{
-		Success:    hr.Success,
+		Success:    hr.Success || hr.IsTerminalByDesign(), // GH-4794: a superseded/canceled execution is not a genuine failure
 		BranchName: hr.BranchName,
 		PRNumber:   hr.PRNumber,
 		PRURL:      hr.PRURL,
@@ -868,7 +870,7 @@ func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkco
 	hr, execErr := handleIssueGeneric(ctx, deps, info, task)
 
 	issueResult := &sdkcore.IssueResult{
-		Success:    hr.Success || hr.IsDispatchGated(), // GH-4587: an admission-gate decline is not a genuine failure
+		Success:    hr.Success || hr.IsDispatchGated() || hr.IsTerminalByDesign(), // GH-4587/GH-4794: admission-gate declines and superseded/canceled executions are not genuine failures
 		BranchName: hr.BranchName,
 		PRNumber:   hr.PRNumber,
 		PRURL:      hr.PRURL,

--- a/internal/adapters/github/cleanup.go
+++ b/internal/adapters/github/cleanup.go
@@ -44,6 +44,13 @@ type Cleaner struct {
 	// issue from the poller's persistent processed store so it can be re-dispatched.
 	OnStartupRecovered func(issueNumber int)
 
+	// OnRetryReadyCleaned is called when a pilot-retry-ready label is removed
+	// from a closed issue. GH-4794: a superseded/canceled execution can leave
+	// (or find already present) a stale retry label on an issue that was
+	// closed out from under it; that label must not survive closure and
+	// misrepresent the queue as still needing a re-pick.
+	OnRetryReadyCleaned func(issueNumber int)
+
 	mu      sync.Mutex
 	running bool
 	stopCh  chan struct{}
@@ -73,6 +80,17 @@ func WithOnFailedCleaned(fn func(issueNumber int)) CleanerOption {
 func WithOnInProgressCleaned(fn func(issueNumber int)) CleanerOption {
 	return func(c *Cleaner) {
 		c.OnInProgressCleaned = fn
+	}
+}
+
+// WithOnRetryReadyCleaned sets the callback for when a pilot-retry-ready
+// label is removed from a closed issue. GH-4794: a superseded/canceled
+// execution can leave (or find already present) a stale retry label on an
+// issue that closed out from under it; the callback receives the issue
+// number so callers can clear any related poller/queue state.
+func WithOnRetryReadyCleaned(fn func(issueNumber int)) CleanerOption {
+	return func(c *Cleaner) {
+		c.OnRetryReadyCleaned = fn
 	}
 }
 
@@ -221,7 +239,7 @@ func (c *Cleaner) Cleanup(ctx context.Context) error {
 	// GH-2354: Also clean up pilot-in-progress labels left on CLOSED issues.
 	// Externally closed issues (e.g. `gh issue close`) retain the label; the
 	// dashboard monitor keeps them in its queue view until the task is pruned.
-	closedCleaned, err := c.cleanupClosedInProgressLabels(ctx, activeTaskIDs)
+	closedCleaned, err := c.cleanupClosedLabel(ctx, LabelInProgress, c.OnInProgressCleaned, activeTaskIDs)
 	if err != nil {
 		return fmt.Errorf("failed to cleanup closed in-progress labels: %w", err)
 	}
@@ -240,13 +258,23 @@ func (c *Cleaner) Cleanup(ctx context.Context) error {
 		return fmt.Errorf("failed to cleanup blocked labels: %w", err)
 	}
 
-	totalCleaned := inProgressCleaned + closedCleaned + failedCleaned + blockedCleaned
+	// GH-4794: Clean up pilot-retry-ready labels left on CLOSED issues. A
+	// superseded/canceled execution's issue may have been closed while a
+	// retry label was still (or newly) attached; left alone it misrepresents
+	// the queue as still needing a re-pick.
+	closedRetryReadyCleaned, err := c.cleanupClosedLabel(ctx, LabelRetryReady, c.OnRetryReadyCleaned, activeTaskIDs)
+	if err != nil {
+		return fmt.Errorf("failed to cleanup closed retry-ready labels: %w", err)
+	}
+
+	totalCleaned := inProgressCleaned + closedCleaned + failedCleaned + blockedCleaned + closedRetryReadyCleaned
 	if totalCleaned > 0 {
 		c.logger.Info("Stale label cleanup completed",
 			slog.Int("in_progress_cleaned", inProgressCleaned),
 			slog.Int("closed_in_progress_cleaned", closedCleaned),
 			slog.Int("failed_cleaned", failedCleaned),
 			slog.Int("blocked_cleaned", blockedCleaned),
+			slog.Int("closed_retry_ready_cleaned", closedRetryReadyCleaned),
 		)
 	}
 
@@ -356,30 +384,35 @@ func (c *Cleaner) cleanupLabel(ctx context.Context, label string, threshold time
 	return cleanedCount, nil
 }
 
-// cleanupClosedInProgressLabels removes the pilot-in-progress label from
-// issues that are CLOSED on GitHub but still carry the label. This happens
-// when an issue is closed externally (e.g. `gh issue close`) without the
-// label being cleared. The dashboard monitor treats such tasks as live and
-// keeps them in the queue view — GH-2354.
+// cleanupClosedLabel removes the given label from issues that are CLOSED on
+// GitHub but still carry it. This happens when an issue is closed externally
+// (e.g. `gh issue close`) without the label being cleared — originally added
+// for pilot-in-progress (GH-2354, whose dashboard-monitor tasks stay live in
+// the queue view otherwise) and generalized to also cover pilot-retry-ready
+// (GH-4794, where a stale retry label on a closed issue misrepresents queue
+// state and invites a spurious re-pick).
 //
-// No staleness threshold is applied: a closed issue should never carry the
-// in-progress label, so we clean immediately on discovery. Active executions
+// No staleness threshold is applied: a closed issue should never carry
+// either label, so we clean immediately on discovery. Active executions
 // (tracked in the memory store) are still skipped so an in-flight run isn't
-// silently stripped while it's still working.
-func (c *Cleaner) cleanupClosedInProgressLabels(ctx context.Context, activeTaskIDs map[string]bool) (int, error) {
+// silently stripped while it's still working. onCleaned, if non-nil, is
+// invoked once per issue actually cleaned (e.g. to prune the dashboard
+// monitor or poller processed-map).
+func (c *Cleaner) cleanupClosedLabel(ctx context.Context, label string, onCleaned func(issueNumber int), activeTaskIDs map[string]bool) (int, error) {
 	issues, err := c.client.ListIssues(ctx, c.owner, c.repo, &ListIssuesOptions{
-		Labels: []string{LabelInProgress},
+		Labels: []string{label},
 		State:  StateClosed,
 	})
 	if err != nil {
-		return 0, fmt.Errorf("failed to list closed issues with %s label: %w", LabelInProgress, err)
+		return 0, fmt.Errorf("failed to list closed issues with %s label: %w", label, err)
 	}
 
 	if len(issues) == 0 {
 		return 0, nil
 	}
 
-	c.logger.Debug("Found closed issues with in-progress label",
+	c.logger.Debug("Found closed issues with label",
+		slog.String("label", label),
 		slog.Int("count", len(issues)),
 	)
 
@@ -397,25 +430,28 @@ func (c *Cleaner) cleanupClosedInProgressLabels(ctx context.Context, activeTaskI
 			c.logger.Debug("Closed issue has active execution, skipping",
 				slog.Int("issue", issue.Number),
 				slog.String("task_id", taskID),
+				slog.String("label", label),
 			)
 			continue
 		}
 
-		c.logger.Info("Removing in-progress label from closed issue",
+		c.logger.Info("Removing label from closed issue",
 			slog.Int("issue", issue.Number),
 			slog.String("title", issue.Title),
+			slog.String("label", label),
 		)
 
-		if err := c.client.RemoveLabel(ctx, c.owner, c.repo, issue.Number, LabelInProgress); err != nil {
-			c.logger.Warn("Failed to remove in-progress label from closed issue",
+		if err := c.client.RemoveLabel(ctx, c.owner, c.repo, issue.Number, label); err != nil {
+			c.logger.Warn("Failed to remove label from closed issue",
 				slog.Int("issue", issue.Number),
+				slog.String("label", label),
 				slog.Any("error", err),
 			)
 			continue
 		}
 
-		if c.OnInProgressCleaned != nil {
-			c.OnInProgressCleaned(issue.Number)
+		if onCleaned != nil {
+			onCleaned(issue.Number)
 		}
 
 		cleanedCount++

--- a/internal/adapters/github/cleanup_test.go
+++ b/internal/adapters/github/cleanup_test.go
@@ -885,6 +885,149 @@ func TestCleaner_Cleanup_ClosedInProgressWithActiveExecutionSkipped(t *testing.T
 	}
 }
 
+// GH-4794: pilot-retry-ready label on externally-closed issues should be
+// cleaned up immediately (a superseded/canceled execution can leave this
+// label on an issue that closed out from under it), and the callback should
+// fire so callers can clear related poller/queue state.
+func TestCleaner_Cleanup_ClosedRetryReadyIssueCleaned(t *testing.T) {
+	store := createTestStore(t)
+	defer func() { _ = store.Close() }()
+
+	closedIssues := []*Issue{
+		{
+			Number:    4794,
+			Title:     "Externally closed issue with stray retry label",
+			Labels:    []Label{{Name: LabelRetryReady}},
+			State:     StateClosed,
+			UpdatedAt: time.Now(), // recent — threshold must be ignored for closed
+		},
+	}
+
+	var (
+		mu              sync.Mutex
+		removeLabelHit  bool
+		sawStateClosed  bool
+		commentOnClosed bool
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues" {
+			state := r.URL.Query().Get("state")
+			if state == "closed" {
+				sawStateClosed = true
+				_ = json.NewEncoder(w).Encode(closedIssues)
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]*Issue{})
+			return
+		}
+
+		if r.Method == http.MethodDelete && r.URL.Path == "/repos/owner/repo/issues/4794/labels/"+LabelRetryReady {
+			removeLabelHit = true
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		if r.Method == http.MethodPost && r.URL.Path == "/repos/owner/repo/issues/4794/comments" {
+			commentOnClosed = true
+			_ = json.NewEncoder(w).Encode(&Comment{ID: 1})
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	var callbackIssue int
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
+		Enabled:   true,
+		Interval:  30 * time.Minute,
+		Threshold: 1 * time.Hour,
+	}, WithOnRetryReadyCleaned(func(n int) { callbackIssue = n }))
+
+	if err := cleaner.Cleanup(context.Background()); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if !sawStateClosed {
+		t.Error("expected ListIssues to be called with state=closed")
+	}
+	if !removeLabelHit {
+		t.Error("RemoveLabel should have been called for closed retry-ready issue")
+	}
+	if commentOnClosed {
+		t.Error("AddComment must NOT be called for closed-issue cleanup (silent)")
+	}
+	if callbackIssue != 4794 {
+		t.Errorf("OnRetryReadyCleaned callback issue = %d, want 4794", callbackIssue)
+	}
+}
+
+// GH-4794: active executions for closed issues must NOT have the
+// pilot-retry-ready label stripped while the task is still running in-memory
+// (mirrors the pilot-in-progress protection for GH-2354).
+func TestCleaner_Cleanup_ClosedRetryReadyWithActiveExecutionSkipped(t *testing.T) {
+	store := createTestStore(t)
+	defer func() { _ = store.Close() }()
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-4795",
+		TaskID:      "GH-4795",
+		ProjectPath: "/test/project",
+		Status:      "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	closedIssues := []*Issue{
+		{Number: 4795, Title: "Closed but still running", Labels: []Label{{Name: LabelRetryReady}}, State: StateClosed, UpdatedAt: time.Now()},
+	}
+
+	removeLabelHit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues" {
+			if r.URL.Query().Get("state") == "closed" {
+				_ = json.NewEncoder(w).Encode(closedIssues)
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]*Issue{})
+			return
+		}
+		if r.Method == http.MethodDelete {
+			removeLabelHit = true
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	callbackFired := false
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
+		Enabled: true, Interval: 30 * time.Minute, Threshold: 1 * time.Hour,
+	}, WithOnRetryReadyCleaned(func(int) { callbackFired = true }))
+
+	if err := cleaner.Cleanup(context.Background()); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	if removeLabelHit {
+		t.Error("RemoveLabel must NOT be called for closed issue with active execution")
+	}
+	if callbackFired {
+		t.Error("OnRetryReadyCleaned must NOT fire for closed issue with active execution")
+	}
+}
+
 // TestCleaner_StartupRecover_StuckIssueUnlabeled verifies that an open issue
 // carrying pilot-in-progress with no live execution row gets its label stripped.
 func TestCleaner_StartupRecover_StuckIssueUnlabeled(t *testing.T) {

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -57,6 +57,29 @@ func isTerminalExecutionStatus(status string) bool {
 	return terminalExecutionStatuses[status]
 }
 
+// terminalByDesignExecutionStatuses is the subset of terminalExecutionStatuses
+// that represent an execution deliberately not carried out — the work was
+// correctly declined/abandoned, not botched — as opposed to a genuine
+// failure. GH-4794: a superseded execution (issue closed before/during
+// pickup, see the pickup-time and pre-PR revalidation guards below) or a
+// canceled one (operator-initiated via `pilot task cancel`) is the success
+// path for "this work is no longer wanted", not a failure. Post-execution
+// classification (cmd/pilot/handler_common.go's handleIssueGeneric and the
+// per-adapter translations in cmd/pilot/handlers.go) consults this so these
+// statuses never produce a failure report/alert or trigger a vendored-SDK
+// poller's "no PR, unmarking for retry" branch.
+var terminalByDesignExecutionStatuses = map[string]bool{
+	string(ExecStatusSuperseded): true,
+	string(ExecStatusCanceled):   true,
+}
+
+// IsTerminalByDesignStatus reports whether status is a terminal-by-design
+// non-failure (superseded or canceled) rather than a genuine completion or
+// failure.
+func IsTerminalByDesignStatus(status string) bool {
+	return terminalByDesignExecutionStatuses[status]
+}
+
 // DispatcherConfig configures the task dispatcher behavior.
 type DispatcherConfig struct {
 	// StaleTaskDuration is a backwards-compat alias for StaleRunningThreshold.


### PR DESCRIPTION
## Summary

- `handleIssueGeneric` (the shared choke point for all adapters) now classifies a terminal execution using the status vocabulary (`superseded`/`canceled` vs `failed`) as source of truth, instead of inferring failure from "no PR produced".
- New `executor.IsTerminalByDesignStatus` + `HandlerResult.TerminalByDesign`/`IsTerminalByDesign()` mirror the existing `ErrDispatchGated`/`IsDispatchGated()` pattern (GH-4587/GH-4469).
- `classifyWaitedExecution` / `classifyResultAlert` (new pure functions in `handler_common.go`) suppress the false `TaskFailed` alert and the vendored-SDK poller's "no PR, unmarking for retry" branch for superseded/canceled executions, while leaving genuine failures (`exec.Status == "failed"`) untouched.
- Wired `IsTerminalByDesign()` into the github/gitlab/azuredevops SDK translation layers in `handlers.go` alongside the existing `IsDispatchGated()` check, and guarded the GitLab failure-note-posting branch.
- Extended the `github-cleanup` component's closed-issue label sweep (which already strips `pilot-in-progress`) to also strip `pilot-retry-ready` from closed issues, in case it was left behind before this fix, via a new `WithOnRetryReadyCleaned` option.

No changes to the dispatcher's supersede decision itself (it was already correct) or to the real-failure path.

## Test plan

- [x] `classifyWaitedExecution`/`classifyResultAlert` unit tests: superseded, canceled, failed, completed
- [x] `TestHandlerResult_IsTerminalByDesign`
- [x] `TestSDKTranslation_TerminalByDesign_DoesNotMislabelAsFailed` (github/gitlab/azuredevops formulas)
- [x] `TestHandleIssueGeneric_SupersededExecution_EndToEnd` — real dispatcher + real git repo + registered `IssueStateChecker`, reproduces the exact GH-4756 incident log path; asserts no alert fires and `IsTerminalByDesign()` is true
- [x] `TestCleaner_Cleanup_ClosedRetryReadyIssueCleaned` / `TestCleaner_Cleanup_ClosedRetryReadyWithActiveExecutionSkipped`
- [x] `go build ./...`
- [x] `go test ./...` (all packages green)
- [x] `golangci-lint run` on touched packages (pre-existing unrelated findings in `budget.go`/`azuredevops/converter.go` only)