### PR TITLE
feat(executor): TASK-459 Phase 3 — recorded status is authoritative (GH-4817)

### DIFF
--- a/.agent/system/irreversible-actions.md
+++ b/.agent/system/irreversible-actions.md
@@ -1,6 +1,6 @@
 # Irreversible-action inventory (TASK-459 Phase 1)
 
-**Status**: Phase 2 of 4 landed (Phase 5's false-success class split to TASK-460, 2026-08-08). Phase 1 built the inventory + `Verdict`
+**Status**: Phase 3 (GH-4817) landed 2026-08-09. Phase 1 built the inventory + `Verdict`
 contract with no behaviour change. Phase 2 migrated the CI-failure path —
 `handleCIFailed`'s ladder (family 1's `MaxCIFixIterations` close, family 3's
 pre-merge `CreateFailureIssue`, family 8's zero-evidence `escalateAndHold`)
@@ -9,8 +9,24 @@ a *new* family-8 zero-evidence hold that didn't exist before Phase 2 — the
 post-merge path previously spawned a fix issue for any `CIFailure` with no
 classification at all) — to gate on `Verdict.AuthorizesDestructive()`
 instead of raw `FailureClass`/string/nil-check comparisons. Their rows below
-are marked `typed-verdict` accordingly. All other rows are still Phase
-1-only classification; Phase 3 covers executor/dispatcher/poller sites.
+are marked `typed-verdict` accordingly. Phase 3 (GH-4817, this leg) migrated
+family 4/5/6/7's executor/dispatcher/poller sites named in the Phase-1 §9
+findings: `recoverStaleRunningTasks`/`recoverStaleQueuedTasks` now write
+typed `stalled`/`canceled` instead of collapsing every boot-time orphan to
+`failed`; the GitLab and CLI GH-3053 "no commit, no PR" demotions now
+consult `IsNoArtifactExplainedOutcome` (typed outcome check) before
+inferring failure from an absent artifact alone (closing the
+`side-effect-inferred` gap flagged in family 7's `IsTerminalByDesignStatus`
+row below); five additive label/comment-write sites (family 5) now gate on
+a fresh `fetchIssueState` re-read of the target issue and skip the write on
+positive evidence it's already closed, failing open on a lookup error; and
+`checkWorktreePruned` (finish_tripwires.go) now excludes `superseded`/
+`canceled` rows from its "commits but no PR" violation, alongside the
+pre-existing `decomposed` carve-out. Rows below are updated in place per
+site; see the row-level Evidence column for the `re-read` tag Phase 3 added.
+All rows not called out as `typed-verdict` or Phase-3-updated are still
+Phase 1-only classification. Phase 4 (`check-destructive-calls.sh` grep
+gate) is next.
 
 **Purpose**: Every call site in the daemon that closes a PR, deletes a
 branch, spawns a fix issue, burns retry budget, writes a terminal label, or
