### PR TITLE
fix(gateway): chat API gateway-mode wiring hole + latestSeq for reset detection

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -382,6 +382,28 @@ func main() {
 	}
 }
 
+// gatewayChatNeedsOwnRunner reports whether gateway mode must build a
+// dedicated executor.Runner for the chat API on its own, separate from the
+// needsPollingInfra block. GH-4843 (D1): chat is an HTTP endpoint, not a
+// polling adapter — before this fix, chatEnabled didn't factor into
+// needsPollingInfra at all, so a webhooks-only gateway daemon (chat enabled,
+// zero polling adapters) left gwRunner nil, silently wiring
+// WithChatHandler(nil, ...) and leaving the chat routes unregistered (a 404)
+// despite the startup log claiming "Chat API enabled in gateway mode". When
+// needsPollingInfra is already true, that block builds gwRunner itself, so
+// this only needs to cover the gap case.
+//
+// Decision: fixed by building a second, chat-scoped runner rather than
+// folding chatEnabled into needsPollingInfra's own condition. The latter
+// would also pull in that block's polling-only side effects (memory store +
+// dispatcher, teams RBAC, approval handlers, autopilot controller, alerts
+// engine) for a deployment that only asked for the chat HTTP endpoint —
+// scope creep with real side effects (e.g. autopilot starting to act on PRs)
+// for config that never opted into it.
+func gatewayChatNeedsOwnRunner(chatEnabled, needsPollingInfra bool) bool {
+	return chatEnabled && !needsPollingInfra
+}
+
 func newStartCmd() *cobra.Command {
 	var (
 		dashboardMode bool
@@ -665,6 +687,14 @@ Examples:
 					cfg.Adapters.GitHub.Polling != nil && cfg.Adapters.GitHub.Polling.Enabled) ||
 				(slackFlagSet && hasSlack) ||
 				adapterPollerEnabled
+			// GH-4843 (D1): chat is an HTTP endpoint, not a polling adapter, so
+			// it must NOT gate on needsPollingInfra the way Telegram/Slack/GitHub
+			// polling do — a webhooks-only gateway daemon with chat enabled and
+			// zero polling adapters still needs a runner to dispatch chat tasks.
+			// Checked separately from needsPollingInfra below so a chat-only
+			// deployment doesn't also spin up autopilot/approvals/alerts infra
+			// it never asked for.
+			chatEnabled := cfg.Adapters.Chat != nil && cfg.Adapters.Chat.Enabled
 
 			// Shared infrastructure for polling adapters
 			var gwRunner *executor.Runner
@@ -1038,6 +1068,21 @@ Examples:
 					// GH-2291: Progress/token callbacks are registered by runDashboardMode
 					// which merges task states from both adapter pollers and gateway webhooks.
 				}
+			} else if gatewayChatNeedsOwnRunner(chatEnabled, needsPollingInfra) {
+				// GH-4843 (D1): chat needs a runner to dispatch tasks even when
+				// no polling adapter is enabled — build just enough of it
+				// (mirrors the runner-setup prefix of the needsPollingInfra
+				// block above) without the rest of that block's polling-only
+				// infra (memory store/dispatcher, teams, approvals, autopilot,
+				// alerts), which a chat-only deployment never asked for.
+				var runnerErr error
+				gwRunner, runnerErr = executor.NewRunnerWithConfig(cfg.Executor)
+				if runnerErr != nil {
+					return fmt.Errorf("failed to create executor runner for chat API: %w", runnerErr)
+				}
+				gwRunner.SetRepoAllowlist(newConfigRepoAllowlist(cfg))
+				gwRunner.SetGithubSideEffectSearcher(executor.NewGithubSideEffectSearcher())
+				gwRunner.SetQualityCheckerFactory(newProjectQualityCheckerFactory(cfg))
 			}
 
 			// Enable Telegram polling in gateway mode only if --telegram flag was explicitly passed (GH-351)
@@ -1067,10 +1112,18 @@ Examples:
 			// GH-4835: enable the web chat API (console Operator chat panel)
 			// in gateway mode whenever adapters.chat.enabled is true. No CLI
 			// flag gate like Telegram/Slack polling — this is an HTTP
