### PR TITLE
GH-4825: fix(autopilot): failure-issue bodies must include the failing lines, not a top-truncated log excerpt

### DIFF
--- a/.agent/tasks/gh-4825.md
+++ b/.agent/tasks/gh-4825.md
@@ -1,0 +1,43 @@
+# GH-4825
+
+**Created:** 2026-08-11
+
+## Problem
+
+GitHub Issue GH-4825: fix(autopilot): failure-issue bodies must include the failing lines, not a top-truncated log excerpt
+
+## Context
+
+The auto-generated `CreateFailureIssue` body for #4820 (spawned after PR#4818's CI-failure close, 2026-08-09) truncated the CI logs **before** the actual failing line — the errcheck finding in `gh4405_test.go:167` WAS present in the run log (`gh run view --log-failed` surfaces it in one grep), but the excerpt embedded in the issue body cut off above it.
+
+The preflight judge caught it (`reject_vague`) and the issue died as an orphan — defense-in-depth worked — but that's the backstop doing the primary's job. The spawned issue's body is the fix executor's **evidence**: an issue whose logs omit the failing line either burns an execution on re-deriving what the spawner already had, or produces a vague fix. This is the TASK-459 evidence-quality invariant applied to the fix-issue spawn path.
+
+Current excerpt machinery (anchors @ main 2026-08-11):
+
+- `internal/autopilot/ci_failure_excerpt.go` — GH-4779-era excerpter; its own doc comment (:25) says the OLD behavior "concatenated whole job logs and then hard-truncated"; it now budgets with `truncateKeepingTail` (:190).
+- `internal/autopilot/feedback_loop.go:67` — `truncateKeepingTail(strings.Join(excerpt, "\n"), maxChars)`; `:344` — `truncateKeepingTail(bundle, maxCIErrorExcerptChars)`; `:459` — 4000-char bound for issue bodies.
+- `internal/autopilot/ci_monitor.go:816` — "Logs are truncated to maxLen total characters to keep issues readable."
+- Spawn site: `internal/autopilot/controller.go:2637` → `feedbackLoop.CreateFailureIssue`.
+
+## Implementation
+
+1. **Audit first**: reproduce how #4820's body lost the errcheck line despite the GH-4779 excerpter existing — identify which path built that body (which of the truncation sites above ran) and why tail-keeping still dropped the failing line (e.g. failing line mid-log with a long tail of teardown noise after it).
+2. **Match-anchored excerpting**: the failure-issue body generator must extract the *specific failing lines* (lint findings, `--- FAIL` test output, compile errors — the grep-able failure markers per check type) and budget the excerpt AROUND those matches (context lines before/after), not from the top or tail of the log. Fall back to current tail-keeping only when no marker matches.
+3. Keep the existing total-size bounds (GitHub body limits, `:459`); the change is what the budget is spent on, not how much.
+4. Apply at every body-building site that feeds `CreateFailureIssue` (the truncation sites above — one fact, one implementation; do not leave a second drifting excerpt path).
+
+## Acceptance
+
+- [ ] Table-driven test: a log where the failing line sits mid-file with long noise after it → generated body contains the failing line (the #4820 shape, e.g. an errcheck finding), within budget.
+- [ ] Test: lint, test-failure, and compile-error marker types each extracted; no-marker log falls back to tail-keeping.
+- [ ] Test: total body stays within the existing size bound.
+- [ ] No second excerpt implementation remains for the fix-issue path (grep-verifiable single call path).
+
+## Refs
+
+- Observed: PR#4818 lint cycle 2026-08-09; orphan #4820 closed 2026-08-10.
+- Recorded: `.agent/system/approval-architecture-roadmap.md` § backlog (2026-08-10 bullets).
+- Related: TASK-459 (evidence contracts — spawning a fix issue burns execution budget) · GH-4779 (`ciFailureConclusions` / excerpter) · #4826 (recovery-owner leg, same incident).
+
+## Acceptance Criteria
+

--- a/internal/autopilot/ci_failure_excerpt.go
+++ b/internal/autopilot/ci_failure_excerpt.go
@@ -9,12 +9,6 @@ import (
 	ghadapter "github.com/qf-studio/pilot/internal/adapters/github"
 )
 
-// failedCheckExcerptMaxLines is how many trailing lines of a failing step's
-// log to keep per check (GH-4460). Large enough to show the actual
-// assertion/panic/compiler-error plus a few lines of surrounding context,
-// without dragging in the job's runner-provisioning preamble.
-const failedCheckExcerptMaxLines = 200
-
 // failedCheckExcerptBudgetChars caps the total size of the multi-check
 // failing-step excerpt bundle embedded in a continuation issue body, so a
 // PR with several failing checks still produces a body comfortably under

--- a/internal/autopilot/ci_failure_excerpt_test.go
+++ b/internal/autopilot/ci_failure_excerpt_test.go
@@ -3,10 +3,12 @@ package autopilot
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	ghadapter "github.com/qf-studio/pilot/internal/adapters/github"
 	"github.com/qf-studio/pilot/internal/testutil"
@@ -193,8 +195,8 @@ func TestCIMonitor_GetFailedCheckExcerpts_FallsBackToAnnotations(t *testing.T) {
 // TestCIMonitor_GetFailedCheckExcerpts_FallsBackToWholeJobWithoutStepLogClient
 // verifies the third fallback tier: when no StepLogClient is wired at all
 // (e.g. an older Controller wiring, or SetStepLogClient was never called),
-// buildFailingStepExcerpt still produces a useful tail — just the whole
-// job's last N lines rather than the isolated failing step.
+// buildFailingStepExcerpt still produces a useful excerpt — match-anchored
+// against the whole job log rather than the isolated failing step.
 func TestCIMonitor_GetFailedCheckExcerpts_FallsBackToWholeJobWithoutStepLogClient(t *testing.T) {
 	server := gh4460NewTestServer(t, []github.CheckRun{
 		{ID: 100, Name: "test", Status: "completed", Conclusion: "failure", DetailsURL: "https://github.com/owner/repo/runs/100"},
@@ -210,10 +212,9 @@ func TestCIMonitor_GetFailedCheckExcerpts_FallsBackToWholeJobWithoutStepLogClien
 	if body == "" {
 		t.Fatal("expected non-empty excerpt body")
 	}
-	// The fixture log is short enough that tailLines(_, 200) keeps everything,
-	// including the preamble — this tier is a fallback, not a fix, for checks
-	// with no wired StepLogClient. What matters is it still surfaces the
-	// actual failure line rather than truncating before reaching it.
+	// This tier is a fallback, not a fix, for checks with no wired
+	// StepLogClient. What matters is it still surfaces the actual failure
+	// line rather than truncating before reaching it.
 	if !strings.Contains(body, "TestForecastMonthlyBurn") {
 		t.Errorf("expected whole-job tail to still include the failure, got:\n%s", body)
 	}
@@ -370,4 +371,85 @@ func TestSliceLogByStepWindow(t *testing.T) {
 			t.Error("expected false when step has no StartedAt/CompletedAt")
 		}
 	})
+}
+
+// TestCIMonitor_GetFailedCheckExcerpts_MidStepFailureSurvivesNoise covers
+// GH-4825 in the step-log tier specifically (buildFailingStepExcerpt's
+// "step" source — the common production path when a StepLogClient is
+// wired): a failing step's own log can keep emitting output well past the
+// actual failure line (more lint findings, cleanup noise). A plain
+// last-N-lines tail on the step window would drop the failure entirely;
+// this verifies GetFailedCheckExcerpts survives it end-to-end via
+// match-anchored extraction.
+func TestCIMonitor_GetFailedCheckExcerpts_MidStepFailureSurvivesNoise(t *testing.T) {
+	const failingLine = "internal/executor/gh4405_test.go:167:2: Error return value of `w.Write` is not checked (errcheck)"
+
+	stepStart, err := time.Parse(time.RFC3339Nano, "2026-08-09T10:00:05.0000000Z")
+	if err != nil {
+		t.Fatalf("failed to parse fixture step start: %v", err)
+	}
+	ts := func(offsetMillis int) string {
+		return stepStart.Add(time.Duration(offsetMillis) * time.Millisecond).Format("2006-01-02T15:04:05.0000000Z")
+	}
+
+	var logBuilder strings.Builder
+	logBuilder.WriteString("2026-08-09T10:00:00.0000000Z Current runner version: '2.319.1'\n")
+	logBuilder.WriteString("2026-08-09T10:00:00.1000000Z Runner Image Provisioner\n")
+	fmt.Fprintf(&logBuilder, "%s ##[group]Run golangci-lint run\n", ts(0))
+	for i := 1; i <= 30; i++ {
+		fmt.Fprintf(&logBuilder, "%s golangci-lint: checking package %d\n", ts(i), i)
+	}
+	fmt.Fprintf(&logBuilder, "%s %s\n", ts(31), failingLine)
+	for i := 32; i <= 431; i++ {
+		fmt.Fprintf(&logBuilder, "%s post-lint noise line %d\n", ts(i), i)
+	}
+	fmt.Fprintf(&logBuilder, "%s ##[error]Process completed with exit code 1.\n", ts(432))
+	jobLog := logBuilder.String()
+
+	steps := []ghadapter.JobStep{
+		{Name: "Set up job", Status: "completed", Conclusion: "success", Number: 1,
+			StartedAt: "2026-08-09T10:00:00.0000000Z", CompletedAt: "2026-08-09T10:00:04.9000000Z"},
+		{Name: "Run golangci-lint run", Status: "completed", Conclusion: "failure", Number: 2,
+			StartedAt: ts(0), CompletedAt: ts(432)},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/commits/abc123/check-runs":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{ID: 200, Name: "lint", Status: "completed", Conclusion: "failure", DetailsURL: "https://github.com/owner/repo/runs/200"},
+				},
+			})
+		case "/repos/owner/repo/actions/jobs/200/logs":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(jobLog))
+		case "/repos/owner/repo/actions/jobs/200":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(ghadapter.WorkflowJob{ID: 200, Name: "lint", Status: "completed", Steps: steps})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	sdkClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	adapterClient := ghadapter.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	monitor := NewCIMonitor(sdkClient, "owner", "repo", DefaultConfig())
+	monitor.SetStepLogClient(adapterClient)
+
+	body := monitor.GetFailedCheckExcerpts(context.Background(), "abc123")
+
+	if !strings.Contains(body, failingLine) {
+		t.Errorf("expected the mid-step errcheck finding to survive, got:\n%s", body)
+	}
+	if strings.Contains(body, "Current runner version") {
+		t.Errorf("excerpt should not contain runner-setup preamble, got:\n%s", body)
+	}
+	if len(body) > failedCheckExcerptBudgetChars+len(ciExcerptSentinel) {
+		t.Errorf("body length = %d, want <= %d", len(body), failedCheckExcerptBudgetChars+len(ciExcerptSentinel))
+	}
 }

