### PR TITLE
GH-4833: fix(memory): pilot-canary-sandbox rows written with is_canary=0 — canary cost/issues leak into fleet-wide metrics

### DIFF
--- a/cmd/pilot/handler_common.go
+++ b/cmd/pilot/handler_common.go
@@ -106,6 +106,15 @@ type HandlerDeps struct {
 	Enforcer     *budget.Enforcer
 	ProjectPath  string
 
+	// ProjectRepo is the "owner/repo" the GitHub SDK poller already matched
+	// this task's projects[] entry against (GH-4833). When set, it takes
+	// precedence over ProjectPath for resolving that projects[] entry inside
+	// handleIssueGeneric — see the canary-stamping comment below for why the
+	// path alone isn't reliable. Adapters without a repo-based project match
+	// (Linear, Jira, Asana, Plane, direct filesystem paths) leave this empty
+	// and keep the existing ProjectPath-only resolution.
+	ProjectRepo string
+
 	// Metrics records the GH-4376 repick-storm skip counter (and any other
 	// poller skip/dispatch counters this chokepoint later grows) onto
 	// pilot_poller_skipped_total. Nil is tolerated — the admission gate and
@@ -134,8 +143,28 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 	// executions row (ExecutionLifecycle.Begin) and the runner's live
 	// metrics guard. deps.Cfg.GetProject returns nil for an unregistered
 	// path (e.g. ad-hoc CLI runs), which correctly resolves to non-canary.
+	//
+	// GH-4833: prefer an exact GitHub "owner/repo" match (deps.ProjectRepo)
+	// over the path lookup when both are available. githubSDKPollerTargets
+	// (poller_github.go) falls back to the default adapter repo's project
+	// path for any projects[] entry with no explicit `path` set — a
+	// perfectly normal config for a repo-only registration (e.g. a synthetic
+	// sandbox project that only needs GitHub polling + a canary flag, not a
+	// distinct local checkout). That fallback makes deps.Cfg.GetProject(path)
+	// silently resolve to the DEFAULT project instead of the actual matched
+	// one, discarding its Canary=true (confirmed root cause of
+	// pilot-canary-sandbox rows landing is_canary=0 despite Canary: true
+	// being configured). FindProjectByRepo sidesteps the path entirely,
+	// matching the same pattern ResolveProjectBoard already uses.
 	if deps.Cfg != nil {
-		if proj := deps.Cfg.GetProject(projectPath); proj != nil {
+		var proj *config.ProjectConfig
+		if deps.ProjectRepo != "" {
+			proj = deps.Cfg.FindProjectByRepo(deps.ProjectRepo)
+		}
+		if proj == nil {
+			proj = deps.Cfg.GetProject(projectPath)
+		}
+		if proj != nil {
 			task.IsCanary = proj.Canary
 		}
 	}

--- a/cmd/pilot/handler_common_test.go
+++ b/cmd/pilot/handler_common_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/qf-studio/pilot/internal/adapters/gitlab"
 	"github.com/qf-studio/pilot/internal/alerts"
 	"github.com/qf-studio/pilot/internal/budget"
+	"github.com/qf-studio/pilot/internal/config"
 	"github.com/qf-studio/pilot/internal/executor"
 	"github.com/qf-studio/pilot/internal/memory"
 )
@@ -1009,6 +1010,153 @@ func TestHandleIssueGeneric_NilEnforcer(t *testing.T) {
 	}()
 
 	_, _ = handleIssueGeneric(context.Background(), deps, info, task)
+}
+
+// TestHandleIssueGeneric_CanaryStampedViaProjectRepo is the GH-4833
+// regression test for pilot-canary-sandbox rows landing is_canary=0: a
+// projects[] entry with no explicit `path` (a perfectly normal config for a
+// repo-only registration, e.g. a synthetic canary sandbox that doesn't need
+// its own local checkout override) makes githubSDKPollerTargets fall back to
+// the default adapter repo's project path — so the canary project and the
+// default project resolve to the SAME deps.ProjectPath. Before this fix,
+// handleIssueGeneric's deps.Cfg.GetProject(projectPath) then silently
+// resolved to whichever project happened to match that shared path first,
+// discarding the actual matched project's Canary flag. deps.ProjectRepo lets
+// the caller pass its already-resolved "owner/repo" match through, sidestepping
+// the ambiguous path entirely (mirroring config.FindProjectByRepo's use in
+// ResolveProjectBoard).
+func TestHandleIssueGeneric_CanaryStampedViaProjectRepo(t *testing.T) {
+	sharedPath := "/tmp/pilot-gh-4833-shared-path-does-not-exist"
+	cfg := &config.Config{
+		Projects: []*config.ProjectConfig{
+			{
+				Name:   "pilot",
+				Path:   sharedPath,
+				GitHub: &config.ProjectGitHubConfig{Owner: "qf-studio", Repo: "pilot"},
+				Canary: false,
+			},
+			{
+				Name: "pilot-canary-sandbox",
+				// No explicit Path — githubSDKPollerTargets falls back to the
+				// default project's path for entries like this in production.
+				GitHub: &config.ProjectGitHubConfig{Owner: "qf-studio", Repo: "pilot-canary-sandbox"},
+				Canary: true,
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		projectRepo string
+		wantCanary  bool
+	}{
+		{
+			name:        "ProjectRepo resolves the canary project despite the shared path",
+			projectRepo: "qf-studio/pilot-canary-sandbox",
+			wantCanary:  true,
+		},
+		{
+			name:        "ProjectRepo resolves the default (non-canary) project — no false positive",
+			projectRepo: "qf-studio/pilot",
+			wantCanary:  false,
+		},
+		{
+			name:        "no ProjectRepo — falls back to the path lookup (existing behavior preserved)",
+			projectRepo: "",
+			wantCanary:  false, // GetProject(sharedPath) matches the first (non-canary) entry
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			budgetCfg := &budget.Config{Enabled: true}
+			enforcer := budget.NewEnforcer(budgetCfg, nil)
+			enforcer.Pause("test: short-circuit before dispatch — canary stamping runs before this gate")
+
+			deps := HandlerDeps{
+				Cfg:         cfg,
+				Monitor:     executor.NewMonitor(),
+				Enforcer:    enforcer,
+				ProjectPath: sharedPath,
+				ProjectRepo: tt.projectRepo,
+			}
+			info := IssueInfo{TaskID: "GH-4833", Title: "canary probe", Adapter: "github", LogMark: "▸"}
+			task := &executor.Task{ID: "GH-4833", Title: "canary probe", Branch: "pilot/GH-4833", ProjectPath: sharedPath}
+
+			if _, err := handleIssueGeneric(context.Background(), deps, info, task); err == nil {
+				t.Fatal("expected budget-exceeded error from the early return")
+			}
+
+			if task.IsCanary != tt.wantCanary {
+				t.Errorf("task.IsCanary = %v, want %v", task.IsCanary, tt.wantCanary)
+			}
+		})
+	}
+}
+
+// TestHandleIssueGeneric_CanaryStampedViaProjectRepo_PersistsThroughRealStore
+// is the end-to-end companion to
+// TestHandleIssueGeneric_CanaryStampedViaProjectRepo: drives the REAL
+// dispatcher/store (not a mock) through handleIssueGeneric's QueueTask call,
+// then asserts the persisted execution row's is_canary column via
+// store.GetLatestExecutionByTaskID — closing the loop from GH-4833's
+// production evidence (480 pilot-canary-sandbox rows with is_canary=0 in the
+// 30d window) all the way to the actual write path.
+func TestHandleIssueGeneric_CanaryStampedViaProjectRepo_PersistsThroughRealStore(t *testing.T) {
+	sharedPath := "/tmp/pilot-gh-4833-e2e-shared-path-does-not-exist"
+	cfg := &config.Config{
+		Projects: []*config.ProjectConfig{
+			{
+				Name:   "pilot",
+				Path:   sharedPath,
+				GitHub: &config.ProjectGitHubConfig{Owner: "qf-studio", Repo: "pilot"},
+				Canary: false,
+			},
+			{
+				Name:   "pilot-canary-sandbox",
+				GitHub: &config.ProjectGitHubConfig{Owner: "qf-studio", Repo: "pilot-canary-sandbox"},
+				Canary: true,
+			},
+		},
+	}
+
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	dispatcher := executor.NewDispatcher(store, executor.NewRunner(), nil)
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	t.Cleanup(dispatcher.Stop)
+
+	taskID := "GH-4833-E2E"
+	deps := HandlerDeps{
+		Cfg:         cfg,
+		Dispatcher:  dispatcher,
+		Monitor:     executor.NewMonitor(),
+		ProjectPath: sharedPath,
+		ProjectRepo: "qf-studio/pilot-canary-sandbox",
+	}
+	info := IssueInfo{TaskID: taskID, Title: "canary probe e2e", Adapter: "github", LogMark: "▸"}
+	task := &executor.Task{ID: taskID, Title: "canary probe e2e", Branch: "pilot/" + taskID, ProjectPath: sharedPath}
+
+	// A short-lived context lets WaitForExecution bail out quickly via
+	// ctx.Done() instead of blocking on a real backend execution against a
+	// project path that doesn't exist — QueueTask (and the is_canary write)
+	// already completed synchronously before WaitForExecution starts polling.
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	_, _ = handleIssueGeneric(ctx, deps, info, task)
+
+	exec, err := store.GetLatestExecutionByTaskID(taskID, sharedPath)
+	if err != nil {
+		t.Fatalf("GetLatestExecutionByTaskID failed: %v", err)
+	}
+	if !exec.IsCanary {
+		t.Error("expected persisted execution row to have is_canary=1 for the canary-designated project, got false")
+	}
 }
 
 // --- GH-4794: superseded/canceled executions must not be reported as

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -889,6 +889,12 @@ func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkco
 		ProjectPath:  projectPath,
 		Metrics:      metrics,
 	}
