### PR TITLE
fix(autopilot): TASK-459 Phase 2 — CI-failure path consumes typed Verdicts (#4811)

### DIFF
--- a/.agent/system/irreversible-actions.md
+++ b/.agent/system/irreversible-actions.md
@@ -1,7 +1,16 @@
 # Irreversible-action inventory (TASK-459 Phase 1)
 
-**Status**: Phase 1 of 5 — inventory + `Verdict` contract only. No behaviour
-change; no call site below is migrated in this phase.
+**Status**: Phase 2 of 5 landed. Phase 1 built the inventory + `Verdict`
+contract with no behaviour change. Phase 2 migrated the CI-failure path —
+`handleCIFailed`'s ladder (family 1's `MaxCIFixIterations` close, family 3's
+pre-merge `CreateFailureIssue`, family 8's zero-evidence `escalateAndHold`)
+and the post-merge CI rung (family 3's post-merge `CreateFailureIssue`, plus
+a *new* family-8 zero-evidence hold that didn't exist before Phase 2 — the
+post-merge path previously spawned a fix issue for any `CIFailure` with no
+classification at all) — to gate on `Verdict.AuthorizesDestructive()`
+instead of raw `FailureClass`/string/nil-check comparisons. Their rows below
+are marked `typed-verdict` accordingly. All other rows are still Phase
+1-only classification; Phase 3 covers executor/dispatcher/poller sites.
 
 **Purpose**: Every call site in the daemon that closes a PR, deletes a
 branch, spawns a fix issue, burns retry budget, writes a terminal label, or
@@ -50,7 +59,7 @@ branch/commits may also be deleted immediately after, see family 2)
 
 | Site | Subsystem | Reversibility | Blast radius | Evidence | required_checks scoping |
 |---|---|---|---|---|---|
