### PR TITLE
GH-4826: fix(autopilot): CI-failure close arms both fix-issue and source-retry chains — no designated recovery owner

### DIFF
--- a/.agent/tasks/gh-4826.md
+++ b/.agent/tasks/gh-4826.md
@@ -1,0 +1,44 @@
+# GH-4826
+
+**Created:** 2026-08-11
+
+## Problem
+
+GitHub Issue GH-4826: fix(autopilot): CI-failure close arms both fix-issue and source-retry chains — no designated recovery owner
+
+## Context
+
+After the CI-failure close of PR#4818 (2026-08-09), BOTH recovery paths armed simultaneously:
+
+- the fix-issue chain (#4820, spawned by `CreateFailureIssue`), and
+- the source-issue retry chain (#4817 unmarked → retry generation → PR#4821).
+
+GH-3806's `TerminalLabel` mechanism exists precisely to designate a follow-up issue as the retry owner (mark the source terminal so it isn't re-queued while a follow-up owns the work), but it didn't fire on this path — the close handler spawned the fix issue without marking the source, so two executors could have raced the same failure. Benign this time only because preflight `reject_vague`-ed #4820; a fix-issue vs source-retry pair has different task keys, so TASK-407's admission claim cannot catch it (that guard is same-task only).
+
+Anchors (@ main 2026-08-11):
+
+- `internal/autopilot/controller.go:2419` — `handleCIFailed` ("creates fix issue via feedback loop"); spawn at `:2637` → `feedbackLoop.CreateFailureIssue`.
+- `prState.TerminalLabel` set sites: `controller.go:2581, 2707, 2964, 3030` (LabelFailed), `:5375` (LabelSuperseded); poller-side respect at `:7269-7288`.
+- GH-3806: the designating mechanism this path failed to invoke.
+
+## Implementation
+
+1. Map the CI-failure close ladder in `handleCIFailed` + its callees: for each branch that reaches `CreateFailureIssue`, determine what currently marks (or fails to mark) the source issue/PR terminal, and which branches leave the source eligible for retry re-queue.
+2. Enforce single ownership at the spawn point: when `CreateFailureIssue` succeeds, the source must be marked terminal (fix issue owns recovery); when no fix issue is spawned, the source retry chain owns it. The choice may stay class-dependent (infra vs code per the TASK-459 verdicts) — but **simultaneous arming must be structurally impossible at the call site**, not dependent on preflight rejecting the fix issue.
+3. Wire the invariant where the spawn happens (one seam), not per-branch — a new branch added later must inherit exclusivity by construction.
+
+## Acceptance
+
+- [ ] Test reproducing the #4818 shape: CI-failure close spawns a fix issue → source issue is marked terminal and the retry path declines to re-queue it (assert through recorded state, not a mock echo).
+- [ ] Test: failure class where no fix issue is spawned → source retry chain remains armed; no terminal mark.
+- [ ] Test: `CreateFailureIssue` dedup/budget-decline path (returns without spawning) → source retry stays armed (no orphaned "both disarmed" state either — exactly one owner in every branch).
+- [ ] Grep/structural check or test asserting the exclusivity lives at the spawn seam, not duplicated per branch.
+
+## Refs
+
+- Observed: PR#4818 → #4820 + #4817-retry, 2026-08-09; #4820 closed as orphan 2026-08-10.
+- Recorded: `.agent/system/approval-architecture-roadmap.md` § backlog (2026-08-10 bullets).
+- Related: GH-3806 (TerminalLabel) · TASK-407 (admission claim — same-task only) · TASK-459 (fix-issue spawn is budget-burning) · #4825 (evidence leg, same incident).
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2432,6 +2432,41 @@ func ciFailedChecksSummary(failedChecks []string) string {
 	return fmt.Sprintf("CI checks failed (%s)", strings.Join(failedChecks, ", "))
 }
 
+// spawnFailureIssue is the single seam through which every CI-failure rung
+// (pre-merge handleCIFailed and post-merge handlePostMergeCI today; any
+// future rung tomorrow) must create a continuation fix issue via
+// c.feedbackLoop.CreateFailureIssue. GH-4826: the incident behind this
+// function was PR#4818's CI-failure close arming BOTH recovery paths at
+// once — the spawned fix issue (#4820) AND the source issue's own
+// pilot-retry-ready re-queue (#4817 → PR#4821) — because the branch that
+// spawned the fix issue was trusted to also remember to mark the source
+// terminal, and a sibling branch (the post-merge rung) did not. Centralizing
+// the ownership decision here, at the one place CreateFailureIssue is ever
+// called, means a call site inherits exclusivity by construction instead of
+// having to remember it on its own:
+//
+//   - CreateFailureIssue succeeds (issueNum > 0, err == nil): the fix issue
+//     now owns recovery — prState.TerminalLabel is set to github.LabelFailed
+//     so notifyExternalClose (GH-3806) marks the source issue pilot-failed
+//     instead of pilot-retry-ready, and it is never re-queued alongside the
+//     fix issue that already continues the work.
+//   - CreateFailureIssue declines or fails (dedup/budget claim in flight,
+//     GH-4307; or a transient create error): no fix issue exists to own the
+//     work, so prState.TerminalLabel is left untouched — the source retry
+//     chain remains the sole owner. Exactly one owner in every branch, never
+//     both, never neither.
+//
+// Callers keep their own branching on the returned (issueNum, err) for
+// messaging/comments/escalation — this seam only owns the TerminalLabel
+// decision, so a caller cannot accidentally skip it.
+func (c *Controller) spawnFailureIssue(ctx context.Context, prState *PRState, failureType FailureType, failedChecks []string, logs string, iteration int) (int, error) {
+	issueNum, err := c.feedbackLoop.CreateFailureIssue(ctx, prState, failureType, failedChecks, logs, iteration)
+	if err == nil && issueNum > 0 {
+		prState.TerminalLabel = github.LabelFailed
+	}
+	return issueNum, err
+}
+
 func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error {
 	// GH-4533: classify the failure as code vs. CI infrastructure outage
 	// before doing anything else. An infra-classified failure with retry
@@ -2634,7 +2669,7 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 	// continuation issue body is self-contained enough to pass preflight.
 	ciLogs := c.ciMonitor.GetFailedCheckExcerpts(ctx, prState.HeadSHA)
 
-	issueNum, err := c.feedbackLoop.CreateFailureIssue(ctx, prState, FailureCIPreMerge, failedChecks, ciLogs, iteration+1)
+	issueNum, err := c.spawnFailureIssue(ctx, prState, FailureCIPreMerge, failedChecks, ciLogs, iteration+1)
 	// GH-4459: the PR must never be closed unless the continuation fix issue
 	// actually cleared preflight admission — CreateFailureIssue's dedup guard
 	// can legitimately return (0, nil) when a claim is in flight but not yet
@@ -2697,14 +2732,14 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 		}
 	}
 
