### PR TITLE
fix(autopilot): recovery-owner designation survives restart, extended to review path (GH-4841)

### DIFF
--- a/.agent/tasks/gh-4841.md
+++ b/.agent/tasks/gh-4841.md
@@ -1,0 +1,43 @@
+# GH-4841
+
+**Created:** 2026-08-11
+
+## Problem
+
+GitHub Issue GH-4841: fix(autopilot): recovery-owner designation must survive restart — persist it and extend the seam to the review path
+
+# fix(autopilot): recovery-owner designation must survive restart — persist it and extend the seam to the review path
+
+**Status**: 📋 Ready to dispatch
+**Created**: 2026-08-11
+**Assignee**: Pilot
+
+## Context
+
+PR#4840 (GH-4826) built the right seam: `spawnFailureIssue` (internal/autopilot/controller.go:2462) designates exactly one recovery owner per CI-failure close, and TerminalLabel is set iff `CreateFailureIssue` returns a live issue. Post-merge review found the designation is **in-memory only** — one daemon restart in the wrong window resurrects the exact double-arm incident the PR fixed. The daemon has a documented history of mid-flow restarts (GH-4807).
+
+Crash window: `TerminalLabel` (internal/autopilot/types.go:1169) has **no column** in `SavePRState`/`GetPRState` (internal/autopilot/state_store.go:638-727). A crash between the PR close (controller.go:2720) and the end-of-ProcessPR persist (controller.go:2093) rehydrates the PR label-less at StageCIFailed; `checkExternalMergeOrClose` (processAllPRs, controller.go:6881) runs before any handler, has no StageCIFailed guard, and the self-close markers (controller.go:582-591) are also in-memory — so `notifyExternalClose` (controller.go:7455-7458) defaults to `pilot-retry-ready` while the spawned fix issue is live. Double-arm, restored by restart.
+
+Same shape on the review path: `handleReviewRequested` still closes before designating — direct `CreateReviewIssue` (controller.go:3007), close (controller.go:3050), designation after (controller.go:3065), in-memory.
+
+## Implementation
+
+1. **Persist the ownership decision.** Either add a `terminal_label` column to the PR-state store (SavePRState/GetPRState/RestoreState roundtrip, migration included) **or** make `notifyExternalClose` consult the durable `autopilot_spawned_fixes` claim before defaulting to retry-ready. Prefer whichever is smaller and closes BOTH the pre-merge (controller.go:2672) and post-merge (controller.go:4283) rungs; state your choice in the PR description.
+2. **Extend the designate-before-close seam to `handleReviewRequested`** — route it through `spawnFailureIssue`-style ordering (designate, then close), or persist its designation the same way as (1).
+3. **Crash/rehydration test**: simulate close → crash (no persist) → RestoreState → external-close scan; assert retry is NOT armed while a spawned fix issue is designated. This is the test PR#4840's review flagged as missing (structural string-match only today, gh4826_test.go:443).
+
+Out of scope: owner-death recovery (preflight-rejected fix issues) — separate issue; iteration-cap sites (controller.go:2594/2616) spawn nothing, leave them.
+
+## Acceptance
+
+- Daemon restart at ANY point between PR close and persist does not arm `pilot-retry-ready` when a spawned fix issue is the designated owner (proven by the rehydration test, not by inspection).
+- Review path shares the designate-before-close ordering or durable designation.
+- Existing GH-4826 tests still pass; no schema change beyond the one migration if option (1a) chosen.
+
+## Refs
+
+- Review verdict: https://github.com/qf-studio/pilot/pull/4840#issuecomment-5253781955 (D1, D4)
+- Prior work: PR#4840 (GH-4826), incident GH-4820, restart history GH-4807
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2952,6 +2952,22 @@ func (c *Controller) logCIFailureClassification(prState *PRState, checks []Faile
 	}
 }
 