-| `internal/autopilot/controller.go:2453` (`handleCIFailed`, `MaxCIFixIterations` rung) | autopilot | irreversible | Discards the PR + all executor work on it (the #4765/#4768/#4770 incident shape); triggers the follow-on branch-delete-adjacent cleanup | `counter` — `iteration >= MaxCIFixIterations`, iteration parsed by regex from issue body text. Reached only after upstream `classifyPRFailure`/platform-breaker gates (2350-2404), but the close trigger itself is evidence-blind to *what* failed, only *how many times* | **Authoritative for the iteration count itself (scope-agnostic), but the whole `handleCIFailed` function is only entered because `CIMonitor.CheckCI`/`checkRequiredChecks` aggregated `CIFailure` from in-scope checks only** — a failing but unscoped check never reaches this rung at all |
+| `internal/autopilot/controller.go:2550` (`handleCIFailed`, `MaxCIFixIterations` rung) | autopilot | irreversible | Discards the PR + all executor work on it (the #4765/#4768/#4770 incident shape); triggers the follow-on branch-delete-adjacent cleanup | `typed-verdict` (TASK-459 Phase 2) — the counter rung is unreachable unless `verdict.AuthorizesDestructive()` gated earlier in the function (controller.go:2501); the close trigger itself is still `counter`-driven (`iteration >= MaxCIFixIterations`) but is now provably behind positive-evidence, not just behind the platform-breaker/upstream gates | **Authoritative for the iteration count itself (scope-agnostic), but the whole `handleCIFailed` function is only entered because `CIMonitor.CheckCI`/`checkRequiredChecks` aggregated `CIFailure` from in-scope checks only** — a failing but unscoped check never reaches this rung at all |
 | `internal/autopilot/controller.go:2579` (`handleReviewRequested` tail) | autopilot | irreversible | Discards the PR | `raw-string`/`raw-bool` — driven by `ListPullRequestReviews`/`GetPullRequestComments` review state, not CI | N/A — review path, not CI-scoped |
 | `internal/autopilot/controller.go:2784` (`handleReviewRequested`, `ReviewFeedback.MaxIterations` rung) | autopilot | irreversible | Discards the PR | `counter` — same `parseAutopilotIteration` mechanism as 2453 | N/A |
 | `internal/autopilot/controller.go:2842` (`handleReviewRequested` fallthrough, immediately followed by branch delete at 2847) | autopilot | irreversible | Discards the PR + branch | `raw-bool`/`counter` per the preceding review-state checks | N/A |
@@ -70,8 +79,8 @@ branch/commits may also be deleted immediately after, see family 2)
 
 | Site | Subsystem | Reversibility | Blast radius | Evidence | required_checks scoping |
 |---|---|---|---|---|---|
-| `internal/autopilot/controller.go:2531` (`handleCIFailed` main rung) | autopilot | costly-reversible — a spurious issue can be closed by a human, but burns a full executor dispatch first (the #4766/#4769/#4775 incident shape: ~$ per junk fix run) | Executor $ + operator triage time | `typed`+`raw-string` — `failedChecks` from `CIMonitor.GetFailedChecks`, already `isScopedCheck`-filtered | **Yes — decorative for unscoped checks.** The issue body's diagnosis (failed-check names + logs) only ever names checks the allowlist let through; an actually-failing unlisted check contributes zero evidence to the spawned issue |
-| `internal/autopilot/controller.go:3977` (post-merge CI failure rung) | autopilot | costly-reversible | Same as above, post-merge variant | Same evidence chain | Yes, same scoping |
+| `internal/autopilot/controller.go:2628` (`handleCIFailed` main rung) | autopilot | costly-reversible — a spurious issue can be closed by a human, but burns a full executor dispatch first (the #4766/#4769/#4775 incident shape: ~$ per junk fix run) | Executor $ + operator triage time | `typed-verdict` (TASK-459 Phase 2) — unreachable unless `verdict.AuthorizesDestructive()` gated earlier (controller.go:2501); `failedChecks` feeding the issue body is still `CIMonitor.GetFailedChecks`, already `isScopedCheck`-filtered | **Yes — decorative for unscoped checks.** The issue body's diagnosis (failed-check names + logs) only ever names checks the allowlist let through; an actually-failing unlisted check contributes zero evidence to the spawned issue |
+| `internal/autopilot/controller.go:4122` (post-merge CI failure rung) | autopilot | costly-reversible | Same as above, post-merge variant | `typed-verdict` (TASK-459 Phase 2) — previously this rung had **no classification at all** (any post-merge `CIFailure` spawned a fix issue modulo iteration/size guards); now unreachable unless `postMergeVerdict.AuthorizesDestructive()` gated earlier (controller.go:4112), the same construction as the pre-merge rung | Yes, same scoping |
 | `internal/autopilot/feedback_loop.go:156` (`FeedbackLoop.CreateFailureIssue`, the shared implementation both rungs above call) | autopilot | — | — | Has its own dedup guard: SQLite claim (`ClaimSpawnedFix`, GH-4307/#4319) + GitHub-search belt-and-suspenders (`SpawnedFixExists`) so two ticks racing on the same failure spawn exactly one issue — this guard is about *duplication*, not about evidence quality | Inherits caller's scoping |
 | `internal/executor/epic.go:1501` (`subIssueCreator.CreateIssue`, epic decomposition) | executor | costly-reversible | Different family — decomposition sub-issue spawn, not CI-fix-driven | `raw` decomposition logic, not CI evidence | N/A |
 | `internal/comms/issue_intake.go:144` (generic issue-intake `CreateIssue`) | comms | costly-reversible | Adapter-driven (e.g. Slack), not autonomous-daemon-invoked in the CI-fix sense | N/A | N/A |
@@ -126,15 +135,16 @@ branch/commits may also be deleted immediately after, see family 2)
 
 ## 8. `escalateAndHold` and hold/escalation (semi-destructive: never closes/deletes/merges, but pages a human and parks the PR — operator-costly)
 
-Defined once at `internal/autopilot/controller.go:5204`. Call sites:
+Defined once at `internal/autopilot/controller.go:5349`. Call sites:
 
 | Site | Reason string | Evidence gating this call |
 |---|---|---|
-| `controller.go:2411` | "CI failure with zero gathered evidence" | `typed` + `nil-check` — `classifyPRFailure == FailureClassUnknown` *and* `perCheckLogs` came back empty. This is the GH-4779 fix that already implements the TASK-459 invariant for one site: zero evidence routes here, never to `ClosePullRequest`/`CreateFailureIssue` |
-| `controller.go:2516` | "CI fix size guard fired" | `counter` — production-line diff stat vs `MaxCIFixPRSize`; fails open (does not hold) if `ListPullRequestFiles` errors |
-| `controller.go:2551` | "CI-fix continuation declined at preflight" | `nil-check` — `CreateFailureIssue` returned an error or a legitimate dedup-claim-in-flight `(0, nil)`; chosen over closing to avoid GH-4415's double-lost-work dead end |
-| `controller.go:4929` | "auto-rebase failed" | `raw-bool` — `attemptMechanicalConflictResolution` (local merge replay) found the conflict surface isn't confined to go.mod/go.sum |
-| `controller.go:5130` (`holdClosedIssueWorkNotOnMain`) | "source issue #N is closed but {situation}" | `re-read` — `checkPRWorkOnMain` reachability check errored or returned false; fail-safe against discarding unmerged work |
+| `controller.go:2508` | "CI failure with zero gathered evidence" | `typed-verdict` (TASK-459 Phase 2) — `!verdict.AuthorizesDestructive()`, i.e. `Class() == FailureClassUnknown` or `Evidence() == ""`, superseding the prior direct `classifyPRFailure == FailureClassUnknown` + `nil-check` comparison with the same GH-4779 invariant expressed through the shared gate helper |
+| `controller.go:4117` (new in Phase 2 — no equivalent pre-Phase-2 site) | "post-merge CI failure with zero gathered evidence" | `typed-verdict` — `!postMergeVerdict.AuthorizesDestructive()`. Previously the post-merge rung had no zero-evidence gate at all; a GH-4779-style race on the post-merge check-runs re-fetch would have spawned a fix issue blind. Closes that gap using the same `newCIFailureVerdict`/`AuthorizesDestructive()` construction as the pre-merge site |
+| `controller.go:2613` | "CI fix size guard fired" | `counter` — production-line diff stat vs `MaxCIFixPRSize`; fails open (does not hold) if `ListPullRequestFiles` errors |
+| `controller.go:2648` | "CI-fix continuation declined at preflight" | `nil-check` — `CreateFailureIssue` returned an error or a legitimate dedup-claim-in-flight `(0, nil)`; chosen over closing to avoid GH-4415's double-lost-work dead end |
+| `controller.go:5074` | "auto-rebase failed" | `raw-bool` — `attemptMechanicalConflictResolution` (local merge replay) found the conflict surface isn't confined to go.mod/go.sum |
+| `controller.go:5274` (`holdClosedIssueWorkNotOnMain`) | "source issue #N is closed but {situation}" | `re-read` — `checkPRWorkOnMain` reachability check errored or returned false; fail-safe against discarding unmerged work |
 | `internal/executor/dispatcher.go:1811/1832/1851` (`stallTaskAfterRepickHardCap`/`StallCap`/`InfraCap`, via `escalateStalledTask` at 1911) | Three distinct named reasons (repick-hard-cap / stall-watchdog-cap / infra-cap) | `counter` — raw consecutive-drop-count thresholds, each with its own distinct reason string (deliberately not conflating "code is broken" vs "environment kept failing"); idempotent via matching the prior `Error` string exactly. This is the executor-level (pre-GitHub-PR) analog of `escalateAndHold` |
 
 ## 9. Cross-cutting findings
@@ -149,9 +159,20 @@ Defined once at `internal/autopilot/controller.go:5204`. Call sites:
 
 ## How Phase 2+ consumes this
 
-Phase 2 gates `handleCIFailed`'s three rungs (family 1's `controller.go:2453`,
-family 3's `:2531`/`:3977`, family 8's `:2411`) behind the `Verdict` type
-defined in `internal/autopilot/failure_class.go`. Phase 3 does the same for
+**Phase 2 (landed, TASK-459)** gated `handleCIFailed`'s rungs (family 1's
+`controller.go:2550`, family 3's `:2628`, family 8's `:2508`) and the
+post-merge CI rung (family 3's `:4122`, plus the new family-8 hold at
+`:4117` that didn't exist pre-Phase-2) behind `Verdict.AuthorizesDestructive()`,
+using the `Verdict` type defined in `internal/autopilot/failure_class.go`.
+The gate requires both a non-`Unknown` `Class()` and non-empty `Evidence()`
+— a bare `Class() != FailureClassUnknown` check was explicitly rejected
+during Phase 2 review because a zero-value `Verdict{}` has `Class() ==
+FailureClassUnknown` by construction but that alone doesn't rule out every
+degenerate-construction path, so `Evidence()` is checked independently.
+`maybeRetryInfraFailure`'s infra-retry gate deliberately does *not* require
+`AuthorizesDestructive()` (retry is non-destructive and must keep admitting
+`FailureClassUnknown` per GH-4779) and `PlatformBreaker.Observe` remains
+upstream of and independent from this gate. Phase 3 does the same for
 families 4/6/7's executor/dispatcher/poller sites. Phase 4 adds
 `scripts/check-destructive-calls.sh` to keep new call sites from bypassing
 the contract. This document is not re-derived per phase — update the

--- a/.agent/tasks/gh-4811.md
+++ b/.agent/tasks/gh-4811.md
@@ -1,0 +1,94 @@
+# GH-4811
+
+**Created:** 2026-08-08
+
+## Problem
+
+GitHub Issue GH-4811: feat(autopilot): TASK-459 Phase 2 — CI-failure path consumes typed Verdicts; evidence-free routes to hold
+
+# feat(autopilot): TASK-459 Phase 2 — CI-failure path consumes typed Verdicts; evidence-free routes to hold
+
+## Context
+
+Phase 1 (#4796 → PR#4802) landed the irreversible-action inventory (`.agent/system/irreversible-actions.md`) and the `Verdict` contract (`internal/autopilot/failure_class.go`: unexported fields, `NewVerdict`/`NewUnknownVerdict`, evidence-free construction downgrades to `FailureClassUnknown`). No call site was migrated.
+
+Phase 2 migrates the biggest offender: the CI-failure path. Per the inventory's "How Phase 2+ consumes this" section, that means `handleCIFailed` (`internal/autopilot/controller.go:2426`) and its destructive rungs, plus the post-merge CI-failure rung. During the 2026-08-06 GitHub Actions outage this path closed a correct PR three times (#4765/#4768/#4770, ~$10.65 discarded) and spawned three junk fix-issues — because the rungs act on raw `FailureClass` values, nil-checks, and counters instead of an evidence-carrying verdict.
+
+**Post-merge review of PR#4802 found one contract hazard this phase must handle** (finding 1 below): `Verdict`'s unexported fields do not restrict construction *within* package `autopilot` — which is where every consumer of this phase lives. The zero value `Verdict{}` has `Class() == FailureClass("")`, which is neither `FailureClassUnknown` nor a destructive class. A gate written as `class != FailureClassUnknown → act` would therefore authorize a destructive action on a zero-value verdict.
+
+## Tasks
+
+### 1. Harden the Verdict zero value (PR#4802 review finding)
+
+- `Verdict.Class()` returns `FailureClassUnknown` when the underlying class is empty, so a zero-value `Verdict` reads as Unknown, never as "not-Unknown".
+- Add a construction-rules test case for the zero value (`var v Verdict` → `Class() == FailureClassUnknown`, `Evidence() == ""`).
+
+### 2. Construct the Verdict at the classification boundary
+
+- Where `handleCIFailed` currently derives a `FailureClass` (via `classifyPRFailure` and the gathered per-check logs), construct a `Verdict` instead: evidence = the specific matched signature / failed-check name / log excerpt that produced the class (not a restatement of the class); source = the classifier function name; scope = `c.repoKey()`.
+- The zero-gathered-evidence case (GH-4779, currently the `escalateAndHold("CI failure with zero gathered evidence")` rung) constructs via `NewUnknownVerdict`.
+
+### 3. Rungs consume the Verdict only
+
+- Every `ClosePullRequest`, `CreateFailureIssue`, and `escalateAndHold` decision reachable from the CI-failure path takes the `Verdict` — never a raw `FailureClass`, raw string, or `failedChecks` nil-check. This covers `handleCIFailed`'s ladder (close on `MaxCIFixIterations`, fix-issue spawn, size-guard/preflight escalations, `maybeRetryInfraFailure` budget) and the post-merge CI-failure `CreateFailureIssue` rung (inventory family 3, controller.go ~:3977 at inventory time — line refs have drifted, trace from `handleCIFailed` and the post-merge handler on current `main`).
+- **Gate semantics — positive evidence required**: destructive rungs proceed only when the verdict carries non-empty `Evidence()` AND a class that authorizes that action. Do NOT write the gate as `Class() != FailureClassUnknown` (finding 1: the zero value slips through that form). Centralize the check in one small helper (e.g. `(Verdict).AuthorizesDestructive()` or equivalent) so Phase 4's grep gate has a single seam to enforce.
+- Evidence-free / Unknown verdicts route to hold (`escalateAndHold`), preserving GH-4779's behaviour — now enforced by the type flow rather than one hand-written rung.
+
+### 4. Preserve behaviour on positive evidence
+
+- Genuine code failures with evidence: today's ladder unchanged (fix-issue → iterations → close at cap).
+- Infra-classified with evidence: rerun budget (`maybeRetryInfraFailure`) unchanged.
+- Platform-breaker composition: the breaker suppression upstream in `handleCIFailed` (#4797/#4806) stays exactly where it is — it is a cross-PR correlation gate; the Verdict is a per-PR evidence gate downstream of it. Do not reorder or merge them.
+
+### 5. Regression tests for the outage shapes
+
+Table-driven tests driving the 2026-08-06 shapes (fixtures already exist in `failure_class_test.go` from #4787) through the rung *decisions*:
+
+- Infra-classified failure → rerun path, `ClosePullRequest`/`CreateFailureIssue` never called.
+- Zero-evidence / Unknown → hold, nothing destructive called.
+- Zero-value `Verdict{}` reaching a rung → hold (finding-1 regression).
+- Genuine code failure with evidence → existing ladder behaviour byte-for-byte (existing `handleCIFailed` tests stay green).
+
+### 6. Update the inventory
+
+- `.agent/system/irreversible-actions.md`: for each migrated site, update its row's evidence column to `typed-verdict` in place (do not delete rows) and refresh that row's drifted `file:line` ref (three controller.go merges landed after the inventory was written — e.g. the `MaxCIFixIterations` close moved from :2453 to ~:2539).
+
+## Decision point (call it in the PR body)
+
+**SHA binding**: the contract carries project scope but not the head SHA the evidence was gathered for (stale-check-run evidence was the #4781 shape). Bias: do NOT extend the shipped contract; the gathering side is already guarded by #4790's check-run dedupe, and `handleCIFailed` acts in the same tick it gathers. Document that constraint on the constructor call site. Only carry the SHA (inside the evidence string, not a new field) if implementation shows the verdict crossing a tick boundary.
+
+## Acceptance Criteria
+
+- [ ] `Verdict.Class()` zero-value hardening + test (finding 1).
+- [ ] Every `ClosePullRequest`/`CreateFailureIssue`/`escalateAndHold` decision reachable from the CI-failure path (pre-merge `handleCIFailed` ladder + post-merge CI rung) consumes a `Verdict`; no raw-class/string/nil-check gating remains on those rungs.
+- [ ] Destructive rungs require positive evidence via a single shared gate helper; Unknown/evidence-free/zero-value verdicts route to hold.
+- [ ] Outage-shape regression tests green; existing controller tests green unchanged (no behaviour change for positively-evidenced failures).
+- [ ] Inventory rows for migrated sites updated (evidence column + refreshed line refs).
+- [ ] `make build`, `make test`, `make lint` green.
+
+## Out of Scope
+
+- Destructive sites outside the CI-failure path: review-path closes (`handleReviewRequested`), merge-conflict closes, external-close handling, executor/dispatcher/poller sites — Phase 3.
+- `SetApprovalDecision` CAS arbitration and the `handleReleasing` retry/escalation ladder (flagged "not fully traced" by Phase 1) — Phase 3 pickup; do not expand into them here.
+- `scripts/check-destructive-calls.sh` grep gate, status-vocabulary parity tables, SOP — Phase 4. (Phase 4's grep should also ban composite-literal `Verdict{` construction outside `failure_class.go` — review finding 2.)
+- Classification internals (#4787) and platform-breaker internals (#4797/#4806) — consumed, not modified.
+- The `required_checks` allowlist policy (founder config decision).
+
+## Verify
+
+```bash
+make build
+make test
+make lint
+```
+
+## Refs
+
+- Task doc: `.agent/tasks/TASK-459-irreversible-action-audit.md` (Phase 2 of 5)
+- Contract + inventory: #4796 → PR#4802 (post-merge review findings in PR comments)
+- Inventory: `.agent/system/irreversible-actions.md` § "How Phase 2+ consumes this"
+- Outage fixtures: #4787 (`failure_class_test.go`)
+- Composes with: platform breaker #4797/#4806 · check-run dedupe #4790 · GH-4779 zero-evidence hold
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2435,6 +2435,15 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 	failureClass := classifyPRFailure(perCheckLogs)
 	c.logCIFailureClassification(prState, perCheckLogs, failureClass)
 
+	// TASK-459 Phase 2: construct the evidence-carrying Verdict once, right
+	// at the classification boundary. Every destructive rung below (close on
+	// MaxCIFixIterations, fix-issue spawn) is now gated on
+	// verdict.AuthorizesDestructive() rather than comparing failureClass
+	// directly — failureClass itself stays in scope for metrics/logging and
+	// the platform-breaker correlation gate below, which are observational,
+	// not decision points this task migrates.
+	verdict := newCIFailureVerdict(failureClass, perCheckLogs, c.repoKey())
+
 	// GH-4791: record this observation for cross-PR platform-outage
 	// correlation before anything else — even PRs that end up auto-retried
 	// below (maybeRetryInfraFailure) or otherwise short-circuited still feed
@@ -2446,7 +2455,7 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 	if failureClass == FailureClassInfraBilling {
 		c.alertBillingRefusalOnce(perCheckLogs)
 	}
-	infraNote, retried := c.maybeRetryInfraFailure(ctx, prState, perCheckLogs, failureClass)
+	infraNote, retried := c.maybeRetryInfraFailure(ctx, prState, perCheckLogs, verdict)
 	if retried {
 		return nil
 	}
@@ -2477,17 +2486,19 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 
 	// GH-4779 THE INVARIANT: a CIFailure aggregate with zero gathered
 	// evidence must never fall through to the destructive fix-issue/close
-	// path below. classifyPRFailure only returns FailureClassUnknown when
-	// perCheckLogs came back empty despite CI's own aggregate status already
-	// being CIFailure to reach handleCIFailed at all — the check-runs list
-	// API call itself failed, or no in-scope check run actually carried a
-	// CIFailure-mapped conclusion. maybeRetryInfraFailure above already gave
-	// this the same infra-rerun chance as a classified infra failure (its
-	// gate now also admits FailureClassUnknown); reaching here means that
-	// path found nothing to rerun (there is no job ID to resolve when there
-	// is no evidence), so hold for a human instead of closing a PR autopilot
-	// never actually looked at.
-	if failureClass == FailureClassUnknown {
+	// path below. TASK-459 Phase 2 now enforces this via
+	// verdict.AuthorizesDestructive() rather than a hand-written
+	// FailureClassUnknown comparison — verdict is Unknown/evidence-free
+	// exactly when perCheckLogs came back empty despite CI's own aggregate
+	// status already being CIFailure to reach handleCIFailed at all (the
+	// check-runs list API call itself failed, or no in-scope check run
+	// actually carried a CIFailure-mapped conclusion). maybeRetryInfraFailure
+	// above already gave this the same infra-rerun chance as a classified
+	// infra failure (its gate now also admits FailureClassUnknown); reaching
+	// here means that path found nothing to rerun (there is no job ID to
+	// resolve when there is no evidence), so hold for a human instead of
+	// closing a PR autopilot never actually looked at.
+	if !verdict.AuthorizesDestructive() {
 		failedChecks, err := c.ciMonitor.GetFailedChecks(ctx, prState.HeadSHA)
 		if err != nil {
 			c.log.Warn("failed to get failed checks for zero-evidence escalation", "pr", prState.PRNumber, "error", err)
@@ -2717,7 +2728,16 @@ const maxInfraRerunBudget = 2
 // rerunInfraFailures below has no job IDs to resolve and falls through with
 // retried=false — but it costs nothing to try, and it means a future signal
 // that lets Unknown carry partial evidence doesn't need this gate revisited.
-func (c *Controller) maybeRetryInfraFailure(ctx context.Context, prState *PRState, checks []FailedCheckLog, class FailureClass) (note string, retried bool) {
+//
+// TASK-459 Phase 2: takes verdict rather than a raw FailureClass — the gate
+// below reads verdict.Class(), which is hardened to read a zero-value
+// Verdict as Unknown (never a bare "" that could slip past the IsInfra()
+// check). This retry gate deliberately does not also require
+// verdict.AuthorizesDestructive(): retrying is the non-destructive rung, and
+// Unknown must still get the same rerun chance an evidenced infra
+// classification gets, per the GH-4779 note above.
+func (c *Controller) maybeRetryInfraFailure(ctx context.Context, prState *PRState, checks []FailedCheckLog, verdict Verdict) (note string, retried bool) {
+	class := verdict.Class()
 	if (!class.IsInfra() && class != FailureClassUnknown) || c.stepLogClient == nil {
 		return "", false
 	}
@@ -4033,6 +4053,16 @@ func (c *Controller) handlePostMergeCI(ctx context.Context, prState *PRState) er
 		// GH-4460: failing-step-tail excerpts, see the matching comment above.
 		ciLogs := c.ciMonitor.GetFailedCheckExcerpts(ctx, mainSHA)
 
+		// TASK-459 Phase 2: classify per-check evidence and construct a
+		// Verdict the same way handleCIFailed's pre-merge path does. Before
+		// this, the post-merge rung spawned a fix issue for ANY post-merge
+		// CIFailure with no classification at all — the same evidence-blind
+		// shape GH-4779 fixed pre-merge (family 3 of the irreversible-action
+		// inventory).
+		postMergePerCheckLogs := c.ciMonitor.GetFailedCheckLogsByCheck(ctx, mainSHA)
+		postMergeClass := classifyPRFailure(postMergePerCheckLogs)
+		postMergeVerdict := newCIFailureVerdict(postMergeClass, postMergePerCheckLogs, c.repoKey())
+
 		// GH-4312: port the pre-merge cascade/size guards (~:1502-1593) to the
 		// post-merge path. Post-merge failures normally start a new lineage
 		// (iteration 1), but when prState.IssueNumber is itself a spawned fix
@@ -4072,6 +4102,20 @@ func (c *Controller) handlePostMergeCI(ctx context.Context, prState *PRState) er
 					skipSpawn = true
 				}
 			}
+		}
+
+		// TASK-459 Phase 2 (GH-4779 parity for the post-merge rung): zero
+		// gathered evidence must never authorize CreateFailureIssue here
+		// either — route to escalateAndHold instead, same as the pre-merge
+		// invariant, rather than spawning a fix issue nothing was actually
+		// classified against.
+		if !skipSpawn && !postMergeVerdict.AuthorizesDestructive() {
+			c.log.Warn("post-merge CI failure with zero gathered evidence, holding instead of spawning fix issue",
+				"pr", prState.PRNumber, "sha", ShortSHA(mainSHA))
+			comment := fmt.Sprintf("Post-merge CI reported failure, but no evidence could be gathered from any check run to classify it — holding this PR for manual review instead of spawning a fix issue blind. %s",
+				ciFailedChecksSummary(failedChecks))
+			c.escalateAndHold(ctx, prState, "post-merge CI failure with zero gathered evidence", []string{labelNeedsHuman}, comment)
+			skipSpawn = true
 		}
 
 		if !skipSpawn {

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -5589,6 +5589,98 @@ func TestHandlePostMergeCI_CIFailure_MarksStageFailedNotRemoved(t *testing.T) {
 	}
 }
 
+// TestHandlePostMergeCI_ZeroEvidence_EscalatesInsteadOfSpawning is the
+// TASK-459 Phase 2 regression test for the post-merge CI-failure
+// CreateFailureIssue rung (family 3 of the irreversible-action inventory,
+// controller.go ~:3977 at inventory time): the initial CheckCI status
+// determination sees a failing check (that's the only way this rung is
+// reached at all), but the classification re-fetch a moment later races
+// GitHub's own status propagation and comes back with zero check runs —
+// the exact GH-4779 shape, replayed for the post-merge path, which
+// previously had no classification step at all and would spawn a fix issue
+// for any post-merge CIFailure regardless of evidence.
+func TestHandlePostMergeCI_ZeroEvidence_EscalatesInsteadOfSpawning(t *testing.T) {
+	issueCreated := false
+	var labelsAdded []string
+	checkRunsCalls := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/zeroevidencepm1/check-runs":
+			checkRunsCalls++
+			if checkRunsCalls == 1 {
+				// First call — CheckCI's own status determination — sees a
+				// failing check, which is what routes into the CIFailure
+				// switch case at all.
+				resp := github.CheckRunsResponse{
+					TotalCount: 1,
+					CheckRuns: []github.CheckRun{
+						{Name: "ci", Status: "completed", Conclusion: "failure"},
+					},
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(mustJSON(t, resp))
+				return
+			}
+			// Every subsequent call (GetFailedChecks / GetFailedCheckExcerpts
+			// / GetFailedCheckLogsByCheck) comes back with nothing — the
+			// zero-gathered-evidence race.
+			resp := github.CheckRunsResponse{TotalCount: 0, CheckRuns: []github.CheckRun{}}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			issueCreated = true
+			resp := github.Issue{Number: 700}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, resp))
+		case strings.Contains(r.URL.Path, "/labels") && r.Method == http.MethodPost:
+			var body map[string][]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			labelsAdded = append(labelsAdded, body["labels"]...)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Label{})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:             124,
+		IssueNumber:          33,
+		Stage:                StagePostMergeCI,
+		PostMergeSHA:         "zeroevidencepm1",
+		PostMergeCIStartedAt: time.Now(),
+	}
+	c.mu.Lock()
+	c.activePRs[124] = prState
+	c.mu.Unlock()
+
+	if err := c.handlePostMergeCI(context.Background(), prState); err != nil {
+		t.Fatalf("handlePostMergeCI returned unexpected error: %v", err)
+	}
+
+	if issueCreated {
+		t.Error("no fix issue should be spawned when there is zero gathered evidence post-merge")
+	}
+	if prState.Stage != StageFailed {
+		t.Errorf("stage = %s, want %s", prState.Stage, StageFailed)
+	}
+	found := false
+	for _, l := range labelsAdded {
+		if l == labelNeedsHuman {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected pilot-needs-human label via escalateAndHold, got labels: %v", labelsAdded)
+	}
+}
+
 // TestHandlePostMergeCI_CIFailure_MaxCIFixIterationsGuard verifies GH-4312:
 // the pre-merge iteration-depth guard (controller.go handleCIFailed, ~:1502)
 // is ported to the post-merge path — when the merged PR's issue is itself a

--- a/internal/autopilot/failure_class.go
+++ b/internal/autopilot/failure_class.go
@@ -1,6 +1,7 @@
 package autopilot
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -296,6 +297,54 @@ func classifyPRFailure(checks []FailedCheckLog) FailureClass {
 	return FailureClassInfra
 }
 
+// ciFailureVerdictEvidence names the concrete evidence backing a
+// classifyPRFailure result (TASK-459 Phase 2): the specific failed check(s)
+// and classification signal(s) that produced class, not a restatement of
+// class itself. Re-derives each check's own classification the same way
+// classifyPRFailure did, then keeps only the checks whose own IsInfra()
+// matches class's — for an infra-family aggregate that is every check (all
+// of them must be infra-family for classifyPRFailure to report infra at
+// all); for a code aggregate that is the specific check(s) that actually
+// tipped the verdict to code, which may coexist with other infra-classified
+// checks in the same run.
+//
+// Only meaningful when class != FailureClassUnknown; classifyPRFailure only
+// returns Unknown when checks is empty, in which case there is nothing here
+// to name (callers use NewUnknownVerdict directly instead of calling this).
+func ciFailureVerdictEvidence(checks []FailedCheckLog, class FailureClass) string {
+	var parts []string
+	for _, chk := range checks {
+		chkClass, signal := classifyCheckFailureFull(chk)
+		if chkClass.IsInfra() == class.IsInfra() {
+			parts = append(parts, fmt.Sprintf("%s:%s(%s)", chk.CheckName, chkClass, signal))
+		}
+	}
+	return strings.Join(parts, "; ")
+}
+
+// newCIFailureVerdict constructs the TASK-459 Phase 2 Verdict for a
+// classifyPRFailure result. source is always "classifyPRFailure" — the
+// function that produced class — regardless of which per-check signal
+// tiers actually fired (those are named individually inside the Evidence()
+// string via ciFailureVerdictEvidence). scope is conventionally
+// Controller.repoKey().
+//
+// SHA binding: the returned Verdict does not carry the HeadSHA checks was
+// gathered against — only the evidence text names individual checks, not a
+// commit. This is a deliberate scope fence (TASK-459 Phase 2 decision
+// point): handleCIFailed always acts on this verdict within the same tick
+// it gathers checks, so there is no tick boundary for a stale-SHA verdict to
+// cross, and the gathering side is already guarded against stale check-run
+// evidence by #4790's check-run dedupe. Do not extend the shipped Verdict
+// contract with a SHA field unless a future call site is found to actually
+// carry a verdict across a tick boundary.
+func newCIFailureVerdict(class FailureClass, checks []FailedCheckLog, scope string) Verdict {
+	if class == FailureClassUnknown {
+		return NewUnknownVerdict("classifyPRFailure", scope)
+	}
+	return NewVerdict(class, ciFailureVerdictEvidence(checks, class), "classifyPRFailure", scope)
+}
+
 // Verdict is the typed, evidence-carrying result of a classification that
 // authorizes (or withholds) an irreversible or operator-costly autopilot
 // action — TASK-459 Phase 1. `.agent/system/irreversible-actions.md`
@@ -360,7 +409,21 @@ func NewUnknownVerdict(source, scope string) Verdict {
 // Class returns the verdict's failure classification. Callers gating a
 // destructive action must treat FailureClassUnknown as "do not act" —
 // never as a synonym for FailureClassCode.
-func (v Verdict) Class() FailureClass { return v.class }
+//
+// A zero-value Verdict (var v Verdict, or any Verdict{} composite literal
+// built outside this file's constructors) has an empty underlying class —
+// neither FailureClassUnknown nor a destructive class, since FailureClass is
+// just a string type. Class() maps that empty class to FailureClassUnknown
+// here so a zero-value Verdict always reads as "do not act", never as
+// "not-Unknown" (TASK-459 Phase 2, PR#4802 review finding 1: a gate written
+// as `class != FailureClassUnknown` would otherwise authorize a destructive
+// action on a zero-value Verdict, since "" != "unknown").
+func (v Verdict) Class() FailureClass {
+	if v.class == "" {
+		return FailureClassUnknown
+	}
+	return v.class
+}
 
 // Evidence returns the positive fact backing this verdict. Always empty for
 // FailureClassUnknown; always non-empty for every other class, guaranteed
@@ -377,3 +440,24 @@ func (v Verdict) Source() string { return v.source }
 // authorize an action within its own scope — evidence gathered for one
 // project's required_checks configuration says nothing about another's.
 func (v Verdict) Scope() string { return v.scope }
+
+// AuthorizesDestructive reports whether v carries enough positive evidence
+// to authorize an irreversible or operator-costly action — ClosePullRequest,
+// CreateFailureIssue, and their kin (TASK-459 Phase 2). This is the single
+// shared gate every destructive rung in the CI-failure path consumes;
+// Phase 4's grep gate (`scripts/check-destructive-calls.sh`) is meant to
+// require a call to this method (or a composite check equivalent to it)
+// next to every such call site, so it must stay the one seam.
+//
+// Deliberately checks both Evidence() and Class() rather than either alone
+// (PR#4802 review finding 1): Class() is hardened above to read a zero-value
+// Verdict as Unknown, but this method does not lean on that hardening as its
+// only line of defense — a gate written purely as `Class() !=
+// FailureClassUnknown` is the exact form that finding flagged as unsafe, so
+// this helper checks Evidence() explicitly too. Both checks are actually
+// redundant given the constructors' invariant (Evidence() != "" iff Class()
+// != FailureClassUnknown), but redundant-by-construction is the point:
+// either check alone failing keeps this false.
+func (v Verdict) AuthorizesDestructive() bool {
+	return v.Evidence() != "" && v.Class() != FailureClassUnknown
+}

--- a/internal/autopilot/failure_class_test.go
+++ b/internal/autopilot/failure_class_test.go
@@ -1,6 +1,9 @@
 package autopilot
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestClassifyCheckFailure_TableDriven exercises the conservative infra
 // signature set from GH-4526/GH-4531/GH-4533: only unambiguous CI
@@ -565,4 +568,142 @@ func TestVerdict_EvidenceFreeNeverAuthorizesDestructiveClass(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestVerdict_ZeroValue is the TASK-459 Phase 2 regression test for PR#4802
+// review finding 1: a zero-value Verdict (var v Verdict, or any accidental
+// Verdict{} composite literal) must read as FailureClassUnknown with empty
+// evidence — never as some other class a naive `class != FailureClassUnknown`
+// gate would treat as authorized, since the zero value's unexported class
+// field is "" (neither FailureClassUnknown's string value nor any
+// destructive class).
+func TestVerdict_ZeroValue(t *testing.T) {
+	var v Verdict
+	if got := v.Class(); got != FailureClassUnknown {
+		t.Errorf("zero-value Verdict.Class() = %q, want %q", got, FailureClassUnknown)
+	}
+	if got := v.Evidence(); got != "" {
+		t.Errorf("zero-value Verdict.Evidence() = %q, want empty", got)
+	}
+	if got := v.Source(); got != "" {
+		t.Errorf("zero-value Verdict.Source() = %q, want empty", got)
+	}
+	if got := v.Scope(); got != "" {
+		t.Errorf("zero-value Verdict.Scope() = %q, want empty", got)
+	}
+	if v.AuthorizesDestructive() {
+		t.Error("zero-value Verdict.AuthorizesDestructive() = true, want false (finding-1 regression: a zero-value Verdict must never authorize a destructive action)")
+	}
+}
+
+// TestVerdict_AuthorizesDestructive is the TASK-459 Phase 2 contract test
+// for the single shared gate every destructive rung in the CI-failure path
+// consumes: true only for a non-Unknown class carrying non-empty evidence,
+// false for every other combination a Verdict can actually be constructed
+// in — including the finding-1 zero value, which NewVerdict/NewUnknownVerdict
+// can never produce but a bare `Verdict{}` composite literal still can.
+func TestVerdict_AuthorizesDestructive(t *testing.T) {
+	tests := []struct {
+		name string
+		v    Verdict
+		want bool
+	}{
+		{
+			name: "zero value never authorizes (finding 1)",
+			v:    Verdict{},
+			want: false,
+		},
+		{
+			name: "NewUnknownVerdict never authorizes",
+			v:    NewUnknownVerdict("classifyPRFailure", "qf-studio/pilot"),
+			want: false,
+		},
+		{
+			name: "evidence-free NewVerdict request never authorizes",
+			v:    NewVerdict(FailureClassCode, "", "classifyPRFailure", "qf-studio/pilot"),
+			want: false,
+		},
+		{
+			name: "evidenced FailureClassCode authorizes",
+			v:    NewVerdict(FailureClassCode, "ci:code(real_annotation)", "classifyPRFailure", "qf-studio/pilot"),
+			want: true,
+		},
+		{
+			name: "evidenced FailureClassInfra authorizes",
+			v:    NewVerdict(FailureClassInfra, "ci:infra(structural)", "classifyPRFailure", "qf-studio/pilot"),
+			want: true,
+		},
+		{
+			name: "evidenced FailureClassInfraBilling authorizes",
+			v:    NewVerdict(FailureClassInfraBilling, "ci:infra_billing(billing)", "classifyPRFailure", "qf-studio/pilot"),
+			want: true,
+		},
+		{
+			name: "explicit Unknown with evidence still never authorizes",
+			v:    NewVerdict(FailureClassUnknown, "diagnostic note", "classifyPRFailure", "qf-studio/pilot"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.v.AuthorizesDestructive(); got != tt.want {
+				t.Errorf("AuthorizesDestructive() = %v, want %v (class=%q evidence=%q)", got, tt.want, tt.v.Class(), tt.v.Evidence())
+			}
+		})
+	}
+}
+
+// TestCIFailureVerdictEvidence_NamesConcreteChecks verifies
+// ciFailureVerdictEvidence (via newCIFailureVerdict) names the specific
+// failed check(s)/signal(s) that produced class, not a restatement of the
+// class itself — the evidence-quality requirement from TASK-459 Phase 2's
+// task doc ("not a generic 'checks failed' restatement of the verdict
+// itself").
+func TestCIFailureVerdictEvidence_NamesConcreteChecks(t *testing.T) {
+	t.Run("infra aggregate names the infra-classified check", func(t *testing.T) {
+		checks := []FailedCheckLog{
+			{CheckName: "build", Logs: "##[error]Failed to run: step\nUnexpected HTTP response: 503"},
+		}
+		v := newCIFailureVerdict(classifyPRFailure(checks), checks, "qf-studio/pilot")
+		if v.Class() != FailureClassInfra {
+			t.Fatalf("class = %q, want %q", v.Class(), FailureClassInfra)
+		}
+		if !strings.Contains(v.Evidence(), "build") {
+			t.Errorf("Evidence() = %q, want it to name the failing check %q", v.Evidence(), "build")
+		}
+		if v.Evidence() == string(FailureClassInfra) {
+			t.Errorf("Evidence() = %q, must not be a bare restatement of the class", v.Evidence())
+		}
+	})
+
+	t.Run("code aggregate names only the check(s) that tipped it to code", func(t *testing.T) {
+		checks := []FailedCheckLog{
+			{CheckName: "lint", Logs: "internal/foo.go:12:3: undefined: bar"},
+			{CheckName: "build", Logs: "##[error]Failed to run: step\nUnexpected HTTP response: 503"},
+		}
+		v := newCIFailureVerdict(classifyPRFailure(checks), checks, "qf-studio/pilot")
+		if v.Class() != FailureClassCode {
+			t.Fatalf("class = %q, want %q", v.Class(), FailureClassCode)
+		}
+		if !strings.Contains(v.Evidence(), "lint") {
+			t.Errorf("Evidence() = %q, want it to name the code-classified check %q", v.Evidence(), "lint")
+		}
+		if strings.Contains(v.Evidence(), "build") {
+			t.Errorf("Evidence() = %q, must not name the infra-classified check that did not tip the aggregate", v.Evidence())
+		}
+	})
+
+	t.Run("zero checks constructs via NewUnknownVerdict", func(t *testing.T) {
+		v := newCIFailureVerdict(classifyPRFailure(nil), nil, "qf-studio/pilot")
+		if v.Class() != FailureClassUnknown {
+			t.Fatalf("class = %q, want %q", v.Class(), FailureClassUnknown)
+		}
+		if v.Evidence() != "" {
+			t.Errorf("Evidence() = %q, want empty", v.Evidence())
+		}
+		if v.AuthorizesDestructive() {
+			t.Error("AuthorizesDestructive() = true, want false for zero-gathered-evidence verdict")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Phase 2 of TASK-459's irreversible-action audit migrates the CI-failure path — the biggest offender identified in the 2026-08-06 GitHub Actions outage (a correct PR closed 3× / ~$10.65 discarded, 3 junk fix-issues spawned) — from raw `FailureClass`/nil-check gating to consuming the typed, evidence-carrying `Verdict` contract shipped in Phase 1 (#4796 → PR#4802).

- **Finding-1 hardening**: `Verdict.Class()` now maps a zero-value `Verdict{}`'s empty underlying class to `FailureClassUnknown`, so a naive `class != FailureClassUnknown` gate can never slip a degenerate zero-value verdict through. `AuthorizesDestructive()` is the single shared gate (checks both `Evidence()` and `Class()` independently, not just one or the other) — the seam Phase 4's grep gate will enforce.
- **`handleCIFailed`** (pre-merge ladder: `MaxCIFixIterations` close, size-guard/preflight escalations, fix-issue spawn) now constructs a `Verdict` at the classification boundary and gates every reachable destructive rung behind `verdict.AuthorizesDestructive()`. `maybeRetryInfraFailure`'s retry gate is non-destructive and deliberately keeps admitting `Unknown` (GH-4779 parity).
- **Post-merge CI rung** (`handlePostMergeCI`) previously had *no* classification at all — any post-merge `CIFailure` spawned a fix issue blind. It now builds a `Verdict` the same way and holds instead of spawning when evidence is empty, closing the same GH-4779 race shape for that rung.
- Platform-outage breaker composition (#4797/#4806) is untouched — it stays exactly where it was, upstream of and independent from this per-PR evidence gate.
- `.agent/system/irreversible-actions.md` rows for the four migrated sites updated to `typed-verdict` with refreshed line refs.

**Decision point (SHA binding)**: the `Verdict` contract intentionally does not carry the head SHA the evidence was gathered for. `handleCIFailed`/`handlePostMergeCI` always act on the verdict within the same tick they gather it, so there's no tick boundary for stale evidence to cross, and the gathering side is already guarded by #4790's check-run dedupe. Not extending the contract per the task's scope fence.

## Test plan

- [x] `make build`
- [x] `go test ./internal/autopilot/...`
- [x] `make test` (full suite, race-enabled, 54 packages) — green, 0 failures
- [x] New regression tests: `TestVerdict_ZeroValue` (finding-1), `TestVerdict_AuthorizesDestructive` (table-driven gate contract), `TestCIFailureVerdictEvidence_NamesConcreteChecks`, `TestHandlePostMergeCI_ZeroEvidence_EscalatesInsteadOfSpawning`
- [x] Existing `handleCIFailed`/post-merge tests (infra-retry, pre-merge zero-evidence, iteration-cap close) pass unchanged — confirms byte-for-byte behaviour preservation for positively-evidenced failures

## Refs

- Task doc: `.agent/tasks/TASK-459-irreversible-action-audit.md` (Phase 2 of 5)
- Contract + inventory: #4796 → PR#4802
- Inventory: `.agent/system/irreversible-actions.md` § "How Phase 2+ consumes this"
- Outage fixtures: #4787 (`failure_class_test.go`)
- Composes with: platform breaker #4797/#4806 · check-run dedupe #4790 · GH-4779 zero-evidence hold

Closes #4811