### PR TITLE
fix(scripts): destructive-call gate Check 2 portable on BSD grep, wire --self-test into pre-push

### DIFF
--- a/scripts/check-destructive-calls.sh
+++ b/scripts/check-destructive-calls.sh
@@ -77,12 +77,25 @@ DESTRUCTIVE_CALL_ALLOWLIST=(
 # owning file.
 # ---------------------------------------------------------------------------
 #
-# Uses a negative lookbehind so a *qualified* identifier of the same name in
-# an unrelated package (e.g. cmd/pilot/poller_github.go's sdkcore.Verdict)
-# doesn't false-positive, and a leading \b so embedded-suffix type names
-# (PreFlightVerdict{}, JudgeVerdict{} in internal/executor/intent_judge.go)
-# don't either.
-VERDICT_LITERAL_PATTERN='(?<!\.)\bVerdict\{'
+# POSIX ERE (grep -E), portable across BSD grep (macOS) and GNU grep
+# (Linux CI) — deliberately NOT `grep -P`. BSD grep has no -P: it exits 2
+# on an unsupported pattern, and the caller's `|| true` (needed to keep
+# "no matches" from tripping `set -e`) silently turns that error into an
+# empty, "clean" result. That let this exact check pass vacuously on macOS
+# pre-push while flagging real violations in Linux CI (found in post-merge
+# review of PR#4828 / GH-4831).
+#
+# The original PCRE `(?<!\.)\bVerdict\{` used a negative lookbehind to
+# reject a *qualified* identifier of the same name in an unrelated package
+# (e.g. cmd/pilot/poller_github.go's sdkcore.Verdict{}), and a leading \b so
+# embedded-suffix type names (PreFlightVerdict{}, JudgeVerdict{} in
+# internal/executor/intent_judge.go) didn't match either. This pattern gets
+# the same two exclusions without lookbehind or \b: it requires the
+# character immediately before "Verdict{" to be either start-of-line or
+# something that is NOT alnum/underscore (rules out PreFlightVerdict{},
+# whose preceding char is the word char "t") and NOT a dot (rules out
+# sdkcore.Verdict{}, whose preceding char is ".").
+VERDICT_LITERAL_PATTERN='(^|[^A-Za-z0-9_.])Verdict\{'
 
 VERDICT_LITERAL_ALLOWLIST=(
     # The owning file: NewVerdict/NewUnknownVerdict construct Verdict{} here,
@@ -129,15 +142,17 @@ scan_destructive_calls() {
 }
 
 # scan_verdict_literals FILE...
-# Prints grep -PHn-format matches for bare Verdict{} composite literals in
+# Prints grep -HnE-format matches for bare Verdict{} composite literals in
 # the given files, skipping anything on VERDICT_LITERAL_ALLOWLIST. Empty
-# output means clean.
+# output means clean. Uses -E (POSIX ERE), not -P, so this works under BSD
+# grep (macOS) as well as GNU grep (Linux CI) — see the Check 2 comment
+# above for why -P silently no-ops on macOS.
 scan_verdict_literals() {
     local f hit
     for f in "$@"; do
         [ -z "$f" ] && continue
         is_allowlisted "$f" "${VERDICT_LITERAL_ALLOWLIST[@]}" && continue
-        hit=$(grep -PHn "$VERDICT_LITERAL_PATTERN" "$f" 2>/dev/null || true)
+        hit=$(grep -HnE "$VERDICT_LITERAL_PATTERN" "$f" 2>/dev/null || true)
         [ -n "$hit" ] && echo "$hit"
     done
     return 0

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -191,6 +191,15 @@ echo ""
 # 6. DESTRUCTIVE-CALL GATE
 echo -e "${BLUE}[6/8] Destructive-Call Gate${NC}"
 if [ -x "$SCRIPT_DIR/check-destructive-calls.sh" ]; then
+    # Self-test first: proves the gate's own detection logic (seeded
+    # violations caught, allowlisted files not flagged) still works on this
+    # machine's grep before trusting its "clean" verdict below. This is what
+    # would have caught GH-4831 — BSD grep on macOS silently no-op'd Check 2
+    # (bare Verdict{} literals), so the plain run reported false-green while
+    # the self-test failed outright.
+    if ! run_check "check-destructive --self-test" "$SCRIPT_DIR/check-destructive-calls.sh --self-test"; then
+        FAILURES=$((FAILURES + 1))
+    fi
     if ! run_check "check-destructive" "$SCRIPT_DIR/check-destructive-calls.sh"; then
         FAILURES=$((FAILURES + 1))
     fi


### PR DESCRIPTION
## Summary

- `scan_verdict_literals` (Check 2, bare `Verdict{}` literal scan) used `grep -P` (PCRE), which BSD grep on macOS doesn't support — it exits 2, and the `|| true` on the caller silently turned that error into "no matches", so Check 2 passed vacuously on macOS while Linux CI correctly caught violations.
- Replaced the PCRE negative-lookbehind pattern (`(?<!\.)\bVerdict\{`) with a portable POSIX ERE (`(^|[^A-Za-z0-9_.])Verdict\{`, `grep -E`) that gets the same two exclusions (qualified idents like `sdkcore.Verdict{}`, embedded-suffix names like `PreFlightVerdict{}`) via a preceding-character class instead of lookbehind/`\b`.
- Wired `--self-test` into `pre-push-gate.sh` step [6/8] so a broken detector fails the gate instead of reporting false-green — this is exactly what would have caught the bug on the dev laptop that found it.
- Allowlist semantics unchanged (`VERDICT_LITERAL_ALLOWLIST`, Check 1's commented allowlist).

Found in post-merge review of PR#4828 (TASK-459 Phase 4, #4823).

## Test plan

- [x] `bash scripts/check-destructive-calls.sh --self-test` passes (Linux/GNU grep in this sandbox)
- [x] `bash scripts/check-destructive-calls.sh` plain run passes clean on current `main`
- [x] `scripts/pre-push-gate.sh` step [6/8] now runs `--self-test` before the plain scan and fails the step on self-test failure
- [x] CI job `destructive-call-gate` (`.github/workflows/ci.yml`) unchanged — still runs the plain script on Ubuntu, stays green