### PR TITLE
GH-4801: fix(handlers): terminal-by-design Success translation missing in Linear/Jira/Asana/Plane + ungated Plane failure comment (PR#4800 review)

### DIFF
--- a/cmd/pilot/handler_common.go
+++ b/cmd/pilot/handler_common.go
@@ -79,6 +79,22 @@ func (hr *HandlerResult) IsTerminalByDesign() bool {
 	return hr != nil && hr.TerminalByDesign
 }
 
+// EffectiveSuccess reports whether this result should be translated as
+// Success=true on the vendored-SDK sdkcore.IssueResult every adapter handler
+// builds from a HandlerResult. A genuine hr.Success obviously counts, but so
+// does IsDispatchGated() (GH-4587: an admission-gate decline — already
+// active, repick backoff, terminal re-check, claim-lost drop — is not a
+// failed execution) and IsTerminalByDesign() (GH-4794: a superseded/canceled
+// execution is the success path for "this work is no longer wanted"). All
+// seven adapter handlers (github, gitlab, azuredevops, linear, jira, asana,
+// plane) must use this single formula rather than inlining the three-term
+// OR — GH-4801 found four of the seven still building Success: hr.Success
+// bare, and azuredevops missing the GH-4587 term entirely, after PR#4800
+// only fixed github/gitlab/azuredevops's IsTerminalByDesign gap.
+func (hr *HandlerResult) EffectiveSuccess() bool {
+	return hr.Success || hr.IsDispatchGated() || hr.IsTerminalByDesign()
+}
+
 // HandlerDeps groups the shared infrastructure parameters every handler requires.
 type HandlerDeps struct {
 	Cfg          *config.Config

--- a/cmd/pilot/handler_common_test.go
+++ b/cmd/pilot/handler_common_test.go
@@ -1162,11 +1162,13 @@ func TestHandlerResult_IsTerminalByDesign(t *testing.T) {
 	}
 }
 
-// TestSDKTranslation_TerminalByDesign_DoesNotMislabelAsFailed drives the
-// exact Success translation formulas handlers.go now uses for github/gitlab
-// (`hr.Success || hr.IsDispatchGated() || hr.IsTerminalByDesign()`) and
-// azuredevops (`hr.Success || hr.IsTerminalByDesign()`) against a manufactured
-// terminal-by-design HandlerResult — mirroring
+// TestSDKTranslation_TerminalByDesign_DoesNotMislabelAsFailed drives
+// HandlerResult.EffectiveSuccess() — the single shared formula all seven
+// adapter handlers (github, gitlab, azuredevops, linear, jira, asana, plane)
+// now use to build sdkcore.IssueResult.Success (GH-4801; previously
+// linear/jira/asana/plane built it bare from hr.Success, and azuredevops
+// omitted the GH-4587 IsDispatchGated() term) — against a manufactured
+// terminal-by-design HandlerResult, mirroring
 // TestGithubSDKTranslation_LiveClaimStillRunning_DoesNotMislabelAsFailed's
 // approach of testing the translation formula directly since the real
 // handlers can't be driven end-to-end without live network/token access.
@@ -1175,15 +1177,52 @@ func TestHandlerResult_IsTerminalByDesign(t *testing.T) {
 // incident).
 func TestSDKTranslation_TerminalByDesign_DoesNotMislabelAsFailed(t *testing.T) {
 	hr := &HandlerResult{Success: false, TerminalByDesign: true}
+	if !hr.EffectiveSuccess() {
+		t.Error("expected EffectiveSuccess() = true for a terminal-by-design result")
+	}
+}
 
-	githubGitlabSuccess := hr.Success || hr.IsDispatchGated() || hr.IsTerminalByDesign()
-	if !githubGitlabSuccess {
-		t.Error("expected Success=true for a terminal-by-design result via the github/gitlab translation formula")
+// TestHandlerResult_EffectiveSuccess_Table covers the four cases the shared
+// GH-4801 helper must classify: a plain successful execution, a GH-4587
+// dispatch-gated admission decline, and a GH-4794 terminal-by-design
+// (superseded/canceled) execution must all report EffectiveSuccess() ==
+// true, while a genuine failure (Success=false, no gating/terminal reason)
+// must report false — the case that legitimately should trip the vendored
+// poller's "failed without PR, unmarking for retry" branch.
+func TestHandlerResult_EffectiveSuccess_Table(t *testing.T) {
+	tests := []struct {
+		name string
+		hr   *HandlerResult
+		want bool
+	}{
+		{
+			name: "plain success",
+			hr:   &HandlerResult{Success: true},
+			want: true,
+		},
+		{
+			name: "dispatch-gated admission decline (GH-4587)",
+			hr:   &HandlerResult{Success: false, Error: executor.ErrDispatchGated},
+			want: true,
+		},
+		{
+			name: "terminal-by-design: superseded/canceled (GH-4794)",
+			hr:   &HandlerResult{Success: false, TerminalByDesign: true},
+			want: true,
+		},
+		{
+			name: "genuine failure",
+			hr:   &HandlerResult{Success: false, Error: errors.New("execution failed: boom")},
+			want: false,
+		},
 	}
 
-	azureDevOpsSuccess := hr.Success || hr.IsTerminalByDesign()
-	if !azureDevOpsSuccess {
-		t.Error("expected Success=true for a terminal-by-design result via the azuredevops translation formula")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.hr.EffectiveSuccess(); got != tt.want {
+				t.Errorf("EffectiveSuccess() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -1299,10 +1338,11 @@ func TestHandleIssueGeneric_SupersededExecution_EndToEnd(t *testing.T) {
 		t.Errorf("expected 0 alerts for a superseded execution (false operator alert, GH-4794), got %d", got)
 	}
 
-	// This is the exact formula handleGithubIssueEventSDK / handleGitlabIssueWithResult
-	// (cmd/pilot/handlers.go) use to build the sdkcore.IssueResult handed back to the poller.
+	// This is the exact formula every adapter handler in cmd/pilot/handlers.go
+	// (github, gitlab, azuredevops, linear, jira, asana, plane) uses to build
+	// the sdkcore.IssueResult handed back to the poller (GH-4801).
 	issueResult := &sdkcore.IssueResult{
-		Success: hr.Success || hr.IsDispatchGated() || hr.IsTerminalByDesign(),
+		Success: hr.EffectiveSuccess(),
 	}
 	if !issueResult.Success {
 		t.Error("expected translated Success=true for a superseded execution — false would trip " +

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -177,7 +177,7 @@ func handleLinearIssueWithResult(ctx context.Context, cfg *config.Config, ev sdk
 	hr, execErr := handleIssueGeneric(ctx, deps, info, task)
 
 	return &sdkcore.IssueResult{
-		Success:    hr.Success,
+		Success:    hr.EffectiveSuccess(), // GH-4587/GH-4794: admission-gate declines and superseded/canceled executions are not genuine failures
 		BranchName: hr.BranchName,
 		PRNumber:   hr.PRNumber,
 		PRURL:      hr.PRURL,
@@ -238,7 +238,7 @@ func handleJiraSDKIssueWithResult(ctx context.Context, cfg *config.Config, ev sd
 	hr, execErr := handleIssueGeneric(ctx, deps, info, task)
 
 	issueResult := &sdkcore.IssueResult{
-		Success:    hr.Success,
+		Success:    hr.EffectiveSuccess(), // GH-4587/GH-4794: admission-gate declines and superseded/canceled executions are not genuine failures
 		BranchName: hr.BranchName,
 		PRNumber:   hr.PRNumber,
 		PRURL:      hr.PRURL,
@@ -300,7 +300,7 @@ func handleAsanaIssueWithResult(ctx context.Context, cfg *config.Config, ev sdkc
 	hr, execErr := handleIssueGeneric(ctx, deps, info, task)
 
 	issueResult := &sdkcore.IssueResult{
-		Success:    hr.Success,
+		Success:    hr.EffectiveSuccess(), // GH-4587/GH-4794: admission-gate declines and superseded/canceled executions are not genuine failures
 		BranchName: hr.BranchName,
 		PRNumber:   hr.PRNumber,
 		PRURL:      hr.PRURL,
@@ -436,7 +436,7 @@ func handlePlaneIssueWithResult(ctx context.Context, cfg *config.Config, client 
 	hr, execErr := handleIssueGeneric(ctx, deps, info, task)
 
 	issueResult := &sdkcore.IssueResult{
-		Success:    hr.Success,
+		Success:    hr.EffectiveSuccess(), // GH-4587/GH-4794: admission-gate declines and superseded/canceled executions are not genuine failures
 		BranchName: hr.BranchName,
 		PRNumber:   hr.PRNumber,
 		PRURL:      hr.PRURL,
@@ -476,7 +476,10 @@ func handlePlaneIssueWithResult(ctx context.Context, cfg *config.Config, client 
 				)
 			}
 		}
-	} else if hr.Result != nil {
+	} else if hr.Result != nil && !hr.IsTerminalByDesign() {
+		// GH-4794/GH-4801: a superseded/canceled execution is the success path
+		// for "this work is no longer wanted" — don't post a failure comment
+		// on a closed/canceled work item for it (mirrors GitLab's gate below).
 		comment := fmt.Sprintf("<p>❌ Pilot execution failed:</p><pre>%s</pre>", hr.Result.Error)
 		if err := client.AddComment(ctx, workspaceSlug, projectID, issueID, comment); err != nil {
 			logging.WithComponent("plane").Warn("Failed to add failure comment",
@@ -557,7 +560,7 @@ func handleGitlabIssueWithResult(ctx context.Context, cfg *config.Config, client
 	hr, execErr := handleIssueGeneric(ctx, deps, info, task)
 
 	issueResult := &sdkcore.IssueResult{
-		Success:    hr.Success || hr.IsDispatchGated() || hr.IsTerminalByDesign(), // GH-4587/GH-4794: admission-gate declines and superseded/canceled executions are not genuine failures
+		Success:    hr.EffectiveSuccess(), // GH-4587/GH-4794: admission-gate declines and superseded/canceled executions are not genuine failures
 		BranchName: hr.BranchName,
 		PRNumber:   hr.PRNumber,
 		PRURL:      hr.PRURL,
@@ -672,7 +675,12 @@ func handleAzureDevOpsIssueWithResult(ctx context.Context, cfg *config.Config, e
 	hr, execErr := handleIssueGeneric(ctx, deps, info, task)
 
 	issueResult := &sdkcore.IssueResult{
-		Success:    hr.Success || hr.IsTerminalByDesign(), // GH-4794: a superseded/canceled execution is not a genuine failure
+		// GH-4801: azuredevops previously omitted the GH-4587 IsDispatchGated()
+		// term (PR#4800 only added IsTerminalByDesign() here) — git history
+		// shows GH-4587 was scoped to "GitHub/GitLab SDK translation sites"
+		// only, never a deliberate azuredevops exclusion, so unifying onto the
+		// shared helper is a genuine bug fix, not a behavior regression.
+		Success:    hr.EffectiveSuccess(), // GH-4587/GH-4794: admission-gate declines and superseded/canceled executions are not genuine failures
 		BranchName: hr.BranchName,
 		PRNumber:   hr.PRNumber,
 		PRURL:      hr.PRURL,
@@ -870,7 +878,7 @@ func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkco
 	hr, execErr := handleIssueGeneric(ctx, deps, info, task)
 
 	issueResult := &sdkcore.IssueResult{
-		Success:    hr.Success || hr.IsDispatchGated() || hr.IsTerminalByDesign(), // GH-4587/GH-4794: admission-gate declines and superseded/canceled executions are not genuine failures
+		Success:    hr.EffectiveSuccess(), // GH-4587/GH-4794: admission-gate declines and superseded/canceled executions are not genuine failures
 		BranchName: hr.BranchName,
 		PRNumber:   hr.PRNumber,
 		PRURL:      hr.PRURL,


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4801.

Closes #4801

## Changes

GitHub Issue GH-4801: fix(handlers): terminal-by-design Success translation missing in Linear/Jira/Asana/Plane + ungated Plane failure comment (PR#4800 review)

## Problem

PR#4800 (GH-4794) fixed the `sdkcore.IssueResult.Success` translation for superseded/canceled ("terminal-by-design") executions — but only for three of the seven adapter handlers in `cmd/pilot/handlers.go`:

- Fixed: github (`:873`), gitlab (`:560`), azuredevops (`:675`)
- **Missed: Linear (`:180`), Jira (`:241`), Asana (`:303`), Plane (`:439`)** — all still build `sdkcore.IssueResult{Success: hr.Success}` bare.

On those four trackers a superseded/canceled execution still reports `Success=false` with no PR, tripping the vendored SDK poller's "failed without PR, unmarking for retry" branch — the exact GH-4794 incident shape. The four are ALSO missing GH-4587's `hr.IsDispatchGated()` term (pre-existing gap: an admission-gate decline reports as failure there too).

Additionally, Plane's host-side failure comment (`:480`, `} else if hr.Result != nil {` → `❌ Pilot execution failed`) lacks the `!hr.IsTerminalByDesign()` gate GitLab received (`:609`) — a superseded execution posts a failure comment on a closed work item.

## Acceptance

1. Introduce **one shared helper** on `HandlerResult` (`cmd/pilot/handler_common.go`), e.g. `EffectiveSuccess() bool { return hr.Success || hr.IsDispatchGated() || hr.IsTerminalByDesign() }`, with a doc comment naming GH-4587 + GH-4794.
2. All seven adapter handlers' `IssueResult.Success` fields use it — including rewriting the three sites PR#4800 fixed inline, so the formula exists exactly once (TASK-459 pattern-3 hygiene: one fact, one implementation).
3. Plane's failure-comment branch gains `&& !hr.IsTerminalByDesign()`, mirroring GitLab's `:609`.
4. Tests: extend `TestSDKTranslation_TerminalByDesign_DoesNotMislabelAsFailed` (handler_common_test.go) to assert the helper, and a table covering the three inputs (plain success, dispatch-gated, terminal-by-design) → all `EffectiveSuccess() == true`, plus genuine failure → false.
5. `make build` / `make test` / `make lint` green.

## Scope fence

Translation formula + Plane comment gate only. No changes to `classifyWaitedExecution`/`classifyResultAlert`, the dispatcher vocabulary, or the cleaner. If azuredevops intentionally omits `IsDispatchGated()` (it did pre-PR#4800), preserve that by NOT switching it to the helper without checking git history first — if the omission was accidental, unify; note the finding in the PR either way.

**This task must NOT be decomposed — implement as a single PR.** <!-- pilot:no-decompose -->

## Refs

- Found in post-merge review of PR#4800: https://github.com/qf-studio/pilot/pull/4800#issuecomment-5220926846
- Prior art: GH-4794 (the class definition) · GH-4587 (dispatch-gated term) · TASK-441 L3 (primary-adapter fix → sibling-adapter audit precedent, fixes #4723/#4725/#4728/#4729/#4730)
- TASK-459 Phase 4 candidate: shared-formula hygiene (one fact, one implementation)