+	if repoOwner != "" && repoName != "" {
+		// GH-4833: pass the already-resolved repo match through so
+		// handleIssueGeneric's canary-stamping prefers it over the
+		// (possibly default-project-colliding) projectPath.
+		deps.ProjectRepo = repoOwner + "/" + repoName
+	}
 	info := IssueInfo{
 		TaskID:  taskID,
 		Title:   title,

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -592,6 +592,27 @@ projects:
   #     schedule: "0 21 * * FRI"          # Fridays 21:00
   #     schedule_timezone: "Europe/Berlin"
 
+  # Canary/synthetic sandbox example (GH-4240/GH-4833): `canary: true` marks
+  # a project as a synthetic sandbox rather than real work. Executions
+  # dispatched for it are still fully persisted and event-logged, but they're
+  # excluded from success-rate/cost/throughput metrics, the metrics hydrator,
+  # and dashboard history — so a scheduled canary probe (e.g. a GitHub
+  # Actions cron that files a real issue to prove the daemon still ships
+  # code end-to-end) can run indefinitely without skewing fleet-wide
+  # averages. `path` is intentionally omitted here: a repo-only registration
+  # (github.owner/github.repo set, no local checkout override) is normal for
+  # a project that doesn't need its own distinct working directory. GH-4833:
+  # `canary` designation is matched by `github.owner`/`github.repo`
+  # (config.FindProjectByRepo, the same lookup ResolveProjectBoard uses) —
+  # NOT by `path` — because two projects sharing the same (or absent) `path`
+  # would otherwise collide on a path-based lookup and silently resolve to
+  # the wrong project's Canary flag.
+  # - name: "pilot-canary-sandbox"
+  #   github:
+  #     owner: "qf-studio"
+  #     repo: "pilot-canary-sandbox"
+  #   canary: true
+
 # Autopilot settings
 autopilot:
   enabled: false


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4833.

Closes #4833

## Changes

GitHub Issue GH-4833: fix(memory): pilot-canary-sandbox rows written with is_canary=0 — canary cost/issues leak into fleet-wide metrics

## Problem

`pilot-canary-sandbox` executions are written with `is_canary=0`, so canary work leaks into fleet-wide metrics.

Evidence (verified against the production DB 2026-08-10, during TASK-462 research): 480 rows in the 30d window for `pilot-canary-sandbox` carry `is_canary=0`, contributing **$36.92 / 37 issues** to fleet averages. With PR#4830 making fleet-wide the default dashboard scope, this skew is now on the default view (cost card, task breakdown, cost/delivered), and it also affects the fleet-wide `pilot_window_*` Prometheus gauges.

## Tasks (do not decompose — one subsystem, one PR)

1. **Root-cause the write path.** Find where `is_canary` is populated on execution rows (memory store `SaveExecution` / executor lifecycle) and what designates a project as canary (config field? repo-name match?). Determine why `pilot-canary-sandbox` rows get `0` — designation never configured, or configured but ignored by the write path.
2. **Fix so canary designation reaches the row.** If the mechanism is config, ensure the field decodes and flows task→lifecycle→store (this repo's known decode-only-field class — verify end to end); if repo-name-based, make the match explicit and documented. Every new execution for a canary-designated project must persist `is_canary=1`.
3. **Test**: execution written for a canary-designated project persists `is_canary=1`; non-canary unchanged. Assert through the real store, not a mock.
4. **Document** the designation mechanism in `configs/pilot.example.yaml` (or wherever it lives).

**Out of scope**: backfilling the historical 480 rows — operator decision after the fix lands (30d windows age the skew out regardless).

## Refs

- Split from TASK-462 spec § Out of scope — `.agent/tasks/archive/TASK-462-dashboard-fleet-wide-metrics-scope.md`
- PR#4830 · #4829 · GH-4735 (windowed stats)