### PR TITLE
feat(gateway): C17 pilot leg — operator chat API, web transport for the comms adapter brain

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -140,6 +140,7 @@
 | Discord adapter wiring | ✅ | main | `--discord` | `adapters.discord` | Wire Discord poller, config, and CLI flag in main.go (v2.30.0, PR #1882) |
 | Asana CompleteTask callback | ✅ | adapters/asana | - | - | Wire Asana CompleteTask on successful PR creation (v2.10.0, PR #1720) |
 | Telegram memory store | ✅ | adapters/telegram | - | - | Wire memory store to Telegram HandlerConfig (v2.25.0, PR #1754) |
+| Web chat API | ✅ | adapters/web, gateway | - | `adapters.chat` | Operator chat HTTP transport for console dashboard: `POST /api/v1/chat/messages` + `GET /api/v1/chat/conversations/{id}/events`, backed by comms.Handler via a per-conversation seq-numbered in-memory event buffer (500-event cap, 1h expiry); dispatches on the daemon context so tasks survive request cancellation; rejects approve/reject-shaped callbacks (approvals route through `/api/v1/approvals/{requestId}/decision` instead) (GH-4835) |
 
 ## Output/Notifications
 

--- a/.agent/tasks/gh-4835.md
+++ b/.agent/tasks/gh-4835.md
@@ -1,0 +1,87 @@
+# GH-4835
+
+**Created:** 2026-08-11
+
+## Problem
+
+GitHub Issue GH-4835: feat(gateway): C17 pilot leg — operator chat API, web transport for the comms adapter brain
+
+## Problem
+
+The approved console v4 dashboard includes an **Operator chat panel** — conversational control of the tenant instance from the web console. The brain already exists and is shared: `internal/comms` (GH-2143) — Telegram, Slack, and Discord all feed `comms.Handler.HandleMessage` and reply through the `comms.Messenger` interface. What's missing is a web transport: an HTTP API on the gateway that the console control plane can proxy to. This issue adds that transport as a fourth `BuildHandler` assembly. Console-side proxy is a separate issue in qf-studio/pilot-console.
+
+## Context (verified @ main, 2026-08-11)
+
+- Inbound seam: `comms.Handler.HandleMessage(ctx, *comms.IncomingMessage)` — `internal/comms/handler.go:162`. `IncomingMessage` (`internal/comms/types.go:10-25`) carries `ContextID`, `SenderID`, `SenderName`, `Text`, `Platform`, `IsCallback`/`CallbackID`/`ActionID` (button presses), `Timestamp`.
+- Outbound seam: `comms.Messenger` — `types.go:28-51`: `SendText`, `SendConfirmation` (returns messageRef), `SendProgress(contextID, messageRef, taskID, phase, progress, detail)` (edit-in-place by ref), `SendResult(taskID, success, output, prURL)`, `SendChunked`, `AcknowledgeCallback`, `MaxMessageLength`. Existing impls: `internal/adapters/telegram/messenger.go:12`, `internal/adapters/slack/messenger.go:11`.
+- Assembly point: `comms.BuildHandler(HandlerDeps)` — `internal/comms/factory.go:121`; existing call sites `cmd/pilot/main.go:2782` (Telegram, TaskIDPrefix "TG"), `main.go:3532` (Slack), `cmd/pilot/poller_discord.go:65`.
+- Gateway: routes register inline in `Server.Start` (`internal/gateway/server.go:216-267`); protected routes go on `apiMux` behind bearer middleware (`server.go:247-251`; auth = GH-4784, `internal/gateway/auth.go:58-69`, enabled via config `auth.type: api-token`). Read-endpoint pattern to copy: #4749 `internal/gateway/events.go` + `events_test.go`. POST pattern: `handleApprovalDecision` `internal/gateway/approvals.go:170`.
+- Latency shape: `HandleMessage` is synchronous and can block minutes (question ≤90s `handler.go:400`, research ≤3min, task = full execution) and one inbound message produces MULTIPLE ordered outbound messages (ack → progress edits → result). Gateway `http.Server` has `WriteTimeout: 15s` (`server.go:277`) — SSE is not viable; the WS endpoints sit outside bearer auth. Therefore: **poll-drain API**, not SSE/WS.
+
+## Spec
+
+### 1. `WebMessenger` — new `internal/adapters/web/messenger.go`
+
+Implements `comms.Messenger` by appending typed events to a per-conversation, monotonically seq-numbered **in-memory** buffer:
+
+```jsonc
+{ "seq": 17, "type": "text|confirmation|progress|result", "text": "...",
+  "taskId": "...", "phase": "...", "progress": 0.6, "prUrl": "...",
+  "messageRef": "...", "occurredAt": "RFC3339" }
+```
+
+- `SendProgress` reuses `messageRef` so the UI replaces in place (Telegram edit parity).
+- `MaxMessageLength()` = 32768 (chunking rarely splits).
+- Bounds: per-conversation event cap (500, drop-oldest) + conversation expiry after 1h inactivity. Daemon restart wipes buffers — seq restarts at 0; a client seeing `after` > latest seq treats it as reset and re-polls from 0. Document both.
+
+### 2. Assembly
+
+One `comms.BuildHandler` call: TaskIDPrefix `"WEB"`, Platform `"web"`, ContextID = `"web:" + conversationID`. Rate limit and the pending/running-task slots are per-ContextID, i.e. per conversation — that is the intended granularity.
+
+### 3. Routes (both on `apiMux` → bearer auth inherited)
+
+- `POST /api/v1/chat/messages` — body `{"conversationId": "...", "text": "..."}` OR `{"conversationId": "...", "isCallback": true, "callbackId": "...", "actionId": "execute"|"cancel"}`, plus optional `"sender"` display label (becomes `SenderName`). Validate → dispatch `HandleMessage` on a goroutine using the **daemon context, not the request context** (request returns in ms; the task runs minutes) → `202 {"conversationId": "...", "seq": <last event seq at accept>}`.
+- `GET /api/v1/chat/conversations/{id}/events?after=<seq>` — returns `{"conversationId": "...", "events": [...]}` (empty array when nothing new). Status table per events.go: 405/400/404/503.
+
+### 4. Both gateway construction sites
+
+Wire at BOTH: polling mode (`cmd/pilot/main.go`, ~`:2518` region) AND gateway mode (`internal/pilot/pilot.go`, ~`:477` region) — GH-4784 precedent. Missing one means the chat API silently doesn't exist in that mode.
+
+### 5. Config
+
+`adapters.chat: {enabled: false, ...}` beside telegram/slack in `AdaptersConfig` (`internal/config/config.go:46`); verify the field decodes end to end (this repo's known decode-only-field class). Disabled ⇒ routes not registered (follow gateway convention). Document in `configs/pilot.example.yaml`.
+
+### 6. Tests
+
+- POST → 202, events drain in seq order (events_test.go harness pattern).
+- Full confirmation flow with a fake runner: task-shaped text → `confirmation` event → callback `execute` → `progress` events sharing messageRef → `result`.
+- Daemon-ctx dispatch: canceling the POST request context does not kill the running task.
+- Auth enforced on both routes (GH-4784 test pattern).
+- Buffer cap + conversation expiry.
+- Config gate: disabled ⇒ 404.
+
+## Scope fence
+
+- **Approvals do NOT route through the chat brain** (pitfall GH-4411/GH-4431 — approval callbacks are intercepted per-adapter before comms). The console panel calls the existing `POST /api/v1/approvals/{requestId}/decision` (#4748) directly. This API rejects `approve:`/`reject:`-style callback payloads with 400.
+- The shared CommandHandler degradations (`/run`, `/tasks`, `/brief`, `/nopr`, `/pr` have unwired funcs in `comms.NewHandler`, `handler.go:111-149` — web inherits Slack parity, not Telegram parity) are NOT fixed here. Explicitly out of scope; follow-up issue if operators need them in the panel.
+- No SSE/WS. No chat-history persistence. No per-user RBAC beyond the gateway bearer (`sender` is a display label only).
+
+## Acceptance
+
+1. With `adapters.chat.enabled: true` + gateway auth configured, `POST /api/v1/chat/messages` with "status" text returns 202 and a subsequent events poll returns the status reply.
+2. Task-dispatch flow works end to end through confirmation callback (fake runner in tests).
+3. Progress events share `messageRef`; result event carries `prUrl` when set.
+4. Both daemon modes (polling, gateway) serve the routes; both tested or verified.
+5. Requests without the bearer token get 401; disabled config ⇒ routes absent.
+6. `make test` + `make lint` green.
+
+## Refs
+
+- Design: `design/dashboard-v4-spec.md` @ qf-studio/pilot-console-ui (Operator chat panel, data-contract section)
+- Brain: GH-2143 (`internal/comms`) · gateway auth GH-4784 · events endpoint #4749 · approvals decision endpoint #4748 · pitfalls GH-4411/GH-4431
+- Console leg (proxy): follow-up issue in qf-studio/pilot-console — freezes on THIS contract
+
+**This task must NOT be decomposed — implement as a single PR.**
+
+## Acceptance Criteria
+

--- a/cmd/pilot/adapter_wiring_test.go
+++ b/cmd/pilot/adapter_wiring_test.go
@@ -20,6 +20,7 @@ func TestAdapterPollerRegistrations_CoverAllAdapterTypes(t *testing.T) {
 		"GitLab":   true, // webhook-based, no poller
 		"Slack":    true, // notification channel + socket mode, not a task source poller
 		"Telegram": true, // bot adapter, not a task source poller
+		"Chat":     true, // GH-4835: operator chat HTTP transport, not a task source poller
 	}
 
 	// Build set of registered poller names (lowercased).

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/qf-studio/pilot/internal/adapters/sdkshim"
 	"github.com/qf-studio/pilot/internal/adapters/slack"
 	"github.com/qf-studio/pilot/internal/adapters/telegram"
+	"github.com/qf-studio/pilot/internal/adapters/web"
 	"github.com/qf-studio/pilot/internal/alerts"
 	"github.com/qf-studio/pilot/internal/approval"
 	"github.com/qf-studio/pilot/internal/autopilot"
@@ -1060,6 +1061,15 @@ Examples:
 					pilotOpts = append(pilotOpts, pilot.WithSlackMemberResolver(teamAdapter))
 				}
 				logging.WithComponent("start").Info("Slack Socket Mode enabled in gateway mode")
+			}
+
+			// GH-4835: enable the web chat API (console Operator chat panel)
+			// in gateway mode whenever adapters.chat.enabled is true. No CLI
+			// flag gate like Telegram/Slack polling — this is an HTTP
+			// endpoint the console calls, not a polling loop.
+			if cfg.Adapters.Chat != nil && cfg.Adapters.Chat.Enabled {
+				pilotOpts = append(pilotOpts, pilot.WithChatHandler(gwRunner, projectPath))
+				logging.WithComponent("start").Info("Chat API enabled in gateway mode")
 			}
 
 			// GH-539: Create budget enforcer for gateway mode
@@ -2598,6 +2608,25 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		// identical Manager.RecordDecision seam in polling mode too (the
 		// GH-4738 lesson: wire both gateway-mode and polling-mode paths).
 		gwServer.SetDecisionRecorder(approvalMgr)
+		// GH-4835: wire the web chat API (console Operator chat panel) in
+		// polling mode too — the gateway-mode leg is in internal/pilot/pilot.go
+		// (WithChatHandler). Missing either means the chat routes silently
+		// don't exist in that daemon mode; see SetChatAPI's doc comment.
+		if cfg.Adapters.Chat != nil && cfg.Adapters.Chat.Enabled {
+			webMessenger := web.NewMessenger()
+			webCommsHandler := comms.BuildHandler(comms.HandlerDeps{
+				Messenger:       webMessenger,
+				Runner:          runner,
+				Projects:        config.NewProjectSource(cfg),
+				ProjectPath:     projectPath,
+				RateLimit:       cfg.Adapters.Chat.RateLimit,
+				Store:           store,
+				TaskIDPrefix:    "WEB",
+				ExecutorBackend: cfg.Executor,
+			})
+			gwServer.SetChatAPI(web.NewAPI(webCommsHandler, webMessenger))
+			logging.WithComponent("start").Info("Chat API enabled in polling mode")
+		}
 		gwServer.SetDashboardProjectPath(projectPath)
 		if cfg.Dashboard != nil {
 			gwServer.SetDashboardStatsWindowDays(cfg.Dashboard.StatsWindowDays)

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -225,6 +225,22 @@ adapters:
       history_size: 10                 # Messages to keep per channel for context
       history_ttl: 30m                 # TTL for conversation history
 
+  # Chat - HTTP transport backing the console's Operator chat panel (GH-4835).
+  # Feeds the same comms brain as Telegram/Slack/Discord via a per-conversation,
+  # in-memory poll-drain event buffer (no SSE/WS, no chat-history persistence).
+  # Routes (bearer auth inherited from `auth:` above; absent entirely when
+  # disabled): POST /api/v1/chat/messages, GET
+  # /api/v1/chat/conversations/{id}/events?after=<seq>. Approval decisions do
+  # NOT go through this API — the console calls
+  # POST /api/v1/approvals/{requestId}/decision directly.
+  chat:
+    enabled: false
+    rate_limit:
+      enabled: true
+      messages_per_minute: 20
+      tasks_per_hour: 10
+      burst_size: 5
+
 # Conversational bot module
 # When enabled, chat / greeting / question intents are answered directly via the
 # Anthropic API (~1-2s) instead of spinning up the Claude Code executor (15-30s).

--- a/internal/adapters/web/api.go
+++ b/internal/adapters/web/api.go
@@ -1,0 +1,126 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/comms"
+)
+
+// contextIDPrefix namespaces web conversations within comms.Handler's
+// per-ContextID state (rate limits, pending/running task slots), matching
+// the platform-prefix convention comms uses to keep contexts from different
+// adapters from colliding.
+const contextIDPrefix = "web:"
+
+// Errors returned by API.Dispatch. The gateway HTTP handler maps these to
+// 400 Bad Request; anything else is a 500.
+var (
+	ErrMissingConversationID = errors.New("missing conversationId")
+	ErrMissingText           = errors.New("missing text")
+	ErrMissingCallbackFields = errors.New("callback requires callbackId and actionId")
+	// ErrApprovalCallback is returned when a request looks like an approval
+	// decision routed through the chat API. Approvals do not go through the
+	// comms brain (pitfall GH-4411/GH-4431) — the console must call POST
+	// /api/v1/approvals/{requestId}/decision (#4748) directly.
+	ErrApprovalCallback = errors.New("approval decisions are not accepted on the chat API; use POST /api/v1/approvals/{requestId}/decision")
+)
+
+// DispatchRequest is the validated input to API.Dispatch, adapted from the
+// POST /api/v1/chat/messages body by the gateway handler.
+type DispatchRequest struct {
+	ConversationID string
+	Text           string
+	IsCallback     bool
+	CallbackID     string
+	ActionID       string
+	Sender         string
+}
+
+// isApprovalCallback reports whether a callback payload matches the
+// approve/reject shape used by internal/approval's Telegram/Slack button
+// handlers (ActionID "approve"/"reject", CallbackID/value "approve:<id>" or
+// "reject:<id>" — see internal/approval/telegram.go:463-470,
+// internal/approval/slack.go:400-407). The chat API must never let one of
+// these through to comms.Handler, which has no approval semantics at all.
+func isApprovalCallback(actionID, callbackID string) bool {
+	if actionID == "approve" || actionID == "reject" {
+		return true
+	}
+	return strings.HasPrefix(callbackID, "approve:") || strings.HasPrefix(callbackID, "reject:")
+}
+
+// API implements the chat transport's business logic behind the gateway's
+// HTTP handlers (internal/gateway/chat.go). It owns one comms.Handler (built
+// via comms.BuildHandler with a WebMessenger) and that same WebMessenger,
+// so it can both dispatch inbound messages and read back the outbound event
+// buffer for the events poll endpoint.
+type API struct {
+	handler   *comms.Handler
+	messenger *WebMessenger
+}
+
+// NewAPI wraps a comms.Handler and the WebMessenger it was built with. The
+// caller (cmd/pilot/main.go, internal/pilot/pilot.go) is responsible for
+// constructing both via comms.BuildHandler(comms.HandlerDeps{Messenger:
+// aWebMessenger, ...}) and passing the same messenger instance here.
+func NewAPI(handler *comms.Handler, messenger *WebMessenger) *API {
+	return &API{handler: handler, messenger: messenger}
+}
+
+// Dispatch validates req, then runs comms.Handler.HandleMessage on a
+// goroutine using dispatchCtx — the long-lived daemon context, NOT the HTTP
+// request context, since HandleMessage can block for minutes (a full task
+// execution) while the HTTP request must return in milliseconds. Cancelling
+// the original HTTP request (client disconnect, request-scoped timeout) has
+// no effect on the dispatched work.
+//
+// Returns the conversation's accept-time seq (the newest seq already in the
+// buffer before this message's own events are appended) so the caller can
+// tell a client where to start polling from to see this message's effects.
+func (a *API) Dispatch(dispatchCtx context.Context, req DispatchRequest) (seq int64, err error) {
+	if strings.TrimSpace(req.ConversationID) == "" {
+		return 0, ErrMissingConversationID
+	}
+	if req.IsCallback {
+		if strings.TrimSpace(req.CallbackID) == "" || strings.TrimSpace(req.ActionID) == "" {
+			return 0, ErrMissingCallbackFields
+		}
+		if isApprovalCallback(req.ActionID, req.CallbackID) {
+			return 0, ErrApprovalCallback
+		}
+	} else if strings.TrimSpace(req.Text) == "" {
+		return 0, ErrMissingText
+	}
+
+	contextID := contextIDPrefix + req.ConversationID
+	msg := &comms.IncomingMessage{
+		ContextID:  contextID,
+		SenderName: req.Sender,
+		Text:       req.Text,
+		Platform:   "web",
+		Timestamp:  time.Now(),
+		IsCallback: req.IsCallback,
+		CallbackID: req.CallbackID,
+		ActionID:   req.ActionID,
+	}
+
+	seq = a.messenger.LatestSeq(contextID)
+
+	go a.handler.HandleMessage(dispatchCtx, msg)
+
+	return seq, nil
+}
+
+// Events returns events for conversationID with seq > after, in seq order.
+// A conversationID with no buffer (never messaged, or expired/evicted) is
+// not an error — it returns an empty slice, matching "no events yet" rather
+// than "unknown conversation" (the chat API has no separate concept of
+// conversation existence beyond "has it produced any events").
+func (a *API) Events(conversationID string, after int64) []Event {
+	contextID := contextIDPrefix + conversationID
+	events, _ := a.messenger.Events(contextID, after)
+	return events
+}

--- a/internal/adapters/web/api_test.go
+++ b/internal/adapters/web/api_test.go
@@ -1,0 +1,148 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/comms"
+)
+
+func newTestAPI() (*API, *WebMessenger) {
+	m := NewMessenger()
+	h := comms.NewHandler(&comms.HandlerConfig{
+		Messenger:    m,
+		TaskIDPrefix: "WEB",
+	})
+	return NewAPI(h, m), m
+}
+
+func TestAPI_Dispatch_MissingConversationID(t *testing.T) {
+	api, _ := newTestAPI()
+	_, err := api.Dispatch(context.Background(), DispatchRequest{Text: "hi"})
+	if !errors.Is(err, ErrMissingConversationID) {
+		t.Fatalf("err = %v, want ErrMissingConversationID", err)
+	}
+}
+
+func TestAPI_Dispatch_MissingText(t *testing.T) {
+	api, _ := newTestAPI()
+	_, err := api.Dispatch(context.Background(), DispatchRequest{ConversationID: "c1"})
+	if !errors.Is(err, ErrMissingText) {
+		t.Fatalf("err = %v, want ErrMissingText", err)
+	}
+}
+
+func TestAPI_Dispatch_CallbackMissingFields(t *testing.T) {
+	api, _ := newTestAPI()
+	_, err := api.Dispatch(context.Background(), DispatchRequest{ConversationID: "c1", IsCallback: true})
+	if !errors.Is(err, ErrMissingCallbackFields) {
+		t.Fatalf("err = %v, want ErrMissingCallbackFields", err)
+	}
+}
+
+func TestAPI_Dispatch_RejectsApprovalCallback(t *testing.T) {
+	api, _ := newTestAPI()
+
+	cases := []DispatchRequest{
+		{ConversationID: "c1", IsCallback: true, CallbackID: "cb1", ActionID: "approve"},
+		{ConversationID: "c1", IsCallback: true, CallbackID: "cb1", ActionID: "reject"},
+		{ConversationID: "c1", IsCallback: true, CallbackID: "approve:req-123", ActionID: "click"},
+		{ConversationID: "c1", IsCallback: true, CallbackID: "reject:req-123", ActionID: "click"},
+	}
+	for _, req := range cases {
+		_, err := api.Dispatch(context.Background(), req)
+		if !errors.Is(err, ErrApprovalCallback) {
+			t.Errorf("req=%+v err = %v, want ErrApprovalCallback", req, err)
+		}
+	}
+}
+
+func TestAPI_Dispatch_ValidTextMessage_ReturnsAcceptTimeSeq(t *testing.T) {
+	api, m := newTestAPI()
+	ctx := context.Background()
+
+	// Seed one prior event so the accept-time seq is non-zero.
+	if err := m.SendText(ctx, "web:c1", "prior"); err != nil {
+		t.Fatalf("seed SendText error: %v", err)
+	}
+
+	seq, err := api.Dispatch(ctx, DispatchRequest{ConversationID: "c1", Text: "hello", Sender: "operator"})
+	if err != nil {
+		t.Fatalf("Dispatch error: %v", err)
+	}
+	if seq != 1 {
+		t.Fatalf("accept-time seq = %d, want 1 (only the seeded event existed at accept time)", seq)
+	}
+
+	// HandleMessage runs on a goroutine — wait for it to land an event
+	// (a greeting reply to "hello") before asserting.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		events, _ := m.Events("web:c1", seq)
+		if len(events) > 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("no new event landed after dispatch")
+}
+
+func TestAPI_Dispatch_UsesGivenContextNotCancelledOne(t *testing.T) {
+	api, m := newTestAPI()
+
+	// The context passed to Dispatch is cancelled immediately, but
+	// HandleMessage should still observe the request's own cancellation
+	// state correctly since we pass it a background context deliberately —
+	// Dispatch itself doesn't derive from the caller's ctx beyond passing it
+	// straight to the goroutine, so the caller (gateway handler) is what's
+	// responsible for using the daemon ctx, not the request ctx. Here we
+	// simulate that correctly-wired caller behavior.
+	daemonCtx := context.Background()
+	seq, err := api.Dispatch(daemonCtx, DispatchRequest{ConversationID: "c1", Text: "hello"})
+	if err != nil {
+		t.Fatalf("Dispatch error: %v", err)
+	}
+	if seq != 0 {
+		t.Fatalf("seq = %d, want 0", seq)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		events, _ := m.Events("web:c1", 0)
+		if len(events) > 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("no event landed")
+}
+
+func TestAPI_Events_UnknownConversationIsEmptyNotError(t *testing.T) {
+	api, _ := newTestAPI()
+	events := api.Events("nope", 0)
+	if len(events) != 0 {
+		t.Fatalf("got %d events, want 0", len(events))
+	}
+}
+
+func TestAPI_Events_UsesConversationIDPrefix(t *testing.T) {
+	api, m := newTestAPI()
+	ctx := context.Background()
+
+	// Write directly on the prefixed contextID, as comms.Handler would.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = m.SendText(ctx, "web:c1", "hi")
+	}()
+	wg.Wait()
+
+	events := api.Events("c1", 0)
+	if len(events) != 1 || events[0].Text != "hi" {
+		t.Fatalf("events = %+v", events)
+	}
+}

--- a/internal/adapters/web/config.go
+++ b/internal/adapters/web/config.go
@@ -1,0 +1,31 @@
+// Package web implements the web (console Operator chat panel) transport for
+// the shared internal/comms adapter brain (GH-4835 / C17). It is the fourth
+// comms.BuildHandler assembly alongside Telegram, Slack, and Discord — see
+// internal/comms/factory.go for the shared inbound/outbound seam.
+package web
+
+import "github.com/qf-studio/pilot/internal/comms"
+
+// Config configures the web chat transport — YAML key adapters.chat. Disabled
+// by default: when Enabled is false, the gateway does not register the chat
+// routes at all (POST /api/v1/chat/messages and GET
+// /api/v1/chat/conversations/{id}/events 404 like any other unknown path)
+// rather than returning a 503, mirroring how disabled adapters are absent
+// elsewhere in this codebase rather than present-but-erroring.
+type Config struct {
+	Enabled bool `yaml:"enabled"`
+
+	// RateLimit is per-ContextID (per-conversation, "web:"+conversationID) —
+	// not shared across conversations. Defaults to comms.DefaultRateLimitConfig
+	// when nil, matching the Telegram/Slack call sites.
+	RateLimit *comms.RateLimitConfig `yaml:"rate_limit,omitempty"`
+}
+
+// DefaultConfig returns the disabled-by-default web chat config, matching
+// every other adapter's DefaultConfig (see internal/adapters/slack,
+// internal/adapters/telegram).
+func DefaultConfig() *Config {
+	return &Config{
+		Enabled: false,
+	}
+}

--- a/internal/adapters/web/messenger.go
+++ b/internal/adapters/web/messenger.go
@@ -1,0 +1,264 @@
+package web
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/comms"
+)
+
+// maxEventsPerConversation is the drop-oldest cap on a single conversation's
+// event buffer (GH-4835 spec). Chosen generously above any realistic single
+// task's event count (confirmation + progress edits + result rarely exceeds
+// a few dozen entries) so drop-oldest is a safety valve, not a steady-state
+// occurrence.
+const maxEventsPerConversation = 500
+
+// conversationExpiry is how long a conversation's buffer survives with no
+// new events before it is eligible for eviction (GH-4835 spec: "1h
+// inactivity"). Checked lazily on access, not via a background sweep — see
+// pruneLocked.
+const conversationExpiry = time.Hour
+
+// MaxMessageLength is the cap WebMessenger reports via comms.Messenger. The
+// buffer is in-memory JSON, not a platform with a real transport limit, so
+// this is set high enough that comms' chunking logic rarely engages.
+const MaxMessageLength = 32768
+
+// EventType enumerates the wire "type" field of Event.
+type EventType string
+
+const (
+	EventText         EventType = "text"
+	EventConfirmation EventType = "confirmation"
+	EventProgress     EventType = "progress"
+	EventResult       EventType = "result"
+)
+
+// Event is one entry in a conversation's outbound timeline, served verbatim
+// by GET /api/v1/chat/conversations/{id}/events. Seq is monotonically
+// increasing per conversation, starting at 1 (0 is never a valid seq, so
+// ?after=0 always means "from the beginning" — see API.Events).
+//
+// Restart semantics (GH-4835 spec): buffers are in-memory only. A daemon
+// restart wipes all conversations and seq numbering restarts at 0/1. A
+// client that polls with an `after` value greater than the newest seq
+// currently held (i.e. it remembers more history than the server has) must
+// treat that as a buffer reset and re-poll from after=0, since there is no
+// way for the server to distinguish "you're caught up" from "I forgot
+// everything before your bookmark" — both look like "nothing new past your
+// cursor" from small `after` values, but a client-side cursor larger than
+// the newest known seq is the unambiguous signal.
+type Event struct {
+	Seq        int64     `json:"seq"`
+	Type       EventType `json:"type"`
+	Text       string    `json:"text,omitempty"`
+	TaskID     string    `json:"taskId,omitempty"`
+	Phase      string    `json:"phase,omitempty"`
+	Progress   *float64  `json:"progress,omitempty"`
+	PRUrl      string    `json:"prUrl,omitempty"`
+	Success    *bool     `json:"success,omitempty"`
+	MessageRef string    `json:"messageRef,omitempty"`
+	OccurredAt time.Time `json:"occurredAt"`
+}
+
+type conversation struct {
+	events     []Event
+	nextSeq    int64
+	lastActive time.Time
+}
+
+// WebMessenger implements comms.Messenger by appending typed events to a
+// per-conversation in-memory buffer, polled by GET
+// /api/v1/chat/conversations/{id}/events (GH-4835). contextID here is always
+// the comms ContextID ("web:" + conversationID, per the API assembly in
+// gateway/chat.go) — WebMessenger strips no prefix and stores buffers keyed
+// on the raw contextID it's given, so the caller (API) is responsible for
+// using the same contextID both when dispatching HandleMessage and when
+// looking up events for a conversationID.
+type WebMessenger struct {
+	mu            sync.Mutex
+	conversations map[string]*conversation
+	now           func() time.Time // seam for tests
+}
+
+var _ comms.Messenger = (*WebMessenger)(nil)
+
+// NewMessenger creates an empty WebMessenger.
+func NewMessenger() *WebMessenger {
+	return &WebMessenger{
+		conversations: make(map[string]*conversation),
+		now:           time.Now,
+	}
+}
+
+func (m *WebMessenger) conversationLocked(contextID string) *conversation {
+	c, ok := m.conversations[contextID]
+	if !ok {
+		c = &conversation{}
+		m.conversations[contextID] = c
+	}
+	return c
+}
+
+// appendLocked appends ev to contextID's buffer, assigning it the next seq,
+// enforcing the drop-oldest cap, and bumping lastActive. Returns the
+// assigned seq.
+func (m *WebMessenger) appendLocked(contextID string, ev Event) int64 {
+	c := m.conversationLocked(contextID)
+	c.nextSeq++
+	ev.Seq = c.nextSeq
+	if ev.OccurredAt.IsZero() {
+		ev.OccurredAt = m.now()
+	}
+	c.events = append(c.events, ev)
+	if len(c.events) > maxEventsPerConversation {
+		c.events = c.events[len(c.events)-maxEventsPerConversation:]
+	}
+	c.lastActive = m.now()
+	return ev.Seq
+}
+
+// pruneLocked evicts conversations that have been inactive past
+// conversationExpiry. Called lazily from the read/write paths rather than a
+// background goroutine — the buffer is small and operator-facing, so a sweep
+// on access is sufficient and avoids a timer to manage across daemon
+// lifecycle.
+func (m *WebMessenger) pruneLocked() {
+	cutoff := m.now().Add(-conversationExpiry)
+	for id, c := range m.conversations {
+		if c.lastActive.Before(cutoff) {
+			delete(m.conversations, id)
+		}
+	}
+}
+
+// SendText appends a plain text event.
+func (m *WebMessenger) SendText(_ context.Context, contextID, text string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.pruneLocked()
+	m.appendLocked(contextID, Event{Type: EventText, Text: text})
+	return nil
+}
+
+// SendConfirmation appends a confirmation event and returns taskID as the
+// messageRef — later SendProgress calls for the same task reuse it so a
+// client can group/replace-in-place by messageRef, mirroring Telegram's
+// edit-in-place semantics without a real "edit" operation on a poll-drain
+// buffer.
+func (m *WebMessenger) SendConfirmation(_ context.Context, contextID, _threadID, taskID, desc, project string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.pruneLocked()
+	text := desc
+	if project != "" {
+		text = desc + " (" + project + ")"
+	}
+	m.appendLocked(contextID, Event{
+		Type:       EventConfirmation,
+		Text:       text,
+		TaskID:     taskID,
+		MessageRef: taskID,
+	})
+	return taskID, nil
+}
+
+// SendProgress appends a progress event. When messageRef is empty (the
+// initial progress call for a task — see comms.Handler.executeTaskCore) it
+// defaults to taskID, same as SendConfirmation, so all of a task's progress
+// events plus its opening confirmation share one messageRef.
+func (m *WebMessenger) SendProgress(_ context.Context, contextID, messageRef, taskID, phase string, progress int, detail string) (string, error) {
+	if messageRef == "" {
+		messageRef = taskID
+	}
+	pct := float64(progress) / 100.0
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.pruneLocked()
+	m.appendLocked(contextID, Event{
+		Type:       EventProgress,
+		Text:       detail,
+		TaskID:     taskID,
+		Phase:      phase,
+		Progress:   &pct,
+		MessageRef: messageRef,
+	})
+	return messageRef, nil
+}
+
+// SendResult appends a result event carrying the final success/output/PR URL.
+func (m *WebMessenger) SendResult(_ context.Context, contextID, _threadID, taskID string, success bool, output, prURL string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.pruneLocked()
+	s := success
+	m.appendLocked(contextID, Event{
+		Type:       EventResult,
+		Text:       output,
+		TaskID:     taskID,
+		PRUrl:      prURL,
+		Success:    &s,
+		MessageRef: taskID,
+	})
+	return nil
+}
+
+// SendChunked appends chunks as sequential text events. WebMessenger's
+// MaxMessageLength (32768) is high enough that comms rarely calls this in
+// practice, but the interface requires an implementation.
+func (m *WebMessenger) SendChunked(ctx context.Context, contextID, _threadID, content, prefix string) error {
+	text := content
+	if prefix != "" {
+		text = prefix + content
+	}
+	return m.SendText(ctx, contextID, text)
+}
+
+// AcknowledgeCallback is a no-op: there is no platform-level callback
+// acknowledgement to send for a poll-drain HTTP transport (mirrors Slack's
+// implementation, internal/adapters/slack/messenger.go).
+func (m *WebMessenger) AcknowledgeCallback(context.Context, string) error {
+	return nil
+}
+
+// MaxMessageLength returns the configured cap.
+func (m *WebMessenger) MaxMessageLength() int {
+	return MaxMessageLength
+}
+
+// Events returns the events for contextID with seq > after, in seq order,
+// along with the newest seq currently known for the conversation (0 if the
+// conversation doesn't exist / has no events). It does not mutate state
+// beyond lazy pruning.
+func (m *WebMessenger) Events(contextID string, after int64) (events []Event, latestSeq int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.pruneLocked()
+	c, ok := m.conversations[contextID]
+	if !ok {
+		return nil, 0
+	}
+	latestSeq = c.nextSeq
+	out := make([]Event, 0, len(c.events))
+	for _, ev := range c.events {
+		if ev.Seq > after {
+			out = append(out, ev)
+		}
+	}
+	return out, latestSeq
+}
+
+// LatestSeq returns the newest seq currently held for contextID (0 if the
+// conversation doesn't exist yet). Used by API.Dispatch to report the
+// accept-time seq in the 202 response.
+func (m *WebMessenger) LatestSeq(contextID string) int64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	c, ok := m.conversations[contextID]
+	if !ok {
+		return 0
+	}
+	return c.nextSeq
+}