-	// GH-3806: name the reason (and the follow-up issue that now owns this work)
-	// so notifyExternalClose can post the audit-trail comments and mark this
-	// issue pilot-failed instead of leaving it stranded on a stale label — the
-	// fix issue created above carries the retry forward, so this issue must not
-	// also be re-queued (that would double-dispatch the same failure).
+	// GH-3806/GH-4826: name the reason (and the follow-up issue that now owns
+	// this work) so notifyExternalClose can post the audit-trail comments and
+	// mark this issue pilot-failed instead of leaving it stranded on a stale
+	// label. prState.TerminalLabel itself was already set by spawnFailureIssue
+	// above the moment CreateFailureIssue succeeded — it is not set here, so
+	// this rung cannot forget it the way the post-merge rung once did.
 	prState.Stage = StageFailed
 	prState.Error = fmt.Sprintf("%s; fix issue #%d created to continue this work%s", ciFailedChecksSummary(failedChecks), issueNum, infraNote)
-	prState.TerminalLabel = github.LabelFailed
 	c.metrics.RecordPRFailed()
 	c.metrics.RecordPRFailedClass(failureClass)
 	c.recordCIFailVerdict(failureClass)
@@ -4237,7 +4272,15 @@ func (c *Controller) handlePostMergeCI(ctx context.Context, prState *PRState) er
 		}
 
 		if !skipSpawn {
-			issueNum, issueErr := c.feedbackLoop.CreateFailureIssue(ctx, prState, FailureCIPostMerge, failedChecks, ciLogs, iteration+1)
+			// GH-4826: route through the shared spawnFailureIssue seam rather
+			// than calling feedbackLoop.CreateFailureIssue directly — this rung
+			// is the one that used to leave prState.TerminalLabel unset even on
+			// a successful spawn. The original issue is normally already closed
+			// by handleMerging before a PR can ever reach StagePostMergeCI, so
+			// notifyExternalClose's label write is a no-op here today, but this
+			// rung must still not be the one branch that forgets the invariant
+			// if that ever changes.
+			issueNum, issueErr := c.spawnFailureIssue(ctx, prState, FailureCIPostMerge, failedChecks, ciLogs, iteration+1)
 			if issueErr != nil {
 				c.log.Error("failed to create post-merge fix issue", "error", issueErr)
 			} else {

--- a/internal/autopilot/gh4826_test.go
+++ b/internal/autopilot/gh4826_test.go
@@ -1,0 +1,368 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	ghadapter "github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GH-4826: after the CI-failure close of PR#4818, BOTH recovery paths armed
+// simultaneously — the spawned fix issue (#4820) AND the source issue's own
+// pilot-retry-ready re-queue (#4817 -> PR#4821) — because the branch that
+// spawned the fix issue was trusted to also remember to mark the source
+// terminal. The fix centralizes that decision in spawnFailureIssue
+// (controller.go), the single seam through which every CreateFailureIssue
+// call must pass. These tests exercise the seam's three possible outcomes
+// plus a structural check that the exclusivity isn't duplicated per branch.
+
+// TestGH4826_SpawnSuccess_MarksSourceTerminal_NotRetryReady reproduces the
+// #4818 shape: a CI-failure close that successfully spawns a fix issue must
+// mark the source issue terminal (TerminalLabel) so the retry path declines
+// to re-queue it. Assertion goes through recorded controller state
+// (prState.TerminalLabel) and, downstream, the literal label written to the
+// source issue by notifyExternalClose — not a mock call-count echo.
+func TestGH4826_SpawnSuccess_MarksSourceTerminal_NotRetryReady(t *testing.T) {
+	const codeLog = `Run golangci-lint run ./...
+internal/autopilot/controller.go:1234:6: Error return value of c.ghClient.ClosePullRequest is not checked (errcheck)
+##[error]Process completed with exit code 1.`
+
+	issueCreated := false
+	prClosed := false
+	var issueLabelsAdded []string
+	var issueLabelsRemoved []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/gh4826sha1/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{ID: 301, Name: "lint", Status: "completed", Conclusion: "failure"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/actions/jobs/301/logs":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(codeLog))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			issueCreated = true
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, github.Issue{Number: 4820}))
+		case r.URL.Path == "/repos/owner/repo/pulls/4818" && r.Method == http.MethodPatch:
+			prClosed = true
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/repos/owner/repo/issues/4817" && r.Method == http.MethodGet:
+			// Source issue is still open when notifyExternalClose looks it up.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, github.Issue{Number: 4817, State: github.StateOpen}))
+		case r.URL.Path == "/repos/owner/repo/issues/4817/labels" && r.Method == http.MethodPost:
+			var body map[string][]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			issueLabelsAdded = append(issueLabelsAdded, body["labels"]...)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Label{})
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/4817/labels/") && r.Method == http.MethodDelete:
+			removed := strings.TrimPrefix(r.URL.Path, "/repos/owner/repo/issues/4817/labels/")
+			issueLabelsRemoved = append(issueLabelsRemoved, removed)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	stepClient := ghadapter.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithStepLogClient(stepClient))
+
+	prState := &PRState{
+		PRNumber:    4818,
+		IssueNumber: 4817,
+		HeadSHA:     "gh4826sha1",
+		Stage:       StageCIFailed,
+	}
+
+	if err := c.handleCIFailed(context.Background(), prState); err != nil {
+		t.Fatalf("handleCIFailed returned unexpected error: %v", err)
+	}
+
+	if !issueCreated {
+		t.Fatal("expected a fix issue to be spawned for this genuine code failure")
+	}
+	if !prClosed {
+		t.Fatal("expected the source PR to be closed once the fix issue was spawned")
+	}
+
+	// The core invariant: the spawn seam must have marked the source PR
+	// state terminal so the source issue is not left eligible for a
+	// competing retry re-queue. This is recorded controller state, not a
+	// mock echo.
+	if prState.TerminalLabel != github.LabelFailed {
+		t.Fatalf("prState.TerminalLabel = %q, want %q (fix issue now owns recovery)", prState.TerminalLabel, github.LabelFailed)
+	}
+
+	// Downstream: notifyExternalClose (GH-3806) must read that recorded
+	// state and label the source issue pilot-failed, never
+	// pilot-retry-ready — the exact #4818 shape where both fix-issue and
+	// source-retry chains armed simultaneously.
+	c.notifyExternalClose(context.Background(), prState)
+
+	foundFailed := false
+	foundRetryReady := false
+	for _, l := range issueLabelsAdded {
+		if l == github.LabelFailed {
+			foundFailed = true
+		}
+		if l == github.LabelRetryReady {
+			foundRetryReady = true
+		}
+	}
+	if !foundFailed {
+		t.Errorf("expected source issue to be labeled %q, got labels added: %v", github.LabelFailed, issueLabelsAdded)
+	}
+	if foundRetryReady {
+		t.Errorf("source issue must NOT be labeled %q once a fix issue owns recovery — this is the #4818 dual-arm shape; labels added: %v", github.LabelRetryReady, issueLabelsAdded)
+	}
+}
+
+// TestGH4826_NoSpawn_ZeroEvidence_LeavesSourceRetryArmed covers the failure
+// class where handleCIFailed never reaches CreateFailureIssue at all (zero
+// gathered evidence, GH-4779) — no fix issue exists to own the work, so the
+// source retry chain must remain the sole owner: TerminalLabel stays unset.
+func TestGH4826_NoSpawn_ZeroEvidence_LeavesSourceRetryArmed(t *testing.T) {
+	issueCreated := false
+	prClosed := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/gh4826zero/check-runs":
+			resp := github.CheckRunsResponse{TotalCount: 0, CheckRuns: []github.CheckRun{}}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			issueCreated = true
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, github.Issue{Number: 9991}))
+		case r.URL.Path == "/repos/owner/repo/pulls/71" && r.Method == http.MethodPatch:
+			prClosed = true
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:    71,
+		IssueNumber: 72,
+		HeadSHA:     "gh4826zero",
+		Stage:       StageCIFailed,
+	}
+
+	if err := c.handleCIFailed(context.Background(), prState); err != nil {
+		t.Fatalf("handleCIFailed returned unexpected error: %v", err)
+	}
+
+	if issueCreated {
+		t.Error("no fix issue should be spawned when there is zero evidence to point it at")
+	}
+	if prClosed {
+		t.Error("PR must NOT be closed when no fix issue was spawned")
+	}
+	if prState.TerminalLabel != "" {
+		t.Errorf("prState.TerminalLabel = %q, want empty — no fix issue exists, source retry chain must remain the sole owner", prState.TerminalLabel)
+	}
+}
+
+// TestGH4826_DedupDecline_LeavesSourceRetryArmed_NoOrphan covers
+// CreateFailureIssue's dedup/budget-decline path (GH-4307): a claim is
+// already in flight for this exact failure signal, so CreateFailureIssue
+// returns (0, nil) without minting a new issue. No fix issue exists to own
+// the work, so the source retry chain must remain armed — and, just as
+// importantly, this must not land in an orphaned "both disarmed" state
+// either: the PR is held via escalateAndHold, not closed with no owner.
+func TestGH4826_DedupDecline_LeavesSourceRetryArmed_NoOrphan(t *testing.T) {
+	const codeLog = `Run golangci-lint run ./...
+internal/autopilot/controller.go:1:1: some lint error (errcheck)
+##[error]Process completed with exit code 1.`
+
+	issueCreated := false
+	prClosed := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/gh4826dedup/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{ID: 401, Name: "lint", Status: "completed", Conclusion: "failure"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/actions/jobs/401/logs":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(codeLog))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			issueCreated = true
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, github.Issue{Number: 5555}))
+		case r.URL.Path == "/repos/owner/repo/pulls/81" && r.Method == http.MethodPatch:
+			prClosed = true
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	stepClient := ghadapter.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithStepLogClient(stepClient))
+
+	store := newTestStateStore(t)
+	c.SetStateStore(store)
+
+	// Pre-claim the exact dedup key handleCIFailed will derive for this PR
+	// (classified failed check == "lint") so CreateFailureIssue's dedup
+	// guard declines: a claim is in flight but the issue number has not
+	// been recorded yet, so GetSpawnedFixIssue returns 0.
+	dedupRepo := "owner/repo"
+	dedupKey := spawnedFixDedupKey(81, FailureCIPreMerge, []string{"lint"})
+	if claimed, err := store.ClaimSpawnedFix(dedupRepo, dedupKey); err != nil || !claimed {
+		t.Fatalf("failed to pre-seed dedup claim: claimed=%v err=%v", claimed, err)
+	}
+
+	prState := &PRState{
+		PRNumber:    81,
+		IssueNumber: 82,
+		HeadSHA:     "gh4826dedup",
+		Stage:       StageCIFailed,
+	}
+
+	if err := c.handleCIFailed(context.Background(), prState); err != nil {
+		t.Fatalf("handleCIFailed returned unexpected error: %v", err)
+	}
+
+	if issueCreated {
+		t.Error("no fix issue should be created — the dedup claim was already in flight")
+	}
+	if prClosed {
+		t.Error("PR must NOT be closed when the dedup guard declined to spawn a fix issue — that would orphan the work with no owner")
+	}
+	if prState.TerminalLabel != "" {
+		t.Errorf("prState.TerminalLabel = %q, want empty — dedup decline means no fix issue owns the work, source retry chain must remain armed", prState.TerminalLabel)
+	}
+	if prState.Stage != StageFailed {
+		t.Errorf("Stage = %s, want %s (escalateAndHold)", prState.Stage, StageFailed)
+	}
+}
+
+// TestGH4826_TerminalLabelOwnershipLivesAtSpawnSeam is a structural
+// regression guard: the TerminalLabel-on-spawn-success decision must live
+// exactly once, inside spawnFailureIssue, and every CreateFailureIssue call
+// site in controller.go must route through that seam rather than calling
+// feedbackLoop.CreateFailureIssue directly. Without this, a future CI-failure
+// rung (a third one, or a rewrite of an existing one) could reintroduce the
+// #4818 shape by calling CreateFailureIssue directly and forgetting to mark
+// the source terminal — exactly what the post-merge rung did before this fix.
+func TestGH4826_TerminalLabelOwnershipLivesAtSpawnSeam(t *testing.T) {
+	src, err := os.ReadFile("controller.go")
+	if err != nil {
+		t.Fatalf("failed to read controller.go: %v", err)
+	}
+	text := string(src)
+
+	// Every direct call to feedbackLoop.CreateFailureIssue must live inside
+	// spawnFailureIssue's own body — no other function may call it directly.
+	directCallRe := regexp.MustCompile(`c\.feedbackLoop\.CreateFailureIssue\(`)
+	directCalls := directCallRe.FindAllStringIndex(text, -1)
+	if len(directCalls) != 1 {
+		t.Fatalf("expected exactly 1 direct call to c.feedbackLoop.CreateFailureIssue (inside spawnFailureIssue), found %d", len(directCalls))
+	}
+
+	seamStart := strings.Index(text, "func (c *Controller) spawnFailureIssue(")
+	if seamStart == -1 {
+		t.Fatal("spawnFailureIssue function not found in controller.go")
+	}
+	seamEnd := findFuncBodyEnd(t, text, seamStart)
+
+	if directCalls[0][0] < seamStart || directCalls[0][0] > seamEnd {
+		t.Errorf("the single direct CreateFailureIssue call must be inside spawnFailureIssue (bytes %d-%d), found at byte %d", seamStart, seamEnd, directCalls[0][0])
+	}
+
+	// The TerminalLabel = github.LabelFailed assignment that fires on spawn
+	// success must appear exactly once inside that same seam.
+	spawnSuccessAssignRe := regexp.MustCompile(`prState\.TerminalLabel = github\.LabelFailed`)
+	allAssigns := spawnSuccessAssignRe.FindAllStringIndex(text, -1)
+	inSeam := 0
+	for _, m := range allAssigns {
+		if m[0] >= seamStart && m[0] <= seamEnd {
+			inSeam++
+		}
+	}
+	if inSeam != 1 {
+		t.Errorf("expected exactly 1 `prState.TerminalLabel = github.LabelFailed` assignment inside spawnFailureIssue, found %d", inSeam)
+	}
+
+	// Both known CI-failure rungs must call the seam, not the raw method.
+	for _, marker := range []string{
+		"c.spawnFailureIssue(ctx, prState, FailureCIPreMerge,",
+		"c.spawnFailureIssue(ctx, prState, FailureCIPostMerge,",
+	} {
+		if !strings.Contains(text, marker) {
+			t.Errorf("expected controller.go to contain %q — a CI-failure rung must route through the spawnFailureIssue seam", marker)
+		}
+	}
+}
+
+// findFuncBodyEnd returns the byte offset of the closing brace that matches
+// the first '{' found at or after funcStart, by brace-depth counting. Good
+// enough for controller.go's plain Go source (no braces inside string
+// literals between a func signature and its body in this file).
+func findFuncBodyEnd(t *testing.T, text string, funcStart int) int {
+	t.Helper()
+	openIdx := strings.Index(text[funcStart:], "{")
+	if openIdx == -1 {
+		t.Fatal("could not find opening brace for function")
+	}
+	depth := 0
+	for i := funcStart + openIdx; i < len(text); i++ {
+		switch text[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	t.Fatal("could not find matching closing brace for function")
+	return -1
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4826.

Closes #4826

## Changes

GitHub Issue GH-4826: fix(autopilot): CI-failure close arms both fix-issue and source-retry chains — no designated recovery owner

## Context

After the CI-failure close of PR#4818 (2026-08-09), BOTH recovery paths armed simultaneously:

- the fix-issue chain (#4820, spawned by `CreateFailureIssue`), and
- the source-issue retry chain (#4817 unmarked → retry generation → PR#4821).

GH-3806's `TerminalLabel` mechanism exists precisely to designate a follow-up issue as the retry owner (mark the source terminal so it isn't re-queued while a follow-up owns the work), but it didn't fire on this path — the close handler spawned the fix issue without marking the source, so two executors could have raced the same failure. Benign this time only because preflight `reject_vague`-ed #4820; a fix-issue vs source-retry pair has different task keys, so TASK-407's admission claim cannot catch it (that guard is same-task only).

Anchors (@ main 2026-08-11):

- `internal/autopilot/controller.go:2419` — `handleCIFailed` ("creates fix issue via feedback loop"); spawn at `:2637` → `feedbackLoop.CreateFailureIssue`.
- `prState.TerminalLabel` set sites: `controller.go:2581, 2707, 2964, 3030` (LabelFailed), `:5375` (LabelSuperseded); poller-side respect at `:7269-7288`.
- GH-3806: the designating mechanism this path failed to invoke.

## Implementation

1. Map the CI-failure close ladder in `handleCIFailed` + its callees: for each branch that reaches `CreateFailureIssue`, determine what currently marks (or fails to mark) the source issue/PR terminal, and which branches leave the source eligible for retry re-queue.
2. Enforce single ownership at the spawn point: when `CreateFailureIssue` succeeds, the source must be marked terminal (fix issue owns recovery); when no fix issue is spawned, the source retry chain owns it. The choice may stay class-dependent (infra vs code per the TASK-459 verdicts) — but **simultaneous arming must be structurally impossible at the call site**, not dependent on preflight rejecting the fix issue.
3. Wire the invariant where the spawn happens (one seam), not per-branch — a new branch added later must inherit exclusivity by construction.

## Acceptance

- [ ] Test reproducing the #4818 shape: CI-failure close spawns a fix issue → source issue is marked terminal and the retry path declines to re-queue it (assert through recorded state, not a mock echo).
- [ ] Test: failure class where no fix issue is spawned → source retry chain remains armed; no terminal mark.
- [ ] Test: `CreateFailureIssue` dedup/budget-decline path (returns without spawning) → source retry stays armed (no orphaned "both disarmed" state either — exactly one owner in every branch).
- [ ] Grep/structural check or test asserting the exclusivity lives at the spawn seam, not duplicated per branch.

## Refs

- Observed: PR#4818 → #4820 + #4817-retry, 2026-08-09; #4820 closed as orphan 2026-08-10.
- Recorded: `.agent/system/approval-architecture-roadmap.md` § backlog (2026-08-10 bullets).
- Related: GH-3806 (TerminalLabel) · TASK-407 (admission claim — same-task only) · TASK-459 (fix-issue spawn is budget-burning) · #4825 (evidence leg, same incident).