--- a/internal/autopilot/ci_monitor.go
+++ b/internal/autopilot/ci_monitor.go
@@ -1029,7 +1029,14 @@ func (m *CIMonitor) buildFailingStepExcerpt(ctx context.Context, run github.Chec
 			if jobLog, logErr := m.ghClient.GetJobLogs(ctx, m.owner, m.repo, run.ID); logErr == nil {
 				if window, ok := sliceLogByStepWindow(jobLog, step); ok {
 					excerpt.StepName = step.Name
-					excerpt.Tail = tailLines(window, failedCheckExcerptMaxLines)
+					// GH-4825: match-anchored extraction, not a plain tail
+					// cut — a failing step's own log can still run long
+					// after the actual failure line (more lint findings,
+					// cleanup output), which a tail-only cut would drop.
+					// AssembleFailureExcerptsBody applies the final
+					// even-split char budget across checks below, so this
+					// pre-budget here is deliberately generous.
+					excerpt.Tail = extractFailureExcerpt(window, failedCheckExcerptBudgetChars)
 					excerpt.Source = "step"
 					return excerpt
 				}
@@ -1052,13 +1059,15 @@ func (m *CIMonitor) buildFailingStepExcerpt(ctx context.Context, run github.Chec
 		}
 	}
 
-	// Fallback: whole job log, tail only (still better than head-of-log).
+	// Fallback: whole job log, match-anchored (still better than
+	// head-of-log, and better than a plain tail cut — see the "step" tier
+	// above, GH-4825).
 	jobLog, err := m.ghClient.GetJobLogs(ctx, m.owner, m.repo, run.ID)
 	if err != nil {
 		m.log.Warn("failed to fetch logs for check run", "check", run.Name, "id", run.ID, "error", err)
 		return excerpt
 	}
-	excerpt.Tail = tailLines(jobLog, failedCheckExcerptMaxLines)
+	excerpt.Tail = extractFailureExcerpt(jobLog, failedCheckExcerptBudgetChars)
 	excerpt.Source = "job"
 	return excerpt
 }