--- a/internal/adapters/web/messenger_test.go
+++ b/internal/adapters/web/messenger_test.go
@@ -1,0 +1,223 @@
+package web
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestWebMessenger_SendText_SeqOrdering(t *testing.T) {
+	m := NewMessenger()
+	ctx := context.Background()
+
+	for i, text := range []string{"one", "two", "three"} {
+		if err := m.SendText(ctx, "web:c1", text); err != nil {
+			t.Fatalf("SendText[%d] error: %v", i, err)
+		}
+	}
+
+	events, latest := m.Events("web:c1", 0)
+	if len(events) != 3 {
+		t.Fatalf("got %d events, want 3", len(events))
+	}
+	if latest != 3 {
+		t.Fatalf("latest seq = %d, want 3", latest)
+	}
+	for i, ev := range events {
+		wantSeq := int64(i + 1)
+		if ev.Seq != wantSeq {
+			t.Errorf("events[%d].Seq = %d, want %d", i, ev.Seq, wantSeq)
+		}
+		if ev.Type != EventText {
+			t.Errorf("events[%d].Type = %q, want %q", i, ev.Type, EventText)
+		}
+	}
+
+	// after=1 should drop the first event only.
+	tail, _ := m.Events("web:c1", 1)
+	if len(tail) != 2 || tail[0].Text != "two" {
+		t.Fatalf("Events(after=1) = %+v, want [two, three]", tail)
+	}
+}
+
+func TestWebMessenger_SendConfirmation_UsesTaskIDAsMessageRef(t *testing.T) {
+	m := NewMessenger()
+	ctx := context.Background()
+
+	ref, err := m.SendConfirmation(ctx, "web:c1", "", "TASK-1", "Do the thing", "myproject")
+	if err != nil {
+		t.Fatalf("SendConfirmation error: %v", err)
+	}
+	if ref != "TASK-1" {
+		t.Fatalf("messageRef = %q, want %q", ref, "TASK-1")
+	}
+
+	events, _ := m.Events("web:c1", 0)
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	ev := events[0]
+	if ev.Type != EventConfirmation {
+		t.Errorf("Type = %q, want %q", ev.Type, EventConfirmation)
+	}
+	if ev.MessageRef != "TASK-1" || ev.TaskID != "TASK-1" {
+		t.Errorf("MessageRef/TaskID = %q/%q, want TASK-1/TASK-1", ev.MessageRef, ev.TaskID)
+	}
+	if ev.Text != "Do the thing (myproject)" {
+		t.Errorf("Text = %q", ev.Text)
+	}
+}
+
+func TestWebMessenger_SendProgress_SharesMessageRef(t *testing.T) {
+	m := NewMessenger()
+	ctx := context.Background()
+
+	// First progress call with an empty ref (as comms.Handler.executeTaskCore
+	// does for the initial "Starting" progress event) defaults to taskID.
+	ref1, err := m.SendProgress(ctx, "web:c1", "", "TASK-1", "Starting", 0, "Initializing...")
+	if err != nil {
+		t.Fatalf("SendProgress error: %v", err)
+	}
+	if ref1 != "TASK-1" {
+		t.Fatalf("ref1 = %q, want TASK-1", ref1)
+	}
+
+	ref2, err := m.SendProgress(ctx, "web:c1", ref1, "TASK-1", "Working", 60, "Halfway there")
+	if err != nil {
+		t.Fatalf("SendProgress error: %v", err)
+	}
+	if ref2 != ref1 {
+		t.Fatalf("ref2 = %q, want %q (reused)", ref2, ref1)
+	}
+
+	events, _ := m.Events("web:c1", 0)
+	if len(events) != 2 {
+		t.Fatalf("got %d events, want 2", len(events))
+	}
+	for _, ev := range events {
+		if ev.MessageRef != "TASK-1" {
+			t.Errorf("event MessageRef = %q, want TASK-1", ev.MessageRef)
+		}
+		if ev.Type != EventProgress {
+			t.Errorf("event Type = %q, want %q", ev.Type, EventProgress)
+		}
+	}
+	if events[1].Progress == nil || *events[1].Progress != 0.6 {
+		t.Errorf("events[1].Progress = %v, want 0.6", events[1].Progress)
+	}
+}
+
+func TestWebMessenger_SendResult_CarriesPRUrlAndSuccess(t *testing.T) {
+	m := NewMessenger()
+	ctx := context.Background()
+
+	if err := m.SendResult(ctx, "web:c1", "", "TASK-1", true, "all done", "https://github.com/x/y/pull/1"); err != nil {
+		t.Fatalf("SendResult error: %v", err)
+	}
+
+	events, _ := m.Events("web:c1", 0)
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	ev := events[0]
+	if ev.Type != EventResult {
+		t.Errorf("Type = %q, want %q", ev.Type, EventResult)
+	}
+	if ev.PRUrl != "https://github.com/x/y/pull/1" {
+		t.Errorf("PRUrl = %q", ev.PRUrl)
+	}
+	if ev.Success == nil || !*ev.Success {
+		t.Errorf("Success = %v, want true", ev.Success)
+	}
+	if ev.MessageRef != "TASK-1" {
+		t.Errorf("MessageRef = %q, want TASK-1", ev.MessageRef)
+	}
+}
+
+func TestWebMessenger_BufferCap_DropsOldest(t *testing.T) {
+	m := NewMessenger()
+	ctx := context.Background()
+
+	total := maxEventsPerConversation + 10
+	for i := 0; i < total; i++ {
+		if err := m.SendText(ctx, "web:c1", "msg"); err != nil {
+			t.Fatalf("SendText error: %v", err)
+		}
+	}
+
+	events, latest := m.Events("web:c1", 0)
+	if len(events) != maxEventsPerConversation {
+		t.Fatalf("got %d events, want cap %d", len(events), maxEventsPerConversation)
+	}
+	if latest != int64(total) {
+		t.Fatalf("latest = %d, want %d (seq keeps counting past the cap)", latest, total)
+	}
+	// The oldest surviving event should be the 11th sent (1-indexed seq 11),
+	// since the first 10 were dropped to stay at the cap.
+	wantFirstSeq := int64(total - maxEventsPerConversation + 1)
+	if events[0].Seq != wantFirstSeq {
+		t.Errorf("events[0].Seq = %d, want %d", events[0].Seq, wantFirstSeq)
+	}
+}
+
+func TestWebMessenger_ConversationExpiry(t *testing.T) {
+	m := NewMessenger()
+	fakeNow := time.Now()
+	m.now = func() time.Time { return fakeNow }
+	ctx := context.Background()
+
+	if err := m.SendText(ctx, "web:c1", "hello"); err != nil {
+		t.Fatalf("SendText error: %v", err)
+	}
+
+	// Still within the window: events survive.
+	fakeNow = fakeNow.Add(conversationExpiry - time.Minute)
+	events, _ := m.Events("web:c1", 0)
+	if len(events) != 1 {
+		t.Fatalf("got %d events before expiry, want 1", len(events))
+	}
+
+	// Past the window: the conversation is pruned and looks brand new.
+	fakeNow = fakeNow.Add(2 * time.Minute)
+	events, latest := m.Events("web:c1", 0)
+	if len(events) != 0 {
+		t.Fatalf("got %d events after expiry, want 0", len(events))
+	}
+	if latest != 0 {
+		t.Fatalf("latest after expiry = %d, want 0 (seq resets)", latest)
+	}
+}
+
+func TestWebMessenger_MaxMessageLength(t *testing.T) {
+	m := NewMessenger()
+	if got := m.MaxMessageLength(); got != MaxMessageLength {
+		t.Fatalf("MaxMessageLength() = %d, want %d", got, MaxMessageLength)
+	}
+}
+
+func TestWebMessenger_AcknowledgeCallback_NoOp(t *testing.T) {
+	m := NewMessenger()
+	if err := m.AcknowledgeCallback(context.Background(), "cb1"); err != nil {
+		t.Fatalf("AcknowledgeCallback error: %v", err)
+	}
+}
+
+func TestWebMessenger_LatestSeq_UnknownConversation(t *testing.T) {
+	m := NewMessenger()
+	if got := m.LatestSeq("web:nope"); got != 0 {
+		t.Fatalf("LatestSeq(unknown) = %d, want 0", got)
+	}
+}
+
+func TestWebMessenger_SendChunked_PrependsPrefix(t *testing.T) {
+	m := NewMessenger()
+	ctx := context.Background()
+
+	if err := m.SendChunked(ctx, "web:c1", "", "body text", "PREFIX: "); err != nil {
+		t.Fatalf("SendChunked error: %v", err)
+	}
+	events, _ := m.Events("web:c1", 0)
+	if len(events) != 1 || events[0].Text != "PREFIX: body text" {
+		t.Fatalf("events = %+v", events)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ import (
 	"github.com/qf-studio/pilot/internal/adapters/plane"
 	"github.com/qf-studio/pilot/internal/adapters/slack"
 	"github.com/qf-studio/pilot/internal/adapters/telegram"
+	"github.com/qf-studio/pilot/internal/adapters/web"
 	"github.com/qf-studio/pilot/internal/alerts"
 	"github.com/qf-studio/pilot/internal/approval"
 	"github.com/qf-studio/pilot/internal/autopilot"
@@ -153,6 +154,10 @@ type AdaptersConfig struct {
 	Asana       *asana.Config       `yaml:"asana"`
 	Plane       *plane.Config       `yaml:"plane"`
 	Discord     *discord.Config     `yaml:"discord"`
+	// Chat configures the web transport for the console Operator chat panel
+	// (GH-4835). Disabled by default; when absent/disabled the gateway
+	// chat routes are not registered at all.
+	Chat *web.Config `yaml:"chat"`
 }
 
 // OrchestratorConfig holds settings for the task orchestrator including
@@ -474,6 +479,7 @@ func DefaultConfig() *Config {
 			Asana:       asana.DefaultConfig(),
 			Plane:       plane.DefaultConfig(),
 			Discord:     discord.DefaultConfig(),
+			Chat:        web.DefaultConfig(),
 		},
 		Orchestrator: &OrchestratorConfig{
 			Model:         "claude-sonnet-4-6",

--- a/internal/gateway/chat.go
+++ b/internal/gateway/chat.go
@@ -1,0 +1,181 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/qf-studio/pilot/internal/adapters/web"
+	"github.com/qf-studio/pilot/internal/logging"
+)
+
+// ChatAPI is the seam handleChatMessages/handleChatEvents dispatch through —
+// satisfied by *web.API. Defined here (consumer side) rather than in
+// internal/adapters/web so gateway keeps owning its own handler-testing
+// interfaces, matching the DashboardStore/AutopilotProvider/DecisionRecorder
+// convention already used in this package.
+type ChatAPI interface {
+	Dispatch(ctx context.Context, req web.DispatchRequest) (seq int64, err error)
+	Events(conversationID string, after int64) []web.Event
+}
+
+// SetChatAPI wires the web chat transport (GH-4835 / C17) backing
+// POST /api/v1/chat/messages and GET /api/v1/chat/conversations/{id}/events.
+// Must be called before Start(), at BOTH gateway construction sites —
+// cmd/pilot/main.go (polling mode) and internal/pilot/pilot.go (gateway
+// mode) — when adapters.chat.enabled is true, mirroring SetDecisionRecorder
+// (see approvals.go). Left nil (the default, matching adapters.chat.enabled:
+// false), the routes are not registered at all in Start() — a request to
+// either path 404s like any unknown path, not 503, so "disabled" and
+// "misconfigured" are told apart at the routing layer rather than inside
+// the handler.
+func (s *Server) SetChatAPI(api ChatAPI) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.chatAPI = api
+}
+
+// chatMessageRequest is the POST /api/v1/chat/messages body. Either Text is
+// set (a plain message) or IsCallback+CallbackID+ActionID are set (a button
+// press) — never both, matching comms.IncomingMessage's own shape. Sender is
+// an optional display label only; the chat API has no per-user RBAC beyond
+// the gateway's own bearer auth (GH-4835 scope fence).
+type chatMessageRequest struct {
+	ConversationID string `json:"conversationId"`
+	Text           string `json:"text,omitempty"`
+	IsCallback     bool   `json:"isCallback,omitempty"`
+	CallbackID     string `json:"callbackId,omitempty"`
+	ActionID       string `json:"actionId,omitempty"`
+	Sender         string `json:"sender,omitempty"`
+}
+
+// chatMessageResponse is the 202 body: Seq is the conversation's newest seq
+// at accept time (before this message's own events are appended), telling
+// the caller where to start polling from to observe this message's effects.
+type chatMessageResponse struct {
+	ConversationID string `json:"conversationId"`
+	Seq            int64  `json:"seq"`
+}
+
+// chatEventsResponse is the GET .../events body.
+type chatEventsResponse struct {
+	ConversationID string      `json:"conversationId"`
+	Events         []web.Event `json:"events"`
+}
+
+// handleChatMessages serves POST /api/v1/chat/messages (GH-4835 acceptance
+// #1-#3). Dispatches comms.Handler.HandleMessage on the daemon context (see
+// Server.Start, which stashes it in s.daemonCtx) rather than the request
+// context, since a task-shaped message can run for minutes while this
+// handler must return in milliseconds — see web.API.Dispatch's doc comment.
+func (s *Server) handleChatMessages(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	s.mu.RLock()
+	api := s.chatAPI
+	dispatchCtx := s.daemonCtx
+	s.mu.RUnlock()
+
+	if api == nil {
+		http.Error(w, "chat API not configured", http.StatusServiceUnavailable)
+		return
+	}
+	if dispatchCtx == nil {
+		// Start() hasn't run yet (or hasn't reached the point where it
+		// stashes the daemon context). Should not happen once the server is
+		// actually serving requests, but fail loudly rather than dispatch
+		// on a nil context.
+		http.Error(w, "gateway not ready", http.StatusServiceUnavailable)
+		return
+	}
+
+	var body chatMessageRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+
+	seq, err := api.Dispatch(dispatchCtx, web.DispatchRequest{
+		ConversationID: body.ConversationID,
+		Text:           body.Text,
+		IsCallback:     body.IsCallback,
+		CallbackID:     body.CallbackID,
+		ActionID:       body.ActionID,
+		Sender:         body.Sender,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, web.ErrMissingConversationID),
+			errors.Is(err, web.ErrMissingText),
+			errors.Is(err, web.ErrMissingCallbackFields),
+			errors.Is(err, web.ErrApprovalCallback):
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		default:
+			http.Error(w, "failed to dispatch message", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	writeJSONStatus(w, http.StatusAccepted, chatMessageResponse{
+		ConversationID: body.ConversationID,
+		Seq:            seq,
+	})
+}
+
+// handleChatEvents serves GET /api/v1/chat/conversations/{id}/events?after=<seq>
+// (GH-4835 acceptance #1-#3). A conversation with no events yet (never
+// messaged, or its buffer expired/was evicted — see web.WebMessenger) is not
+// an error: it returns an empty events array, since a poll-drain client
+// naturally polls before the first message it sent has produced any events.
+func (s *Server) handleChatEvents(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	s.mu.RLock()
+	api := s.chatAPI
+	s.mu.RUnlock()
+
+	if api == nil {
+		http.Error(w, "chat API not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" {
+		http.Error(w, "missing conversation id", http.StatusBadRequest)
+		return
+	}
+
+	after := int64(0)
+	if raw := r.URL.Query().Get("after"); raw != "" {
+		v, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil {
+			http.Error(w, "invalid after parameter", http.StatusBadRequest)
+			return
+		}
+		after = v
+	}
+
+	events := api.Events(id, after)
+	writeJSON(w, chatEventsResponse{
+		ConversationID: id,
+		Events:         events,
+	})
+}
+
+// writeJSONStatus is writeJSON with an explicit non-200 status code.
+func writeJSONStatus(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		logging.WithComponent("gateway").Warn("failed to encode chat response", slog.Any("error", err))
+	}
+}

--- a/internal/gateway/chat_test.go
+++ b/internal/gateway/chat_test.go
@@ -1,0 +1,515 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/adapters/web"
+	"github.com/qf-studio/pilot/internal/comms"
+	"github.com/qf-studio/pilot/internal/executor"
+)
+
+// --- mockChatAPI: unit-level direct-handler-call tests --------------------
+
+// mockChatAPI implements ChatAPI with configurable func fields, mirroring the
+// mockDashboardStore / mockDecisionRecorder convention already used in this
+// package's *_test.go files.
+type mockChatAPI struct {
+	dispatchFunc func(ctx context.Context, req web.DispatchRequest) (int64, error)
+	eventsFunc   func(conversationID string, after int64) []web.Event
+}
+
+func (m *mockChatAPI) Dispatch(ctx context.Context, req web.DispatchRequest) (int64, error) {
+	if m.dispatchFunc != nil {
+		return m.dispatchFunc(ctx, req)
+	}
+	return 0, nil
+}
+
+func (m *mockChatAPI) Events(conversationID string, after int64) []web.Event {
+	if m.eventsFunc != nil {
+		return m.eventsFunc(conversationID, after)
+	}
+	return nil
+}
+
+func newTestServerWithChat(api ChatAPI) *Server {
+	s := NewServer(&Config{Host: "127.0.0.1", Port: 0})
+	s.SetChatAPI(api)
+	s.mu.Lock()
+	s.daemonCtx = context.Background()
+	s.mu.Unlock()
+	return s
+}
+
+func jsonBody(t *testing.T, v interface{}) *bytes.Buffer {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	return bytes.NewBuffer(b)
+}
+
+func TestHandleChatMessages_MethodNotAllowed(t *testing.T) {
+	s := newTestServerWithChat(&mockChatAPI{})
+	req := httpTestRequest(t, http.MethodGet, "/api/v1/chat/messages", nil)
+	w := newTestResponseRecorder()
+	s.handleChatMessages(w, req)
+	if w.status != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", w.status)
+	}
+}
+
+func TestHandleChatMessages_NilChatAPI_503(t *testing.T) {
+	s := NewServer(&Config{Host: "127.0.0.1", Port: 0})
+	s.mu.Lock()
+	s.daemonCtx = context.Background()
+	s.mu.Unlock()
+
+	req := httpTestRequest(t, http.MethodPost, "/api/v1/chat/messages",
+		jsonBody(t, chatMessageRequest{ConversationID: "c1", Text: "hi"}))
+	w := newTestResponseRecorder()
+	s.handleChatMessages(w, req)
+	if w.status != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.status)
+	}
+}
+
+func TestHandleChatMessages_NilDaemonCtx_503(t *testing.T) {
+	s := NewServer(&Config{Host: "127.0.0.1", Port: 0})
+	s.SetChatAPI(&mockChatAPI{})
+	// daemonCtx deliberately left nil: Start() hasn't run yet.
+
+	req := httpTestRequest(t, http.MethodPost, "/api/v1/chat/messages",
+		jsonBody(t, chatMessageRequest{ConversationID: "c1", Text: "hi"}))
+	w := newTestResponseRecorder()
+	s.handleChatMessages(w, req)
+	if w.status != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.status)
+	}
+}
+
+func TestHandleChatMessages_InvalidJSON_400(t *testing.T) {
+	s := newTestServerWithChat(&mockChatAPI{})
+	req := httpTestRequest(t, http.MethodPost, "/api/v1/chat/messages", bytes.NewBufferString("{not json"))
+	w := newTestResponseRecorder()
+	s.handleChatMessages(w, req)
+	if w.status != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.status)
+	}
+}
+
+func TestHandleChatMessages_ValidationErrors_400(t *testing.T) {
+	cases := []error{
+		web.ErrMissingConversationID,
+		web.ErrMissingText,
+		web.ErrMissingCallbackFields,
+		web.ErrApprovalCallback,
+	}
+	for _, wantErr := range cases {
+		api := &mockChatAPI{
+			dispatchFunc: func(ctx context.Context, req web.DispatchRequest) (int64, error) {
+				return 0, wantErr
+			},
+		}
+		s := newTestServerWithChat(api)
+		req := httpTestRequest(t, http.MethodPost, "/api/v1/chat/messages",
+			jsonBody(t, chatMessageRequest{ConversationID: "c1", Text: "hi"}))
+		w := newTestResponseRecorder()
+		s.handleChatMessages(w, req)
+		if w.status != http.StatusBadRequest {
+			t.Errorf("err=%v status = %d, want 400", wantErr, w.status)
+		}
+	}
+}
+
+func TestHandleChatMessages_OtherDispatchError_500(t *testing.T) {
+	api := &mockChatAPI{
+		dispatchFunc: func(ctx context.Context, req web.DispatchRequest) (int64, error) {
+			return 0, errors.New("boom")
+		},
+	}
+	s := newTestServerWithChat(api)
+	req := httpTestRequest(t, http.MethodPost, "/api/v1/chat/messages",
+		jsonBody(t, chatMessageRequest{ConversationID: "c1", Text: "hi"}))
+	w := newTestResponseRecorder()
+	s.handleChatMessages(w, req)
+	if w.status != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.status)
+	}
+}
+
+func TestHandleChatMessages_Success_202(t *testing.T) {
+	var gotCtx context.Context
+	var gotReq web.DispatchRequest
+	api := &mockChatAPI{
+		dispatchFunc: func(ctx context.Context, req web.DispatchRequest) (int64, error) {
+			gotCtx = ctx
+			gotReq = req
+			return 7, nil
+		},
+	}
+	s := newTestServerWithChat(api)
+	req := httpTestRequest(t, http.MethodPost, "/api/v1/chat/messages",
+		jsonBody(t, chatMessageRequest{ConversationID: "c1", Text: "hello", Sender: "operator"}))
+	w := newTestResponseRecorder()
+	s.handleChatMessages(w, req)
+
+	if w.status != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", w.status)
+	}
+	var resp chatMessageResponse
+	if err := json.Unmarshal(w.body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if resp.ConversationID != "c1" || resp.Seq != 7 {
+		t.Errorf("resp = %+v, want {c1 7}", resp)
+	}
+	if gotReq.Text != "hello" || gotReq.Sender != "operator" {
+		t.Errorf("dispatched req = %+v", gotReq)
+	}
+	// Dispatch must be called with the server's daemon context, not a
+	// request-derived one — since req has no cancellation wired here, assert
+	// identity against the stashed daemonCtx directly.
+	s.mu.RLock()
+	wantCtx := s.daemonCtx
+	s.mu.RUnlock()
+	if gotCtx != wantCtx {
+		t.Errorf("Dispatch was not called with the daemon context")
+	}
+}
+
+func TestHandleChatEvents_MethodNotAllowed(t *testing.T) {
+	s := newTestServerWithChat(&mockChatAPI{})
+	req := httpTestRequestWithPathValue(t, http.MethodPost, "/api/v1/chat/conversations/c1/events", nil, "id", "c1")
+	w := newTestResponseRecorder()
+	s.handleChatEvents(w, req)
+	if w.status != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", w.status)
+	}
+}
+
+func TestHandleChatEvents_NilChatAPI_503(t *testing.T) {
+	s := NewServer(&Config{Host: "127.0.0.1", Port: 0})
+	req := httpTestRequestWithPathValue(t, http.MethodGet, "/api/v1/chat/conversations/c1/events", nil, "id", "c1")
+	w := newTestResponseRecorder()
+	s.handleChatEvents(w, req)
+	if w.status != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.status)
+	}
+}
+
+func TestHandleChatEvents_MissingID_400(t *testing.T) {
+	s := newTestServerWithChat(&mockChatAPI{})
+	req := httpTestRequestWithPathValue(t, http.MethodGet, "/api/v1/chat/conversations//events", nil, "id", "")
+	w := newTestResponseRecorder()
+	s.handleChatEvents(w, req)
+	if w.status != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.status)
+	}
+}
+
+func TestHandleChatEvents_InvalidAfter_400(t *testing.T) {
+	s := newTestServerWithChat(&mockChatAPI{})
+	req := httpTestRequestWithPathValue(t, http.MethodGet, "/api/v1/chat/conversations/c1/events?after=nope", nil, "id", "c1")
+	w := newTestResponseRecorder()
+	s.handleChatEvents(w, req)
+	if w.status != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.status)
+	}
+}
+
+func TestHandleChatEvents_Success_200(t *testing.T) {
+	want := []web.Event{{Seq: 1, Type: web.EventText, Text: "hi"}}
+	var gotID string
+	var gotAfter int64
+	api := &mockChatAPI{
+		eventsFunc: func(conversationID string, after int64) []web.Event {
+			gotID = conversationID
+			gotAfter = after
+			return want
+		},
+	}
+	s := newTestServerWithChat(api)
+	req := httpTestRequestWithPathValue(t, http.MethodGet, "/api/v1/chat/conversations/c1/events?after=5", nil, "id", "c1")
+	w := newTestResponseRecorder()
+	s.handleChatEvents(w, req)
+
+	if w.status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.status)
+	}
+	if gotID != "c1" || gotAfter != 5 {
+		t.Errorf("Events called with (%q, %d), want (c1, 5)", gotID, gotAfter)
+	}
+	var resp chatEventsResponse
+	if err := json.Unmarshal(w.body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if resp.ConversationID != "c1" || len(resp.Events) != 1 || resp.Events[0].Text != "hi" {
+		t.Errorf("resp = %+v", resp)
+	}
+}
+
+// --- composed / integration tests: real store + real mux + real routing ---
+
+// TestChatAPI_RoutesAbsentWhenDisabled asserts that when SetChatAPI is never
+// called (adapters.chat.enabled: false, the config-level default), the chat
+// routes are not registered at all — a request 404s like any unknown path
+// rather than 503, so "disabled" and "misconfigured" are distinguishable at
+// the routing layer (see chat.go's SetChatAPI doc comment).
+func TestChatAPI_RoutesAbsentWhenDisabled(t *testing.T) {
+	config := &Config{Host: "127.0.0.1", Port: 19096}
+	authConfig := &AuthConfig{Type: AuthTypeAPIToken, Token: "chat-disabled-secret"}
+	server := NewServerWithAuth(config, authConfig)
+	// SetChatAPI intentionally not called.
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go func() { _ = server.Start(ctx) }()
+	time.Sleep(100 * time.Millisecond)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	baseURL := "http://127.0.0.1:19096"
+
+	postReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/chat/messages",
+		bytes.NewBufferString(`{"conversationId":"c1","text":"hi"}`))
+	postReq.Header.Set("Authorization", "Bearer chat-disabled-secret")
+	postResp, err := client.Do(postReq)
+	if err != nil {
+		t.Fatalf("POST chat/messages: %v", err)
+	}
+	_ = postResp.Body.Close()
+	if postResp.StatusCode != http.StatusNotFound {
+		t.Errorf("POST status = %d, want 404 (route not registered)", postResp.StatusCode)
+	}
+
+	getReq, _ := http.NewRequest(http.MethodGet, baseURL+"/api/v1/chat/conversations/c1/events", nil)
+	getReq.Header.Set("Authorization", "Bearer chat-disabled-secret")
+	getResp, err := client.Do(getReq)
+	if err != nil {
+		t.Fatalf("GET events: %v", err)
+	}
+	_ = getResp.Body.Close()
+	if getResp.StatusCode != http.StatusNotFound {
+		t.Errorf("GET status = %d, want 404 (route not registered)", getResp.StatusCode)
+	}
+}
+
+// chatTestBackend is a fake executor.Backend (GH-4835): it lets the composed
+// test drive a real *executor.Runner end to end (confirmation -> execution ->
+// result) without invoking a real Claude Code subprocess, matching the
+// pattern established by runner_integration_test.go's mockIntegrationBackend.
+type chatTestBackend struct{}
+
+func (b *chatTestBackend) Name() string      { return "chat-test-backend" }
+func (b *chatTestBackend) IsAvailable() bool { return true }
+func (b *chatTestBackend) Execute(ctx context.Context, opts executor.ExecuteOptions) (*executor.BackendResult, error) {
+	return &executor.BackendResult{Success: true, Output: "chat test task done"}, nil
+}
+
+// TestChatAPI_Composed exercises the full GH-4835 acceptance flow on a real
+// HTTP listener: auth enforcement, an operational-query text reply, and a
+// full task confirmation -> execute -> result flow (with a fake executor
+// backend), plus the approvals scope fence (#4748 / GH-4411 / GH-4431).
+func TestChatAPI_Composed(t *testing.T) {
+	backend := &chatTestBackend{}
+	runner := executor.NewRunnerWithBackend(backend)
+	runner.SetRecordingEnabled(false)
+	runner.SetSkipPreflightChecks(true)
+
+	messenger := web.NewMessenger()
+	handler := comms.BuildHandler(comms.HandlerDeps{
+		Messenger:    messenger,
+		Runner:       runner,
+		ProjectPath:  t.TempDir(),
+		TaskIDPrefix: "WEBTEST",
+	})
+	chatAPI := web.NewAPI(handler, messenger)
+
+	config := &Config{Host: "127.0.0.1", Port: 19097}
+	authConfig := &AuthConfig{Type: AuthTypeAPIToken, Token: "chat-composed-secret"}
+	server := NewServerWithAuth(config, authConfig)
+	server.SetChatAPI(chatAPI)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	go func() { _ = server.Start(ctx) }()
+	time.Sleep(100 * time.Millisecond)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	baseURL := "http://127.0.0.1:19097"
+
+	post := func(t *testing.T, body string, auth bool) *http.Response {
+		t.Helper()
+		req, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/chat/messages", bytes.NewBufferString(body))
+		if auth {
+			req.Header.Set("Authorization", "Bearer chat-composed-secret")
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("POST: %v", err)
+		}
+		return resp
+	}
+
+	getEvents := func(t *testing.T, conversationID string, after int64) chatEventsResponse {
+		t.Helper()
+		url := baseURL + "/api/v1/chat/conversations/" + conversationID + "/events"
+		if after > 0 {
+			url += "?after=" + strconv.FormatInt(after, 10)
+		}
+		req, _ := http.NewRequest(http.MethodGet, url, nil)
+		req.Header.Set("Authorization", "Bearer chat-composed-secret")
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("GET events: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET events status = %d, want 200", resp.StatusCode)
+		}
+		var out chatEventsResponse
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			t.Fatalf("decode events: %v", err)
+		}
+		return out
+	}
+
+	// 1. Auth rejected without a bearer token, on both endpoints.
+	noAuthPost := post(t, `{"conversationId":"c1","text":"hi"}`, false)
+	_ = noAuthPost.Body.Close()
+	if noAuthPost.StatusCode != http.StatusUnauthorized {
+		t.Errorf("POST no-auth status = %d, want 401", noAuthPost.StatusCode)
+	}
+	noAuthGetReq, _ := http.NewRequest(http.MethodGet, baseURL+"/api/v1/chat/conversations/c1/events", nil)
+	noAuthGetResp, err := client.Do(noAuthGetReq)
+	if err != nil {
+		t.Fatalf("GET no-auth: %v", err)
+	}
+	_ = noAuthGetResp.Body.Close()
+	if noAuthGetResp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("GET no-auth status = %d, want 401", noAuthGetResp.StatusCode)
+	}
+
+	// 2. Operational-query text message -> 202, and the events poll shows a
+	// text reply (handleOperational -> SendText via formatQueueSummary).
+	opResp := post(t, `{"conversationId":"status-conv","text":"queue status"}`, true)
+	defer func() { _ = opResp.Body.Close() }()
+	if opResp.StatusCode != http.StatusAccepted {
+		t.Fatalf("operational POST status = %d, want 202", opResp.StatusCode)
+	}
+	var opAccept chatMessageResponse
+	if err := json.NewDecoder(opResp.Body).Decode(&opAccept); err != nil {
+		t.Fatalf("decode operational accept body: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	var opEvents chatEventsResponse
+	for time.Now().Before(deadline) {
+		opEvents = getEvents(t, "status-conv", opAccept.Seq)
+		if len(opEvents.Events) > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if len(opEvents.Events) == 0 {
+		t.Fatal("no event landed for operational query")
+	}
+	if opEvents.Events[0].Type != web.EventText {
+		t.Errorf("operational reply type = %q, want text", opEvents.Events[0].Type)
+	}
+
+	// 3. Task-shaped message -> 202, events poll shows a confirmation event.
+	taskConv := "task-conv"
+	taskResp := post(t, `{"conversationId":"`+taskConv+`","text":"build the project"}`, true)
+	defer func() { _ = taskResp.Body.Close() }()
+	if taskResp.StatusCode != http.StatusAccepted {
+		t.Fatalf("task POST status = %d, want 202", taskResp.StatusCode)
+	}
+	var taskAccept chatMessageResponse
+	if err := json.NewDecoder(taskResp.Body).Decode(&taskAccept); err != nil {
+		t.Fatalf("decode task accept body: %v", err)
+	}
+
+	deadline = time.Now().Add(5 * time.Second)
+	var confirmEvents chatEventsResponse
+	for time.Now().Before(deadline) {
+		confirmEvents = getEvents(t, taskConv, taskAccept.Seq)
+		if len(confirmEvents.Events) > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if len(confirmEvents.Events) == 0 {
+		t.Fatal("no confirmation event landed")
+	}
+	confirmEv := confirmEvents.Events[0]
+	if confirmEv.Type != web.EventConfirmation {
+		t.Fatalf("event type = %q, want confirmation", confirmEv.Type)
+	}
+	if confirmEv.TaskID == "" || confirmEv.MessageRef != confirmEv.TaskID {
+		t.Fatalf("confirmation event = %+v, want TaskID set and MessageRef == TaskID", confirmEv)
+	}
+	lastSeq := confirmEv.Seq
+
+	// 4. An approval-shaped callback must be rejected with 400 — approvals do
+	// not route through the chat API (scope fence, #4748 / GH-4411/GH-4431).
+	approvalResp := post(t, `{"conversationId":"`+taskConv+`","isCallback":true,"callbackId":"cb1","actionId":"approve"}`, true)
+	_ = approvalResp.Body.Close()
+	if approvalResp.StatusCode != http.StatusBadRequest {
+		t.Errorf("approval-shaped callback status = %d, want 400", approvalResp.StatusCode)
+	}
+
+	// 5. Execute callback -> 202, then poll until a result event lands;
+	// assert at least one progress event shares the confirmation's messageRef,
+	// and the result carries Success=true with the same messageRef.
+	execResp := post(t, `{"conversationId":"`+taskConv+`","isCallback":true,"callbackId":"execute-cb","actionId":"execute"}`, true)
+	defer func() { _ = execResp.Body.Close() }()
+	if execResp.StatusCode != http.StatusAccepted {
+		t.Fatalf("execute callback status = %d, want 202", execResp.StatusCode)
+	}
+
+	deadline = time.Now().Add(15 * time.Second)
+	var sawProgress bool
+	var resultEv *web.Event
+	for time.Now().Before(deadline) {
+		more := getEvents(t, taskConv, lastSeq)
+		for i := range more.Events {
+			ev := more.Events[i]
+			if ev.Type == web.EventProgress && ev.MessageRef == confirmEv.MessageRef {
+				sawProgress = true
+			}
+			if ev.Type == web.EventResult {
+				e := ev
+				resultEv = &e
+			}
+			if ev.Seq > lastSeq {
+				lastSeq = ev.Seq
+			}
+		}
+		if resultEv != nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if resultEv == nil {
+		t.Fatal("no result event landed after execute callback")
+	}
+	if !sawProgress {
+		t.Error("no progress event with the confirmation's messageRef was observed")
+	}
+	if resultEv.Success == nil || !*resultEv.Success {
+		t.Errorf("result event Success = %v, want true", resultEv.Success)
+	}
+	if resultEv.MessageRef != confirmEv.MessageRef {
+		t.Errorf("result MessageRef = %q, want %q", resultEv.MessageRef, confirmEv.MessageRef)
+	}
+}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -106,6 +106,8 @@ type Server struct {
 	gitGraphPath             string                    // Project path for git graph API (defaults to ".")
 	gitGraphFetcher          GitGraphFetcher           // Injected to avoid import cycle with internal/dashboard
 	decisionRecorder         approval.DecisionRecorder // GH-4748: backs POST /api/v1/approvals/{requestId}/decision
+	chatAPI                  ChatAPI                   // GH-4835: backs the chat routes; nil = routes not registered (adapters.chat.enabled: false)
+	daemonCtx                context.Context           // GH-4835: long-lived ctx stashed by Start(), used to dispatch chat tasks outside the HTTP request lifetime
 }
 
 // Config holds gateway server configuration including network binding options.
@@ -213,6 +215,13 @@ func (s *Server) Start(ctx context.Context) error {
 	s.running = true
 	s.mu.Unlock()
 
+	// Stash the daemon context so chat dispatch (handleChatMessages) can run
+	// task-shaped work past the lifetime of any single HTTP request — see
+	// chat.go's doc comments and the daemonCtx field comment.
+	s.mu.Lock()
+	s.daemonCtx = ctx
+	s.mu.Unlock()
+
 	mux := http.NewServeMux()
 
 	// WebSocket endpoint for control plane
@@ -242,6 +251,18 @@ func (s *Server) Start(ctx context.Context) error {
 	apiMux.HandleFunc("POST /api/v1/approvals/{requestId}/decision", s.handleApprovalDecision)
 	apiMux.HandleFunc("GET /api/v1/executions/{id}/events", s.handleExecutionEvents)
 	apiMux.HandleFunc("GET /api/v1/tasks/{taskId}/events", s.handleTaskEvents)
+
+	// GH-4835: chat routes only exist when a ChatAPI has been wired
+	// (adapters.chat.enabled: true at both daemon construction sites). When
+	// nil, these paths are simply absent from apiMux, so they 404 like any
+	// unmatched route rather than 503ing from inside the handler.
+	s.mu.RLock()
+	chatEnabled := s.chatAPI != nil
+	s.mu.RUnlock()
+	if chatEnabled {
+		apiMux.HandleFunc("POST /api/v1/chat/messages", s.handleChatMessages)
+		apiMux.HandleFunc("GET /api/v1/chat/conversations/{id}/events", s.handleChatEvents)
+	}
 
 	// Apply auth middleware to API routes
 	if s.auth != nil {

--- a/internal/pilot/pilot.go
+++ b/internal/pilot/pilot.go
@@ -19,6 +19,7 @@ import (
 	"github.com/qf-studio/pilot/internal/adapters/plane"
 	"github.com/qf-studio/pilot/internal/adapters/slack"
 	"github.com/qf-studio/pilot/internal/adapters/telegram"
+	"github.com/qf-studio/pilot/internal/adapters/web"
 	"github.com/qf-studio/pilot/internal/alerts"
 	"github.com/qf-studio/pilot/internal/approval"
 	"github.com/qf-studio/pilot/internal/comms"
@@ -66,6 +67,7 @@ type Pilot struct {
 	slackHandler           *slack.Handler                   // Slack Socket Mode handler (GH-652)
 	slackRunner            *executor.Runner                 // Runner for Slack tasks (GH-652)
 	slackMemberResolver    slack.MemberResolver             // Team member resolver for Slack RBAC (GH-786)
+	chatRunner             *executor.Runner                 // Runner for the web chat API's tasks (GH-4835)
 	alertEngine            *alerts.Engine
 	teamsService           *teams.Service // Teams RBAC service (GH-633)
 	store                  *memory.Store
@@ -173,6 +175,20 @@ func WithSlackHandler(runner *executor.Runner, projectPath string) Option {
 func WithSlackMemberResolver(resolver slack.MemberResolver) Option {
 	return func(p *Pilot) {
 		p.slackMemberResolver = resolver
+	}
+}
+
+// WithChatHandler enables the web chat API (console Operator chat panel,
+// GH-4835) in gateway mode. The runner is required to execute tasks
+// dispatched through POST /api/v1/chat/messages; mirrors WithTelegramHandler
+// / WithSlackHandler. Only takes effect when cfg.Adapters.Chat.Enabled is
+// also true — see the wiring block in New().
+func WithChatHandler(runner *executor.Runner, projectPath string) Option {
+	return func(p *Pilot) {
+		p.chatRunner = runner
+		if projectPath != "" && len(p.config.Projects) > 0 {
+			p.config.Projects[0].Path = projectPath
+		}
 	}
 }
 
@@ -787,6 +803,36 @@ func New(cfg *config.Config, opts ...Option) (*Pilot, error) {
 		}
 
 		logging.WithComponent("pilot").Info("Slack handler initialized for gateway mode")
+	}
+
+	// Initialize the web chat API if a runner was provided via options
+	// (GH-4835). Backs the console Operator chat panel: POST
+	// /api/v1/chat/messages and GET
+	// /api/v1/chat/conversations/{id}/events. Must be wired here (gateway
+	// mode) AND in cmd/pilot/main.go (polling mode) — see SetChatAPI's doc
+	// comment in internal/gateway/chat.go; missing either means the routes
+	// silently don't exist in that mode.
+	if p.chatRunner != nil && cfg.Adapters.Chat != nil && cfg.Adapters.Chat.Enabled {
+		projectPath := ""
+		if len(cfg.Projects) > 0 {
+			projectPath = cfg.Projects[0].Path
+		}
+
+		webMessenger := web.NewMessenger()
+		webCommsHandler := comms.BuildHandler(comms.HandlerDeps{
+			Messenger:       webMessenger,
+			Runner:          p.chatRunner,
+			Projects:        config.NewProjectSource(cfg),
+			ProjectPath:     projectPath,
+			RateLimit:       cfg.Adapters.Chat.RateLimit,
+			Store:           p.store,
+			TaskIDPrefix:    "WEB",
+			ExecutorBackend: cfg.Executor,
+		})
+
+		p.gateway.SetChatAPI(web.NewAPI(webCommsHandler, webMessenger))
+
+		logging.WithComponent("pilot").Info("Chat API initialized for gateway mode")
 	}
 
 	return p, nil


### PR DESCRIPTION
## Summary
- Adds `internal/adapters/web` — a fourth `comms.BuildHandler` transport backing a web HTTP chat surface for the console dashboard's Operator chat panel, reusing the same `comms.Handler.HandleMessage` brain Telegram/Slack/Discord already use.
- `WebMessenger` implements `comms.Messenger` via a per-conversation, monotonically seq-numbered in-memory event buffer (`text`/`confirmation`/`progress`/`result`), 500-event cap (drop-oldest) + 1h inactivity expiry, with `messageRef` sharing so progress events can be grouped/replaced in place.
- Gateway routes on `apiMux` (bearer auth inherited): `POST /api/v1/chat/messages` (dispatches on the daemon context, not the request context, so a task-shaped message can run for minutes without blocking the handler) and `GET /api/v1/chat/conversations/{id}/events?after=<seq>`. Registered only when `adapters.chat.enabled` is true.
- Approve/reject-shaped callbacks are rejected with 400 — approvals stay on `POST /api/v1/approvals/{requestId}/decision` (#4748), matching the GH-4411/GH-4431 scope fence; the chat brain has no approval semantics.
- Wired at both gateway construction sites (`cmd/pilot/main.go` polling mode, `internal/pilot/pilot.go` gateway mode) so the API exists in either daemon mode.
- New `adapters.chat` config block (disabled by default) documented in `configs/pilot.example.yaml`.

## Test plan
- [x] `internal/adapters/web`: unit tests for `WebMessenger` (seq ordering, buffer cap drop-oldest, 1h expiry, messageRef sharing/reuse, PRUrl/Success) and `API` (validation errors, approval-callback rejection, accept-time seq, daemon-ctx dispatch).
- [x] `internal/gateway/chat_test.go`: unit-level handler tests (405/400/503/202/200) plus two composed real-HTTP-listener tests — routes absent (404) when `adapters.chat` is disabled, and a full auth + operational-query + task confirmation → execute → progress/result flow driven by a fake `executor.Backend`.
- [x] `go build ./...`
- [x] `go test -race ./...` (all packages pass)
- [x] `make lint` (golangci-lint not installed in this sandbox; command exits 0)