### PR TITLE
GH-4807: fix(autopilot): breaker-held PRs stranded by restart (RestoreState skips StageFailed) and by Observe-path close (re-drive only fires from the monitor) — PR#4806 review

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1625,16 +1625,22 @@ const selfUpgradeAdmissionPauseOwner = "self-upgrade"
 // nothing failing anywhere would otherwise never close and its parked PRs
 // would never re-drive. EvaluateClose applies the identical check standalone.
 //
-// The OPEN transition needs no monitor tick: it's always detected
-// synchronously inside whichever controller's handleCIFailed call correlates
-// it (alertPlatformBreakerTransition pauses admission and fires the alert
-// immediately). This monitor only ever fires the CLOSE alert, resumes
-// admission (if pauseAdmissionEnabled), and re-drives every controller's
-// breaker-held PRs — deliberately NOT duplicating alertPlatformBreakerTransition
-// so the close alert fires exactly once fleet-wide (not once per controller),
-// matching the "exactly one alert on close" acceptance criterion from part 1.
-// A nil breaker or empty interval makes this a no-op; dispatcher may be nil
-// (admission pause simply skipped) since Dispatcher itself is optional.
+// GH-4807: the OPEN transition still needs no monitor tick — it's always
+// detected synchronously inside whichever controller's handleCIFailed call
+// correlates it (alertPlatformBreakerTransition pauses admission and fires
+// the alert immediately). But a CLOSE can *also* happen synchronously that
+// same way: any CI-failure observation landing after the quiet deadline
+// closes the breaker inside Observe itself, and alertPlatformBreakerTransition
+// resumes admission and fires the close alert for it right there. That path
+// has no access to the fleet-wide `controllers` map (Controller only knows
+// its own activePRs), so it never re-drives held PRs — they stayed parked
+// until this monitor's own EvaluateClose happened to fire, or the re-adopt
+// cap, or a later episode that closed via this monitor's path instead. This
+// loop now tracks the breaker's open/closed state across ticks (dropping the
+// old `if !breaker.IsOpen() { continue }` pre-check) so it notices an
+// Observe-path close within one probe_interval and re-drives for it too —
+// without re-alerting, since alertPlatformBreakerTransition already fired
+// the close alert exactly once for that transition.
 func startPlatformBreakerMonitor(ctx context.Context, breaker *autopilot.PlatformBreaker, dispatcher *executor.Dispatcher, controllers map[string]*autopilot.Controller, alertsEngine *alerts.Engine, pauseAdmissionEnabled bool, interval time.Duration, log *slog.Logger) {
 	if breaker == nil {
 		return
@@ -1648,47 +1654,84 @@ func startPlatformBreakerMonitor(ctx context.Context, breaker *autopilot.Platfor
 	ticker := time.NewTicker(interval)
 	go func() {
 		defer ticker.Stop()
+		wasOpen := breaker.IsOpen()
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if !breaker.IsOpen() {
-					continue
-				}
-				result := breaker.EvaluateClose()
-				if !result.JustClosed {
-					continue
-				}
-				log.Info("platform-outage breaker closed during a quiet spell (no CI activity to trigger Observe) — re-driving held PRs",
-					"correlated_prs", result.CorrelatedPRs)
-
-				if dispatcher != nil && pauseAdmissionEnabled {
-					dispatcher.ResumeAdmissionFor(autopilot.PlatformBreakerAdmissionPauseOwner)
-				}
-
-				for _, ctrl := range controllers {
-					ctrl.ReDriveBreakerHeldPRs(ctx)
-				}
-
-				if alertsEngine == nil {
-					log.Error("platform breaker close alert not delivered: alertsEngine is nil")
-					continue
-				}
-				alertsEngine.ProcessEvent(alerts.Event{
-					Type: alerts.EventType("platform_breaker_close"),
-					Error: fmt.Sprintf(
-						"Platform-outage breaker CLOSED: quiet period elapsed with no new infra/unknown-class CI failure (detected by the periodic monitor during a quiet spell — nothing was failing anywhere to trigger this via a live CI check). Normal CI-failure handling has resumed. PRs held during the outage: %s",
-						strings.Join(result.CorrelatedPRs, ", "),
-					),
-					Timestamp: time.Now(),
-					Metadata: map[string]string{
-						"prs": strings.Join(result.CorrelatedPRs, ","),
-					},
-				})
+				wasOpen = platformBreakerMonitorTick(ctx, breaker, dispatcher, controllers, alertsEngine, pauseAdmissionEnabled, wasOpen, log)
 			}
 		}
 	}()
+}
+
+// platformBreakerMonitorTick runs one evaluation of the platform-outage
+// breaker's close condition, extracted out of startPlatformBreakerMonitor's
+// ticker loop so it can be driven directly (and deterministically) by tests
+// instead of waiting on a real time.Ticker. wasOpen is the breaker's open
+// state as observed on the PREVIOUS tick (or at monitor start); the return
+// value is the state observed at the end of THIS tick, meant to be threaded
+// back in as wasOpen on the next call.
+func platformBreakerMonitorTick(ctx context.Context, breaker *autopilot.PlatformBreaker, dispatcher *executor.Dispatcher, controllers map[string]*autopilot.Controller, alertsEngine *alerts.Engine, pauseAdmissionEnabled bool, wasOpen bool, log *slog.Logger) bool {
+	var result autopilot.PlatformBreakerResult
+	if wasOpen {
+		// Only worth the time-based check while we last saw the breaker
+		// open — a no-op otherwise (mirrors the old IsOpen() pre-check for
+		// the never-opened-yet case).
+		result = breaker.EvaluateClose()
+	}
+	nowOpen := breaker.IsOpen()
+	// GH-4807: wasOpen but no longer, and THIS tick's EvaluateClose didn't
+	// cause it (JustClosed false) — the only other way that happens is an
+	// Observe-path close between ticks.
+	observePathClose := wasOpen && !nowOpen && !result.JustClosed
+
+	if !result.JustClosed && !observePathClose {
+		return nowOpen
+	}
+
+	if observePathClose {
+		log.Info("platform-outage breaker closed via an Observe-path CI-failure evaluation (caught on next monitor tick) — re-driving held PRs; close alert already fired at the transition")
+	} else {
+		log.Info("platform-outage breaker closed during a quiet spell (no CI activity to trigger Observe) — re-driving held PRs",
+			"correlated_prs", result.CorrelatedPRs)
+	}
+
+	if dispatcher != nil && pauseAdmissionEnabled {
+		// Idempotent no-op if alertPlatformBreakerTransition already resumed
+		// admission for the Observe-path case (ResumeAdmissionFor deletes a
+		// possibly-absent owner key) — see Dispatcher.ResumeAdmissionFor.
+		dispatcher.ResumeAdmissionFor(autopilot.PlatformBreakerAdmissionPauseOwner)
+	}
+
+	for _, ctrl := range controllers {
+		ctrl.ReDriveBreakerHeldPRs(ctx)
+	}
+
+	if !result.JustClosed {
+		// Observe-path close: alertPlatformBreakerTransition already fired
+		// the close alert exactly once for this transition — do not
+		// duplicate it here.
+		return nowOpen
+	}
+
+	if alertsEngine == nil {
+		log.Error("platform breaker close alert not delivered: alertsEngine is nil")
+		return nowOpen
+	}
+	alertsEngine.ProcessEvent(alerts.Event{
+		Type: alerts.EventType("platform_breaker_close"),
+		Error: fmt.Sprintf(
+			"Platform-outage breaker CLOSED: quiet period elapsed with no new infra/unknown-class CI failure (detected by the periodic monitor during a quiet spell — nothing was failing anywhere to trigger this via a live CI check). Normal CI-failure handling has resumed. PRs held during the outage: %s",
+			strings.Join(result.CorrelatedPRs, ", "),
+		),
+		Timestamp: time.Now(),
+		Metadata: map[string]string{
+			"prs": strings.Join(result.CorrelatedPRs, ","),
+		},
+	})
+	return nowOpen
 }
 
 // startQueueDepthRefresh launches a background loop that periodically calls

