### PR TITLE
fix(autopilot): AggregateMetrics.Snapshot now carries PlatformBreakerTrips/PlatformBreakerOpen

### DIFF
--- a/internal/autopilot/metrics_aggregate.go
+++ b/internal/autopilot/metrics_aggregate.go
@@ -117,6 +117,14 @@ func (a *AggregateMetrics) Snapshot() MetricsSnapshot {
 			agg.CIRuns[k] += v
 		}
 		agg.CircuitBreakerTrips += s.CircuitBreakerTrips
+		// GH-4798: PlatformBreakerTrips/PlatformBreakerOpen (GH-4791) were
+		// added to Metrics/MetricsSnapshot but never copied here — same bug
+		// shape as GH-4738 above. Trips sum (each controller counts its own
+		// suppressed actions); Open is OR'd (each controller mirrors the
+		// shared process-wide breaker state as of its own most recent
+		// Observe, so any controller having last seen it open means open).
+		agg.PlatformBreakerTrips += s.PlatformBreakerTrips
+		agg.PlatformBreakerOpen = agg.PlatformBreakerOpen || s.PlatformBreakerOpen
 		for k, v := range s.APIErrors {
 			agg.APIErrors[k] += v
 		}

--- a/internal/autopilot/metrics_aggregate_test.go
+++ b/internal/autopilot/metrics_aggregate_test.go
@@ -249,3 +249,31 @@ func TestAggregateMetrics_WindowStatsNotSummedAcrossControllers(t *testing.T) {
 		t.Errorf("WindowDeliveryRate = %.4f, must never exceed 1.0", snap.WindowDeliveryRate)
 	}
 }
+
+// TestAggregateMetrics_PropagatesPlatformBreakerFromControllers pins GH-4798:
+// PlatformBreakerTrips/PlatformBreakerOpen (GH-4791) were added to
+// Metrics/MetricsSnapshot but AggregateMetrics.Snapshot — which copies
+// fields explicitly, field-by-field — was never updated to carry them
+// across. Every real deployment reads /metrics through the aggregate
+// (SetMetricsSource(autopilotMetricsAggregate), cmd/pilot/main.go), so both
+// series served 0 in production regardless of breaker state. Same bug shape
+// as GH-4738/PR#4739 in this same file.
+func TestAggregateMetrics_PropagatesPlatformBreakerFromControllers(t *testing.T) {
+	defaultMetrics := NewMetrics()
+	otherMetrics := NewMetrics()
+
+	// Only the non-default (e.g. per-project) controller observed a trip and
+	// the shared breaker open.
+	otherMetrics.RecordPlatformBreakerTrip()
+	otherMetrics.SetPlatformBreakerOpen(true)
+
+	agg := NewAggregateMetrics(defaultMetrics, otherMetrics)
+	snap := agg.Snapshot()
+
+	if snap.PlatformBreakerTrips != 1 {
+		t.Errorf("PlatformBreakerTrips = %d, want 1 (must sum across controllers, not stay at the aggregate's zero value)", snap.PlatformBreakerTrips)
+	}
+	if !snap.PlatformBreakerOpen {
+		t.Errorf("PlatformBreakerOpen = false, want true (must OR across controllers — any controller having last seen it open means open)")
+	}
+}


### PR DESCRIPTION
## Summary
- `AggregateMetrics.Snapshot()` copies `MetricsSnapshot` fields explicitly, field-by-field, and was never updated when PR #4797 (GH-4791) added `PlatformBreakerTrips`/`PlatformBreakerOpen` to `Metrics`/`MetricsSnapshot` — same bug shape as GH-4738/PR#4739 in this same file.
- Since every real deployment reads `/metrics` through the aggregate (`SetMetricsSource(autopilotMetricsAggregate)` in `cmd/pilot/main.go`), both `pilot_platform_breaker_trips_total` and `pilot_platform_breaker_open` served 0 in production regardless of actual breaker state.
- Fix: sum `PlatformBreakerTrips` across controllers (each counts its own suppressed actions) and OR `PlatformBreakerOpen` across controllers (each mirrors the shared process-wide breaker state as of its own most recent `Observe`; any controller having last seen it open means open).

## Test plan
- [x] Added `TestAggregateMetrics_PropagatesPlatformBreakerFromControllers` (PR#4739 style): builds 2 `*Metrics`, records a trip + sets open on only one, wraps in `NewAggregateMetrics`, asserts the aggregate snapshot carries `PlatformBreakerTrips == 1` and `PlatformBreakerOpen == true`.
- [x] `go build ./...`
- [x] `go test ./internal/autopilot/...`

Fixes GH-4798.

🤖 Generated with [Claude Code](https://claude.com/claude-code)