+// spawnReviewIssue is spawnFailureIssue's counterpart for the review-feedback
+// close path (GH-4841). Before this seam existed, handleReviewRequested
+// closed the PR (controller.go ClosePullRequest call below) and only set
+// prState.TerminalLabel afterward — the same designate-after-close ordering
+// GH-4826 fixed for CI failures, reintroduced on this sibling path. Routing
+// through this seam instead means the designation happens the moment
+// CreateReviewIssue actually returns a live issue, strictly before the PR is
+// ever closed, matching spawnFailureIssue's ordering exactly.
+func (c *Controller) spawnReviewIssue(ctx context.Context, prState *PRState, reviews []*github.PullRequestReview, comments []*github.PRReviewComment, iteration int) (int, error) {
+	issueNum, err := c.feedbackLoop.CreateReviewIssue(ctx, prState, reviews, comments, iteration)
+	if err == nil && issueNum > 0 {
+		prState.TerminalLabel = github.LabelFailed
+	}
+	return issueNum, err
+}
+
 // handleReviewRequested processes a PR that received "changes requested" review feedback.
 // It fetches reviews and comments, checks iteration limits, creates a revision issue,
 // learns from the review, then closes the PR and deletes the branch.
@@ -3003,8 +3019,11 @@ func (c *Controller) handleReviewRequested(ctx context.Context, prState *PRState
 		}
 	}
 
-	// Create revision issue with review feedback
-	issueNum, err := c.feedbackLoop.CreateReviewIssue(ctx, prState, reviews, comments, iteration+1)
+	// Create revision issue with review feedback. GH-4841: routed through
+	// spawnReviewIssue rather than calling feedbackLoop.CreateReviewIssue
+	// directly, so prState.TerminalLabel is designated the moment the issue
+	// exists — strictly before the ClosePullRequest call below.
+	issueNum, err := c.spawnReviewIssue(ctx, prState, reviews, comments, iteration+1)
 	if err != nil {
 		return fmt.Errorf("failed to create review issue: %w", err)
 	}
@@ -3057,12 +3076,13 @@ func (c *Controller) handleReviewRequested(ctx context.Context, prState *PRState
 		}
 	}
 
-	// GH-3806: the revision issue created above now owns the retry, so this
-	// issue must be marked pilot-failed rather than re-queued (see the matching
+	// GH-3806/GH-4841: name the reason so notifyExternalClose can post the
+	// audit-trail comments. prState.TerminalLabel itself was already set by
+	// spawnReviewIssue above the moment CreateReviewIssue succeeded — it is
+	// not set here, so this rung cannot forget it (mirrors the matching
 	// comment on handleCIFailed's main CI-fail branch).
 	prState.Stage = StageFailed
 	prState.Error = fmt.Sprintf("changes requested by reviewer; revision issue #%d created to continue this work", issueNum)
-	prState.TerminalLabel = github.LabelFailed
 	c.metrics.RecordPRFailed()
 	return nil
 }
@@ -7457,6 +7477,21 @@ func (c *Controller) notifyExternalClose(ctx context.Context, prState *PRState) 
 		if prState.TerminalLabel != "" {
 			issueLabel = prState.TerminalLabel
 			nextSteps = "This issue will not be retried automatically under its own number — see the reason above for what happens next."
+		} else if c.stateStore != nil {
+			// GH-4841: prState.TerminalLabel is in-memory only and can be lost to
+			// a daemon restart landing between the PR close (handleCIFailed/
+			// handlePostMergeCI/handleReviewRequested) and the end-of-ProcessPR
+			// persistPRState call — the exact window that resurrected the #4818
+			// double-arm shape. Fall back to the durable spawned-fix claim, which
+			// CreateFailureIssue/CreateReviewIssue record synchronously before
+			// either handler ever closes the PR, so it survives that restart.
+			if fixIssue, err := c.stateStore.HasSpawnedFixForPR(c.repoKey(), prState.PRNumber); err != nil {
+				c.log.Warn("durable spawned-fix lookup failed, falling back to retry-ready",
+					"pr", prState.PRNumber, "error", err)
+			} else if fixIssue > 0 {
+				issueLabel = github.LabelFailed
+				nextSteps = fmt.Sprintf("This issue will not be retried automatically under its own number — fix issue #%d already owns this work.", fixIssue)
+			}
 		}
 
 		// TASK-459 Phase 3 Task 5e: skip the label writes below on positive

--- a/internal/autopilot/feedback_loop.go
+++ b/internal/autopilot/feedback_loop.go
@@ -511,6 +511,24 @@ func (f *FeedbackLoop) CreateReviewIssue(ctx context.Context, prState *PRState, 
 		return 0, fmt.Errorf("failed to create review issue: %w", err)
 	}
 
