### PR TITLE
feat(dashboard): fleet-wide metrics scope by default, per-project opt-in

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1020,9 +1020,12 @@ Examples:
 					}
 					model := dashboard.NewModelWithOptions(version, gwStore, gwAutopilotController, nil)
 					model.SetProjectPath(projectPath)
+					scope := ""
 					if cfg.Dashboard != nil {
 						model.SetStatsWindowDays(cfg.Dashboard.StatsWindowDays)
+						scope = cfg.Dashboard.MetricsScopePath
 					}
+					model.SetMetricsScopePath(scope)
 					applyDashboardBannerMeta(&model, cfg, cmd)
 					model.EnableSplash(resolvedConfigPath())
 					gwProgram = tea.NewProgram(model,
@@ -2646,9 +2649,12 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		upgradeRequestCh = make(chan struct{}, 1)
 		model := dashboard.NewModelWithOptions(version, store, autopilotController, upgradeRequestCh)
 		model.SetProjectPath(projectPath)
+		scope := ""
 		if cfg.Dashboard != nil {
 			model.SetStatsWindowDays(cfg.Dashboard.StatsWindowDays)
+			scope = cfg.Dashboard.MetricsScopePath
 		}
+		model.SetMetricsScopePath(scope)
 		applyDashboardBannerMeta(&model, cfg, cmd)
 		model.EnableSplash(resolvedConfigPath())
 		program = tea.NewProgram(model,

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -813,3 +813,12 @@ autopilot:
 dashboard:
   refresh_interval: 1000     # ms
   show_logs: true
+  # metrics_scope_path filters the TUI's store-backed metrics panels (cost
+  # card, task breakdown, recent executions, lifetime tokens, sparklines) to
+  # one project. Default (unset/empty) is fleet-wide, matching the
+  # pilot_window_* Prometheus gauges — the daemon serves multiple repos, so
+  # fleet-wide is the correct default view. Set this to a project path to
+  # restore the old per-project numbers for that one repo. The git-graph
+  # panel always follows the daemon's --project path, regardless of this
+  # setting. (GH-4829)
+  # metrics_scope_path: /path/to/one/project

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -384,6 +384,12 @@ type DashboardConfig struct {
 	// GH-4735: lifetime aggregates blend model eras and are misleading;
 	// history is not deleted, only the headline surfaces are windowed.
 	StatsWindowDays int `yaml:"stats_window_days"`
+	// MetricsScopePath filters the TUI's store-backed metrics panels (cost
+	// card, task breakdown, recent executions, lifetime tokens, sparklines)
+	// to one project path. Empty (default) = fleet-wide, matching the
+	// pilot_window_* Prometheus gauges. The git-graph panel is unaffected —
+	// it follows the daemon's project path. GH-4829.
+	MetricsScopePath string `yaml:"metrics_scope_path"`
 }
 
 // AlertsConfig holds configuration for the alerting system including
@@ -699,6 +705,9 @@ func Load(path string) (*Config, error) {
 	}
 	for _, project := range config.Projects {
 		project.Path = expandPath(project.Path)
+	}
+	if config.Dashboard != nil && config.Dashboard.MetricsScopePath != "" {
+		config.Dashboard.MetricsScopePath = expandPath(config.Dashboard.MetricsScopePath)
 	}
 
 	// Apply bot model default when bot is configured without an explicit model.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -137,6 +137,11 @@ func TestDefaultConfig(t *testing.T) {
 		if config.Dashboard.StatsWindowDays != 30 {
 			t.Errorf("Dashboard.StatsWindowDays = %d, want %d", config.Dashboard.StatsWindowDays, 30)
 		}
+		// GH-4829: zero value (fleet-wide) IS the default — DefaultConfig must
+		// not set it, so the TUI's metrics panels default to all projects.
+		if config.Dashboard.MetricsScopePath != "" {
+			t.Errorf("Dashboard.MetricsScopePath = %q, want empty (fleet-wide default)", config.Dashboard.MetricsScopePath)
+		}
 	})
 
 	t.Run("Alerts", func(t *testing.T) {
@@ -1145,6 +1150,59 @@ func TestExpandPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestLoad_DashboardMetricsScopePath is the GH-4829 config round-trip test:
+// metrics_scope_path parses when present (with ~ expansion, matching
+// default_project) and defaults to "" (fleet-wide) when absent.
+func TestLoad_DashboardMetricsScopePath(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+
+	t.Run("set and tilde-expanded", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+		configContent := `
+dashboard:
+  metrics_scope_path: "~/Projects/startups/pilot"
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		config, err := Load(configPath)
+		if err != nil {
+			t.Fatalf("Load failed: %v", err)
+		}
+
+		want := filepath.Join(homeDir, "Projects/startups/pilot")
+		if config.Dashboard.MetricsScopePath != want {
+			t.Errorf("Dashboard.MetricsScopePath = %q, want %q", config.Dashboard.MetricsScopePath, want)
+		}
+	})
+
+	t.Run("absent defaults to empty", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+		configContent := `
+dashboard:
+  refresh_interval: 500
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		config, err := Load(configPath)
+		if err != nil {
+			t.Fatalf("Load failed: %v", err)
+		}
+
+		if config.Dashboard.MetricsScopePath != "" {
+			t.Errorf("Dashboard.MetricsScopePath = %q, want empty", config.Dashboard.MetricsScopePath)
+		}
+	})
 }
 
 func TestDefaultConfigPath(t *testing.T) {

--- a/internal/dashboard/gitgraph_test.go
+++ b/internal/dashboard/gitgraph_test.go
@@ -7,6 +7,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/qf-studio/pilot/internal/memory"
 )
 
 // makeKey creates a tea.KeyMsg for the given string (single char or named key).
@@ -812,6 +814,79 @@ func TestSetMetricsScopePath(t *testing.T) {
 	}
 	if m.metricsScopePath != "/tmp/metrics-scope" {
 		t.Errorf("metricsScopePath = %q, want /tmp/metrics-scope", m.metricsScopePath)
+	}
+}
+
+// TestMetricsScopePath_FleetWideDefault is the GH-4829 regression: the
+// dashboard's store-backed metrics panels must default to fleet-wide (all
+// projects), not the single project SetProjectPath seeds. main.go wires this
+// by always calling SetMetricsScopePath(cfg.Dashboard.MetricsScopePath) right
+// after SetProjectPath — an empty config value (the default) must explicitly
+// override the seeded scope back to "", not leave it seeded to one project.
+func TestMetricsScopePath_FleetWideDefault(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// Seed executions for two different projects, 150 tokens each.
+	for _, e := range []struct{ id, project string }{
+		{"exec-a", "/proj/a"},
+		{"exec-b", "/proj/b"},
+	} {
+		if err := store.SaveExecution(&memory.Execution{
+			ID: e.id, TaskID: "TASK-" + e.id, ProjectPath: e.project, Status: "completed",
+		}); err != nil {
+			t.Fatalf("SaveExecution %s: %v", e.id, err)
+		}
+		if err := store.SaveExecutionMetrics(&memory.ExecutionMetrics{
+			ExecutionID: e.id, TokensInput: 100, TokensOutput: 50, TokensTotal: 150, EstimatedCostUSD: 1.0,
+		}); err != nil {
+			t.Fatalf("SaveExecutionMetrics %s: %v", e.id, err)
+		}
+	}
+
+	tests := []struct {
+		name          string
+		configure     func(m *Model)
+		wantTotalTkns int // GetLifetimeTokens is queried with m.metricsScopePath
+	}{
+		{
+			name: "SetProjectPath alone seeds scope to that project (existing behavior)",
+			configure: func(m *Model) {
+				m.SetProjectPath("/proj/a")
+			},
+			wantTotalTkns: 150,
+		},
+		{
+			name: "SetMetricsScopePath empty overrides the seed to fleet-wide",
+			configure: func(m *Model) {
+				m.SetProjectPath("/proj/a")
+				m.SetMetricsScopePath("")
+			},
+			wantTotalTkns: 300,
+		},
+		{
+			name: "SetMetricsScopePath to another project overrides the seed",
+			configure: func(m *Model) {
+				m.SetProjectPath("/proj/a")
+				m.SetMetricsScopePath("/proj/b")
+			},
+			wantTotalTkns: 150,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewModelWithStore("test", store)
+			tt.configure(&m)
+			m.hydrateFromStore()
+			if m.metricsCard.TotalTokens != tt.wantTotalTkns {
+				t.Errorf("TotalTokens = %d, want %d (metricsScopePath=%q)",
+					m.metricsCard.TotalTokens, tt.wantTotalTkns, m.metricsScopePath)
+			}
+		})
 	}
 }
 

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -1277,9 +1277,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			int64(outputDelta),
 			costModel,
 		)