@@ -109,8 +125,11 @@ branch/commits may also be deleted immediately after, see family 2)
 | `internal/autopilot/controller.go:6930-6992` (`notifyExternalClose`) | autopilot | cheap-reversible (label), but gates family-7 ledger writes | Splits `pilot-superseded` vs `pilot-failed` on `prState.TerminalLabel == LabelSuperseded` | `raw-string` compare against a flag set upstream (by family-1's `closeConflictSourceIssueClosed`), not re-evidenced here |
 | `internal/autopilot/controller.go:6863` | autopilot | cheap-reversible | Generic `RemoveLabel` in retry-label cleanup helper | — |
 | `internal/autopilot/controller.go:7077-7086` | autopilot | cheap-reversible | Generic terminal-label-application helper shared by multiple ladder rungs | Inherits caller's evidence |
-| `internal/executor/title_rejection.go:220` | executor | cheap-reversible | `pilot-failed`+`pilot-title-rejected` on 2nd consecutive same-title rejection | `raw-string` exact-hash match (family 4) |
-| `internal/executor/dispatcher.go:2019` (`surfaceStalledIssue`, via `escalateStalledTask`) | executor | cheap-reversible | `pilot-blocked` add, `pilot-failed`+`pilot-in-progress` remove | `counter` — raw drop-count threshold; idempotent via matching prior `Error` string |
+| `internal/executor/title_rejection.go:220` (`postTitleRejectionEscalation`) | executor | cheap-reversible | `pilot-failed`+`pilot-title-rejected` on 2nd consecutive same-title rejection | `raw-string` exact-hash match (family 4), **plus `re-read` (GH-4817 Phase 3 Task 5c)** — `fetchIssueState` gate skips the comment+labels on positive evidence the issue is already closed, fails open on lookup error |
+| `internal/executor/dispatcher.go:2036` (`surfaceStalledIssue`, via `escalateStalledTask`) | executor | cheap-reversible | `pilot-blocked` add, `pilot-failed`+`pilot-in-progress` remove | `counter` — raw drop-count threshold; idempotent via matching prior `Error` string. **Plus `re-read` (GH-4817 Phase 3 Task 5a)** — `fetchIssueState` gate skips the label write on positive evidence the issue is already closed, fails open on lookup error |
+| `cmd/pilot/handlers.go:837` (`notifyTaskStartedSDK` call, SDK-dispatch path) | cmd/pilot | cheap-reversible | `pilot-in-progress` add + start comment on SDK-poller dispatch (GH-4687) | `re-read` (GH-4817 Phase 3 Task 5b) — gated on `issueState != githubSDK.StateClosed`; `issueState` defaults to `""` (unknown) on fetch failure or nil `specClient`, so the comparison is against the positive `closed` value only, preserving fail-open on unresolvable state |
+| `internal/executor/epic.go:756` (`handleSubIssueCoverageGap`) | executor | cheap-reversible | `pilot-needs-clarification` add + coverage-gap comment on the parent issue | `counter`-adjacent (planned vs. created sub-issue count mismatch), **plus `re-read` (GH-4817 Phase 3 Task 5d)** — `fetchIssueState` gate on the parent issue skips the label+comment on positive evidence it's already closed (avoids the misleading "this issue stays open" comment on an externally-closed parent), fails open on lookup error |
+| `internal/autopilot/controller.go:7242` (`notifyExternalClose`, label-correction block only — the informational comment below it still posts unconditionally) | autopilot | cheap-reversible | `LabelInProgress`/`LabelFailed` remove + issue-label add, on external PR close | `raw-string` (`prState.TerminalLabel`), **plus `re-read` (GH-4817 Phase 3 Task 5e)** — reuses the `issue`/`err` already fetched earlier in the function for the pilot-done check (no fresh GitHub call) and skips the label writes when `issue.State == github.StateClosed`; the informational comment is deliberately left unconditional since a closed issue has no label/retry state left to protect, only history worth recording |
 | `internal/adapters/github/notifier.go:34,75,81,86,122,127,147` | adapters/github | cheap-reversible | Baseline (non-autopilot) issue-lifecycle labels on the dispatch/execution-complete path | Execution result (success/fail), not CI-check-scoped |
 | `internal/adapters/github/cleanup.go:336,444,521` | adapters/github | cheap-reversible | Background sweep removing stale labels on closed issues (extended by #4800/GH-4794 to strip `pilot-retry-ready`) | Time/state-based sweep |
 | `cmd/pilot/commands.go:1462,1499,1502,1515,1525,1546` | cmd/pilot CLI | cheap-reversible | Operator-invoked `pilot task cancel`/label commands | N/A — manual, not autonomous-daemon-invoked; distinct category, out of scope for the daemon decision ladder proper |
@@ -129,10 +148,11 @@ branch/commits may also be deleted immediately after, see family 2)
 | `internal/memory/store.go:1407` `ReclassifyCompletionAsSuperseded` (GH-4701) | memory store | costly-reversible | Called from `controller.go:6961`, sibling branch when `TerminalLabel == LabelSuperseded` |
 | `internal/memory/store.go:1439` `TerminateNonTerminalExecution` | memory store | costly-reversible | Called from `controller.go:6986`, terminates a still-running row as `failed` when a close is observed before completion |
 | `internal/memory/store.go:1460` `TerminateNonTerminalExecutionAsSuperseded` | memory store | costly-reversible | Called from `controller.go:6984`, superseded sibling |
-| `internal/memory/store.go:2183` `UpdateExecutionStatus` | memory store | costly-reversible | Generic unconditional status writer; callers include `dispatcher.go:372` (boot-time orphan reap -> `stalled`) and `dispatcher.go:1936` (`escalateStalledTask` -> `stalled`, family 4/8) |
+| `internal/memory/store.go:2183` `UpdateExecutionStatus` | memory store | costly-reversible | Generic unconditional status writer; callers include `dispatcher.go:541` `recoverStaleRunningTasks` (boot-time running-orphan reap) and `dispatcher.go:778` `recoverStaleQueuedTasks` (boot-time queued-orphan reap), both **typed as of GH-4817 Phase 3 Tasks 1/2** — `recoverStaleRunningTasks` now writes `stalled` and `recoverStaleQueuedTasks` now writes `canceled`, replacing a prior blanket `failed` write that collapsed every boot-time orphan (including ones later explainable as superseded/canceled work) into the same non-terminal-by-design bucket; and `dispatcher.go:1936` (`escalateStalledTask` -> `stalled`, family 4/8) |
 | `internal/memory/store.go:2247` `UpdateExecutionStatusIfNotTerminal` | memory store | costly-reversible | CAS-guarded (race-safe) writer; callers `dispatcher.go:623,803,926`, `lifecycle.go:220,318,547` (`ExecutionLifecycle.Cancel`, the `pilot task cancel` CLI path, GH-4586 — refuses if already `running` or already terminal) |
 | `internal/memory/store.go:2320` `UpdateExecutionStatusByTaskID` | memory store | costly-reversible | Task-ID-keyed variant |
-| `internal/executor/dispatcher.go:79` `IsTerminalByDesignStatus` (GH-4794, #4800, landed same cycle as this inventory) | executor | N/A — this is the fix, not the hazard | Converts `handleIssueGeneric`'s classification from **`side-effect-inferred`** ("no PR produced" read as failure) to **`typed`** (consult the recorded ledger status vocabulary — `superseded`/`canceled` vs `failed` — directly). Consumed by `cmd/pilot/handlers.go:560,675,873`. This is the concrete instance of root pattern 2 from the TASK-459 brief, already fixed for this one site — the general case is what `Verdict.Scope`+evidence enforcement in later phases generalizes |
+| `internal/executor/dispatcher.go:79` `IsTerminalByDesignStatus` (GH-4794, #4800) / `dispatcher.go:92` `IsNoArtifactExplainedOutcome` (GH-4817, TASK-459 Phase 3 Tasks 3/4) | executor | N/A — this is the fix, not the hazard | Converts three consumers' classification from **`side-effect-inferred`** ("no PR produced" read as failure) to **`typed`** (consult the recorded ledger status vocabulary — `no_op`/`superseded`/`canceled` vs `failed` — directly). `IsTerminalByDesignStatus` (superseded/canceled only) is consumed by `cmd/pilot/handlers.go:560,675,873`. `IsNoArtifactExplainedOutcome` (superset: adds `no_op`) is the GH-4817 Phase 3 addition consumed by the two GH-3053 "no commit, no PR" demotion sites named in the TASK-459 brief's root pattern 2 — `cmd/pilot/handlers.go:597` (`handleGitlabIssueWithResult`, guards `issueResult.Success = false`) and `cmd/pilot/commands.go:1527` (`newGitHubRunCmd`'s CLI no-artifact check) — both previously inferred failure from an absent commit/PR alone with no outcome check at all. The general case is what `Verdict.Scope`+evidence enforcement in later phases generalizes |
+| `internal/executor/finish_tripwires.go:264` `checkWorktreePruned` | executor | N/A — a false-positive-avoidance guard, not itself a destructive write | Flags a "commits with no PR" tripwire violation for rows that requested a PR but produced none. **GH-4817 Phase 3 Task 6** extended the pre-existing `decomposed`-parent carve-out to also exclude `superseded`/`canceled` rows — a superseded/canceled execution can legitimately have a commit with no PR (the work was intentionally abandoned mid-flight), and flagging it as a tripwire violation was a false positive of the same `side-effect-inferred` shape as the GH-3053 sites above. A plain `failed` row still trips the violation (guard is deliberately narrow — see `TestCheckWorktreePruned`'s "guard is narrow" subtest) |
 
 ## 8. `escalateAndHold` and hold/escalation (semi-destructive: never closes/deletes/merges, but pages a human and parks the PR — operator-costly)
 

--- a/.agent/tasks/gh-4817.md
+++ b/.agent/tasks/gh-4817.md
@@ -1,0 +1,104 @@
+# GH-4817
+
+**Created:** 2026-08-09
+
+## Problem
+
+GitHub Issue GH-4817: feat(executor): TASK-459 Phase 3 — recorded status is authoritative; no failure inferred from missing artifacts, no labels on closed issues
+
+# feat(executor): TASK-459 Phase 3 — recorded status is authoritative; no failure inferred from missing artifacts, no labels on closed issues
+
+## Context
+
+Phase 1 (#4796 → PR#4802) landed the irreversible-action inventory and the `Verdict` contract. Phase 2 (#4811 → PR#4812) gated the CI-failure path. Phase 3 targets root pattern 2 from the task brief: **failure inferred from side-effects rather than read from recorded state** — the GH-4794 shape ("no PR appeared" read as failure while the ledger plainly said `superseded`) generalized to every remaining site — plus its sibling defect: label writes that ignore issue open-state (retry/progress labels stranded on closed issues).
+
+The prior fix (`IsTerminalByDesignStatus`, `internal/executor/dispatcher.go:79`, GH-4794/#4800) covered one consumer family (`classifyWaitedExecution` → `EffectiveSuccess()`). This leg fixes the remaining instances in `cmd/pilot/` + `internal/executor/`, plus exactly one guard in `controller.go` whose own comment names the hazard.
+
+Line refs verified on main @ `e3763efd` (2026-08-08). If drifted, re-trace from function names, not line numbers.
+
+## Tasks
+
+### 1. `recoverStaleRunningTasks` writes `stalled`, not `failed` — `internal/executor/dispatcher.go:528-644`
+
+The write at :639 records `failed` after inferring purely from artifact absence: stale timestamp + no completed row (:561) + no live worker (:576) + no merged PR (:595) + no open PR (:621). That evidence is **liveness-loss, not failure** — and the boot-time sibling `reconcileOrphanedExecutions` already writes `ExecStatusStalled` for the same shape (:388, "orphaned by daemon restart"). Align: write `ExecStatusStalled` (via the same CAS-guarded call), keep every existing guard, the merged-PR heal (:595-613), and the GH-4423 open-PR liveness check unchanged. Downstream is already status-driven: `priorClaimWasStalled` (:1297) → stall carve-out (:1673) → `stallTaskAfterStallCap` at cap 8, instead of the failure ladder.
+
+### 2. Stale-queued recovery status — decision point — `internal/executor/dispatcher.go:747-819`
+
+`recoverStaleQueuedTasks` writes `failed` at :819 for "project no longer configured". A queued task that never ran did not *fail*; the operator removing the project is a designed termination. **Bias: `ExecStatusCanceled`** with the reason string retained (precedent: `reclaimSelfOwnedQueuedChild` :942 uses a typed administrative marker for exactly this kind of non-outcome write). If implementation surfaces a downstream consumer that depends on `failed` here, keep `failed` and document why in the PR body.
+
+### 3. GitLab GH-3053 demotion consults the ledger — `cmd/pilot/handlers.go:581-591`
+
+The block flips `issueResult.Success = false` on `!IsEpic && CommitSHA == "" && PRUrl == ""` alone — overriding the `EffectiveSuccess()` value computed at :563 and never consulting the recorded execution status. A `no_op`/terminal-by-design row with no artifacts gets force-flipped to failure, re-arming the vendored SDK poller's unmark-for-retry branch (the exact GH-4794 mechanism). Make the demotion status-aware: statuses where artifact absence is by design must not be flipped. The flip stays for statuses where absence is anomalous — what completed-with-no-artifact *means* is TASK-460; do not expand into it.
+
+### 4. CLI no-artifact inference — `cmd/pilot/commands.go:1523-1539`
+
+Same triple-condition ⇒ `pilot-failed` label + `execution completed but no commits or PR created` error. Same treatment as task 3: consult the recorded execution status before declaring failure. (Open-state guards on `commands.go` label writes stay out of scope — operator-invoked CLI, per inventory family 5.)
+
+### 5. Additive label writes gated on issue open-state
+
+Reuse the existing seams — `executor.IssueStateChecker` (`internal/executor/issue_state.go:66`), resolver `fetchIssueState` (:155-190), registered per-repo at `cmd/pilot/poller_github.go:539` (GH-4656); on the autopilot side `github.Issue.State` + `StateOpen`/`StateClosed` (`internal/adapters/github/types.go:131-132`). Do NOT add fresh GitHub calls where state is already in hand.
+
+| Site | Write | Fix |
+|---|---|---|
+| `internal/executor/dispatcher.go:2005-2035` `surfaceStalledIssue` | +`pilot-blocked`, comment | check open-state; closed ⇒ skip label+comment, log info |
+| `cmd/pilot/handlers.go:801-832` → `notifyTaskStartedSDK` :921 | +`pilot-in-progress` | `issueState` is already fetched at :763 and stored — consult it before labeling |
+| `internal/executor/title_rejection.go:220` | +`pilot-failed` +`pilot-title-rejected` | check open-state |
+| `internal/executor/epic.go:756` | +`pilot-needs-clarification` | check open-state |
+| `internal/autopilot/controller.go:7389` `notifyExternalClose` | +`pilot-retry-ready` (or `TerminalLabel`) | the issue is already fetched at :7336; consult `issue.State` in addition to the `HasLabel(LabelDone)` guard at :7339. The comment at :7331-7335 names this exact hazard ("strands the label on a closed/done issue forever — poller skips non-open issues") but the implemented guard is label-based only. **This is the only controller.go change in this leg.** On skip, still post the informational comment so the discarded work doesn't vanish silently (mirroring the :7344 precedent). |
+
+Gate semantics — positive evidence to suppress: skip the write only when the issue is positively known closed. A state-lookup error fails open (the write proceeds — today's behavior). Removal-only writes (`internal/executor/lifecycle.go:444` etc.) stay as-is: removing a label from a closed issue is a harmless no-op.
+
+### 6. Finish-tripwire excludes designed-terminal statuses — `internal/executor/finish_tripwires.go:268`
+
+The committed-but-no-PR tripwire excludes `ExecStatusDecomposed` but not `superseded`/`canceled` — a superseded row that had committed before being superseded fires a false alert (the GH-4794 false-alert shape, alert-only variant). Add the terminal-by-design statuses to the exclusion.
+
+### 7. Regression tests
+
+Table-driven, per site:
+
+- `superseded`/`canceled`/`no_op` rows are never demoted/reported failed by tasks 3-4.
+- Stale-running recovery writes `stalled` (task 1); merged-PR heal and open-PR liveness check unchanged.
+- Closed issue ⇒ each task-5 site skips its additive write; open issue ⇒ behavior unchanged; state-lookup error ⇒ behavior unchanged (fail-open).
+- Tripwire silent on `superseded`/`canceled` rows with commits (task 6).
+- Existing dispatcher/handler/controller tests green unchanged.
+
+### 8. Update the inventory
+
+`.agent/system/irreversible-actions.md`: update migrated sites' rows in place (evidence column + refreshed line refs); add rows for task 1-6 sites not yet in the table. The `SetApprovalDecision`/`handleReleasing`/watchdog/`outcomeClassifiers` traces were already recorded 2026-08-08 (§9 cross-cutting findings) — do not re-derive them.
+
+## Acceptance Criteria
+
+- [ ] No site in `cmd/pilot/` or `internal/executor/` writes or reports failure from artifact absence when the recorded status vocabulary explains the absence (`superseded`/`canceled`/`no_op`/terminal-by-design).
+- [ ] `recoverStaleRunningTasks` records `stalled`; the queued-recovery status decision (task 2) is documented in the PR body.
+- [ ] The five task-5 additive label sites skip writes on positively-known-closed issues and fail open on lookup errors.
+- [ ] Tripwire silent on terminal-by-design rows.
+- [ ] Inventory rows updated/added.
+- [ ] `make build`, `make test`, `make lint` green; existing tests unchanged.
+
+## Out of Scope
+
+- `internal/executor/lifecycle.go:274` PR-existence promotion (GH-4404 — deliberate documented exception, recorded in the inventory; do not change).
+- `internal/executor/runner.go` `outcomeClassifiers` string table — classification internals (how status is *derived*); this phase governs *consumers* of recorded status.
+- `scope_release.go:433` reason-string routing, `isDuplicateTagError`/`isDuplicateReleaseError` sniffs, `applyApprovalDecision` raw-string gate — traced 2026-08-08, Phase 4 vocabulary targets.
+- Review-path/merge-conflict closes in `controller.go`; any controller.go change beyond the single :7389 guard.
+- What completed-with-no-artifact means for delivery evidence (TASK-460).
+- `commands.go` label open-state guards (operator-invoked CLI category).
+- `scripts/check-destructive-calls.sh`, parity tables, SOP — Phase 4.
+
+## Verify
+
+```bash
+make build
+make test
+make lint
+```
+
+## Refs
+
+- Task doc: `.agent/tasks/TASK-459-irreversible-action-audit.md` (Phase 3 of 4)
+- Inventory: `.agent/system/irreversible-actions.md` (incl. 2026-08-08 Phase-3-prep traces in §9)
+- Prior instance of the fix shape: GH-4794 → #4800 (`IsTerminalByDesignStatus`); caller-supplied-verdict precedent: `epic.go:2558-2561` / `dispatcher.go:2783` (`Finish` with `ExecStatusSuperseded` override)
+- Phases 1-2: #4796 → PR#4802 · #4811 → PR#4812
+
+## Acceptance Criteria
+

--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -1520,7 +1520,11 @@ Examples:
 			// GH-3053: skip for epic-parent results. The parent legitimately
 			// produces no commit/PR when sub-issues handle the work; flagging
 			// it as failed mislabels the issue and posts a misleading comment.
-			if !result.IsEpic && result.CommitSHA == "" && result.PRUrl == "" {
+			// GH-4817 (TASK-459 Phase 3): also skip when the recorded outcome
+			// already explains the absence by design (no_op/terminal-by-design)
+			// — inferring failure from artifact absence alone here ignores the
+			// classification runner.Execute already computed.
+			if !result.IsEpic && result.CommitSHA == "" && result.PRUrl == "" && !executor.IsNoArtifactExplainedOutcome(result.Outcome) {
 				// No commits and no PR - mark as failed
 				if err := client.AddLabels(ctx, owner, repoName, int(issueNum), []string{"pilot-failed"}); err != nil {
 					logGitHubAPIError("AddLabels", owner, repoName, int(issueNum), err)

--- a/cmd/pilot/gh4817_no_artifact_gate_test.go
+++ b/cmd/pilot/gh4817_no_artifact_gate_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// GH-4817 (TASK-459 Phase 3, Tasks 3/4/7): source-level guards proving the
+// two GH-3053 "no commit, no PR" demotion sites consult
+// executor.IsNoArtifactExplainedOutcome before flipping success to failure.
+// Both handleGitlabIssueWithResult and the CLI's newGitHubRunCmd RunE
+// closure build real GitHub/GitLab clients and drive runner.Execute end to
+// end, so — mirroring the existing source-inspection pattern for
+// handleGithubIssueEventSDK (see TestGithubHandlerSDK_NotifyTaskStartedWired) —
+// these assert against the literal guard clause rather than standing up a
+// full mock pipeline.
+
+// TestGitlabHandler_NoArtifactDemotionConsultsOutcome guards the GitLab
+// GH-3053 site (handlers.go, handleGitlabIssueWithResult): a no_op or
+// terminal-by-design (superseded/canceled) outcome must not be demoted to
+// issueResult.Success = false just because no commit/PR was produced.
+func TestGitlabHandler_NoArtifactDemotionConsultsOutcome(t *testing.T) {
+	body := githubFuncBody(t, "handlers.go", "func handleGitlabIssueWithResult(")
+
+	idx := strings.Index(body, "issueResult.Success = false")
+	if idx < 0 {
+		t.Fatal("expected handleGitlabIssueWithResult to still demote issueResult.Success on a genuine no-artifact completion")
+	}
+
+	// The guarding "if" must be the nearest preceding one and must reference
+	// both the terminal-by-design check and the outcome-classification helper.
+	preamble := body[:idx]
+	ifIdx := strings.LastIndex(preamble, "if !hr.IsTerminalByDesign()")
+	if ifIdx < 0 {
+		t.Fatal("expected `if !hr.IsTerminalByDesign() && !executor.IsNoArtifactExplainedOutcome(...)` immediately guarding the Success demotion")
+	}
+	guardClause := preamble[ifIdx:]
+	if !strings.Contains(guardClause, "executor.IsNoArtifactExplainedOutcome(hr.Result.Outcome)") {
+		t.Error("the demotion guard must also consult executor.IsNoArtifactExplainedOutcome(hr.Result.Outcome), not just IsTerminalByDesign()")
+	}
+}
+
+// TestCLIRunCmd_NoArtifactCheckConsultsOutcome guards the CLI's GH-3053 site
+// (commands.go, newGitHubRunCmd's RunE closure): a no_op or terminal-by-design
+// outcome must not be treated as an execution failure just because no
+// commit/PR was produced.
+func TestCLIRunCmd_NoArtifactCheckConsultsOutcome(t *testing.T) {
+	body := githubFuncBody(t, "commands.go", "func newGitHubRunCmd() *cobra.Command {")
+
+	idx := strings.Index(body, "!result.IsEpic && result.CommitSHA == \"\" && result.PRUrl == \"\"")
+	if idx < 0 {
+		t.Fatal("expected the GH-3053 no-artifact condition in newGitHubRunCmd's RunE closure")
+	}
+
+	line := body[idx : idx+strings.Index(body[idx:], "\n")]
+	if !strings.Contains(line, "!executor.IsNoArtifactExplainedOutcome(result.Outcome)") {
+		t.Errorf("the CLI no-artifact condition must also consult !executor.IsNoArtifactExplainedOutcome(result.Outcome), got: %s", line)
+	}
+}

--- a/cmd/pilot/github_sdk_notify_started_test.go
+++ b/cmd/pilot/github_sdk_notify_started_test.go
@@ -161,3 +161,36 @@ func TestGithubHandlerSDK_NotifyTaskStartedWired(t *testing.T) {
 		t.Error("notifyTaskStartedSDK errors must be logged as a non-fatal WARN, not propagated")
 	}
 }
+
+// TestGithubHandlerSDK_NotifyTaskStartedGatedOnIssueState is a source-level
+// guard (GH-4817, TASK-459 Phase 3 Task 5b): the notifyTaskStartedSDK call
+// must be gated on issueState != githubSDK.StateClosed, so a closed issue
+// never gets a stranded pilot-in-progress label/comment. issueState defaults
+// to "" (unknown) on fetch failure or when specClient is nil (see the
+// fetchGithubIssueForSDKTask comment above), so the comparison must be
+// against the positive "closed" value only — never against issueState == ""
+// — to keep the existing fail-open behavior for unresolvable state.
+func TestGithubHandlerSDK_NotifyTaskStartedGatedOnIssueState(t *testing.T) {
+	body := githubFuncBody(t, "handlers.go", "func handleGithubIssueEventSDK(")
+
+	notifyIdx := strings.Index(body, "notifyTaskStartedSDK(")
+	if notifyIdx < 0 {
+		t.Fatal("handleGithubIssueEventSDK must call notifyTaskStartedSDK")
+	}
+
+	// The nearest preceding "if" before the call must gate on issueState,
+	// comparing against the closed constant (not equality with "").
+	preamble := body[:notifyIdx]
+	ifIdx := strings.LastIndex(preamble, "if specClient != nil")
+	if ifIdx < 0 {
+		t.Fatal("expected an `if specClient != nil` guard preceding the notifyTaskStartedSDK call")
+	}
+	guardClause := preamble[ifIdx:]
+	if !strings.Contains(guardClause, "issueState != githubSDK.StateClosed") {
+		t.Error("notifyTaskStartedSDK must only fire when issueState != githubSDK.StateClosed (fail-open on \"\"/unknown)")
+	}
+
+	if !strings.Contains(body, "skipping pilot-in-progress label and comment") {
+		t.Error("expected an informational log line when the label/comment write is skipped for a closed issue")
+	}
+}

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -588,7 +588,15 @@ func handleGitlabIssueWithResult(ctx context.Context, cfg *config.Config, client
 					slog.Any("error", err),
 				)
 			}
-			issueResult.Success = false
+			// GH-4817 (TASK-459 Phase 3): only demote to failure when the
+			// absent commit/PR is anomalous. A no_op/terminal-by-design
+			// outcome deliberately produced no deliverable — consult the
+			// recorded classification instead of inferring failure from
+			// artifact absence alone (the exact GH-4794 mechanism, which
+			// re-arms the vendored SDK poller's unmark-for-retry branch).
+			if !hr.IsTerminalByDesign() && !executor.IsNoArtifactExplainedOutcome(hr.Result.Outcome) {
+				issueResult.Success = false
+			}
 		} else {
 			var parts []string
 			parts = append(parts, "✅ Pilot execution completed successfully!")
@@ -798,7 +806,13 @@ func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkco
 	// auto-creates the label via AddLabels if the repo doesn't have it yet.
 	// Mirrors the non-fatal (WARN-only) pattern at pilot.go:1191-1195 and
 	// controller.go:3011-3015 — labeling must never block dispatch.
-	if specClient != nil {
+	// TASK-459 Phase 3 Task 5b: skip the pilot-in-progress label/comment write
+	// only on positive evidence the issue is already closed. issueState is ""
+	// on fetch failure or when specClient is nil (fail-open default set above,
+	// GH-4050) — treat that as unknown, not closed, so the label still fires
+	// when state can't be determined. Mirrors the surfaceStalledIssue guard
+	// (dispatcher.go).
+	if specClient != nil && issueState != githubSDK.StateClosed {
 		pilotLabel := ""
 		if cfg.Adapters != nil && cfg.Adapters.GitHub != nil {
 			pilotLabel = cfg.Adapters.GitHub.PilotLabel
@@ -829,6 +843,10 @@ func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkco
 		} else {
 			labelTracker.RecordSuccess()
 		}
+	} else if specClient != nil {
+		logging.WithComponent("github").Info("SDK-dispatch: issue already closed, skipping pilot-in-progress label and comment",
+			slog.String("task_id", taskID),
+			slog.Int("issue", issueNum))
 	}
 
 	task := &executor.Task{

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -7386,21 +7386,35 @@ func (c *Controller) notifyExternalClose(ctx context.Context, prState *PRState) 
 			nextSteps = "This issue will not be retried automatically under its own number — see the reason above for what happens next."
 		}
 
-		if err := c.labeler.AddLabels(ctx, c.owner, c.repo, prState.IssueNumber, []string{issueLabel}); err != nil {
-			c.log.Warn("failed to set issue label on PR close", "issue", prState.IssueNumber, "label", issueLabel, "error", err)
-		}
-		if err := c.labeler.RemoveLabel(ctx, c.owner, c.repo, prState.IssueNumber, github.LabelInProgress); err != nil {
-			c.log.Warn("failed to remove pilot-in-progress label", "issue", prState.IssueNumber, "error", err)
-		}
-		if issueLabel != github.LabelFailed {
-			// Remove stale pilot-failed label (GH-1302 gap) — only when we're not
-			// the ones setting it above.
-			if err := c.labeler.RemoveLabel(ctx, c.owner, c.repo, prState.IssueNumber, github.LabelFailed); err != nil {
-				c.log.Debug("failed to remove pilot-failed (may not exist)", "issue", prState.IssueNumber, "error", err)
+		// TASK-459 Phase 3 Task 5e: skip the label writes below on positive
+		// evidence the issue is already closed — reuse the `issue`/`err` fetch
+		// from the pilot-done check above (line ~7336) instead of a fresh
+		// GitHub call. err != nil there already fails open (issue is nil), so
+		// only a clean read with State == closed counts as positive evidence.
+		issueAlreadyClosed := err == nil && issue != nil && issue.State == github.StateClosed
+		if issueAlreadyClosed {
+			c.log.Info("skipping issue label correction: issue already closed", "issue", prState.IssueNumber, "pr", prState.PRNumber)
+		} else {
+			if err := c.labeler.AddLabels(ctx, c.owner, c.repo, prState.IssueNumber, []string{issueLabel}); err != nil {
+				c.log.Warn("failed to set issue label on PR close", "issue", prState.IssueNumber, "label", issueLabel, "error", err)
 			}
+			if err := c.labeler.RemoveLabel(ctx, c.owner, c.repo, prState.IssueNumber, github.LabelInProgress); err != nil {
+				c.log.Warn("failed to remove pilot-in-progress label", "issue", prState.IssueNumber, "error", err)
+			}
+			if issueLabel != github.LabelFailed {
+				// Remove stale pilot-failed label (GH-1302 gap) — only when we're not
+				// the ones setting it above.
+				if err := c.labeler.RemoveLabel(ctx, c.owner, c.repo, prState.IssueNumber, github.LabelFailed); err != nil {
+					c.log.Debug("failed to remove pilot-failed (may not exist)", "issue", prState.IssueNumber, "error", err)
+				}
+			}
+			c.log.Info("corrected issue label on PR close", "issue", prState.IssueNumber, "pr", prState.PRNumber, "label", issueLabel)
 		}
-		c.log.Info("corrected issue label on PR close", "issue", prState.IssueNumber, "pr", prState.PRNumber, "label", issueLabel)
 
+		// Task 5e: unlike the other gated sites, this one still posts the
+		// informational comment on skip — the issue is already closed, so
+		// there's no retry/label state to protect, but the PR-closed context
+		// is still useful history on the issue.
 		issueComment += "\n\n" + nextSteps
 		if _, cerr := c.ghClient.AddComment(ctx, c.owner, c.repo, prState.IssueNumber, issueComment); cerr != nil {
 			c.log.Warn("failed to comment on issue after PR close", "issue", prState.IssueNumber, "error", cerr)

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -7796,16 +7796,27 @@ func TestNotifyExternalClose_ReclassifyNotCalledWithoutEvalStore(t *testing.T) {
 func TestNotifyExternalClose_SkipsRetryReadyWhenDone(t *testing.T) {
 	tests := []struct {
 		name           string
+		issueState     string
 		issueLabels    []github.Label
 		wantRetryAdded bool
 	}{
 		{
+			// A pilot-done issue is normally already closed too — the
+			// pilot-done guard (checked first) is what actually skips
+			// retry-ready here, not the GH-4817 closed-state guard below it.
 			name:           "issue already pilot-done - skip retry-ready",
+			issueState:     "closed",
 			issueLabels:    []github.Label{{Name: github.LabelDone}},
 			wantRetryAdded: false,
 		},
 		{
+			// GH-4817: an issue that's genuinely still open (not done) is the
+			// only realistic fixture for "add retry-ready" — a closed-but-not-
+			// done issue would (correctly) now be skipped by the open-state
+			// guard added in Task 5e, since retry-ready on a closed issue is
+			// dead weight the poller will never pick up.
 			name:           "issue not done - add retry-ready",
+			issueState:     "open",
 			issueLabels:    []github.Label{},
 			wantRetryAdded: true,
 		},
@@ -7818,7 +7829,7 @@ func TestNotifyExternalClose_SkipsRetryReadyWhenDone(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch {
 				case r.URL.Path == "/repos/owner/repo/issues/10" && r.Method == http.MethodGet:
-					issue := github.Issue{Number: 10, State: "closed", Labels: tt.issueLabels}
+					issue := github.Issue{Number: 10, State: tt.issueState, Labels: tt.issueLabels}
 					w.WriteHeader(http.StatusOK)
 					_ = json.NewEncoder(w).Encode(issue)
 
@@ -7855,6 +7866,58 @@ func TestNotifyExternalClose_SkipsRetryReadyWhenDone(t *testing.T) {
 				t.Errorf("pilot-retry-ready added = %v, want %v", retryReadyAdded, tt.wantRetryAdded)
 			}
 		})
+	}
+}
+
+// TestNotifyExternalClose_SkipsLabelWriteWhenIssueClosed (GH-4817, TASK-459
+// Phase 3 Task 5e/7g): when the reused pilot-done GetIssue fetch shows the
+// issue is already closed (but not pilot-done — the pilot-done guard above
+// this code path already covers that case), notifyExternalClose must skip
+// the label correction (AddLabels/RemoveLabel) entirely — there's no retry
+// state to protect on an issue the poller will never revisit — but it must
+// still post the informational issue comment, unlike every other GH-4817
+// open-state-gated site in this codebase (which skip the comment too).
+func TestNotifyExternalClose_SkipsLabelWriteWhenIssueClosed(t *testing.T) {
+	var labelsPosted, labelsDeleted, issueCommentPosted bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues/10" && r.Method == http.MethodGet:
+			issue := github.Issue{Number: 10, State: "closed", Labels: []github.Label{}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(issue)
+		case r.URL.Path == "/repos/owner/repo/issues/10/labels" && r.Method == http.MethodPost:
+			labelsPosted = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/10/labels/") && r.Method == http.MethodDelete:
+			labelsDeleted = true
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/repos/owner/repo/issues/10/comments" && r.Method == http.MethodPost:
+			issueCommentPosted = true
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]int{"id": 2})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{PRNumber: 42, IssueNumber: 10, Error: "CI checks failed"}
+	c.notifyExternalClose(context.Background(), prState)
+
+	if labelsPosted {
+		t.Error("expected no label POST when the issue is already closed")
+	}
+	if labelsDeleted {
+		t.Error("expected no label DELETE when the issue is already closed")
+	}
+	if !issueCommentPosted {
+		t.Error("expected the informational issue comment to still post even though the issue is closed")
 	}
 }
 

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -80,6 +80,19 @@ func IsTerminalByDesignStatus(status string) bool {
 	return terminalByDesignExecutionStatuses[status]
 }
 
+// IsNoArtifactExplainedOutcome reports whether outcome (an ExecutionResult's
+// Outcome field, or a persisted execution's status) explains an absent
+// commit/PR by design rather than by anomaly. GH-4817 (TASK-459 Phase 3):
+// consumers that infer failure from "no commit, no PR" alone (GH-3053's
+// GitLab demotion, the CLI's no-artifact check) must consult this first —
+// a no_op row deliberately produced no deliverable, and superseded/canceled
+// rows are covered by IsTerminalByDesignStatus. What a *completed* row with
+// no artifact means beyond that is TASK-460; this helper does not expand
+// into it.
+func IsNoArtifactExplainedOutcome(outcome string) bool {
+	return outcome == string(ExecStatusNoOp) || IsTerminalByDesignStatus(outcome)
+}
+
 // DispatcherConfig configures the task dispatcher behavior.
 type DispatcherConfig struct {
 	// StaleTaskDuration is a backwards-compat alias for StaleRunningThreshold.
@@ -627,7 +640,17 @@ func (d *Dispatcher) recoverStaleRunningTasks() int {
 			continue
 		}
 
-		d.log.Warn("Marking stale running task as failed",
+		// GH-4817 (TASK-459 Phase 3): a stale "running" row past every liveness
+		// check above is evidence the worker died mid-flight, not evidence the
+		// task's code is broken — the boot-time sibling reconcileOrphanedExecutions
+		// already writes ExecStatusStalled for the exact same shape ("orphaned by
+		// daemon restart", above). Writing "failed" here inferred failure purely
+		// from artifact absence (no completed row, no live worker, no merged/open
+		// PR) — liveness-loss, not a genuine failure — and fed the same
+		// consecutiveDrops counter a real failure would. Downstream is already
+		// status-driven: priorClaimWasStalled -> the stall carve-out ->
+		// stallTaskAfterStallCap at cap 8, instead of the failure ladder.
+		d.log.Warn("Marking stale running task as stalled",
 			slog.String("execution_id", exec.ID),
 			slog.String("task_id", exec.TaskID),
 			slog.Time("created_at", exec.CreatedAt),
@@ -636,18 +659,18 @@ func (d *Dispatcher) recoverStaleRunningTasks() int {
 		// evidence gathered above and this write (the reaper's own TOCTOU
 		// window), the write is rejected instead of clobbering the completed
 		// row. The store already logs the rejection at ERROR with both states.
-		applied, err := d.store.UpdateExecutionStatusIfNotTerminal(exec.ID, "failed", "stale running task recovered (orphaned worker)")
+		applied, err := d.store.UpdateExecutionStatusIfNotTerminal(exec.ID, string(ExecStatusStalled), "stale running task recovered (orphaned worker)")
 		if err != nil {
 			d.log.Error("Failed to mark stale running task", slog.String("id", exec.ID), slog.Any("error", err))
 		} else if !applied {
-			d.log.Warn("Skipped marking stale running task failed — row reached a terminal status during reap (GH-4423 CAS guard)",
+			d.log.Warn("Skipped marking stale running task stalled — row reached a terminal status during reap (GH-4423 CAS guard)",
 				slog.String("execution_id", exec.ID), slog.String("task_id", exec.TaskID))
 		} else {
 			resetCount++
 			// GH-4101: without this, the terminal transition a restart forces on an
 			// orphaned row is invisible in execution_events — the audit trail simply
 			// stops, indistinguishable from a row still legitimately mid-flight.
-			d.recordExecutionEvent(exec.ID, memory.StageFailed, "stale_running recovered after restart")
+			d.recordExecutionEvent(exec.ID, memory.StageStalled, "stale_running recovered after restart")
 		}
 	}
 
@@ -737,13 +760,21 @@ var mergedPRPreflightCheck = func(ctx context.Context, projectPath, branch strin
 	return NewGitOperations(projectPath).FindMergedPRByBranch(ctx, branch)
 }
 
-// recoverStaleQueuedTasks marks orphaned queued tasks as failed: either a
-// duplicate row for a task that already completed, or a queued task whose
-// project has no live worker even after Dispatcher.Start's adoption pass
-// (e.g. the project was removed from config). GH-2331: a live worker means
-// the task is simply waiting its turn — Pilot runs tasks serially per
-// project, and a sibling taking 8+ minutes (common for epic/Navigator work)
-// would otherwise exceed the 5-minute threshold and get killed mid-queue.
+// recoverStaleQueuedTasks reaps orphaned queued tasks: either deleting a
+// duplicate row for a task that already completed, or marking canceled a
+// queued task whose project has no live worker even after Dispatcher.Start's
+// adoption pass (e.g. the project was removed from config). GH-2331: a live
+// worker means the task is simply waiting its turn — Pilot runs tasks
+// serially per project, and a sibling taking 8+ minutes (common for
+// epic/Navigator work) would otherwise exceed the 5-minute threshold and get
+// killed mid-queue.
+//
+// GH-4817 (TASK-459 Phase 3): a queued task that never ran did not fail —
+// the operator removing the project (or a restart racing adoption) is a
+// designed termination, not a code defect. Marking it "canceled" mirrors
+// reclaimSelfOwnedQueuedChild's use of a typed administrative marker for
+// exactly this kind of non-outcome write, and keeps it out of failure-ladder
+// consumers (retry budgets, alerting) that "failed" would otherwise feed.
 func (d *Dispatcher) recoverStaleQueuedTasks() int {
 	var resetCount int
 
@@ -802,7 +833,7 @@ func (d *Dispatcher) recoverStaleQueuedTasks() int {
 			continue
 		}
 
-		d.log.Warn("Marking orphaned queued task as failed",
+		d.log.Warn("Marking orphaned queued task as canceled",
 			slog.String("execution_id", exec.ID),
 			slog.String("task_id", exec.TaskID),
 			slog.Time("created_at", exec.CreatedAt),
@@ -816,17 +847,17 @@ func (d *Dispatcher) recoverStaleQueuedTasks() int {
 		// above; if this row went terminal between the guards above and this
 		// write, the write is rejected instead of clobbering it (the store
 		// already logs both states at ERROR).
-		applied, err := d.store.UpdateExecutionStatusIfNotTerminal(exec.ID, "failed", "queued task orphaned by restart; project no longer configured")
+		applied, err := d.store.UpdateExecutionStatusIfNotTerminal(exec.ID, string(ExecStatusCanceled), "queued task orphaned by restart; project no longer configured")
 		if err != nil {
 			d.log.Error("Failed to mark stale queued task", slog.String("id", exec.ID), slog.Any("error", err))
 		} else if !applied {
-			d.log.Warn("Skipped marking stale queued task failed — row reached a terminal status during reap (GH-4423 CAS guard)",
+			d.log.Warn("Skipped marking stale queued task canceled — row reached a terminal status during reap (GH-4423 CAS guard)",
 				slog.String("execution_id", exec.ID), slog.String("task_id", exec.TaskID))
 		} else {
 			resetCount++
 			// GH-4101: mirrors the stale-running event above — the audit trail must
 			// show why this row went terminal, not just that it did.
-			d.recordExecutionEvent(exec.ID, memory.StageFailed, "stale_queued recovered after restart: project no longer configured")
+			d.recordExecutionEvent(exec.ID, memory.StageCanceled, "stale_queued recovered after restart: project no longer configured")
 		}
 	}
 
@@ -2020,6 +2051,21 @@ func (d *Dispatcher) surfaceStalledIssue(task *Task, reason string) {
 
 	ctx, cancel := context.WithTimeout(d.ctx, 30*time.Second)
 	defer cancel()
+
+	// GH-4817 (TASK-459 Phase 3): a closed issue has already left the
+	// poller's candidate set — labeling/commenting on it strands
+	// pilot-blocked (and the removed pilot-failed/pilot-in-progress) on an
+	// issue no human will revisit, with no poller pass left to ever clean it
+	// up. Positive evidence of closed suppresses the write; a lookup error
+	// fails open (today's behavior — proceed with the write).
+	if state, err := fetchIssueState(ctx, d.runner, task, task.ProjectPath); err != nil {
+		d.log.Warn("stalled-issue surfacing: failed to check issue state before labeling; proceeding (fail-open)",
+			slog.String("task_id", task.ID), slog.Any("error", err))
+	} else if state.Closed {
+		d.log.Info("stalled-issue surfacing: issue already closed, skipping pilot-blocked label and comment",
+			slog.String("task_id", task.ID))
+		return
+	}
 
 	comment := fmt.Sprintf(
 		"Pilot stopped retrying (repick hard cap): %s\n\n"+

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -693,15 +693,16 @@ func TestDispatcher_RecoverStaleTasks(t *testing.T) {
 	}
 	defer dispatcher.Stop()
 
-	// Check that the task was marked failed (not re-queued — re-queuing without
-	// a worker just recreates the orphan).
+	// Check that the task was marked stalled (not re-queued — re-queuing
+	// without a worker just recreates the orphan; not failed — a stale
+	// running row is liveness-loss, not a genuine failure, GH-4817).
 	updated, err := store.GetExecution("exec-recover")
 	if err != nil {
 		t.Fatalf("failed to get execution: %v", err)
 	}
 
-	if updated.Status != "failed" {
-		t.Errorf("expected recovered task to have status 'failed', got '%s'", updated.Status)
+	if updated.Status != "stalled" {
+		t.Errorf("expected recovered task to have status 'stalled', got '%s'", updated.Status)
 	}
 }
 
@@ -807,18 +808,18 @@ func TestRecoverStaleTasks_QueuedAndRunning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get execution: %v", err)
 	}
-	if exec.Status != "failed" {
-		t.Errorf("expected exec-stale-run to be 'failed', got '%s'", exec.Status)
+	if exec.Status != "stalled" {
+		t.Errorf("expected exec-stale-run to be 'stalled', got '%s'", exec.Status)
 	}
 
 	// GH-3732: the queued sibling must NOT be reaped as an orphan — its
 	// project gets re-adopted at Start, so a real worker should pick it up
-	// instead of the stale-queued reap wrongly failing it.
+	// instead of the stale-queued reap wrongly canceling it.
 	exec, err = store.GetExecution("exec-stale-q")
 	if err != nil {
 		t.Fatalf("failed to get execution: %v", err)
 	}
-	if exec.Status == "failed" && exec.Error == "queued task orphaned by restart; project no longer configured" {
+	if exec.Status == "canceled" && exec.Error == "queued task orphaned by restart; project no longer configured" {
 		t.Errorf("expected exec-stale-q to be adopted, not reaped as an orphan (error=%q)", exec.Error)
 	}
 
@@ -1003,11 +1004,11 @@ func TestRecoverStaleRunningTasks_HealsUsingRecordedBranchNotTaskID(t *testing.T
 	}
 }
 
-// TestRecoverStaleRunningTasks_MarksFailedWhenNoMergedPR guards the negative
+// TestRecoverStaleRunningTasks_MarksStalledWhenNoMergedPR guards the negative
 // case: a genuinely orphaned running row (no live worker, no merged PR on its
-// branch) must still be marked "failed" — the GH-4092 healing path must not
+// branch) must still be marked "stalled" — the GH-4092 healing path must not
 // swallow real orphans.
-func TestRecoverStaleRunningTasks_MarksFailedWhenNoMergedPR(t *testing.T) {
+func TestRecoverStaleRunningTasks_MarksStalledWhenNoMergedPR(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
 
@@ -1036,8 +1037,8 @@ func TestRecoverStaleRunningTasks_MarksFailedWhenNoMergedPR(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get execution: %v", err)
 	}
-	if got.Status != "failed" {
-		t.Errorf("expected genuinely orphaned running task to be marked 'failed', got %q", got.Status)
+	if got.Status != "stalled" {
+		t.Errorf("expected genuinely orphaned running task to be marked 'stalled', got %q", got.Status)
 	}
 }
 
@@ -1197,8 +1198,8 @@ func TestRecoverStaleRunningTasks_WritesExecutionEvent(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 execution event, got %d: %+v", len(events), events)
 	}
-	if events[0].Stage != memory.StageFailed {
-		t.Errorf("expected stage %q, got %q", memory.StageFailed, events[0].Stage)
+	if events[0].Stage != memory.StageStalled {
+		t.Errorf("expected stage %q, got %q", memory.StageStalled, events[0].Stage)
 	}
 	if !strings.Contains(events[0].Detail, "stale_running recovered after restart") {
 		t.Errorf("expected detail to explain the stale_running recovery reason, got %q", events[0].Detail)
@@ -1281,8 +1282,8 @@ func TestRecoverStaleRunningTasks_FateReconstructableFromEventsAlone(t *testing.
 		t.Fatal("execution_events timeline is empty — fate is unrecoverable from events alone (the GH-4050 gap)")
 	}
 	last := events[len(events)-1]
-	if last.Stage != memory.StageFailed {
-		t.Fatalf("reconstructed fate from events: last stage = %q, want %q (terminal failure)", last.Stage, memory.StageFailed)
+	if last.Stage != memory.StageStalled {
+		t.Fatalf("reconstructed fate from events: last stage = %q, want %q (liveness-loss, not a genuine failure)", last.Stage, memory.StageStalled)
 	}
 	if !strings.Contains(last.Detail, "recovered after restart") {
 		t.Errorf("reconstructed fate from events: detail %q does not explain the restart-driven recovery", last.Detail)
@@ -2376,8 +2377,8 @@ func TestRecoverStaleRunningTasks_DecomposedParentGuard(t *testing.T) {
 		wantStatus    string // checked only when !wantDeleted
 	}{
 		{name: "all children completed guard fires", childStatuses: []string{"completed", "completed"}, wantDeleted: true},
-		{name: "one child incomplete falls through to failed", childStatuses: []string{"completed", "running"}, wantDeleted: false, wantStatus: "failed"},
-		{name: "no completed rows falls through to failed", childStatuses: []string{"", ""}, wantDeleted: false, wantStatus: "failed"},
+		{name: "one child incomplete falls through to stalled", childStatuses: []string{"completed", "running"}, wantDeleted: false, wantStatus: "stalled"},
+		{name: "no completed rows falls through to stalled", childStatuses: []string{"", ""}, wantDeleted: false, wantStatus: "stalled"},
 	}
 
 	for _, tc := range tests {
@@ -2447,8 +2448,8 @@ func TestRecoverStaleQueuedTasks_DecomposedParentGuard(t *testing.T) {
 		wantStatus    string
 	}{
 		{name: "all children completed guard fires", childStatuses: []string{"completed", "completed"}, wantDeleted: true},
-		{name: "one child incomplete falls through to failed", childStatuses: []string{"completed", "running"}, wantDeleted: false, wantStatus: "failed"},
-		{name: "no completed rows falls through to failed", childStatuses: []string{"", ""}, wantDeleted: false, wantStatus: "failed"},
+		{name: "one child incomplete falls through to canceled", childStatuses: []string{"completed", "running"}, wantDeleted: false, wantStatus: "canceled"},
+		{name: "no completed rows falls through to canceled", childStatuses: []string{"", ""}, wantDeleted: false, wantStatus: "canceled"},
 	}
 
 	for _, tc := range tests {
@@ -2668,8 +2669,8 @@ func TestRunStaleRecoveryLoop_Periodic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get execution: %v", err)
 	}
-	if updated.Status != "failed" {
-		t.Errorf("expected periodic recovery to mark task 'failed', got '%s'", updated.Status)
+	if updated.Status != "stalled" {
+		t.Errorf("expected periodic recovery to mark task 'stalled', got '%s'", updated.Status)
 	}
 }
 
@@ -2720,7 +2721,7 @@ func TestRecoverStaleTasks_DeletesOrphanWhenCompleted(t *testing.T) {
 	}
 }
 
-func TestRecoverStaleTasks_MarksFailedWhenNoCompleted(t *testing.T) {
+func TestRecoverStaleTasks_MarksStalledOrCanceledWhenNoCompleted(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
 
@@ -2749,13 +2750,14 @@ func TestRecoverStaleTasks_MarksFailedWhenNoCompleted(t *testing.T) {
 	defer dispatcher.Stop()
 
 	// The running orphan has no worker (recoverStaleRunningTasks runs before
-	// adoption) and no completed sibling, so it's genuinely reaped.
+	// adoption) and no completed sibling, so it's genuinely reaped as stalled
+	// (liveness-loss, not a genuine failure — GH-4817).
 	exec, err := store.GetExecution("exec-only-run")
 	if err != nil {
 		t.Fatalf("failed to get execution: %v", err)
 	}
-	if exec.Status != "failed" {
-		t.Errorf("expected exec-only-run to be 'failed', got '%s'", exec.Status)
+	if exec.Status != "stalled" {
+		t.Errorf("expected exec-only-run to be 'stalled', got '%s'", exec.Status)
 	}
 
 	// GH-3732: the queued task's project gets re-adopted at Start, so it must
@@ -2767,7 +2769,7 @@ func TestRecoverStaleTasks_MarksFailedWhenNoCompleted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get execution: %v", err)
 	}
-	if exec.Status == "failed" && exec.Error == "queued task orphaned by restart; project no longer configured" {
+	if exec.Status == "canceled" && exec.Error == "queued task orphaned by restart; project no longer configured" {
 		t.Errorf("expected exec-only-q to be adopted, not reaped as an orphan (error=%q)", exec.Error)
 	}
 }
@@ -2777,7 +2779,7 @@ func TestRecoverStaleTasks_DifferentProjectPath(t *testing.T) {
 	defer cleanup()
 
 	// Scenario: completed execution exists for a DIFFERENT project path.
-	// The orphan should still be marked failed (HasCompletedExecution checks both fields).
+	// The orphan should still be marked stalled (HasCompletedExecution checks both fields).
 	executions := []*memory.Execution{
 		{ID: "exec-diff-completed", TaskID: "TASK-DIFF", ProjectPath: "/project-a", Status: "completed"},
 		{ID: "exec-diff-orphan", TaskID: "TASK-DIFF", ProjectPath: "/project-b", Status: "running"},
@@ -2801,13 +2803,13 @@ func TestRecoverStaleTasks_DifferentProjectPath(t *testing.T) {
 	}
 	defer dispatcher.Stop()
 
-	// Different project path → no match → should be marked failed, not deleted.
+	// Different project path → no match → should be marked stalled, not deleted.
 	exec, err := store.GetExecution("exec-diff-orphan")
 	if err != nil {
 		t.Fatalf("failed to get execution: %v", err)
 	}
-	if exec.Status != "failed" {
-		t.Errorf("expected orphan with different project to be 'failed', got '%s'", exec.Status)
+	if exec.Status != "stalled" {
+		t.Errorf("expected orphan with different project to be 'stalled', got '%s'", exec.Status)
 	}
 }
 
@@ -5041,7 +5043,7 @@ func TestRecoverStaleQueuedTasks_MessageAccuracy(t *testing.T) {
 		{
 			name:          "genuine orphan gets reworded message",
 			injectWorker:  false,
-			wantStatus:    "failed",
+			wantStatus:    "canceled",
 			wantErrSubstr: "queued task orphaned by restart; project no longer configured",
 		},
 		{
@@ -5089,9 +5091,9 @@ func TestRecoverStaleQueuedTasks_MessageAccuracy(t *testing.T) {
 }
 
 // TestRecoverStaleQueuedTasks_WritesExecutionEvent verifies GH-4101: marking
-// an orphaned queued task failed also writes an execution_events row, so its
-// terminal transition is visible in the audit trail instead of the event
-// stream simply stopping.
+// an orphaned queued task canceled also writes an execution_events row, so
+// its terminal transition is visible in the audit trail instead of the
+// event stream simply stopping.
 func TestRecoverStaleQueuedTasks_WritesExecutionEvent(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
@@ -5113,8 +5115,8 @@ func TestRecoverStaleQueuedTasks_WritesExecutionEvent(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 execution event, got %d: %+v", len(events), events)
 	}
-	if events[0].Stage != memory.StageFailed {
-		t.Errorf("expected stage %q, got %q", memory.StageFailed, events[0].Stage)
+	if events[0].Stage != memory.StageCanceled {
+		t.Errorf("expected stage %q, got %q", memory.StageCanceled, events[0].Stage)
 	}
 	if !strings.Contains(events[0].Detail, "stale_queued recovered after restart") {
 		t.Errorf("expected detail to explain the stale_queued recovery reason, got %q", events[0].Detail)

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -753,6 +753,20 @@ func (r *Runner) handleSubIssueCoverageGap(ctx context.Context, plan *EpicPlan, 
 	// to WARN.
 	ghRef := plan.ParentTask.GHIssueRef()
 
+	// TASK-459 Phase 3 Task 5d: skip the label/comment on positive evidence
+	// the parent issue is already closed (fail open on lookup error) — the
+	// comment below asserts "this issue stays open", which would be
+	// misleading if the parent was externally closed between decomposition
+	// and this coverage-gap check.
+	if state, err := fetchIssueState(ctx, r, plan.ParentTask, executionPath); err != nil {
+		r.log.Warn("coverage-gap: failed to check parent issue state before labeling; proceeding (fail-open)",
+			"parent_id", parentID, "error", err)
+	} else if state.Closed {
+		r.log.Info("coverage-gap: parent issue already closed, skipping pilot-needs-clarification label and comment",
+			"parent_id", parentID)
+		return gap
+	}
+
 	if err := ghAddLabels(ctx, executionPath, ghRef, []string{"pilot-needs-clarification"}); err != nil {
 		r.log.Warn("failed to label parent with pilot-needs-clarification after coverage gap",
 			"parent_id", parentID, "error", err)

--- a/internal/executor/finish_tripwires.go
+++ b/internal/executor/finish_tripwires.go
@@ -255,7 +255,12 @@ func checkChildrenTerminal(store *memory.Store, row *memory.Execution) tripwireC
 //     requested one (TaskCreatePR) — the exact "committed work, no
 //     delivery" shape PR#3383 made loud instead of silently discarding.
 //     Skipped for ExecStatusDecomposed rows: a decomposed parent
-//     legitimately has no commit of its own to ship.
+//     legitimately has no commit of its own to ship. GH-4817 (TASK-459
+//     Phase 3): also skipped for terminal-by-design rows (superseded/
+//     canceled) — a row that committed before being superseded/canceled
+//     had its PR deliberately not carried out, not silently discarded; this
+//     tripwire would otherwise fire a false alert on the exact GH-4794
+//     shape (alert-only variant).
 func checkWorktreePruned(row *memory.Execution) tripwireCheckResult {
 	if dirs, err := findOrphanedWorktreeDirs(row.TaskID); err == nil && len(dirs) > 0 {
 		return tripwireCheckResult{
@@ -265,7 +270,8 @@ func checkWorktreePruned(row *memory.Execution) tripwireCheckResult {
 		}
 	}
 
-	if row.TaskCreatePR && row.CommitSHA != "" && row.PRUrl == "" && row.Status != string(ExecStatusDecomposed) {
+	if row.TaskCreatePR && row.CommitSHA != "" && row.PRUrl == "" &&
+		row.Status != string(ExecStatusDecomposed) && !IsTerminalByDesignStatus(row.Status) {
 		return tripwireCheckResult{
 			violated: true,
 			reason: fmt.Sprintf("execution %s committed %s but produced no PR (task requested one)",

--- a/internal/executor/finish_tripwires_test.go
+++ b/internal/executor/finish_tripwires_test.go
@@ -286,6 +286,41 @@ func TestCheckWorktreePruned(t *testing.T) {
 			t.Errorf("expected no violation once a PR exists, got %+v", result)
 		}
 	})
+
+	// GH-4817 (TASK-459 Phase 3 Task 6): commits with no PR is fine for a
+	// terminal-by-design row (superseded/canceled) — mirrors the existing
+	// decomposed-parent carve-out above. The PR was deliberately not carried
+	// out, not silently discarded; this tripwire must not fire the exact
+	// GH-4794 shape (alert-only variant).
+	t.Run("commits with no PR is fine for a superseded row", func(t *testing.T) {
+		result := checkWorktreePruned(&memory.Execution{
+			ID: "exec-superseded", TaskID: "GH-8051", TaskCreatePR: true, CommitSHA: "deadbeef", PRUrl: "",
+			Status: string(ExecStatusSuperseded),
+		})
+		if result.violated {
+			t.Errorf("expected no violation for a superseded row, got %+v", result)
+		}
+	})
+
+	t.Run("commits with no PR is fine for a canceled row", func(t *testing.T) {
+		result := checkWorktreePruned(&memory.Execution{
+			ID: "exec-canceled", TaskID: "GH-8061", TaskCreatePR: true, CommitSHA: "deadbeef", PRUrl: "",
+			Status: string(ExecStatusCanceled),
+		})
+		if result.violated {
+			t.Errorf("expected no violation for a canceled row, got %+v", result)
+		}
+	})
+
+	t.Run("commits with no PR still fails for a plain failed row (guard is narrow)", func(t *testing.T) {
+		result := checkWorktreePruned(&memory.Execution{
+			ID: "exec-failed", TaskID: "GH-8071", TaskCreatePR: true, CommitSHA: "deadbeef", PRUrl: "",
+			Status: string(ExecStatusFailed),
+		})
+		if !result.violated {
+			t.Error("expected a violation for a plain failed row — the terminal-by-design carve-out must not swallow genuine failures")
+		}
+	})
 }
 
 // TestRunFinishTripwireSweep_EmitsAttemptForEveryCheck verifies the sweep

--- a/internal/executor/gh4817_issue_open_state_test.go
+++ b/internal/executor/gh4817_issue_open_state_test.go
@@ -1,0 +1,219 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// GH-4817 (TASK-459 Phase 3, Task 5/7): regression suite for the open-state
+// guards added to every additive GitHub label/comment write site that fires
+// on a stalled/failed/gap execution path. Each site consults the shared
+// fetchIssueState seam (issue_state.go, GH-4656) before writing and skips
+// the write on positive evidence the issue is already closed — a closed
+// issue has already left the poller's candidate set, so labeling/commenting
+// on it strands state no human will ever revisit. A lookup error still
+// fails open (today's pre-GH-4817 behavior), covered elsewhere by every
+// existing test in this suite that leaves fetchIssueState un-stubbed against
+// a projectDir with no git remote (real fetch errors, guard proceeds).
+
+// TestIsNoArtifactExplainedOutcome exercises the classification helper (Task
+// 3/4's shared dependency) that GH-3053's GitLab demotion (handlers.go) and
+// the CLI's no-artifact check (commands.go) both consult before inferring
+// failure from an absent commit/PR alone.
+func TestIsNoArtifactExplainedOutcome(t *testing.T) {
+	tests := []struct {
+		outcome string
+		want    bool
+	}{
+		{outcome: string(ExecStatusNoOp), want: true},
+		{outcome: string(ExecStatusSuperseded), want: true},
+		{outcome: string(ExecStatusCanceled), want: true},
+		{outcome: string(ExecStatusCompleted), want: false},
+		{outcome: string(ExecStatusFailed), want: false},
+		{outcome: "", want: false},
+		{outcome: "some-unrelated-outcome", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.outcome, func(t *testing.T) {
+			if got := IsNoArtifactExplainedOutcome(tt.outcome); got != tt.want {
+				t.Errorf("IsNoArtifactExplainedOutcome(%q) = %v, want %v", tt.outcome, got, tt.want)
+			}
+		})
+	}
+}
+
+// setupFakeGhCLI installs a fake `gh` binary on PATH for the duration of the
+// test that appends its argv to logFile and exits 0. Mirrors the inline
+// pattern already used by TestDispatcher_StallTaskAfterRepickHardCap_SurfacesStalledIssue.
+func setupFakeGhCLI(t *testing.T) (logFile string) {
+	t.Helper()
+	fakeBin := t.TempDir()
+	logFile = filepath.Join(t.TempDir(), "gh-calls.log")
+	script := filepath.Join(fakeBin, "gh")
+	content := "#!/bin/sh\n" + `echo "$@" >> "` + logFile + `"` + "\nexit 0\n"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	origPATH := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+origPATH)
+	return logFile
+}
+
+// Task 5a: dispatcher.go surfaceStalledIssue.
+func TestSurfaceStalledIssue_SkipsWhenIssueClosed(t *testing.T) {
+	logFile := setupFakeGhCLI(t)
+
+	stubFetchIssueState(t, func(_ context.Context, _ *Runner, _ *Task, _ string) (IssueState, error) {
+		return IssueState{Closed: true}, nil
+	})
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	runner := NewRunner()
+	dispatcher := NewDispatcher(store, runner, nil)
+
+	task := &Task{ID: "GH-9101", ProjectPath: t.TempDir(), Title: "Closed head issue", SourceAdapter: "github"}
+	dispatcher.surfaceStalledIssue(task, "repick hard cap reached")
+
+	if _, err := os.ReadFile(logFile); err == nil {
+		t.Error("expected no gh CLI invocation when the issue is already closed")
+	}
+}
+
+// Task 5b: handlers.go notifyTaskStartedSDK caller — the guard itself lives
+// in cmd/pilot (a different module boundary from this package), so it isn't
+// directly testable from internal/executor. It's exercised in
+// cmd/pilot/gh4817_notify_started_gate_test.go instead.
+
+// Task 5c: title_rejection.go postTitleRejectionEscalation.
+func TestPostTitleRejectionEscalation_SkipsWhenIssueClosed(t *testing.T) {
+	logFile := setupFakeGhCLI(t)
+
+	stubFetchIssueState(t, func(_ context.Context, _ *Runner, _ *Task, _ string) (IssueState, error) {
+		return IssueState{Closed: true}, nil
+	})
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	runner := NewRunner()
+	runner.SetLogStore(store)
+
+	task := &Task{
+		ID:            "GH-9102",
+		Title:         "not a conventional title",
+		ProjectPath:   t.TempDir(),
+		SourceAdapter: "github",
+	}
+
+	if err := runner.postTitleRejectionEscalation(context.Background(), task); err != nil {
+		t.Fatalf("postTitleRejectionEscalation: %v", err)
+	}
+
+	if _, err := os.ReadFile(logFile); err == nil {
+		t.Error("expected no gh CLI invocation when the issue is already closed")
+	}
+}
+
+func TestPostTitleRejectionEscalation_ProceedsWhenIssueOpen(t *testing.T) {
+	logFile := setupFakeGhCLI(t)
+
+	stubFetchIssueState(t, func(_ context.Context, _ *Runner, _ *Task, _ string) (IssueState, error) {
+		return IssueState{Closed: false}, nil
+	})
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	runner := NewRunner()
+	runner.SetLogStore(store)
+
+	task := &Task{
+		ID:            "GH-9103",
+		Title:         "not a conventional title",
+		ProjectPath:   t.TempDir(),
+		SourceAdapter: "github",
+	}
+
+	if err := runner.postTitleRejectionEscalation(context.Background(), task); err != nil {
+		t.Fatalf("postTitleRejectionEscalation: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("expected gh CLI to be invoked for an open issue: %v", err)
+	}
+	calls := string(logBytes)
+	if !strings.Contains(calls, "issue comment 9103") {
+		t.Errorf("expected a comment posted to issue 9103, got calls:\n%s", calls)
+	}
+	if !strings.Contains(calls, "--add-label pilot-title-rejected") {
+		t.Errorf("expected pilot-title-rejected to be added, got calls:\n%s", calls)
+	}
+}
+
+// Task 5d: epic.go handleSubIssueCoverageGap.
+func TestHandleSubIssueCoverageGap_SkipsLabelingWhenParentClosed(t *testing.T) {
+	logFile := setupFakeGhCLI(t)
+
+	stubFetchIssueState(t, func(_ context.Context, _ *Runner, _ *Task, _ string) (IssueState, error) {
+		return IssueState{Closed: true}, nil
+	})
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	runner := NewRunner()
+	runner.SetLogStore(store)
+
+	parent := &Task{ID: "GH-9104", ProjectPath: t.TempDir(), SourceAdapter: "github"}
+	plan := &EpicPlan{
+		ParentTask: parent,
+		Subtasks:   []PlannedSubtask{{Title: "sub 1", Order: 1}, {Title: "sub 2", Order: 2}},
+	}
+
+	gap := runner.handleSubIssueCoverageGap(context.Background(), plan, nil, parent.ProjectPath, nil)
+	if gap == nil {
+		t.Fatal("expected a non-nil coverage gap")
+	}
+
+	if _, err := os.ReadFile(logFile); err == nil {
+		t.Error("expected no gh CLI invocation when the parent issue is already closed")
+	}
+}
+
+func TestHandleSubIssueCoverageGap_LabelsWhenParentOpen(t *testing.T) {
+	logFile := setupFakeGhCLI(t)
+
+	stubFetchIssueState(t, func(_ context.Context, _ *Runner, _ *Task, _ string) (IssueState, error) {
+		return IssueState{Closed: false}, nil
+	})
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	runner := NewRunner()
+	runner.SetLogStore(store)
+
+	parent := &Task{ID: "GH-9105", ProjectPath: t.TempDir(), SourceAdapter: "github"}
+	plan := &EpicPlan{
+		ParentTask: parent,
+		Subtasks:   []PlannedSubtask{{Title: "sub 1", Order: 1}, {Title: "sub 2", Order: 2}},
+	}
+
+	gap := runner.handleSubIssueCoverageGap(context.Background(), plan, nil, parent.ProjectPath, nil)
+	if gap == nil {
+		t.Fatal("expected a non-nil coverage gap")
+	}
+
+	logBytes, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("expected gh CLI to be invoked for an open parent issue: %v", err)
+	}
+	calls := string(logBytes)
+	if !strings.Contains(calls, "--add-label pilot-needs-clarification") {
+		t.Errorf("expected pilot-needs-clarification to be added, got calls:\n%s", calls)
+	}
+	if !strings.Contains(calls, "issue comment 9105") {
+		t.Errorf("expected a coverage-gap comment posted to issue 9105, got calls:\n%s", calls)
+	}
+}

--- a/internal/executor/title_rejection.go
+++ b/internal/executor/title_rejection.go
@@ -211,6 +211,20 @@ func (r *Runner) postTitleRejectionEscalation(ctx context.Context, task *Task) e
 	if _, err := fmt.Sscanf(issueNum, "%d", &parsed); err != nil || parsed <= 0 {
 		return fmt.Errorf("invalid issue number %q: %w", issueNum, err)
 	}
+
+	// TASK-459 Phase 3 Task 5c: skip the escalation comment + labels on
+	// positive evidence the issue is already closed (fail open on lookup
+	// error — never block the existing best-effort path on an unrelated
+	// GitHub read failure).
+	if state, err := fetchIssueState(ctx, r, task, task.ProjectPath); err != nil {
+		r.log.Warn("title-rejection escalation: failed to check issue state before labeling; proceeding (fail-open)",
+			"task_id", task.ID, "issue", issueNum, "error", err)
+	} else if state.Closed {
+		r.log.Info("title-rejection escalation: issue already closed, skipping comment and labels",
+			"task_id", task.ID, "issue", issueNum)
+		return nil
+	}
+
 	comment := buildTitleRejectionComment(parsed, task.Title, task.Labels)
 
 	if err := ghIssueComment(ctx, task.ProjectPath, issueNum, comment); err != nil {


### PR DESCRIPTION
## Summary

TASK-459 Phase 3: migrates the executor/dispatcher/poller destructive-action sites named in the Phase-1 irreversible-action inventory to consult recorded ledger status instead of inferring failure from an absent side effect, and gates additive GitHub label/comment writes on the target issue's current open/closed state.

- `recoverStaleRunningTasks`/`recoverStaleQueuedTasks` (dispatcher.go) now write typed `stalled`/`canceled` instead of collapsing every boot-time orphan to `failed`.
- The GitLab (`handleGitlabIssueWithResult`) and CLI (`newGitHubRunCmd`) GH-3053 "no commit, no PR" demotions now consult a new `executor.IsNoArtifactExplainedOutcome` helper (`no_op`/`superseded`/`canceled`) before inferring failure from a missing commit/PR alone.
- Five additive label/comment-write sites now gate on a fresh `fetchIssueState` re-read and skip the write on positive evidence the issue is already closed, failing open on a lookup error:
  - `surfaceStalledIssue` (dispatcher.go)
  - `notifyTaskStartedSDK` caller (handlers.go, SDK-dispatch path)
  - `postTitleRejectionEscalation` (title_rejection.go)
  - `handleSubIssueCoverageGap` (epic.go)
  - `notifyExternalClose` label-correction block (controller.go) — reuses the already-fetched issue state; the informational comment is still posted unconditionally since it's pure history, not retry/label state.
- `checkWorktreePruned` (finish_tripwires.go) excludes `superseded`/`canceled` rows from its "commits but no PR" tripwire violation, alongside the pre-existing `decomposed` carve-out.
- `.agent/system/irreversible-actions.md` updated in place to record the new `re-read` evidence gates.

## Test plan

- [x] `go test ./internal/executor/... ./cmd/pilot/... ./internal/autopilot/...` — new regression tests per site (unit tests via `stubFetchIssueState` + fake `gh` CLI where directly testable; source-level guard tests via the existing `githubFuncBody` pattern for functions too network/SDK-entangled to unit test directly)
- [x] `make build` — green
- [x] `make test` — full suite green