+	// GH-4841: mirror CreateFailureIssue's durable claim (GH-4307), minus the
+	// dedup gate on creation — a repeat review round must still create a new
+	// issue, but a durable row naming its number must exist before
+	// handleReviewRequested's caller (spawnReviewIssue) ever closes the PR, so
+	// notifyExternalClose's HasSpawnedFixForPR fallback can find it even if a
+	// daemon restart loses prState.TerminalLabel. failedChecks is nil (review
+	// feedback has no check-run concept); the dedup key namespace only needs
+	// the PR number to be found by HasSpawnedFixForPR's prefix match.
+	if f.stateStore != nil {
+		dedupRepo := f.owner + "/" + f.repo
+		dedupKey := spawnedFixDedupKey(prState.PRNumber, FailureReviewRequested, nil)
+		if _, claimErr := f.stateStore.ClaimSpawnedFix(dedupRepo, dedupKey); claimErr != nil {
+			f.log.Warn("review-issue durable claim failed", "pr", prState.PRNumber, "error", claimErr)
+		} else if recErr := f.stateStore.RecordSpawnedFixIssue(dedupRepo, dedupKey, issue.Number); recErr != nil {
+			f.log.Warn("failed to record spawned review issue number", "issue", issue.Number, "pr", prState.PRNumber, "error", recErr)
+		}
+	}
+
 	f.log.Info("created review issue",
 		"issue", issue.Number,
 		"pr", prState.PRNumber,

--- a/internal/autopilot/gh4841_test.go
+++ b/internal/autopilot/gh4841_test.go
@@ -1,0 +1,303 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	ghadapter "github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GH-4841: PR#4840 (GH-4826) centralized the recovery-owner designation in
+// spawnFailureIssue, but the designation itself (prState.TerminalLabel) was
+// only ever held in memory. A daemon restart landing between the PR close
+// (visible on GitHub the moment ClosePullRequest returns) and the
+// end-of-ProcessPR persistPRState call rehydrates the PR with TerminalLabel
+// lost — exactly the #4818 double-arm shape PR#4840 fixed, resurrected by a
+// restart. These tests reproduce that crash window end-to-end: spawn (durably
+// claimed) -> close -> simulated crash (no persist) -> RestoreState on a
+// fresh controller sharing the same store -> the external-close scan that
+// would normally arm pilot-retry-ready. They assert the durable
+// HasSpawnedFixForPR fallback in notifyExternalClose still finds the live fix
+// issue and marks pilot-failed instead.
+
+// TestGH4841_CIFailureCrashWindow_RetryNotArmedAfterRestart covers the
+// pre-merge CI-failure rung (handleCIFailed / spawnFailureIssue).
+func TestGH4841_CIFailureCrashWindow_RetryNotArmedAfterRestart(t *testing.T) {
+	const (
+		prNumber    = 9001
+		issueNumber = 9002
+		fixIssueNum = 9003
+	)
+	const codeLog = `Run golangci-lint run ./...
+internal/autopilot/controller.go:1:1: some lint error (errcheck)
+##[error]Process completed with exit code 1.`
+
+	issueCreated := false
+	prClosed := false
+	var issueLabelsAdded []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/gh4841sha/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{ID: 501, Name: "lint", Status: "completed", Conclusion: "failure"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/actions/jobs/501/logs":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(codeLog))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			issueCreated = true
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, github.Issue{Number: fixIssueNum}))
+		case r.URL.Path == "/repos/owner/repo/pulls/9001" && r.Method == http.MethodPatch:
+			prClosed = true
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/repos/owner/repo/issues/9002" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, github.Issue{Number: issueNumber, State: github.StateOpen}))
+		case r.URL.Path == "/repos/owner/repo/issues/9002/labels" && r.Method == http.MethodPost:
+			var body map[string][]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			issueLabelsAdded = append(issueLabelsAdded, body["labels"]...)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Label{})
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/9002/labels/") && r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	stepClient := ghadapter.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	store := newTestStateStore(t)
+
+	// Step 0: seed the store with the row as it was persisted BEFORE this
+	// tick started — the PR already sitting at StageCIFailed from an earlier
+	// persist, TerminalLabel unset. CreatedAt is set far in the past so the
+	// later external-close scan is past GH-4570's grace window and a single
+	// "closed" read is trusted immediately.
+	seedPR := &PRState{
+		PRNumber:    prNumber,
+		PRURL:       "https://github.com/owner/repo/pull/9001",
+		IssueNumber: issueNumber,
+		HeadSHA:     "gh4841sha",
+		Stage:       StageCIFailed,
+		CreatedAt:   time.Now().Add(-1 * time.Hour),
+	}
+	if err := store.SavePRState("owner/repo", seedPR); err != nil {
+		t.Fatalf("seed SavePRState: %v", err)
+	}
+
+	// Step 1: controller A processes the tick that spawns the fix issue and
+	// closes the PR. handleCIFailed is called directly (not via ProcessPR) so
+	// the end-of-cycle persistPRState never runs — simulating a crash between
+	// the close (visible on GitHub the moment ClosePullRequest returns inside
+	// handleCIFailed) and the persist that would normally follow it.
+	controllerA := NewController(cfg, ghClient, nil, "owner", "repo", WithStepLogClient(stepClient))
+	controllerA.SetStateStore(store)
+
+	if err := controllerA.handleCIFailed(context.Background(), seedPR); err != nil {
+		t.Fatalf("handleCIFailed returned unexpected error: %v", err)
+	}
+	if !issueCreated {
+		t.Fatal("expected a fix issue to be spawned")
+	}
+	if !prClosed {
+		t.Fatal("expected the source PR to be closed once the fix issue was spawned")
+	}
+	if seedPR.TerminalLabel != github.LabelFailed {
+		t.Fatalf("prState.TerminalLabel = %q, want %q before the simulated crash", seedPR.TerminalLabel, github.LabelFailed)
+	}
+	// Deliberately do NOT call controllerA.persistPRState(seedPR) here — this
+	// is the crash.
+
+	// Step 2: "restart" — a brand new controller loads the same on-disk
+	// store. It must see the row exactly as seeded in step 0: StageCIFailed,
+	// TerminalLabel empty. The in-memory designation from step 1 is gone.
+	controllerB := NewController(cfg, ghClient, nil, "owner", "repo")
+	controllerB.SetStateStore(store)
+
+	if _, err := controllerB.RestoreState(); err != nil {
+		t.Fatalf("RestoreState: %v", err)
+	}
+	controllerB.mu.RLock()
+	restoredPR, ok := controllerB.activePRs[prNumber]
+	controllerB.mu.RUnlock()
+	if !ok {
+		t.Fatalf("PR %d not present in controller B's activePRs after RestoreState", prNumber)
+	}
+	if restoredPR.TerminalLabel != "" {
+		t.Fatalf("restored TerminalLabel = %q, want empty — the in-memory designation must NOT have survived the simulated crash (otherwise this test isn't exercising the crash window)", restoredPR.TerminalLabel)
+	}
+
+	// Step 3: the external-close scan (processAllPRs' checkExternalMergeOrClose)
+	// observes the PR closed on GitHub — exactly what happens on the next
+	// poll tick after restart. Before GH-4841 this would default to
+	// pilot-retry-ready because restoredPR.TerminalLabel is empty.
+	ghPR := &github.PullRequest{Number: prNumber, State: "closed", Merged: false}
+	externallyResolved := controllerB.checkExternalMergeOrClose(context.Background(), restoredPR, ghPR)
+	if !externallyResolved {
+		t.Fatal("expected checkExternalMergeOrClose to report the PR as externally resolved (closed)")
+	}
+
+	foundFailed := false
+	foundRetryReady := false
+	for _, l := range issueLabelsAdded {
+		if l == github.LabelFailed {
+			foundFailed = true
+		}
+		if l == github.LabelRetryReady {
+			foundRetryReady = true
+		}
+	}
+	if !foundFailed {
+		t.Errorf("expected source issue to be labeled %q via the durable spawned-fix fallback, got labels added: %v", github.LabelFailed, issueLabelsAdded)
+	}
+	if foundRetryReady {
+		t.Errorf("source issue must NOT be labeled %q after a restart lost TerminalLabel while a fix issue is durably designated — labels added: %v", github.LabelRetryReady, issueLabelsAdded)
+	}
+}
+
+// TestGH4841_ReviewRequestedCrashWindow_RetryNotArmedAfterRestart is the
+// review-feedback analog: handleReviewRequested must share the same
+// crash-survival property as the CI-failure rung above.
+func TestGH4841_ReviewRequestedCrashWindow_RetryNotArmedAfterRestart(t *testing.T) {
+	const (
+		prNumber    = 9101
+		issueNumber = 9102
+		fixIssueNum = 9103
+	)
+
+	issueCreated := false
+	prClosed := false
+	var issueLabelsAdded []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/9101/reviews":
+			resp := []*github.PullRequestReview{
+				{ID: 1, User: github.User{Login: "alice"}, Body: "Fix this", State: "CHANGES_REQUESTED"},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/pulls/9101/comments":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			issueCreated = true
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, github.Issue{Number: fixIssueNum}))
+		case r.URL.Path == "/repos/owner/repo/pulls/9101" && r.Method == http.MethodPatch:
+			prClosed = true
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/repos/owner/repo/issues/9102" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, github.Issue{Number: issueNumber, State: github.StateOpen}))
+		case r.URL.Path == "/repos/owner/repo/issues/9102/labels" && r.Method == http.MethodPost:
+			var body map[string][]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			issueLabelsAdded = append(issueLabelsAdded, body["labels"]...)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Label{})
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/9102/labels/") && r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	store := newTestStateStore(t)
+
+	seedPR := &PRState{
+		PRNumber:    prNumber,
+		PRURL:       "https://github.com/owner/repo/pull/9101",
+		IssueNumber: issueNumber,
+		BranchName:  "pilot/GH-9102",
+		HeadSHA:     "gh4841reviewsha",
+		Stage:       StageReviewRequested,
+		CreatedAt:   time.Now().Add(-1 * time.Hour),
+	}
+	if err := store.SavePRState("owner/repo", seedPR); err != nil {
+		t.Fatalf("seed SavePRState: %v", err)
+	}
+
+	controllerA := NewController(cfg, ghClient, nil, "owner", "repo")
+	controllerA.SetStateStore(store)
+
+	if err := controllerA.handleReviewRequested(context.Background(), seedPR); err != nil {
+		t.Fatalf("handleReviewRequested returned unexpected error: %v", err)
+	}
+	if !issueCreated {
+		t.Fatal("expected a revision issue to be spawned")
+	}
+	if !prClosed {
+		t.Fatal("expected the source PR to be closed once the revision issue was spawned")
+	}
+	if seedPR.TerminalLabel != github.LabelFailed {
+		t.Fatalf("prState.TerminalLabel = %q, want %q before the simulated crash", seedPR.TerminalLabel, github.LabelFailed)
+	}
+	// Simulated crash: no persistPRState call.
+
+	controllerB := NewController(cfg, ghClient, nil, "owner", "repo")
+	controllerB.SetStateStore(store)
+
+	if _, err := controllerB.RestoreState(); err != nil {
+		t.Fatalf("RestoreState: %v", err)
+	}
+	controllerB.mu.RLock()
+	restoredPR, ok := controllerB.activePRs[prNumber]
+	controllerB.mu.RUnlock()
+	if !ok {
+		t.Fatalf("PR %d not present in controller B's activePRs after RestoreState", prNumber)
+	}
+	if restoredPR.TerminalLabel != "" {
+		t.Fatalf("restored TerminalLabel = %q, want empty — the in-memory designation must NOT have survived the simulated crash", restoredPR.TerminalLabel)
+	}
+
+	ghPR := &github.PullRequest{Number: prNumber, State: "closed", Merged: false}
+	externallyResolved := controllerB.checkExternalMergeOrClose(context.Background(), restoredPR, ghPR)
+	if !externallyResolved {
+		t.Fatal("expected checkExternalMergeOrClose to report the PR as externally resolved (closed)")
+	}
+
+	foundFailed := false
+	foundRetryReady := false
+	for _, l := range issueLabelsAdded {
+		if l == github.LabelFailed {
+			foundFailed = true
+		}
+		if l == github.LabelRetryReady {
+			foundRetryReady = true
+		}
+	}
+	if !foundFailed {
+		t.Errorf("expected source issue to be labeled %q via the durable spawned-fix fallback, got labels added: %v", github.LabelFailed, issueLabelsAdded)
+	}
+	if foundRetryReady {
+		t.Errorf("source issue must NOT be labeled %q after a restart lost TerminalLabel while a revision issue is durably designated — labels added: %v", github.LabelRetryReady, issueLabelsAdded)
+	}
+}

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -1202,6 +1202,37 @@ func (s *StateStore) GetSpawnedFixIssue(repo, dedupKey string) (int, error) {
 	return issueNumber, nil
 }
 