-		if m.metricsCard.TotalTasks > 0 {
-			m.metricsCard.CostPerTask = m.metricsCard.TotalCostUSD / float64(m.metricsCard.TotalTasks)
-		}
+		// GH-4829: CostPerTask is NOT recomputed here. It stays whatever the
+		// store's GetWindowedStats last set (CostPerDelivered = window cost /
+		// distinct delivered issues), which is a different metric than
+		// TotalCostUSD/AttemptTotal (all execution rows, any status). Live
+		// recompute made the detail line oscillate between two definitions
+		// until the next periodic re-query converged it.
 
 	case addCompletedTaskMsg:
 		prevLen := len(m.completedTasks)
@@ -1297,9 +1300,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.metricsCard.Failed++
 		}
-		if m.metricsCard.TotalTasks > 0 {
-			m.metricsCard.CostPerTask = m.metricsCard.TotalCostUSD / float64(m.metricsCard.TotalTasks)
-		}
+		// GH-4829: CostPerTask is NOT recomputed here — see the updateTokensMsg
+		// case above for why (store's CostPerDelivered vs. AttemptTotal drift).
 
 		// GH-1249: History count changed → force repaint
 		if len(m.completedTasks) != prevLen {
@@ -2493,9 +2495,13 @@ func (m Model) renderEvalStats() string {
 		)
 	}
 