-			// endpoint the console calls, not a polling loop.
-			if cfg.Adapters.Chat != nil && cfg.Adapters.Chat.Enabled {
+			// endpoint the console calls, not a polling loop. gwRunner is
+			// guaranteed non-nil here when chatEnabled (built above by either
+			// the needsPollingInfra block or the chatEnabled else-if), but the
+			// nil check guards against silently logging "enabled" on a path
+			// that left the handler unwired (GH-4843 D1).
+			if chatEnabled {
 				pilotOpts = append(pilotOpts, pilot.WithChatHandler(gwRunner, projectPath))
-				logging.WithComponent("start").Info("Chat API enabled in gateway mode")
+				if gwRunner != nil {
+					logging.WithComponent("start").Info("Chat API enabled in gateway mode")
+				} else {
+					logging.WithComponent("start").Warn("Chat API enabled in config but no runner was constructed — chat routes will not be wired")
+				}
 			}
 
 			// GH-539: Create budget enforcer for gateway mode

--- a/cmd/pilot/wiring_test.go
+++ b/cmd/pilot/wiring_test.go
@@ -746,6 +746,57 @@ func TestConvertKeyboardToTelegram_Empty(t *testing.T) {
 }
 
 // =============================================================================
+// GH-4843 (D1): gatewayChatNeedsOwnRunner — chat/gateway-mode wiring hole
+// =============================================================================
+
+func TestGatewayChatNeedsOwnRunner(t *testing.T) {
+	tests := []struct {
+		name              string
+		chatEnabled       bool
+		needsPollingInfra bool
+		want              bool
+	}{
+		{
+			name:              "chat off, no polling infra",
+			chatEnabled:       false,
+			needsPollingInfra: false,
+			want:              false,
+		},
+		{
+			name:              "chat off, polling infra needed",
+			chatEnabled:       false,
+			needsPollingInfra: true,
+			want:              false,
+		},
+		{
+			// The GH-4843 D1 gap: chat enabled, nothing else needs a runner —
+			// gwRunner would otherwise stay nil and WithChatHandler(nil, ...)
+			// silently leaves the chat routes unregistered.
+			name:              "chat on, no polling infra",
+			chatEnabled:       true,
+			needsPollingInfra: false,
+			want:              true,
+		},
+		{
+			// needsPollingInfra's own block already builds gwRunner — chat
+			// must not build a second, redundant one.
+			name:              "chat on, polling infra also needed",
+			chatEnabled:       true,
+			needsPollingInfra: true,
+			want:              false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := gatewayChatNeedsOwnRunner(tt.chatEnabled, tt.needsPollingInfra); got != tt.want {
+				t.Errorf("gatewayChatNeedsOwnRunner(%v, %v) = %v, want %v", tt.chatEnabled, tt.needsPollingInfra, got, tt.want)
+			}
+		})
+	}
+}
+
+// =============================================================================
 // GH-2134: autopilotProviderAdapter compile check
 // =============================================================================
 

--- a/internal/adapters/web/api.go
+++ b/internal/adapters/web/api.go
@@ -114,13 +114,25 @@ func (a *API) Dispatch(dispatchCtx context.Context, req DispatchRequest) (seq in
 	return seq, nil
 }
 