--- a/internal/autopilot/feedback_loop.go
+++ b/internal/autopilot/feedback_loop.go
@@ -14,11 +14,31 @@ import (
 	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 )
 
-// ciFailureExcerptRe matches the start of an actionable CI failure: a Go test
-// failure header, a panic, or a GitHub Actions error annotation. These lines
-// are typically prefixed by a runner timestamp, so the patterns are not
-// anchored to line start.
-var ciFailureExcerptRe = regexp.MustCompile(`--- FAIL:|panic:|##\[error\]`)
+// failureMarkerRes are the patterns used to locate actionable failure lines
+// within a raw CI log, one per category of failure (GH-4825). Each is
+// checked independently against every line so a log carrying only, say,
+// lint findings (no Go test failure marker at all) still gets accurate
+// match-anchored windows instead of falling through to a blind tail cut.
+var failureMarkerRes = []*regexp.Regexp{
+	// Go test failures/panics, plus the trailing per-package summary line
+	// `go test` prints (`FAIL\t<pkg>\t<duration>`) — kept as its own marker
+	// because on a large panic dump it can sit far enough past the "panic:"
+	// line that a single shared context window wouldn't reach it.
+	regexp.MustCompile(`--- FAIL:|panic:|^FAIL\t`),
+	// GitHub Actions error annotations: the runner's own `##[error]`
+	// workflow command, and the `::error ...::` form tools emit when
+	// configured for GitHub Actions output (e.g. golangci-lint's
+	// --out-format=github-actions).
+	regexp.MustCompile(`##\[error\]|::error\b`),
+	// Compiler, `go vet`, and linter findings: `path/to/file.go:LINE:COL:
+	// message` — the shared output shape for `go build` errors and
+	// golangci-lint's default text output (errcheck, staticcheck, ...).
+	// GH-4825: this marker was missing entirely, so an errcheck finding
+	// with no `--- FAIL:`/`panic:`/`##[error]` anywhere near it fell
+	// through to the no-marker tail fallback and was silently dropped
+	// whenever it wasn't within the trailing N lines of the log.
+	regexp.MustCompile(`\S+\.go:\d+:\d+:`),
+}
 
 // maxCIErrorExcerptChars caps the size of the CI Error Logs section embedded
 // in fix-request issue bodies to stay well within GitHub's issue body limit.