--- a/cmd/pilot/platform_breaker_monitor_test.go
+++ b/cmd/pilot/platform_breaker_monitor_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/autopilot"
+	"github.com/qf-studio/pilot/internal/testutil"
+	githubSDK "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestPlatformBreakerMonitorTick_RedrivesOnObservePathClose covers GH-4807
+// acceptance criterion 2: a breaker close that happens inside
+// PlatformBreaker.Observe (a CI-failure observation landing after the quiet
+// deadline — part 1's TestPlatformBreaker_ClosesAfterQuietPeriod shape,
+// mirrored here with a short real quiet period + sleep instead of a fake
+// clock, since PlatformBreaker's clock hook isn't exported outside package
+// autopilot) must still get its held PRs re-driven.
+//
+// Before the fix, startPlatformBreakerMonitor's ticker loop gated on
+// `if !breaker.IsOpen() { continue }` BEFORE ever calling EvaluateClose: once
+// Observe had already closed the breaker between ticks (and
+// alertPlatformBreakerTransition had already resumed admission + fired the
+// close alert for it, from inside whichever controller's handleCIFailed
+// observed it), the monitor's next tick found the breaker already closed and
+// skipped entirely — so ReDriveBreakerHeldPRs, whose only caller is this
+// monitor, never ran for that transition. Held PRs stayed parked until the
+// re-adopt cap or a later episode that happened to close via the monitor's
+// own EvaluateClose instead.
+func TestPlatformBreakerMonitorTick_RedrivesOnObservePathClose(t *testing.T) {
+	breaker := autopilot.NewPlatformBreaker(3, 15*time.Minute, 5*time.Millisecond, nil)
+
+	breaker.Observe(1, "owner/repo", autopilot.FailureClassInfra)
+	breaker.Observe(2, "owner/repo", autopilot.FailureClassInfra)
+	opened := breaker.Observe(3, "owner/repo", autopilot.FailureClassInfra)
+	if !opened.Open {
+		t.Fatal("test setup: breaker should be open after 3 correlated observations")
+	}
+
+	time.Sleep(10 * time.Millisecond) // exceed the 5ms quiet period
+
+	// Mirrors handleCIFailed's Observe call for some OTHER, code-classified
+	// failure elsewhere: not itself correlation evidence, but it still runs
+	// Observe's lazy time-based close check and closes the breaker right
+	// here — the Observe path, not the monitor's own EvaluateClose.
+	closeResult := breaker.Observe(4, "owner/repo", autopilot.FailureClassCode)
+	if !closeResult.JustClosed {
+		t.Fatal("test setup: breaker should have closed via the Observe path")
+	}
+	if breaker.IsOpen() {
+		t.Fatal("test setup: breaker should be closed after the Observe-path transition")
+	}
+
+	ghClient := githubSDK.NewClient(testutil.FakeGitHubToken)
+	ctrl := autopilot.NewController(autopilot.DefaultConfig(), ghClient, nil, "owner", "repo", autopilot.WithPlatformBreaker(breaker))
+
+	// Park a held PR the way handleCIFailed would have while the breaker was
+	// open, via the store + RestoreState round trip (GH-4807 criterion 1),
+	// rather than reaching into the controller's unexported activePRs map.
+	store, err := autopilot.NewStateStoreFromPath(":memory:")
+	if err != nil {
+		t.Fatalf("NewStateStoreFromPath: %v", err)
+	}
+	held := &autopilot.PRState{
+		PRNumber:          77,
+		IssueNumber:       77,
+		Stage:             autopilot.StageFailed,
+		BreakerHoldActive: true,
+	}
+	if err := store.SavePRState("owner/repo", held); err != nil {
+		t.Fatalf("SavePRState: %v", err)
+	}
+	ctrl.SetStateStore(store)
+	if _, err := ctrl.RestoreState(); err != nil {
+		t.Fatalf("RestoreState: %v", err)
+	}
+	if _, ok := ctrl.GetPRState(77); !ok {
+		t.Fatal("test setup: held PR 77 should have been rehydrated by RestoreState")
+	}
+
+	controllers := map[string]*autopilot.Controller{"owner/repo": ctrl}
+
+	// wasOpen=true mirrors the monitor's previous tick having last observed
+	// the breaker open, before Observe closed it out from under the ticker
+	// between ticks. alertsEngine=nil doubles as an assertion that no alert
+	// is fired for this transition — alertPlatformBreakerTransition already
+	// fired it exactly once at the Observe call above, so a regression that
+	// duplicated it here would nil-pointer panic instead of passing quietly.
+	nowOpen := platformBreakerMonitorTick(context.Background(), breaker, nil, controllers, nil, false, true, slog.Default())
+
+	if nowOpen {
+		t.Error("platformBreakerMonitorTick reported the breaker still open after an Observe-path close")
+	}
+
+	revived, ok := ctrl.GetPRState(77)
+	if !ok {
+		t.Fatal("PR 77 disappeared from activePRs")
+	}
+	if revived.Stage != autopilot.StageWaitingCI {
+		t.Errorf("PR 77 Stage = %v, want StageWaitingCI — Observe-path close did not re-drive it", revived.Stage)
+	}
+	if revived.BreakerHoldActive {
+		t.Error("PR 77 BreakerHoldActive should be cleared after re-drive")
+	}
+}
+
+// TestPlatformBreakerMonitorTick_MonitorPathCloseStillRedrives covers the
+// pre-existing monitor-path close (the original GH-4792 behavior):
+// EvaluateClose itself detects the time-based close on this tick (no Observe
+// call raced it), and this must still re-drive held PRs — the GH-4807
+// Observe-path addition must not regress the path that already worked. (The
+// close-alert-exactly-once behavior on this branch is unchanged code, still
+// covered by the existing alertPlatformBreakerTransition tests.)
+func TestPlatformBreakerMonitorTick_MonitorPathCloseStillRedrives(t *testing.T) {
+	breaker := autopilot.NewPlatformBreaker(3, 15*time.Minute, 5*time.Millisecond, nil)
+
+	breaker.Observe(1, "owner/repo", autopilot.FailureClassInfra)
+	breaker.Observe(2, "owner/repo", autopilot.FailureClassInfra)
+	opened := breaker.Observe(3, "owner/repo", autopilot.FailureClassInfra)
+	if !opened.Open {
+		t.Fatal("test setup: breaker should be open after 3 correlated observations")
+	}
+
+	time.Sleep(10 * time.Millisecond) // exceed the 5ms quiet period, no further Observe call
+
+	if !breaker.IsOpen() {
+		t.Fatal("test setup: breaker must still report open — nothing has evaluated the close yet")
+	}
+
+	ghClient := githubSDK.NewClient(testutil.FakeGitHubToken)
+	ctrl := autopilot.NewController(autopilot.DefaultConfig(), ghClient, nil, "owner", "repo", autopilot.WithPlatformBreaker(breaker))
+
+	store, err := autopilot.NewStateStoreFromPath(":memory:")
+	if err != nil {
+		t.Fatalf("NewStateStoreFromPath: %v", err)
+	}
+	held := &autopilot.PRState{
+		PRNumber:          78,
+		IssueNumber:       78,
+		Stage:             autopilot.StageFailed,
+		BreakerHoldActive: true,
+	}
+	if err := store.SavePRState("owner/repo", held); err != nil {
+		t.Fatalf("SavePRState: %v", err)
+	}
+	ctrl.SetStateStore(store)
+	if _, err := ctrl.RestoreState(); err != nil {
+		t.Fatalf("RestoreState: %v", err)
+	}
+
+	controllers := map[string]*autopilot.Controller{"owner/repo": ctrl}
+
+	nowOpen := platformBreakerMonitorTick(context.Background(), breaker, nil, controllers, nil, false, true, slog.Default())
+	if nowOpen {
+		t.Error("platformBreakerMonitorTick reported the breaker still open after the quiet-period close")
+	}
+
+	revived, ok := ctrl.GetPRState(78)
+	if !ok {
+		t.Fatal("PR 78 disappeared from activePRs")
+	}
+	if revived.Stage != autopilot.StageWaitingCI {
+		t.Errorf("PR 78 Stage = %v, want StageWaitingCI — monitor-path close did not re-drive it", revived.Stage)
+	}
+}

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1746,8 +1746,18 @@ func (c *Controller) RestoreState() (int, error) {
 
 	c.mu.Lock()
 	for _, pr := range states {
-		// Skip terminal states — they shouldn't be active
-		if pr.Stage == StageFailed {
+		// Skip terminal states — they shouldn't be active. Exception
+		// (GH-4807): a PR parked via a platform-outage breaker hold
+		// (BreakerHoldActive, see handleCIFailed / ReDriveBreakerHeldPRs) is
+		// not truly terminal — it's waiting for the breaker to close so it
+		// can be re-driven back into StageWaitingCI. Without this exception,
+		// a daemon restart mid-outage (the 2026-08-06 GitHub Actions outage
+		// restarted the daemon while PRs were held) permanently strands
+		// every held PR: breaker_hold_active survives in SQLite, but the row
+		// never re-enters c.activePRs, and ReDriveBreakerHeldPRs only scans
+		// c.activePRs — so the hold can never be released. Every other
+		// StageFailed row keeps the unconditional skip.
+		if pr.Stage == StageFailed && !pr.BreakerHoldActive {
 			continue
 		}
 		// GH-4331: a scope carrier whose scope-release row already resolved

--- a/internal/autopilot/platform_breaker_redrive_test.go
+++ b/internal/autopilot/platform_breaker_redrive_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/qf-studio/pilot/internal/testutil"
 	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
@@ -205,5 +206,112 @@ func TestReDriveBreakerHeldPRs_MultiplePRs(t *testing.T) {
 		if pr.BreakerReadoptCount != 1 {
 			t.Errorf("pr %d BreakerReadoptCount = %d, want 1", pr.PRNumber, pr.BreakerReadoptCount)
 		}
+	}
+}
+
+// TestController_RestoreState_RehydratesBreakerHeldPR covers GH-4807
+// acceptance criterion 1: a PR parked via a platform-outage breaker hold
+// (StageFailed + BreakerHoldActive) must survive a daemon restart. Before
+// the fix, RestoreState's unconditional `pr.Stage == StageFailed` skip
+// dropped every held PR — breaker_hold_active/breaker_readopt_count
+// persisted in SQLite, but the row never re-entered a fresh controller's
+// activePRs, so ReDriveBreakerHeldPRs (which only scans activePRs) could
+// never revive it. This test saves a held PR directly to the store,
+// constructs a FRESH controller over that same store (simulating the
+// restart), calls RestoreState, then closes the breaker via the monitor
+// path (EvaluateClose + ReDriveBreakerHeldPRs, mirroring
+// startPlatformBreakerMonitor) and asserts the PR re-enters StageWaitingCI.
+func TestController_RestoreState_RehydratesBreakerHeldPR(t *testing.T) {
+	store := newTestStateStore(t)
+
+	held := &PRState{
+		PRNumber:          120,
+		PRURL:             "https://github.com/owner/repo/pull/120",
+		IssueNumber:       120,
+		BranchName:        "pilot/GH-120",
+		HeadSHA:           "sha-restart-held",
+		Stage:             StageFailed,
+		Error:             "platform-outage breaker open — holding PR",
+		BreakerHoldActive: true,
+	}
+	if err := store.SavePRState("owner/repo", held); err != nil {
+		t.Fatalf("SavePRState failed: %v", err)
+	}
+
+	// A PR held at StageFailed for an UNRELATED reason (no BreakerHoldActive)
+	// must still be skipped by RestoreState — only the breaker-hold exception
+	// widens the rehydration filter.
+	plainFailed := &PRState{
+		PRNumber:    121,
+		PRURL:       "https://github.com/owner/repo/pull/121",
+		IssueNumber: 121,
+		BranchName:  "pilot/GH-121",
+		HeadSHA:     "sha-plain-failed",
+		Stage:       StageFailed,
+		Error:       "fix-issue cascade exhausted",
+	}
+	if err := store.SavePRState("owner/repo", plainFailed); err != nil {
+		t.Fatalf("SavePRState failed: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	// Fresh controller over the SAME store — simulates the daemon restart.
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	breaker := NewPlatformBreaker(3, 15*time.Minute, 20*time.Minute, nil)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo", WithPlatformBreaker(breaker))
+	c.SetStateStore(store)
+
+	if _, err := c.RestoreState(); err != nil {
+		t.Fatalf("RestoreState failed: %v", err)
+	}
+
+	restoredHeld, ok := c.GetPRState(120)
+	if !ok {
+		t.Fatal("breaker-held PR 120 was not rehydrated into activePRs — RestoreState still strands it across a restart")
+	}
+	if restoredHeld.Stage != StageFailed || !restoredHeld.BreakerHoldActive {
+		t.Errorf("rehydrated PR 120: Stage=%v BreakerHoldActive=%v, want StageFailed/true", restoredHeld.Stage, restoredHeld.BreakerHoldActive)
+	}
+
+	if _, ok := c.GetPRState(121); ok {
+		t.Error("PR 121 (plain StageFailed, no BreakerHoldActive) should NOT be rehydrated — the skip still applies for ordinary terminal failures")
+	}
+
+	// Open the breaker for real (3 distinct correlated PRs), then close it
+	// via the monitor path: EvaluateClose (time-based, mirrors
+	// startPlatformBreakerMonitor's own call) followed by
+	// ReDriveBreakerHeldPRs.
+	breaker.Observe(1, "owner/repo", FailureClassInfra)
+	breaker.Observe(2, "owner/repo", FailureClassInfra)
+	opened := breaker.Observe(3, "owner/repo", FailureClassInfra)
+	if !opened.Open {
+		t.Fatal("test setup: breaker should be open after 3 correlated observations")
+	}
+
+	breaker.mu.Lock()
+	breaker.lastInfraAt = breaker.lastInfraAt.Add(-30 * time.Minute) // force past the quiet period
+	breaker.mu.Unlock()
+
+	closeResult := breaker.EvaluateClose()
+	if !closeResult.JustClosed {
+		t.Fatal("test setup: breaker should have closed via the time-based quiet-period check")
+	}
+
+	c.ReDriveBreakerHeldPRs(context.Background())
+
+	revived, ok := c.GetPRState(120)
+	if !ok {
+		t.Fatal("PR 120 disappeared from activePRs after re-drive")
+	}
+	if revived.Stage != StageWaitingCI {
+		t.Errorf("PR 120 Stage after re-drive = %v, want StageWaitingCI", revived.Stage)
+	}
+	if revived.BreakerHoldActive {
+		t.Error("PR 120 BreakerHoldActive should be cleared after re-drive")
 	}
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4807.

Closes #4807

## Changes

GitHub Issue GH-4807: fix(autopilot): breaker-held PRs stranded by restart (RestoreState skips StageFailed) and by Observe-path close (re-drive only fires from the monitor) — PR#4806 review

## Problem

PR#4806 (GH-4792, platform-outage breaker part 2) parks breaker-held PRs at `StageFailed` with `BreakerHoldActive=true` and revives them via `Controller.ReDriveBreakerHeldPRs` when the breaker closes. Two recovery-path defects (found in pre-merge review, https://github.com/qf-studio/pilot/pull/4806#issuecomment-5222736662):

1. **Restart strands held PRs.** `RestoreState` (`internal/autopilot/controller.go`, the `if pr.Stage == StageFailed { continue }` skip near the top of the rehydration loop) drops every `StageFailed` row from rehydration. A breaker-held PR therefore survives a daemon restart in SQLite (`breaker_hold_active=1`) but never re-enters `c.activePRs` — and `ReDriveBreakerHeldPRs` iterates only `c.activePRs`. After any restart mid-outage (which is exactly what happened 2026-08-06), every held PR is permanently stranded and the `breaker_hold_active`/`breaker_readopt_count` columns can never do their documented job.
2. **Observe-path close never re-drives.** `ReDriveBreakerHeldPRs` has exactly one caller: `startPlatformBreakerMonitor` (`cmd/pilot/main.go`), gated on `if !breaker.IsOpen() { continue }` before its own `EvaluateClose()`. When the close transition instead happens inside `PlatformBreaker.Observe` (any CI failure arriving after the quiet deadline triggers `closeIfQuietLocked` there), `alertPlatformBreakerTransition` resumes admission and fires the close alert — but the monitor then finds the breaker already closed and skips, so held PRs stay parked until the re-adopt cap or a later episode that happens to close via the monitor path.

## Acceptance

1. `RestoreState` rehydrates rows with `Stage == StageFailed && BreakerHoldActive` into `activePRs` (only those — the unconditional skip stays for every other `StageFailed` row). Regression test: save a held PR, construct a fresh controller over the same store, `RestoreState`, close the breaker via the monitor path, assert the PR re-enters `StageWaitingCI`.
2. Re-drive fires on BOTH close paths. Simplest correct shape: in the monitor loop, drop the `IsOpen()` pre-check and track the breaker's open state across ticks — re-drive whenever `EvaluateClose().JustClosed` OR the observed state transitioned open→closed since the previous tick (covers Observe-path closes within one `probe_interval`). Alternative: have `alertPlatformBreakerTransition`'s `JustClosed` branch trigger the fleet-wide re-drive via a callback — if chosen, keep the close alert exactly-once (the monitor must not also alert). Either way: regression test where the close happens via `Observe` (post-quiet-period code-class failure, part 1's `TestPlatformBreaker_ClosesAfterQuietPeriod` shape) and a held PR still gets re-driven.
3. No change to open-path behavior, suppression, probe, or admission-pause semantics. `make build` / `make test` / `make lint` green, `-race` clean.

## Scope fence

Recovery path only (`RestoreState` + re-drive triggering). No changes to `PlatformBreaker`'s open/close state machine beyond what re-drive triggering strictly needs, no probe changes, no dispatcher changes. #4798 (metrics aggregate) is a separate issue — do not fold it in.

**This task must NOT be decomposed — implement as a single PR.** <!-- pilot:no-decompose -->

## Refs

- Found in pre-merge review of PR#4806: https://github.com/qf-studio/pilot/pull/4806#issuecomment-5222736662
- Sibling follow-up: #4798 (part-1 metrics never reach `AggregateMetrics.Snapshot()`)
- Task: `.agent/tasks/TASK-458-platform-outage-breaker.md` — operator will not enable `platform_breaker` until #4798 + this merge
- Incident context: 2026-08-06 GitHub Actions outage — the daemon WAS restarted mid-outage, so defect 1's trigger is the historical norm, not an edge case