-// Events returns events for conversationID with seq > after, in seq order.
-// A conversationID with no buffer (never messaged, or expired/evicted) is
-// not an error — it returns an empty slice, matching "no events yet" rather
-// than "unknown conversation" (the chat API has no separate concept of
-// conversation existence beyond "has it produced any events").
-func (a *API) Events(conversationID string, after int64) []Event {
+// Events returns events for conversationID with seq > after, in seq order,
+// along with the newest seq currently known for the conversation (0 if it
+// has no buffer). A conversationID with no buffer (never messaged, or
+// expired/evicted) is not an error — it returns an empty slice, matching
+// "no events yet" rather than "unknown conversation" (the chat API has no
+// separate concept of conversation existence beyond "has it produced any
+// events").
+//
+// latestSeq is how a poll-drain client detects a server-side reset (GH-4843
+// D2): if the client's own `after` cursor is greater than latestSeq, the
+// server has forgotten more history than the client remembers (daemon
+// restart wiped the in-memory buffer, or the 1h conversation-expiry evicted
+// it — see WebMessenger's restart-semantics doc comment) and the client must
+// re-poll from after=0. Conversely, `after` less than the oldest retained
+// seq (visible as a gap between the returned events' lowest seq and `after`)
+// signals the drop-oldest cap (500 events, WebMessenger.maxEventsPerConversation)
+// truncated history the client hasn't seen yet — events simply resume from
+// the oldest still-retained entry in that case.
+func (a *API) Events(conversationID string, after int64) (events []Event, latestSeq int64) {
 	contextID := contextIDPrefix + conversationID
-	events, _ := a.messenger.Events(contextID, after)
-	return events
+	return a.messenger.Events(contextID, after)
 }

--- a/internal/adapters/web/api_test.go
+++ b/internal/adapters/web/api_test.go
@@ -93,13 +93,21 @@ func TestAPI_Dispatch_ValidTextMessage_ReturnsAcceptTimeSeq(t *testing.T) {
 func TestAPI_Dispatch_UsesGivenContextNotCancelledOne(t *testing.T) {
 	api, m := newTestAPI()
 
-	// The context passed to Dispatch is cancelled immediately, but
-	// HandleMessage should still observe the request's own cancellation
-	// state correctly since we pass it a background context deliberately —
-	// Dispatch itself doesn't derive from the caller's ctx beyond passing it
-	// straight to the goroutine, so the caller (gateway handler) is what's
-	// responsible for using the daemon ctx, not the request ctx. Here we
-	// simulate that correctly-wired caller behavior.
+	// requestCtx simulates the inbound HTTP request's own context — a real
+	// gateway handler must NOT pass this to Dispatch (see
+	// internal/gateway/chat.go's handleChatMessages, which stashes the
+	// long-lived daemon context precisely to avoid this). It is genuinely
+	// cancelled here (GH-4843 D4: previously this test never cancelled
+	// anything, so the "not cancelled one" behavior it claims to cover was
+	// never actually exercised).
+	requestCtx, cancelRequest := context.WithCancel(context.Background())
+	cancelRequest()
+	if requestCtx.Err() == nil {
+		t.Fatal("test setup bug: requestCtx should already be cancelled")
+	}
+
+	// daemonCtx is what a correctly-wired caller actually passes to
+	// Dispatch — long-lived and never cancelled by the request lifecycle.
 	daemonCtx := context.Background()
 	seq, err := api.Dispatch(daemonCtx, DispatchRequest{ConversationID: "c1", Text: "hello"})
 	if err != nil {
@@ -109,6 +117,10 @@ func TestAPI_Dispatch_UsesGivenContextNotCancelledOne(t *testing.T) {
 		t.Fatalf("seq = %d, want 0", seq)
 	}
 
+	// Dispatch completing (the goroutine landing its event) despite
+	// requestCtx already being cancelled proves Dispatch uses only the
+	// context explicitly given to it, not some other context the caller
+	// happens to also hold.
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		events, _ := m.Events("web:c1", 0)
@@ -117,14 +129,20 @@ func TestAPI_Dispatch_UsesGivenContextNotCancelledOne(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatal("no event landed")
+	t.Fatal("no event landed — dispatch appears to have been affected by the cancelled request context")
 }
 
 func TestAPI_Events_UnknownConversationIsEmptyNotError(t *testing.T) {
 	api, _ := newTestAPI()
-	events := api.Events("nope", 0)
+	events, latestSeq := api.Events("nope", 0)
 	if len(events) != 0 {
 		t.Fatalf("got %d events, want 0", len(events))
+	}
+	if events == nil {
+		t.Error("events = nil, want non-nil empty slice (GH-4843 D3)")
+	}
+	if latestSeq != 0 {
+		t.Errorf("latestSeq = %d, want 0", latestSeq)
 	}
 }
 
@@ -141,8 +159,31 @@ func TestAPI_Events_UsesConversationIDPrefix(t *testing.T) {
 	}()
 	wg.Wait()
 
-	events := api.Events("c1", 0)
+	events, latestSeq := api.Events("c1", 0)
 	if len(events) != 1 || events[0].Text != "hi" {
 		t.Fatalf("events = %+v", events)
+	}
+	if latestSeq != 1 {
+		t.Errorf("latestSeq = %d, want 1", latestSeq)
+	}
+}
+
+// TestAPI_Events_LatestSeqDetectsReset exercises the GH-4843 D2 reset-
+// detection contract end to end through API.Events: after a daemon restart
+// (simulated here by a fresh WebMessenger with no buffer for the
+// conversation), a client polling with a stale `after` cursor greater than
+// the server's latestSeq gets an unambiguous signal — latestSeq (0) is less
+// than its own cursor — telling it to reset to after=0, entirely from the
+// response body.
+func TestAPI_Events_LatestSeqDetectsReset(t *testing.T) {
+	api, _ := newTestAPI()
+
+	const staleClientCursor = 42
+	events, latestSeq := api.Events("c1", staleClientCursor)
+	if len(events) != 0 {
+		t.Fatalf("got %d events, want 0 (fresh buffer)", len(events))
+	}
+	if latestSeq >= staleClientCursor {
+		t.Fatalf("latestSeq = %d, want < %d (client cursor) so reset is detectable", latestSeq, staleClientCursor)
 	}
 }

--- a/internal/adapters/web/messenger.go
+++ b/internal/adapters/web/messenger.go
@@ -238,7 +238,10 @@ func (m *WebMessenger) Events(contextID string, after int64) (events []Event, la
 	m.pruneLocked()
 	c, ok := m.conversations[contextID]
 	if !ok {
-		return nil, 0
+		// GH-4843 D3: an unknown/expired conversation must still serialize
+		// as `"events": []`, not `null` — a nil slice here propagates all
+		// the way to json.Marshal in the gateway handler.
+		return []Event{}, 0
 	}
 	latestSeq = c.nextSeq
 	out := make([]Event, 0, len(c.events))

--- a/internal/gateway/chat.go
+++ b/internal/gateway/chat.go
@@ -19,7 +19,7 @@ import (
 // convention already used in this package.
 type ChatAPI interface {
 	Dispatch(ctx context.Context, req web.DispatchRequest) (seq int64, err error)
-	Events(conversationID string, after int64) []web.Event
+	Events(conversationID string, after int64) (events []web.Event, latestSeq int64)
 }
 
 // SetChatAPI wires the web chat transport (GH-4835 / C17) backing
@@ -60,10 +60,18 @@ type chatMessageResponse struct {
 	Seq            int64  `json:"seq"`
 }
 
-// chatEventsResponse is the GET .../events body.
+// chatEventsResponse is the GET .../events body. LatestSeq is the newest seq
+// currently known for the conversation (0 if it has no buffer yet) — the
+// reset-detection signal documented on web.API.Events (GH-4843 D2): a client
+// whose own `after` cursor exceeds LatestSeq has outlived the server's
+// in-memory buffer (daemon restart, or 1h conversation expiry) and must
+// re-poll from after=0. A gap between the returned Events' lowest seq and
+// `after` (visible against LatestSeq) signals the 500-event drop-oldest cap
+// truncated history instead.
 type chatEventsResponse struct {
 	ConversationID string      `json:"conversationId"`
 	Events         []web.Event `json:"events"`
+	LatestSeq      int64       `json:"latestSeq"`
 }
 
 // handleChatMessages serves POST /api/v1/chat/messages (GH-4835 acceptance
@@ -164,10 +172,14 @@ func (s *Server) handleChatEvents(w http.ResponseWriter, r *http.Request) {
 		after = v
 	}
 
-	events := api.Events(id, after)
+	events, latestSeq := api.Events(id, after)
+	if events == nil {
+		events = []web.Event{}
+	}
 	writeJSON(w, chatEventsResponse{
 		ConversationID: id,
 		Events:         events,
+		LatestSeq:      latestSeq,
 	})
 }
 

--- a/internal/gateway/chat_test.go
+++ b/internal/gateway/chat_test.go
@@ -22,7 +22,7 @@ import (
 // package's *_test.go files.
 type mockChatAPI struct {
 	dispatchFunc func(ctx context.Context, req web.DispatchRequest) (int64, error)
-	eventsFunc   func(conversationID string, after int64) []web.Event
+	eventsFunc   func(conversationID string, after int64) ([]web.Event, int64)
 }
 
 func (m *mockChatAPI) Dispatch(ctx context.Context, req web.DispatchRequest) (int64, error) {
@@ -32,11 +32,11 @@ func (m *mockChatAPI) Dispatch(ctx context.Context, req web.DispatchRequest) (in
 	return 0, nil
 }
 
-func (m *mockChatAPI) Events(conversationID string, after int64) []web.Event {
+func (m *mockChatAPI) Events(conversationID string, after int64) ([]web.Event, int64) {
 	if m.eventsFunc != nil {
 		return m.eventsFunc(conversationID, after)
 	}
-	return nil
+	return nil, 0
 }
 
 func newTestServerWithChat(api ChatAPI) *Server {
@@ -231,10 +231,10 @@ func TestHandleChatEvents_Success_200(t *testing.T) {
 	var gotID string
 	var gotAfter int64
 	api := &mockChatAPI{
-		eventsFunc: func(conversationID string, after int64) []web.Event {
+		eventsFunc: func(conversationID string, after int64) ([]web.Event, int64) {
 			gotID = conversationID
 			gotAfter = after
-			return want
+			return want, 9
 		},
 	}
 	s := newTestServerWithChat(api)
@@ -254,6 +254,62 @@ func TestHandleChatEvents_Success_200(t *testing.T) {
 	}
 	if resp.ConversationID != "c1" || len(resp.Events) != 1 || resp.Events[0].Text != "hi" {
 		t.Errorf("resp = %+v", resp)
+	}
+	if resp.LatestSeq != 9 {
+		t.Errorf("resp.LatestSeq = %d, want 9", resp.LatestSeq)
+	}
+}
+
+// TestHandleChatEvents_UnknownConversation_EventsIsEmptyArrayNotNull covers
+// GH-4843 D3: the wire body for an unknown/expired conversation must contain
+// `"events": []`, not `"events": null` — a nil slice serializes to null,
+// which forces every client to null-check before iterating.
+func TestHandleChatEvents_UnknownConversation_EventsIsEmptyArrayNotNull(t *testing.T) {
+	api := &mockChatAPI{
+		eventsFunc: func(conversationID string, after int64) ([]web.Event, int64) {
+			return nil, 0
+		},
+	}
+	s := newTestServerWithChat(api)
+	req := httpTestRequestWithPathValue(t, http.MethodGet, "/api/v1/chat/conversations/unknown/events", nil, "id", "unknown")
+	w := newTestResponseRecorder()
+	s.handleChatEvents(w, req)
+
+	if w.status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.status)
+	}
+	if !bytes.Contains(w.body.Bytes(), []byte(`"events":[]`)) {
+		t.Errorf("body = %s, want \"events\":[] present (not null)", w.body.String())
+	}
+}
+
+// TestHandleChatEvents_LatestSeqSignalsReset covers GH-4843 D2: a client
+// whose `after` cursor exceeds the response's latestSeq (server buffer
+// reset — daemon restart or conversation-expiry eviction) must be able to
+// detect that from the GET response alone, with no separate signal needed.
+func TestHandleChatEvents_LatestSeqSignalsReset(t *testing.T) {
+	api := &mockChatAPI{
+		eventsFunc: func(conversationID string, after int64) ([]web.Event, int64) {
+			// Fresh post-restart buffer: no events, latestSeq back at 0,
+			// while the client polls with a stale cursor from before restart.
+			return nil, 0
+		},
+	}
+	s := newTestServerWithChat(api)
+	req := httpTestRequestWithPathValue(t, http.MethodGet, "/api/v1/chat/conversations/c1/events?after=100", nil, "id", "c1")
+	w := newTestResponseRecorder()
+	s.handleChatEvents(w, req)
+
+	if w.status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.status)
+	}
+	var resp chatEventsResponse
+	if err := json.Unmarshal(w.body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	const clientCursor = 100
+	if resp.LatestSeq >= clientCursor {
+		t.Fatalf("resp.LatestSeq = %d, want < %d so the client can detect a reset", resp.LatestSeq, clientCursor)
 	}
 }
 

--- a/internal/pilot/chat_gateway_wiring_test.go
+++ b/internal/pilot/chat_gateway_wiring_test.go
@@ -1,0 +1,104 @@
+package pilot
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/adapters/web"
+	"github.com/qf-studio/pilot/internal/config"
+	"github.com/qf-studio/pilot/internal/executor"
+)
+
+// chatOnlyTestBackend is a fake executor.Backend so this test can construct a
+// real *executor.Runner without invoking a real Claude Code subprocess —
+// mirrors internal/gateway/chat_test.go's chatTestBackend. The greeting path
+// exercised below never actually reaches the backend (comms.Handler answers
+// "hello" directly), but WithChatHandler requires a non-nil runner.
+type chatOnlyTestBackend struct{}
+
+func (b *chatOnlyTestBackend) Name() string      { return "chat-only-gateway-test-backend" }
+func (b *chatOnlyTestBackend) IsAvailable() bool { return true }
+func (b *chatOnlyTestBackend) Execute(ctx context.Context, opts executor.ExecuteOptions) (*executor.BackendResult, error) {
+	return &executor.BackendResult{Success: true, Output: "chat-only gateway test task done"}, nil
+}
+
+// TestGatewayMode_ChatEnabledNoPollingAdapters_RoutesServe is the GH-4843 D1
+// regression test: a gateway-mode daemon with the chat API enabled and ZERO
+// polling adapters configured must still serve POST /api/v1/chat/messages
+// and GET .../events. Before the fix, cmd/pilot/main.go's needsPollingInfra
+// gated gwRunner construction and omitted chat entirely, so a chat-only
+// deployment passed WithChatHandler(nil, ...) here — the guard at the top of
+// this block (p.chatRunner != nil) then skipped SetChatAPI, leaving the
+// routes unregistered (a 404) despite the startup log claiming "Chat API
+// enabled in gateway mode". See gatewayChatNeedsOwnRunner in
+// cmd/pilot/main.go for the fix to the caller-side decision; this test
+// exercises the callee side (pilot.New + the real gateway HTTP routes) with
+// the non-nil runner a correctly-wired caller now always supplies.
+func TestGatewayMode_ChatEnabledNoPollingAdapters_RoutesServe(t *testing.T) {
+	backend := &chatOnlyTestBackend{}
+	runner := executor.NewRunnerWithBackend(backend)
+	runner.SetRecordingEnabled(false)
+	runner.SetSkipPreflightChecks(true)
+
+	cfg := config.DefaultConfig()
+	cfg.Memory.Path = t.TempDir()
+	cfg.Gateway.Port = 19199 // distinct from other packages' fixed test ports
+	cfg.Adapters.Chat = &web.Config{Enabled: true}
+	// Deliberately no Telegram/Slack/GitHub polling config — this is the
+	// exact "webhooks-only / chat-only gateway daemon" shape D1 broke.
+
+	projectPath := t.TempDir()
+	p, err := New(cfg, WithChatHandler(runner, projectPath))
+	if err != nil {
+		t.Fatalf("pilot.New: %v", err)
+	}
+	defer func() { _ = p.Stop() }()
+
+	if err := p.Start(); err != nil {
+		t.Fatalf("p.Start: %v", err)
+	}
+	time.Sleep(150 * time.Millisecond)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	baseURL := "http://127.0.0.1:19199"
+
+	postResp, err := client.Post(baseURL+"/api/v1/chat/messages", "application/json",
+		bytes.NewBufferString(`{"conversationId":"gh4843-conv","text":"hello"}`))
+	if err != nil {
+		t.Fatalf("POST chat/messages: %v", err)
+	}
+	defer func() { _ = postResp.Body.Close() }()
+	if postResp.StatusCode != http.StatusAccepted {
+		t.Fatalf("POST status = %d, want 202 (was 404 pre-GH-4843 fix)", postResp.StatusCode)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		getResp, getErr := client.Get(baseURL + "/api/v1/chat/conversations/gh4843-conv/events")
+		if getErr != nil {
+			t.Fatalf("GET events: %v", getErr)
+		}
+		if getResp.StatusCode != http.StatusOK {
+			_ = getResp.Body.Close()
+			t.Fatalf("GET status = %d, want 200 (was 404 pre-GH-4843 fix)", getResp.StatusCode)
+		}
+		var body struct {
+			Events    []web.Event `json:"events"`
+			LatestSeq int64       `json:"latestSeq"`
+		}
+		decodeErr := json.NewDecoder(getResp.Body).Decode(&body)
+		_ = getResp.Body.Close()
+		if decodeErr != nil {
+			t.Fatalf("decode events body: %v", decodeErr)
+		}
+		if len(body.Events) > 0 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("no chat event drained — chat routes did not actually wire through in gateway mode")
+}

--- a/internal/pilot/chat_gateway_wiring_test.go
+++ b/internal/pilot/chat_gateway_wiring_test.go
@@ -46,7 +46,7 @@ func TestGatewayMode_ChatEnabledNoPollingAdapters_RoutesServe(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	cfg.Memory.Path = t.TempDir()
-	cfg.Gateway.Port = 19199 // distinct from other packages' fixed test ports
+	cfg.Gateway.Port = 19099 // distinct from other packages' fixed test ports (19199 collides with cmd/pilot/adapter_preflight_test.go)
 	cfg.Adapters.Chat = &web.Config{Enabled: true}
 	// Deliberately no Telegram/Slack/GitHub polling config — this is the
 	// exact "webhooks-only / chat-only gateway daemon" shape D1 broke.
@@ -64,7 +64,7 @@ func TestGatewayMode_ChatEnabledNoPollingAdapters_RoutesServe(t *testing.T) {
 	time.Sleep(150 * time.Millisecond)
 
 	client := &http.Client{Timeout: 10 * time.Second}
-	baseURL := "http://127.0.0.1:19199"
+	baseURL := "http://127.0.0.1:19099"
 
 	postResp, err := client.Post(baseURL+"/api/v1/chat/messages", "application/json",
 		bytes.NewBufferString(`{"conversationId":"gh4843-conv","text":"hello"}`))


### PR DESCRIPTION
## Summary

Post-merge review follow-up on PR#4838 (GH-4835) found four defects in the poll-drain chat transport. Fixes D1-D4:

- **D1** — gateway mode silently dropped chat routes (404) when no polling adapter was configured, because `needsPollingInfra` never considered chat, leaving `gwRunner` nil. Adds `gatewayChatNeedsOwnRunner` to build a chat-scoped runner independently of `needsPollingInfra`, and turns the misleading "Chat API enabled" log into a warning on any path that still leaves the handler unwired.
- **D2** — GET events never exposed `latestSeq`, making the documented stale-cursor reset rule unimplementable by clients. Threads `latestSeq` through `WebMessenger` → `API.Events` → `ChatAPI` → `chatEventsResponse`, with the reset/truncation contract documented at each hop.
- **D3** — unknown/expired conversations serialized `events` as `null` instead of `[]`. Fixed at the source in `WebMessenger.Events`.
- **D4** — `TestAPI_Dispatch_UsesGivenContextNotCancelledOne` never actually cancelled a context, leaving the cancellation-survival behavior unasserted. Fixed to actually cancel and assert dispatch completes.

Out of scope (per issue): streaming/SSE, auth changes, comms-brain behavior, console-side work (pilot-console#115).

## Test plan

- [x] `go build ./...`
- [x] `go test ./cmd/pilot/... ./internal/adapters/web/... ./internal/gateway/... ./internal/pilot/...` (including `-race`, repeated runs)
- [x] New integration test (`internal/pilot/chat_gateway_wiring_test.go`): gateway mode, chat enabled, zero polling adapters → POST 202 + GET drains events (was 404 pre-fix)
- [x] `latestSeq` reset-detection contract covered in `internal/gateway/chat_test.go` / `internal/adapters/web/api_test.go`
- [x] Unknown conversation returns `{"events": []}`