### PR TITLE
GH-4832: chore(dashboard): metrics-scope hardening follow-ups from PR#4830 review — sentinel overload, path normalization, eval-panel scope

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1026,6 +1026,7 @@ Examples:
 						scope = cfg.Dashboard.MetricsScopePath
 					}
 					model.SetMetricsScopePath(scope)
+					warnIfMetricsScopeEmpty(gwStore, scope)
 					applyDashboardBannerMeta(&model, cfg, cmd)
 					model.EnableSplash(resolvedConfigPath())
 					gwProgram = tea.NewProgram(model,
@@ -2655,6 +2656,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			scope = cfg.Dashboard.MetricsScopePath
 		}
 		model.SetMetricsScopePath(scope)
+		warnIfMetricsScopeEmpty(store, scope)
 		applyDashboardBannerMeta(&model, cfg, cmd)
 		model.EnableSplash(resolvedConfigPath())
 		program = tea.NewProgram(model,
@@ -4075,6 +4077,30 @@ func (s storeExecutionSaver) SaveDeclinedExecution(taskID, projectPath, status, 
 		CreatedAt:   now,
 		CompletedAt: &now,
 	})
+}
+
+// warnIfMetricsScopeEmpty logs a startup warning when a configured
+// dashboard.metrics_scope_path matches zero executions in the store. This is
+// otherwise silent: metrics_scope_path is matched with an exact string
+// comparison against the uncanonicalized executions.project_path column
+// (store.go's GetRecentExecutions/GetLifetimeTokens/GetWindowedStats), so a
+// trailing-slash or symlink variant (e.g. /var vs /private/var) of the real
+// project path yields all-zero scoped metrics with no other indication
+// anything is wrong (GH-4832).
+func warnIfMetricsScopeEmpty(store *memory.Store, scope string) {
+	if store == nil || scope == "" {
+		return
+	}
+	counts, err := store.GetLifetimeTaskCounts(scope)
+	if err != nil {
+		return
+	}
+	if counts.Total == 0 {
+		logging.WithComponent("start").Warn(
+			"dashboard.metrics_scope_path matches zero executions — check for a trailing slash or symlink variant (e.g. /var vs /private/var) of the project_path recorded in the store",
+			slog.String("metrics_scope_path", scope),
+		)
+	}
 }
 
 // countGitHubRepos counts unique GitHub repos from the default config and project-level entries.

--- a/cmd/pilot/metrics_scope_warning_test.go
+++ b/cmd/pilot/metrics_scope_warning_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/logging"
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// TestWarnIfMetricsScopeEmpty covers the GH-4832 startup warning: a
+// configured dashboard.metrics_scope_path that matches zero rows in the
+// store (e.g. a trailing-slash or symlink variant of the recorded
+// project_path) is otherwise silent — GetLifetimeTaskCounts, like the other
+// scoped queries, just returns all-zero.
+func TestWarnIfMetricsScopeEmpty(t *testing.T) {
+	tempDir := t.TempDir()
+	store, err := memory.NewStore(tempDir)
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "e1", TaskID: "GH-4832", ProjectPath: "/repos/pilot", Status: "completed",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	logPath := filepath.Join(tempDir, "warn.log")
+	if err := logging.Init(&logging.Config{Level: "warn", Format: "text", Output: logPath}); err != nil {
+		t.Fatalf("logging.Init: %v", err)
+	}
+	t.Cleanup(func() { _ = logging.Init(logging.DefaultConfig()) })
+
+	readLog := func() string {
+		data, err := os.ReadFile(logPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return ""
+			}
+			t.Fatalf("ReadFile: %v", err)
+		}
+		return string(data)
+	}
+
+	warnIfMetricsScopeEmpty(nil, "/repos/pilot")
+	if got := readLog(); strings.Contains(got, "metrics_scope_path") {
+		t.Errorf("nil store must not warn, got log:\n%s", got)
+	}
+
+	warnIfMetricsScopeEmpty(store, "")
+	if got := readLog(); strings.Contains(got, "metrics_scope_path") {
+		t.Errorf("empty scope (fleet-wide) must not warn, got log:\n%s", got)
+	}
+
+	warnIfMetricsScopeEmpty(store, "/repos/pilot")
+	if got := readLog(); strings.Contains(got, "metrics_scope_path") {
+		t.Errorf("scope matching rows must not warn, got log:\n%s", got)
+	}
+
+	warnIfMetricsScopeEmpty(store, "/repos/pilot/")
+	got := readLog()
+	if !strings.Contains(got, "zero executions") || !strings.Contains(got, "/repos/pilot/") {
+		t.Errorf("trailing-slash scope with zero exact-match rows should warn, got log:\n%s", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -707,7 +707,12 @@ func Load(path string) (*Config, error) {
 		project.Path = expandPath(project.Path)
 	}
 	if config.Dashboard != nil && config.Dashboard.MetricsScopePath != "" {
-		config.Dashboard.MetricsScopePath = expandPath(config.Dashboard.MetricsScopePath)
+		// GH-4832: filepath.Clean closes the trailing-slash class of mismatch
+		// against the uncanonicalized executions.project_path values it's
+		// matched against (store.go's GetRecentExecutions/GetLifetimeTokens/
+		// GetWindowedStats do an exact string match, not CanonicalizeProjectPath) —
+		// a full fix needs both sides canonicalized, tracked separately.
+		config.Dashboard.MetricsScopePath = filepath.Clean(expandPath(config.Dashboard.MetricsScopePath))
 	}
 
 	// Apply bot model default when bot is configured without an explicit model.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1183,6 +1183,32 @@ dashboard:
 		}
 	})
 
