### PR TITLE
GH-4814: feat(autopilot): log platform-breaker armed state + settings at startup

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -2127,6 +2127,21 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				if platformBreakerProbeInterval <= 0 {
 					platformBreakerProbeInterval = autopilot.DefaultPlatformBreakerProbeInterval
 				}
+				// GH-4814: enabling the breaker was otherwise silent at
+				// startup — NewPlatformBreaker logs nothing at construction
+				// and the component=platform-breaker logger only speaks on
+				// the OPEN transition, so confirming today's enablement
+				// required tracing this config decode path by hand. One
+				// INFO line with every resolved setting (including the two,
+				// probe_interval/pause_admission, NewPlatformBreaker itself
+				// never sees) fixes that.
+				logging.WithComponent("platform-breaker").Info("platform-outage breaker enabled",
+					slog.Int("min_correlated_prs", platformBreaker.MinCorrelatedPRs()),
+					slog.Duration("correlation_window", platformBreaker.CorrelationWindow()),
+					slog.Duration("quiet_period", platformBreaker.QuietPeriod()),
+					slog.Duration("probe_interval", platformBreakerProbeInterval),
+					slog.Bool("pause_admission", platformBreakerPauseAdmissionEnabled),
+				)
 			}
 			// GH-4454: every controller's lane-starvation reconciler needs the
 			// same trigger label the GitHub SDK poller watches for

--- a/internal/autopilot/platform_breaker.go
+++ b/internal/autopilot/platform_breaker.go
@@ -208,6 +208,36 @@ func (b *PlatformBreaker) IsOpen() bool {
 	return b.open
 }
 
+// MinCorrelatedPRs, CorrelationWindow, and QuietPeriod expose the resolved
+// (post-default) construction settings — GH-4814: cmd/pilot/main.go logs
+// these once at startup so an operator can confirm the breaker is armed and
+// with which thresholds without tracing the config decode path by hand.
+// Immutable after NewPlatformBreaker, so no locking is needed. A nil
+// receiver returns the zero value.
+func (b *PlatformBreaker) MinCorrelatedPRs() int {
+	if b == nil {
+		return 0
+	}
+	return b.minDistinctPRs
+}
+
+// CorrelationWindow returns the resolved correlation window (see
+// MinCorrelatedPRs).
+func (b *PlatformBreaker) CorrelationWindow() time.Duration {
+	if b == nil {
+		return 0
+	}
+	return b.correlationWindow
+}
+
+// QuietPeriod returns the resolved quiet period (see MinCorrelatedPRs).
+func (b *PlatformBreaker) QuietPeriod() time.Duration {
+	if b == nil {
+		return 0
+	}
+	return b.quietPeriod
+}
+
 // EvaluateClose runs the same time-based close check Observe applies as a
 // side effect, standalone. GH-4792 (TASK-458 part 2): unlike Observe, this
 // is not gated behind a CI-failure event — the periodic breaker monitor

--- a/internal/autopilot/platform_breaker_test.go
+++ b/internal/autopilot/platform_breaker_test.go
@@ -197,6 +197,44 @@ func TestPlatformBreaker_NilReceiverIsNoOp(t *testing.T) {
 	if b.IsOpen() {
 		t.Error("nil breaker IsOpen() = true, want false")
 	}
+	if got := b.MinCorrelatedPRs(); got != 0 {
+		t.Errorf("nil breaker MinCorrelatedPRs() = %d, want 0", got)
+	}
+	if got := b.CorrelationWindow(); got != 0 {
+		t.Errorf("nil breaker CorrelationWindow() = %v, want 0", got)
+	}
+	if got := b.QuietPeriod(); got != 0 {
+		t.Errorf("nil breaker QuietPeriod() = %v, want 0", got)
+	}
+}
+
+// TestPlatformBreaker_ResolvedSettingsGetters verifies MinCorrelatedPRs,
+// CorrelationWindow, and QuietPeriod (GH-4814) expose the POST-default
+// resolved settings — used by cmd/pilot/main.go to log the breaker's armed
+// state at startup — for both explicit and zero-value (default-falling-back)
+// constructor args.
+func TestPlatformBreaker_ResolvedSettingsGetters(t *testing.T) {
+	explicit := NewPlatformBreaker(5, 10*time.Minute, 30*time.Minute, nil)
+	if got := explicit.MinCorrelatedPRs(); got != 5 {
+		t.Errorf("MinCorrelatedPRs() = %d, want 5", got)
+	}
+	if got := explicit.CorrelationWindow(); got != 10*time.Minute {
+		t.Errorf("CorrelationWindow() = %v, want 10m", got)
+	}
+	if got := explicit.QuietPeriod(); got != 30*time.Minute {
+		t.Errorf("QuietPeriod() = %v, want 30m", got)
+	}
+
+	defaulted := NewPlatformBreaker(0, 0, 0, nil)
+	if got := defaulted.MinCorrelatedPRs(); got != DefaultPlatformBreakerMinCorrelatedPRs {
+		t.Errorf("MinCorrelatedPRs() = %d, want default %d", got, DefaultPlatformBreakerMinCorrelatedPRs)
+	}
+	if got := defaulted.CorrelationWindow(); got != DefaultPlatformBreakerCorrelationWindow {
+		t.Errorf("CorrelationWindow() = %v, want default %v", got, DefaultPlatformBreakerCorrelationWindow)
+	}
+	if got := defaulted.QuietPeriod(); got != DefaultPlatformBreakerQuietPeriod {
+		t.Errorf("QuietPeriod() = %v, want default %v", got, DefaultPlatformBreakerQuietPeriod)
+	}
 }
 
 // TestPlatformBreaker_DefaultsApplied verifies zero-value constructor args


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4814.

Closes #4814

## Changes

GitHub Issue GH-4814: feat(autopilot): log platform-breaker armed state + settings at startup

## Context

Enabling the TASK-458 platform breaker on the founder box today (config flip + restart) surfaced an observability gap: the daemon emits **no signal that the breaker is armed**. `NewPlatformBreaker` logs nothing at construction; the `component=platform-breaker` logger first speaks on the OPEN transition; `pilot_platform_breaker_open`/`_trips_total` metrics are snapshot-driven and exported unconditionally (0 whether the breaker is disabled or merely closed). Verifying today's enablement required tracing the config decode path through `cmd/pilot/main.go:2114` by hand.

## Task

One INFO log line at construction time (in `cmd/pilot/main.go` where `pbCfg.Enabled` constructs the breaker, or inside `NewPlatformBreaker`), stating resolved settings:

```
platform-outage breaker enabled  min_correlated_prs=3 correlation_window=15m quiet_period=20m probe_interval=5m pause_admission=true
```

Optionally (cheap, decide in PR): a `pilot_platform_breaker_enabled` gauge (1/0) so dashboards/alerts can assert armed-state without log access.

## Acceptance Criteria

- [ ] Daemon startup with `platform_breaker.enabled: true` logs the settings line exactly once; disabled config logs nothing new.
- [ ] `make build`, `make test`, `make lint` green.

## Refs

- TASK-458 (`.agent/tasks/TASK-458-platform-outage-breaker.md`) · #4797/#4806 · enablement performed 2026-08-08 (operator)