@@ -28,43 +48,88 @@ const maxCIErrorExcerptChars = 4000
 // failure marker is found in the log (e.g. plain build/lint output).
 const ciFailureExcerptFallbackLines = 150
 
-// extractFailureExcerpt returns the actionable slice of CI logs to embed in a
-// fix-request issue body: from the first failure marker onward (this
-// naturally includes the trailing `FAIL <pkg>` summary since it always
-// follows the failure in a Go test log), or the last N lines when no marker
-// is found.
+// failureExcerptContextLines is how many lines of surrounding context to
+// keep before and after each matched failure-marker line.
+const failureExcerptContextLines = 5
+
+// extractFailureExcerpt returns the actionable slice of CI logs to embed in
+// a fix-request issue body: a window of context around every line matching
+// an actionable failure marker (test failure, panic, GH Actions error
+// annotation, or a compiler/lint finding), merged in log order, or the last
+// N lines when no marker is found anywhere in the log.
 //
 // GH-3958: excerpting from the head of the log only captured GitHub Actions
 // runner-provisioning preamble ("Current runner version", "Runner Image
 // Provisioner"...) and never the actual failure, which sits near the end of
-// the log. Every auto-generated fix issue self-rejected as vague as a result.
+// the log.
+//
+// GH-4825: a single "first marker to end of log" cut (the GH-3958 fix) still
+// dropped the failing line when it sat mid-log with a long tail of
+// unrelated output after it (further lint findings, teardown/cache-save
+// logs) — the char-budget truncation then cut through the middle of that
+// tail, discarding the failure before the resulting excerpt even reached
+// it. Match-anchored windows fix this by keeping only the content around
+// each actionable line, regardless of how much unrelated log follows it.
 func extractFailureExcerpt(logs string, maxChars int) string {
 	lines := strings.Split(logs, "\n")
 
-	start := -1
+	var matched []int
 	for i, line := range lines {
-		if ciFailureExcerptRe.MatchString(line) {
-			start = i
-			break
+		for _, re := range failureMarkerRes {
+			if re.MatchString(line) {
+				matched = append(matched, i)
+				break
+			}
 		}
 	}
 
-	var excerpt []string
-	switch {
-	case start >= 0:
-		if start > 3 {
-			start -= 3 // small lead-in context before the failure marker
-		} else {
+	if len(matched) == 0 {
+		return truncateKeepingTail(tailLines(logs, ciFailureExcerptFallbackLines), maxChars)
+	}
+
+	windows := mergeMatchWindows(matched, len(lines), failureExcerptContextLines)
+
+	blocks := make([]string, len(windows))
+	for i, w := range windows {
+		blocks[i] = strings.Join(lines[w[0]:w[1]], "\n")
+	}
+
+	return truncateKeepingTail(strings.Join(blocks, "\n...\n"), maxChars)
+}
+
+// mergeMatchWindows expands each matched line index into a
+// [idx-context, idx+context+1) window clamped to [0, total), then merges
+// overlapping/adjacent windows so a run of nearby failure lines (e.g.
+// several lint findings in the same file, or a failure marker plus its
+// trailing summary line) collapses into one contiguous block instead of
+// duplicating their shared context. matched must be in ascending order,
+// which the single top-to-bottom scan in extractFailureExcerpt guarantees.
+func mergeMatchWindows(matched []int, total, context int) [][2]int {
+	windows := make([][2]int, len(matched))
+	for i, idx := range matched {
+		start := idx - context
+		if start < 0 {
 			start = 0
 		}
-		excerpt = lines[start:]
-	case len(lines) > ciFailureExcerptFallbackLines:
-		excerpt = lines[len(lines)-ciFailureExcerptFallbackLines:]
-	default:
-		excerpt = lines
+		end := idx + context + 1
+		if end > total {
+			end = total
+		}
+		windows[i] = [2]int{start, end}
 	}
 
-	return truncateKeepingTail(strings.Join(excerpt, "\n"), maxChars)
+	merged := windows[:1]
+	for _, w := range windows[1:] {
+		last := &merged[len(merged)-1]
+		if w[0] <= last[1] {
+			if w[1] > last[1] {
+				last[1] = w[1]
+			}
+			continue
+		}
+		merged = append(merged, w)
+	}
+	return merged
 }
 
 // truncateKeepingTail caps s to maxChars while preserving both ends: the

--- a/internal/autopilot/feedback_loop_test.go
+++ b/internal/autopilot/feedback_loop_test.go
@@ -1396,6 +1396,183 @@ func TestExtractFailureExcerpt_OversizedExcerptKeepsTrailingSummary(t *testing.T
 	}
 }
 
+// TestExtractFailureExcerpt_MidLogFailureNoise covers GH-4825: the errcheck
+// finding that spawned orphan issue #4820 sat mid-log with hundreds of
+// unrelated lines after it (further lint output, GH Actions post-job
+// noise). The GH-3958 "first marker to end of log, then char-truncate"
+// strategy still dropped it — the char truncation cut through the middle of
+// that trailing noise before the excerpt ever re-reached the failure.
+// Match-anchored windows must keep the failing line regardless of how much
+// unrelated log follows it.
+func TestExtractFailureExcerpt_MidLogFailureNoise(t *testing.T) {
+	var sb strings.Builder
+	for i := 1; i <= 50; i++ {
+		fmt.Fprintf(&sb, "golangci-lint: analyzing package %d\n", i)
+	}
+	const failingLine = "internal/executor/gh4405_test.go:167:2: Error return value of `w.Write` is not checked (errcheck)"
+	sb.WriteString(failingLine + "\n")
+	for i := 1; i <= 500; i++ {
+		fmt.Fprintf(&sb, "##[endgroup]\nPost job cleanup.\ncache saved successfully (entry %d)\n", i)
+	}
+	logs := sb.String()
+
+	excerpt := extractFailureExcerpt(logs, maxCIErrorExcerptChars)
+
+	if !strings.Contains(excerpt, failingLine) {
+		t.Errorf("excerpt missing the mid-log errcheck finding (#4820 shape), excerpt:\n%s", excerpt)
+	}
+	if len(excerpt) > maxCIErrorExcerptChars+len("\n... (truncated) ...\n") {
+		t.Errorf("excerpt length %d exceeds budget %d", len(excerpt), maxCIErrorExcerptChars)
+	}
+}
+
+// TestExtractFailureExcerpt_MarkerTypes verifies each actionable failure
+// marker category (lint finding, go test failure, compiler error) is
+// extracted with its surrounding context, and that a log with no
+// recognizable marker at all falls back to the trailing-lines behavior
+// (GH-4825).
+func TestExtractFailureExcerpt_MarkerTypes(t *testing.T) {
+	preamble := strings.Repeat("Current runner version: '2.319.1'\nRunner Image Provisioner\n", 20)
+	// Buffer of neutral lines between the preamble and the failing line so
+	// the failure's context window (failureExcerptContextLines) can't reach
+	// back into the preamble text itself.
+	buffer := strings.Repeat("=== RUN   TestSomethingUnrelated\n--- PASS: TestSomethingUnrelated (0.00s)\n", 10)
+	trailingNoise := strings.Repeat("unrelated log output after the failure\n", 300)
+
+	tests := []struct {
+		name        string
+		failingLine string
+		wantContain string
+	}{
+		{
+			name:        "lint finding (errcheck)",
+			failingLine: "internal/foo/bar.go:42:2: Error return value of `f.Close` is not checked (errcheck)",
+			wantContain: "bar.go:42:2: Error return value of `f.Close` is not checked (errcheck)",
+		},
+		{
+			name:        "go test failure",
+			failingLine: "--- FAIL: TestBar (0.01s)",
+			wantContain: "--- FAIL: TestBar (0.01s)",
+		},
+		{
+			name:        "compile error",
+			failingLine: "internal/foo/baz.go:10:5: undefined: someUndefinedFunc",
+			wantContain: "baz.go:10:5: undefined: someUndefinedFunc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logs := preamble + buffer + tt.failingLine + "\n" + trailingNoise
+			excerpt := extractFailureExcerpt(logs, maxCIErrorExcerptChars)
+			if !strings.Contains(excerpt, tt.wantContain) {
+				t.Errorf("excerpt missing %q, excerpt:\n%s", tt.wantContain, excerpt)
+			}
+			if strings.Contains(excerpt, "Current runner version") {
+				t.Errorf("excerpt should not contain runner preamble, excerpt:\n%s", excerpt)
+			}
+		})
+	}
+
+	t.Run("no marker falls back to trailing lines", func(t *testing.T) {
+		var sb strings.Builder
+		for i := 1; i <= 300; i++ {
+			fmt.Fprintf(&sb, "plain build output line %d\n", i)
+		}
+		excerpt := extractFailureExcerpt(sb.String(), maxCIErrorExcerptChars)
+		if !strings.Contains(excerpt, "plain build output line 300") {
+			t.Errorf("expected fallback tail to include the last line, excerpt:\n%s", excerpt)
+		}
+		if !strings.Contains(excerpt, "plain build output line 152") {
+			t.Errorf("expected fallback tail to cover ciFailureExcerptFallbackLines, excerpt:\n%s", excerpt)
+		}
+		if strings.Contains(excerpt, "plain build output line 1\n") {
+			t.Errorf("fallback tail should not reach back to line 1, excerpt:\n%s", excerpt)
+		}
+	})
+}
+
+// TestExtractFailureExcerpt_ManyMatchesStayWithinBudget verifies that a log
+// with many failure-marker matches (e.g. a lint job reporting dozens of
+// findings) still respects maxChars in the concatenated result — matches
+// windows can't add up to an unbounded body just because there were many of
+// them.
+func TestExtractFailureExcerpt_ManyMatchesStayWithinBudget(t *testing.T) {
+	var sb strings.Builder
+	for i := 1; i <= 400; i++ {
+		fmt.Fprintf(&sb, "internal/pkg%d/file.go:%d:2: Error return value is not checked (errcheck)\n", i, i)
+		sb.WriteString(strings.Repeat("unrelated build noise\n", 5))
+	}
+
+	excerpt := extractFailureExcerpt(sb.String(), maxCIErrorExcerptChars)
+
+	if len(excerpt) > maxCIErrorExcerptChars+len("\n... (truncated) ...\n") {
+		t.Errorf("excerpt length %d exceeds budget %d", len(excerpt), maxCIErrorExcerptChars)
+	}
+}
+
+// TestFeedbackLoop_CreateFailureIssue_MidLogErrcheckSurvives is the GH-4825
+// end-to-end regression: an errcheck finding sitting mid-log with a long
+// tail of unrelated noise after it (the #4820 shape) must survive into the
+// generated fix-issue body, and the body must stay within the existing size
+// bound.
+func TestFeedbackLoop_CreateFailureIssue_MidLogErrcheckSurvives(t *testing.T) {
+	capturedBody := ""
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/issues" && r.Method == "POST" {
+			var input github.IssueInput
+			_ = json.NewDecoder(r.Body).Decode(&input)
+			capturedBody = input.Body
+
+			resp := github.Issue{Number: 201}
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+
+	fl := NewFeedbackLoop(ghClient, "owner", "repo", cfg)
+
+	var sb strings.Builder
+	for i := 1; i <= 60; i++ {
+		fmt.Fprintf(&sb, "golangci-lint: checking package %d\n", i)
+	}
+	const failingLine = "internal/executor/gh4405_test.go:167:2: Error return value of `w.Write` is not checked (errcheck)"
+	sb.WriteString(failingLine + "\n")
+	for i := 1; i <= 400; i++ {
+		fmt.Fprintf(&sb, "post-lint noise line %d\n", i)
+	}
+	logs := sb.String()
+
+	prState := &PRState{PRNumber: 43, HeadSHA: "def5678"}
+
+	_, err := fl.CreateFailureIssue(
+		context.Background(),
+		prState,
+		FailureCIPreMerge,
+		[]string{"lint"},
+		logs,
+		0,
+	)
+	if err != nil {
+		t.Fatalf("CreateFailureIssue() error = %v", err)
+	}
+
+	if !strings.Contains(capturedBody, failingLine) {
+		t.Error("body should contain the mid-log errcheck finding (#4820 shape); truncation dropped it before ever reaching it")
+	}
+	const maxIssueBodyChars = 65536 // GitHub issue-body limit
+	if len(capturedBody) > maxIssueBodyChars {
+		t.Errorf("body length %d exceeds GitHub's issue-body limit %d", len(capturedBody), maxIssueBodyChars)
+	}
+}
+
 func mustFLJSON(t *testing.T, v any) []byte {
 	t.Helper()
 	b, err := json.Marshal(v)


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4825.

Closes #4825

## Changes

GitHub Issue GH-4825: fix(autopilot): failure-issue bodies must include the failing lines, not a top-truncated log excerpt

## Context

The auto-generated `CreateFailureIssue` body for #4820 (spawned after PR#4818's CI-failure close, 2026-08-09) truncated the CI logs **before** the actual failing line — the errcheck finding in `gh4405_test.go:167` WAS present in the run log (`gh run view --log-failed` surfaces it in one grep), but the excerpt embedded in the issue body cut off above it.

The preflight judge caught it (`reject_vague`) and the issue died as an orphan — defense-in-depth worked — but that's the backstop doing the primary's job. The spawned issue's body is the fix executor's **evidence**: an issue whose logs omit the failing line either burns an execution on re-deriving what the spawner already had, or produces a vague fix. This is the TASK-459 evidence-quality invariant applied to the fix-issue spawn path.

Current excerpt machinery (anchors @ main 2026-08-11):

- `internal/autopilot/ci_failure_excerpt.go` — GH-4779-era excerpter; its own doc comment (:25) says the OLD behavior "concatenated whole job logs and then hard-truncated"; it now budgets with `truncateKeepingTail` (:190).
- `internal/autopilot/feedback_loop.go:67` — `truncateKeepingTail(strings.Join(excerpt, "\n"), maxChars)`; `:344` — `truncateKeepingTail(bundle, maxCIErrorExcerptChars)`; `:459` — 4000-char bound for issue bodies.
- `internal/autopilot/ci_monitor.go:816` — "Logs are truncated to maxLen total characters to keep issues readable."
- Spawn site: `internal/autopilot/controller.go:2637` → `feedbackLoop.CreateFailureIssue`.

## Implementation

1. **Audit first**: reproduce how #4820's body lost the errcheck line despite the GH-4779 excerpter existing — identify which path built that body (which of the truncation sites above ran) and why tail-keeping still dropped the failing line (e.g. failing line mid-log with a long tail of teardown noise after it).
2. **Match-anchored excerpting**: the failure-issue body generator must extract the *specific failing lines* (lint findings, `--- FAIL` test output, compile errors — the grep-able failure markers per check type) and budget the excerpt AROUND those matches (context lines before/after), not from the top or tail of the log. Fall back to current tail-keeping only when no marker matches.
3. Keep the existing total-size bounds (GitHub body limits, `:459`); the change is what the budget is spent on, not how much.
4. Apply at every body-building site that feeds `CreateFailureIssue` (the truncation sites above — one fact, one implementation; do not leave a second drifting excerpt path).

## Acceptance

- [ ] Table-driven test: a log where the failing line sits mid-file with long noise after it → generated body contains the failing line (the #4820 shape, e.g. an errcheck finding), within budget.
- [ ] Test: lint, test-failure, and compile-error marker types each extracted; no-marker log falls back to tail-keeping.
- [ ] Test: total body stays within the existing size bound.
- [ ] No second excerpt implementation remains for the fix-issue path (grep-verifiable single call path).

## Refs

- Observed: PR#4818 lint cycle 2026-08-09; orphan #4820 closed 2026-08-10.
- Recorded: `.agent/system/approval-architecture-roadmap.md` § backlog (2026-08-10 bullets).
- Related: TASK-459 (evidence contracts — spawning a fix issue burns execution budget) · GH-4779 (`ciFailureConclusions` / excerpter) · #4826 (recovery-owner leg, same incident).