+// HasSpawnedFixForPR reports whether a fix/review issue has already been
+// durably claimed for prNumber, regardless of failure type or the exact set
+// of failed checks — a prefix match on the "fix:pr<N>:" dedup-key namespace
+// (spawnedFixDedupKey) rather than an exact-key lookup like GetSpawnedFixIssue.
+// Returns the most recently recorded issue number, or 0 if no claim has been
+// backfilled with a live issue number yet (no claim at all, or a claim still
+// in flight between ClaimSpawnedFix and RecordSpawnedFixIssue).
+//
+// GH-4841: notifyExternalClose uses this as a durable fallback for
+// prState.TerminalLabel, which is in-memory only and can be lost to a daemon
+// restart landing between a CI-failure/review-feedback PR close and the
+// end-of-cycle persistPRState call. The claim row this reads was written by
+// CreateFailureIssue/CreateReviewIssue synchronously, before either handler
+// ever closes the PR — so it survives exactly the restart window that loses
+// prState.TerminalLabel.
+func (s *StateStore) HasSpawnedFixForPR(repo string, prNumber int) (int, error) {
+	var issueNumber int
+	err := s.db.QueryRow(`
+		SELECT issue_number FROM autopilot_spawned_fixes
+		WHERE repo = ? AND dedup_key LIKE ? AND issue_number > 0
+		ORDER BY created_at DESC LIMIT 1
+	`, repo, fmt.Sprintf("fix:pr%d:%%", prNumber)).Scan(&issueNumber)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return issueNumber, nil
+}
+
 // GetScopeRelease returns one scope-release row by repo+scopeKey, or nil, nil
 // if not found.
 func (s *StateStore) GetScopeRelease(repo, scopeKey string) (*ScopeRelease, error) {


### PR DESCRIPTION
## Summary

- Persists the recovery-owner designation (`prState.TerminalLabel`) across daemon restarts by making `notifyExternalClose` fall back to a durable `autopilot_spawned_fixes` claim (via new `HasSpawnedFixForPR`) when the in-memory label was lost to a crash between PR close and `persistPRState`. No schema migration needed — the claim row is written synchronously by `CreateFailureIssue`/`CreateReviewIssue` before either handler closes the PR, so it inherently survives the crash window that a `terminal_label` column on `autopilot_pr_state` would not close.
- Extends the designate-before-close ordering (GH-4826) to the review-feedback path: new `spawnReviewIssue` seam sets `TerminalLabel` the instant `CreateReviewIssue` returns a live issue, strictly before `handleReviewRequested` closes the PR. `CreateReviewIssue` now records a durable spawned-fix claim the same way `CreateFailureIssue` does.

## Design choice (per issue's Refs, item 1)

Chose the durable-claim fallback over a `terminal_label` DB column: the crash happens *before* `persistPRState` runs regardless of what columns that call would write, so a new column wouldn't close the window. The `autopilot_spawned_fixes` table is already written synchronously ahead of the PR close, so consulting it in `notifyExternalClose` closes the gap with no migration.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/autopilot/... -run 'GH4841|GH4826' -v` — new crash/rehydration tests pass for both the pre-merge CI-failure rung and the review-requested rung (seed PR state → invoke close handler directly, simulating a crash with no persist → `RestoreState` on a fresh controller sharing the store → external-close scan asserts `pilot-failed` is applied, not `pilot-retry-ready`)
- [x] `go test ./internal/autopilot/...` — full package suite passes, including existing GH-4826 tests
- [x] `go vet ./internal/autopilot/...`