+	t.Run("trailing slash is cleaned (GH-4832)", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+		configContent := `
+dashboard:
+  metrics_scope_path: "/repos/pilot/"
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		config, err := Load(configPath)
+		if err != nil {
+			t.Fatalf("Load failed: %v", err)
+		}
+
+		// A trailing-slash config value must not silently mismatch the
+		// uncanonicalized executions.project_path values it's matched
+		// against (store.go), so Load cleans it the same way filepath.Clean
+		// would for any other project path.
+		want := "/repos/pilot"
+		if config.Dashboard.MetricsScopePath != want {
+			t.Errorf("Dashboard.MetricsScopePath = %q, want %q", config.Dashboard.MetricsScopePath, want)
+		}
+	})
+
 	t.Run("absent defaults to empty", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.yaml")

--- a/internal/dashboard/gitgraph_test.go
+++ b/internal/dashboard/gitgraph_test.go
@@ -875,6 +875,21 @@ func TestMetricsScopePath_FleetWideDefault(t *testing.T) {
 			},
 			wantTotalTkns: 150,
 		},
+		{
+			// GH-4832 regression: once SetMetricsScopePath has been called
+			// explicitly, a later SetProjectPath (e.g. a runtime project
+			// switch) must NOT re-seed metricsScopePath — "" is both "unset"
+			// and the meaningful fleet-wide value, so without the
+			// metricsScopeSet guard this would silently flip fleet-wide back
+			// to per-project.
+			name: "runtime project switch after explicit fleet-wide scope stays fleet-wide",
+			configure: func(m *Model) {
+				m.SetProjectPath("/proj/a")
+				m.SetMetricsScopePath("")
+				m.SetProjectPath("/proj/b")
+			},
+			wantTotalTkns: 300,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -523,7 +523,14 @@ type Model struct {
 	projectPath        string // Working directory for git commands
 	defaultProjectPath string // Fallback project path from config (GH-2167)
 	metricsScopePath   string // Project path used to filter store/metrics queries (GH-3531)
-	gitProjectName     string // Current project name shown in git panel title (GH-2167)
+	// metricsScopeSet is true once SetMetricsScopePath has been called
+	// explicitly. Guards SetProjectPath from re-seeding metricsScopePath —
+	// without it, "" is overloaded as both "unset" and the meaningful
+	// fleet-wide value, so a later runtime SetProjectPath call (e.g. a
+	// project switch) would silently flip an explicitly-set fleet-wide scope
+	// back to per-project (GH-4832).
+	metricsScopeSet bool
+	gitProjectName  string // Current project name shown in git panel title (GH-2167)
 	// statsWindowDays is the rolling window (days) for windowed cost/success
 	// stats (GH-4735), set from config.DashboardConfig.StatsWindowDays via
 	// SetStatsWindowDays. 0 means unset — effectiveStatsWindowDays() falls
@@ -942,15 +949,20 @@ func NewModelWithOptions(version string, store *memory.Store, controller *autopi
 }
 
 // SetProjectPath sets the working directory used for git graph commands.
-// The first call also sets the default fallback path (GH-2167) and seeds
+// The first call also sets the default fallback path (GH-2167) and, unless
+// SetMetricsScopePath has already been called explicitly, seeds
 // metricsScopePath so callers that only call SetProjectPath retain their
-// current behavior (metrics scoped to the same project).
+// current behavior (metrics scoped to the same project). GH-4832: the seed
+// is gated on metricsScopeSet rather than `metricsScopePath == ""` because
+// "" is also the meaningful fleet-wide value — without the gate, a later
+// SetProjectPath call (e.g. a runtime project switch) would silently flip
+// an explicitly-set fleet-wide scope back to per-project.
 func (m *Model) SetProjectPath(path string) {
 	m.projectPath = path
 	if m.defaultProjectPath == "" {
 		m.defaultProjectPath = path
 	}
-	if m.metricsScopePath == "" {
+	if !m.metricsScopeSet {
 		m.metricsScopePath = path
 	}
 }
@@ -958,8 +970,10 @@ func (m *Model) SetProjectPath(path string) {
 // SetMetricsScopePath sets the project path used to filter store queries
 // (recent executions, lifetime tokens, task counts, sparklines, eval panel).
 // Defaults to the value passed to SetProjectPath when not set explicitly.
+// Once called, SetProjectPath no longer overwrites metricsScopePath (GH-4832).
 func (m *Model) SetMetricsScopePath(path string) {
 	m.metricsScopePath = path
+	m.metricsScopeSet = true
 }
 
 // SetStatsWindowDays sets the rolling window (days) used for windowed
@@ -1254,10 +1268,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case updateTokensMsg:
 		// GH-4735: this optimistically increments the (now windowed)
-		// TotalCostUSD/CostPerTask for immediate in-session feedback. It is
-		// not window-aware — it just adds today's delta — so it can drift
-		// from the true windowed value until the next every-5th-tick
+		// TotalCostUSD for immediate in-session feedback. It is not
+		// window-aware — it just adds today's delta — so it can drift from
+		// the true windowed value until the next every-5th-tick
 		// storeRefreshCmd re-query converges it back to GetWindowedStats.
+		// (CostPerTask is NOT recomputed here — see the GH-4829 note below.)
 		// Calculate delta and persist to session
 		inputDelta := msg.InputTokens - m.tokenUsage.InputTokens
 		outputDelta := msg.OutputTokens - m.tokenUsage.OutputTokens
@@ -2430,7 +2445,10 @@ func (m Model) renderEvalStats() string {
 
 	tw := m.effectivePanelTotalWidth()
 
-	tasks, err := m.store.ListEvalTasks(memory.EvalTaskFilter{ProjectPath: m.defaultProjectPath, Limit: 200})
+	// GH-4832: scoped by metricsScopePath (not defaultProjectPath) so the
+	// query matches the panel label below, which already reflects the
+	// metrics scope.
+	tasks, err := m.store.ListEvalTasks(memory.EvalTaskFilter{ProjectPath: m.metricsScopePath, Limit: 200})
 	if err != nil || len(tasks) == 0 {
 		return ""
 	}

--- a/internal/dashboard/tui_test.go
+++ b/internal/dashboard/tui_test.go
@@ -1626,8 +1626,9 @@ func TestRenderEvalStats(t *testing.T) {
 }
 
 // TestRenderEvalStats_ProjectFilter verifies that renderEvalStats scopes its
-// ListEvalTasks query to m.defaultProjectPath when set and returns all tasks
-// when defaultProjectPath is empty (global mode).
+// ListEvalTasks query to m.metricsScopePath when set and returns all tasks
+// when metricsScopePath is empty (fleet-wide mode). GH-4832: the eval query
+// aligns with the metrics scope, not the git-graph defaultProjectPath.
 func TestRenderEvalStats_ProjectFilter(t *testing.T) {
 	store, err := memory.NewStore(t.TempDir())
 	if err != nil {
@@ -1661,28 +1662,28 @@ func TestRenderEvalStats_ProjectFilter(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		defaultProject string
-		wantRate       string
-		wantTaskCount  string
+		name          string
+		metricsScope  string
+		wantRate      string
+		wantTaskCount string
 	}{
 		{
-			name:           "scoped to alpha: only 4 passing tasks",
-			defaultProject: "/proj/alpha",
-			wantRate:       "100.0%",
-			wantTaskCount:  "(4 tasks)",
+			name:          "scoped to alpha: only 4 passing tasks",
+			metricsScope:  "/proj/alpha",
+			wantRate:      "100.0%",
+			wantTaskCount: "(4 tasks)",
 		},
 		{
-			name:           "global mode: all 10 tasks, 40% pass",
-			defaultProject: "",
-			wantRate:       "40.0%",
-			wantTaskCount:  "(10 tasks)",
+			name:          "global mode: all 10 tasks, 40% pass",
+			metricsScope:  "",
+			wantRate:      "40.0%",
+			wantTaskCount: "(10 tasks)",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := Model{store: store, defaultProjectPath: tt.defaultProject}
+			m := Model{store: store, metricsScopePath: tt.metricsScope}
 			got := m.renderEvalStats()
 			plain := stripANSI(got)
 			if !strings.Contains(plain, tt.wantRate) {
@@ -2419,37 +2420,37 @@ func TestRenderEvalStats_ProjectPathFilter(t *testing.T) {
 	}
 
 	tests := []struct {
-		name            string
-		defaultProjPath string
-		wantTaskCount   string // substring of "(N tasks)"
-		wantRate        string // substring of "X.X%"
+		name          string
+		metricsScope  string
+		wantTaskCount string // substring of "(N tasks)"
+		wantRate      string // substring of "X.X%"
 	}{
 		{
-			name:            "scoped to alpha sees only alpha task (100%)",
-			defaultProjPath: "/projects/alpha",
-			wantTaskCount:   "(1 tasks)",
-			wantRate:        "100.0%",
+			name:          "scoped to alpha sees only alpha task (100%)",
+			metricsScope:  "/projects/alpha",
+			wantTaskCount: "(1 tasks)",
+			wantRate:      "100.0%",
 		},
 		{
-			name:            "global mode (empty path) sees all tasks (50%)",
-			defaultProjPath: "",
-			wantTaskCount:   "(2 tasks)",
-			wantRate:        "50.0%",
+			name:          "global mode (empty path) sees all tasks (50%)",
+			metricsScope:  "",
+			wantTaskCount: "(2 tasks)",
+			wantRate:      "50.0%",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := NewModelWithStore("test", store)
-			m.defaultProjectPath = tt.defaultProjPath
+			m.metricsScopePath = tt.metricsScope
 
 			out := stripANSI(m.renderEvalStats())
 
 			if !strings.Contains(out, tt.wantTaskCount) {
-				t.Errorf("renderEvalStats(%q): want %q in output; got:\n%s", tt.defaultProjPath, tt.wantTaskCount, out)
+				t.Errorf("renderEvalStats(%q): want %q in output; got:\n%s", tt.metricsScope, tt.wantTaskCount, out)
 			}
 			if !strings.Contains(out, tt.wantRate) {
-				t.Errorf("renderEvalStats(%q): want %q in output; got:\n%s", tt.defaultProjPath, tt.wantRate, out)
+				t.Errorf("renderEvalStats(%q): want %q in output; got:\n%s", tt.metricsScope, tt.wantRate, out)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4832.

Closes #4832

## Changes

GitHub Issue GH-4832: chore(dashboard): metrics-scope hardening follow-ups from PR#4830 review — sentinel overload, path normalization, eval-panel scope

## Context

Post-merge review of PR#4830 (issue #4829, TASK-462 — fleet-wide metrics scope) found no defects; verdict notes-only. Three hardening notes are worth fixing together. **Dispatched 2026-08-11 (founder call). One subsystem, one PR — do not decompose.**

## Notes

1. **Sentinel-value overload in `SetProjectPath`** (`internal/dashboard/tui.go:948-956`): it seeds `metricsScopePath` when empty — but `""` is now also the *meaningful* fleet-wide value. Not active today (both main.go call sites immediately follow with `SetMetricsScopePath`), but any future runtime project switch silently flips fleet-wide back to per-project. Fix direction: separate "unset" from "fleet-wide" (dedicated bool or set-once flag), or drop the seeding and make main.go ordering explicit.

2. **Silent zero-rows on path mismatch**: `metrics_scope_path` is exact-string-matched against uncanonicalized `executions.project_path` (`internal/memory/store.go:1604, 3734-3736, 3872-3876`). A trailing slash or symlink variant (`/var` vs `/private/var`) yields all-zero scoped metrics with no warning. `CanonicalizeProjectPath` (store.go:3049) exists for exactly this class (GH-4297) but is unused here; one-sided canonicalization would itself mismatch raw rows, so the fix is either both-sided or, as a minimum, `filepath.Clean` in config `Load` (closes the trailing-slash case) + a startup warning when a configured scope matches zero rows.

3. **Eval panel ignores the scope** (pre-existing): `renderEvalStats` queries by `m.defaultProjectPath` (`internal/dashboard/tui.go:2433`) while the panel label now reflects `metricsScopePath` (tui.go:2498-2505) — per-project opt-in users see a label describing a filter the data doesn't use. Align the eval query with the metrics scope.

Cosmetic (fold in if touching the file anyway): stale comment at tui.go:1256-1258 still claims `updateTokensMsg` recomputes CostPerTask, contradicted 20 lines below.

## Refs

PR#4830 · #4829 · `.agent/tasks/TASK-462-dashboard-fleet-wide-metrics-scope.md`