+	// GH-4829: metricsScopePath is fleet-wide (empty) by default now, so an
+	// empty scope must render as "all projects" rather than a blank label.
 	info := ""
 	if m.metricsScopePath != "" {
 		info = dimStyle.Render("global")
+	} else {
+		info = dimStyle.Render("all projects")
 	}
 	return renderPanelInfo("eval", info, line, tw)
 }

--- a/internal/dashboard/tui_test.go
+++ b/internal/dashboard/tui_test.go
@@ -668,6 +668,11 @@ func TestUpdateTokensMsg_AddsToLifetimeTotals(t *testing.T) {
 	}
 
 	m := NewModelWithStore("test", store)
+	// GH-4829: CostPerTask now only ever carries the store's CostPerDelivered
+	// value (set by hydrateFromStore/GetWindowedStats) — pin a sentinel here
+	// so the assertion below fails if updateTokensMsg recomputes it.
+	m.metricsCard.CostPerTask = 42.0
+	m.metricsCard.TotalTasks = 3
 
 	// Simulate a token update from a running execution (cumulative: 2000 in, 1000 out)
 	updated, _ := m.Update(updateTokensMsg{InputTokens: 2000, OutputTokens: 1000, TotalTokens: 3000})
@@ -683,10 +688,18 @@ func TestUpdateTokensMsg_AddsToLifetimeTotals(t *testing.T) {
 	if model.metricsCard.TotalTokens != 18000 {
 		t.Errorf("TotalTokens = %d, want 18000", model.metricsCard.TotalTokens)
 	}
+	// GH-4829: CostPerTask must NOT be recomputed from TotalCostUSD/TotalTasks.
+	if model.metricsCard.CostPerTask != 42.0 {
+		t.Errorf("CostPerTask = %v, want unchanged 42.0 (must not be recomputed live)", model.metricsCard.CostPerTask)
+	}
 }
 
 func TestAddCompletedTask_NewFieldsStored(t *testing.T) {
 	m := NewModel("test")
+	// GH-4829: pin a sentinel CostPerTask so we can assert addCompletedTaskMsg
+	// does not recompute it from TotalCostUSD/TotalTasks.
+	m.metricsCard.CostPerTask = 42.0
+	m.metricsCard.TotalCostUSD = 10.0
 
 	// Send a completed task with parentID and isEpic=false (sub-issue)
 	msg := addCompletedTaskMsg(CompletedTask{
@@ -709,6 +722,10 @@ func TestAddCompletedTask_NewFieldsStored(t *testing.T) {
 	}
 	if task.IsEpic {
 		t.Error("IsEpic = true, want false")
+	}
+	// GH-4829: CostPerTask must NOT be recomputed from TotalCostUSD/TotalTasks.
+	if model.metricsCard.CostPerTask != 42.0 {
+		t.Errorf("CostPerTask = %v, want unchanged 42.0 (must not be recomputed live)", model.metricsCard.CostPerTask)
 	}
 
 	// Send an epic task with SubIssues, TotalSubs, DoneSubs


### PR DESCRIPTION
## Summary

- Fixes GH-4829: the TUI dashboard's store-backed metrics panels (cost card, task breakdown, recent executions, lifetime tokens, sparklines) silently filtered to one project even though the Prometheus `pilot_window_*` gauges are fleet-wide, causing the two surfaces to disagree.
- Adds `DashboardConfig.MetricsScopePath` (`metrics_scope_path` in config, `~`-expanded at load); empty (default) is fleet-wide.
- Wires `model.SetMetricsScopePath(cfg.Dashboard.MetricsScopePath)` at both dashboard construction sites (`cmd/pilot/main.go` gateway mode and polling mode), overriding the seed `SetProjectPath` leaves behind.
- Drops the live `CostPerTask` recompute (`TotalCostUSD/AttemptTotal`) that fought the store's `CostPerDelivered` value and made the detail line oscillate between two definitions.
- Eval panel: empty scope now renders "all projects" instead of a blank string.

Git-graph panel and `--project`/`-p` flag behavior are unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go test -count=1 ./internal/dashboard/... ./internal/config/... ./cmd/...` — all green
- [x] `go vet ./cmd/pilot/... ./internal/dashboard/... ./internal/config/...`
- [x] Verified both dashboard construction sites (gateway ~1022, polling ~2651) call `SetMetricsScopePath` after `SetProjectPath`
- [x] Verified config round-trip test for `metrics_scope_path` (absent → empty, set → parsed + `~`-expanded)