### PR TITLE
fix(autopilot): owner-death recovery — re-arm or escalate when a designated fix issue dies

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -4146,11 +4146,22 @@ func (c terminalCompletionChecker) InvalidateCompletion(taskID, projectPath stri
 // GH-2802: Persists pre-flight rejection records for observability.
 type storeExecutionSaver struct {
 	store *memory.Store
+	// controller is optional (nil for a repo with no autopilot controller
+	// wired) — when set, a preflight decline of a Pilot-spawned fix issue
+	// reacts via the owner-death path (GH-4842) instead of only being
+	// recorded for observability.
+	controller *autopilot.Controller
 }
+
+// ownerDeathReactTimeout bounds the synchronous owner-death reaction
+// (GitHub issue fetch + label/comment writes) fired from inside
+// SaveDeclinedExecution, which the SDK poller calls inline on every
+// pre-flight decline.
+const ownerDeathReactTimeout = 15 * time.Second
 
 func (s storeExecutionSaver) SaveDeclinedExecution(taskID, projectPath, status, reason string) error {
 	now := time.Now()
-	return s.store.SaveExecution(&memory.Execution{
+	err := s.store.SaveExecution(&memory.Execution{
 		ID:          fmt.Sprintf("%s-preflight-%d", taskID, now.UnixNano()),
 		TaskID:      taskID,
 		ProjectPath: projectPath,
@@ -4159,6 +4170,20 @@ func (s storeExecutionSaver) SaveDeclinedExecution(taskID, projectPath, status, 
 		CreatedAt:   now,
 		CompletedAt: &now,
 	})
+
+	// GH-4842: a preflight decline is owner death for a Pilot-spawned fix
+	// issue — react (re-arm/escalate its source) using the same signal the
+	// SDK already produces here, instead of adding a new poller.
+	if status == "declined-preflight" && s.controller != nil {
+		var issueNum int
+		if _, scanErr := fmt.Sscanf(taskID, "GH-%d", &issueNum); scanErr == nil && issueNum > 0 {
+			ctx, cancel := context.WithTimeout(context.Background(), ownerDeathReactTimeout)
+			s.controller.ReactToDeclinedFixIssue(ctx, issueNum, reason)
+			cancel()
+		}
+	}
+
+	return err
 }
 
 // warnIfMetricsScopeEmpty logs a startup warning when a configured

--- a/cmd/pilot/poller_github.go
+++ b/cmd/pilot/poller_github.go
@@ -481,7 +481,10 @@ func startGithubSDKPollerForRepo(ctx context.Context, deps *PollerDeps, log *slo
 				repoFullName: target.repoFullName,
 			}
 			if deps.Store != nil {
-				pollerDeps.ExecutionSaver = storeExecutionSaver{store: deps.Store}
+				// GH-4842: wire the per-repo controller (may be nil) so a
+				// preflight decline of a Pilot-spawned fix issue can react
+				// via the owner-death path.
+				pollerDeps.ExecutionSaver = storeExecutionSaver{store: deps.Store, controller: controller}
 			}
 		}
 	}

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1839,6 +1839,9 @@ func (c *Controller) SetOnIssueDone(fn func(issueNumber int)) {
 // SetOnIssueDone above. GH-3954.
 func (c *Controller) SetAlertsEngine(engine alertSink) {
 	c.alertsEngine = engine
+	if c.feedbackLoop != nil {
+		c.feedbackLoop.SetAlertsEngine(engine)
+	}
 }
 
 // OnPRCreated registers a new PR for autopilot processing.

--- a/internal/autopilot/feedback_loop.go
+++ b/internal/autopilot/feedback_loop.go
@@ -161,6 +161,7 @@ type FeedbackLoop struct {
 	issueLabels  []string
 	learningLoop *memory.LearningLoop // GH-1979: optional, annotates issues with known patterns
 	stateStore   *StateStore          // GH-4307: optional, dedups fix-issue creation across retries/daemons
+	alertsEngine alertSink            // GH-4842: optional, observes owner-death (dead designated fix issue) events
 	log          *slog.Logger
 }
 
@@ -185,6 +186,12 @@ func (f *FeedbackLoop) SetLearningLoop(ll *memory.LearningLoop) {
 // existing claim and always creates a new issue (pre-GH-4307 behavior).
 func (f *FeedbackLoop) SetStateStore(store *StateStore) {
 	f.stateStore = store
+}
+
+// SetAlertsEngine wires an alert sink so owner-death events discovered via
+// the dedup open-state check (GH-4842) are observable, not just logged.
+func (f *FeedbackLoop) SetAlertsEngine(engine alertSink) {
+	f.alertsEngine = engine
 }
 
 // spawnedFixDedupKey identifies one failure signal for idempotent fix-issue
@@ -253,14 +260,36 @@ func (f *FeedbackLoop) CreateFailureIssue(ctx context.Context, prState *PRState,
 				"pr", prState.PRNumber, "error", claimErr)
 		} else if !claimed {
 			existing, lookupErr := f.stateStore.GetSpawnedFixIssue(dedupRepo, dedupKey)
-			if lookupErr != nil {
+			switch {
+			case lookupErr != nil:
 				f.log.Warn("duplicate fix-issue creation suppressed but issue lookup failed",
 					"pr", prState.PRNumber, "failure", failureType, "error", lookupErr)
-			} else {
-				f.log.Info("duplicate fix-issue creation suppressed",
-					"pr", prState.PRNumber, "failure", failureType, "existing_issue", existing)
+				return existing, nil
+			case existing <= 0:
+				return existing, nil
+			default:
+				// GH-4842: verify the previously-designated fix issue is
+				// still a live owner before handing it back out. A fix
+				// issue that closed without ever shipping is dead — it
+				// must never be re-designated as the recovery owner via
+				// dedup; fall through and mint a replacement instead.
+				existingIssue, err := f.ghClient.GetIssue(ctx, f.owner, f.repo, existing)
+				switch {
+				case err != nil:
+					f.log.Warn("owner-health check failed, returning existing fix issue unverified",
+						"pr", prState.PRNumber, "failure", failureType, "existing_issue", existing, "error", err)
+					return existing, nil
+				case classifyOwnerHealth(existingIssue) != ownerDead:
+					f.log.Info("duplicate fix-issue creation suppressed",
+						"pr", prState.PRNumber, "failure", failureType, "existing_issue", existing)
+					return existing, nil
+				}
+				f.log.Warn("designated fix issue is dead (closed without shipping) — minting a replacement",
+					"pr", prState.PRNumber, "failure", failureType, "dead_issue", existing)
+				f.fireOwnerDeathAlert(existing, fmt.Sprintf("fix issue #%d closed without shipping, replacing via dedup path", existing), "replaced")
+				// fall through: dedupKey stays set so RecordSpawnedFixIssue
+				// below overwrites this dead issue's row with the replacement.
 			}
-			return existing, nil
 		}
 	}
 

--- a/internal/autopilot/owner_death.go
+++ b/internal/autopilot/owner_death.go
@@ -1,0 +1,202 @@
+package autopilot
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/alerts"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// ownerHealth classifies whether a designated recovery owner (a spawned fix
+// issue holding TerminalLabel for its source) is still able to do its job.
+// GH-4842: a designated owner that dies — declined at preflight, or closed
+// without ever shipping a merged PR — leaves its source issue permanently
+// stranded (pilot-failed, zero live owners) unless something re-arms or
+// escalates it.
+type ownerHealth int
+
+const (
+	// ownerAlive: still open, may yet ship.
+	ownerAlive ownerHealth = iota
+	// ownerShipped: closed with pilot-done — did its job, not a death.
+	ownerShipped
+	// ownerDead: closed without shipping — never merged a fixing PR.
+	ownerDead
+)
+
+// classifyOwnerHealth inspects a (possibly closed) fix issue and reports
+// whether its closure represents a completed hand-off (ownerShipped), no
+// closure at all (ownerAlive), or an owner-death event (ownerDead) that
+// must trigger source re-arm/escalation.
+func classifyOwnerHealth(issue *github.Issue) ownerHealth {
+	if issue == nil || issue.State != github.StateClosed {
+		return ownerAlive
+	}
+	if github.HasLabel(issue, github.LabelDone) {
+		return ownerShipped
+	}
+	return ownerDead
+}
+
+// fixIssueSourceRe extracts the source issue number embedded by
+// FeedbackLoop.generateBody/CreateReviewIssue ("Depends on: #123"). Anchored
+// to line start so it can't match unrelated inline "Depends on" prose.
+var fixIssueSourceRe = regexp.MustCompile(`(?m)^Depends on: #(\d+)\s*$`)
+
+// autopilotMetaMarkerRe requires the autopilot-meta marker to be present
+// before trusting a "Depends on" line as a Pilot-authored source reference —
+// distinguishes autopilot-spawned fix issues from unrelated uses of the same
+// phrase (e.g. epic decomposition in internal/executor/epic.go).
+var autopilotMetaMarkerRe = regexp.MustCompile(`<!--\s*autopilot-meta\b`)
+
+// parseFixIssueSource recovers the source issue number from a spawned fix
+// issue's body, without any new persistence (GH-4842 explicitly scopes
+// designation persistence out — this piggybacks on the existing body
+// convention instead).
+func parseFixIssueSource(body string) (int, bool) {
+	if !autopilotMetaMarkerRe.MatchString(body) {
+		return 0, false
+	}
+	m := fixIssueSourceRe.FindStringSubmatch(body)
+	if len(m) < 2 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// emitOwnerDeathAlert fires an alerts.Event for an owner-death reaction
+// (rearm/escalate/replace). Shared by Controller and FeedbackLoop, which
+// each hold their own optional alertSink. Logs (rather than drops silently)
+// when no sink is wired, since owner-death is exactly the kind of event that
+// must not go unnoticed per the issue's acceptance criteria.
+func emitOwnerDeathAlert(engine alertSink, log *slog.Logger, repoKey string, issueNum int, reasonMsg, outcome string) {
+	if engine == nil {
+		log.Error("owner-death: alert not delivered, alerts engine not wired", "issue", issueNum, "reason", reasonMsg, "outcome", outcome)
+		return
+	}
+	engine.ProcessEvent(alerts.Event{
+		Type:      alerts.EventTypeTaskFailed,
+		TaskID:    fmt.Sprintf("owner-death-%d", issueNum),
+		TaskTitle: fmt.Sprintf("Issue #%d: designated fix issue died", issueNum),
+		Project:   repoKey,
+		Error:     reasonMsg,
+		Timestamp: time.Now(),
+		Metadata: map[string]string{
+			"repo":    repoKey,
+			"issue":   strconv.Itoa(issueNum),
+			"outcome": outcome,
+		},
+	})
+}
+
+// fireOwnerDeathAlert emits an owner-death alert for the dedup-path reaction
+// in CreateFailureIssue (a dead designated fix issue discovered and replaced
+// while re-checking the spawned-fix claim).
+func (f *FeedbackLoop) fireOwnerDeathAlert(issueNum int, reasonMsg, outcome string) {
+	emitOwnerDeathAlert(f.alertsEngine, f.log, f.owner+"/"+f.repo, issueNum, reasonMsg, outcome)
+}
+
+// ReactToDeclinedFixIssue handles the preflight-decline owner-death path
+// (GH-4842 implementation step 1a). It is invoked synchronously from
+// storeExecutionSaver.SaveDeclinedExecution whenever the SDK poller's
+// pre-flight judge rejects a task before dispatch — the SDK already calls
+// this exactly once per decline, so no new poller/goroutine is needed to
+// observe it.
+func (c *Controller) ReactToDeclinedFixIssue(ctx context.Context, issueNumber int, reason string) {
+	issue, err := c.ghClient.GetIssue(ctx, c.owner, c.repo, issueNumber)
+	if err != nil {
+		c.log.Warn("owner-death: failed to fetch declined issue", "issue", issueNumber, "error", err)
+		return
+	}
+	detail := fmt.Sprintf("declined at preflight: %s", reason)
+	c.reactToDeadFixIssue(ctx, issue, detail)
+}
+
+// reactToDeadFixIssue is the shared reaction for both owner-death paths
+// (preflight-declined and closed-unmerged): trace the dead fix issue back
+// to its source via the body convention, and either re-arm the source for
+// retry or escalate to needs-human if retries are already exhausted.
+func (c *Controller) reactToDeadFixIssue(ctx context.Context, deadIssue *github.Issue, detail string) {
+	sourceNum, ok := parseFixIssueSource(deadIssue.Body)
+	if !ok {
+		// Not a Pilot-spawned fix issue (or body doesn't carry the
+		// autopilot-meta marker) — nothing to react to.
+		return
+	}
+	source, err := c.ghClient.GetIssue(ctx, c.owner, c.repo, sourceNum)
+	if err != nil {
+		c.log.Warn("owner-death: failed to fetch source issue", "fix_issue", deadIssue.Number, "source", sourceNum, "error", err)
+		return
+	}
+	if source.State == github.StateClosed {
+		c.log.Info("owner-death: source issue already closed, nothing to re-arm", "fix_issue", deadIssue.Number, "source", sourceNum)
+		return
+	}
+	if !github.HasLabel(source, github.LabelFailed) {
+		// Source isn't currently designated to this fix issue (already
+		// re-armed by something else, or was never in the TerminalLabel
+		// state to begin with) — avoid double-processing.
+		c.log.Info("owner-death: source issue not currently designated to this fix issue, skipping", "fix_issue", deadIssue.Number, "source", sourceNum)
+		return
+	}
+	reasonMsg := fmt.Sprintf("its designated fix issue #%d died (%s)", deadIssue.Number, detail)
+	if github.HasLabel(source, github.LabelRetryExhausted) {
+		c.escalateDeadOwnerSource(ctx, source, reasonMsg)
+		return
+	}
+	c.rearmDeadOwnerSource(ctx, source, reasonMsg)
+}
+
+// rearmDeadOwnerSource restores pilot-retry-ready on the source issue so it
+// re-enters the normal retry ladder, mirroring the relabeling notifyExternalClose
+// already performs for the reactive-close path (controller.go).
+func (c *Controller) rearmDeadOwnerSource(ctx context.Context, source *github.Issue, reasonMsg string) {
+	if err := c.labeler.AddLabels(ctx, c.owner, c.repo, source.Number, []string{github.LabelRetryReady}); err != nil {
+		c.log.Warn("owner-death: failed to add retry-ready label", "issue", source.Number, "error", err)
+	}
+	if err := c.labeler.RemoveLabel(ctx, c.owner, c.repo, source.Number, github.LabelFailed); err != nil {
+		c.log.Debug("owner-death: failed to remove pilot-failed label (may not exist)", "issue", source.Number, "error", err)
+	}
+	comment := fmt.Sprintf(
+		"\U0001F501 **Owner-death recovery**: %s. Re-armed for automatic retry (`%s` restored).",
+		reasonMsg, github.LabelRetryReady,
+	)
+	if _, err := c.ghClient.AddComment(ctx, c.owner, c.repo, source.Number, comment); err != nil {
+		c.log.Warn("owner-death: failed to post re-arm comment", "issue", source.Number, "error", err)
+	}
+	c.fireOwnerDeathAlert(source.Number, reasonMsg, "rearmed")
+	c.log.Warn("owner-death: source re-armed after designated fix issue died", "source", source.Number, "reason", reasonMsg)
+}
+
+// escalateDeadOwnerSource holds the source issue for manual review instead
+// of re-arming, because its retry budget is already exhausted — re-arming
+// here would silently bypass the retry-exhausted ceiling.
+func (c *Controller) escalateDeadOwnerSource(ctx context.Context, source *github.Issue, reasonMsg string) {
+	if err := c.labeler.AddLabels(ctx, c.owner, c.repo, source.Number, []string{labelNeedsHuman}); err != nil {
+		c.log.Warn("owner-death: failed to add needs-human label", "issue", source.Number, "error", err)
+	}
+	comment := fmt.Sprintf(
+		"\U0001F6A8 **Owner-death recovery**: %s, and its retries are already exhausted. Holding for manual review (`%s`).",
+		reasonMsg, labelNeedsHuman,
+	)
+	if _, err := c.ghClient.AddComment(ctx, c.owner, c.repo, source.Number, comment); err != nil {
+		c.log.Warn("owner-death: failed to post escalation comment", "issue", source.Number, "error", err)
+	}
+	c.fireOwnerDeathAlert(source.Number, reasonMsg, "escalated")
+	c.log.Warn("owner-death: source escalated to needs-human, retries exhausted", "source", source.Number, "reason", reasonMsg)
+}
+
+// fireOwnerDeathAlert emits an owner-death alert on behalf of the controller
+// (rearm/escalate reactions).
+func (c *Controller) fireOwnerDeathAlert(sourceIssueNum int, reasonMsg, outcome string) {
+	emitOwnerDeathAlert(c.alertsEngine, c.log, c.repoKey(), sourceIssueNum, reasonMsg, outcome)
+}

--- a/internal/autopilot/owner_death_test.go
+++ b/internal/autopilot/owner_death_test.go
@@ -1,0 +1,401 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestClassifyOwnerHealth covers the pure classifier GH-4842 relies on to
+// tell "still might ship" (ownerAlive), "did its job" (ownerShipped), and
+// "died without shipping" (ownerDead) apart.
+func TestClassifyOwnerHealth(t *testing.T) {
+	tests := []struct {
+		name  string
+		issue *github.Issue
+		want  ownerHealth
+	}{
+		{
+			name:  "nil issue is alive",
+			issue: nil,
+			want:  ownerAlive,
+		},
+		{
+			name:  "open issue is alive",
+			issue: &github.Issue{Number: 1, State: github.StateOpen},
+			want:  ownerAlive,
+		},
+		{
+			name:  "closed with pilot-done is shipped, not death",
+			issue: &github.Issue{Number: 2, State: github.StateClosed, Labels: []github.Label{{Name: github.LabelDone}}},
+			want:  ownerShipped,
+		},
+		{
+			name:  "closed without pilot-done is dead",
+			issue: &github.Issue{Number: 3, State: github.StateClosed, Labels: []github.Label{{Name: github.LabelRetryExhausted}}},
+			want:  ownerDead,
+		},
+		{
+			name:  "closed with no labels at all is dead",
+			issue: &github.Issue{Number: 4, State: github.StateClosed},
+			want:  ownerDead,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyOwnerHealth(tt.issue); got != tt.want {
+				t.Errorf("classifyOwnerHealth() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseFixIssueSource covers recovering the source issue number from a
+// spawned fix issue's body — the mechanism GH-4842 uses instead of adding
+// new persistence for the designation itself.
+func TestParseFixIssueSource(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantNum int
+		wantOK  bool
+	}{
+		{
+			name:    "well-formed autopilot-spawned body",
+			body:    "Some intro text.\n\nDepends on: #123\n\n<!-- autopilot-meta branch:pilot/GH-42 pr:42 iteration:1 -->",
+			wantNum: 123,
+			wantOK:  true,
+		},
+		{
+			name:    "no autopilot-meta marker at all — not a Pilot-spawned fix issue",
+			body:    "Depends on: #123\n\nJust a regular issue mentioning a dependency.",
+			wantNum: 0,
+			wantOK:  false,
+		},
+		{
+			name:    "autopilot-meta present but no Depends-on line",
+			body:    "Some fix issue body.\n\n<!-- autopilot-meta branch:pilot/GH-42 pr:42 iteration:1 -->",
+			wantNum: 0,
+			wantOK:  false,
+		},
+		{
+			name:    "Depends-on inline (not line-anchored) must not match — avoids epic-decomposition false positive",
+			body:    "See also Depends on: #123 mentioned inline.\n\n<!-- autopilot-meta branch:pilot/GH-42 pr:42 iteration:1 -->",
+			wantNum: 0,
+			wantOK:  false,
+		},
+		{
+			name:    "empty body",
+			body:    "",
+			wantNum: 0,
+			wantOK:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotNum, gotOK := parseFixIssueSource(tt.body)
+			if gotOK != tt.wantOK || gotNum != tt.wantNum {
+				t.Errorf("parseFixIssueSource() = (%d, %v), want (%d, %v)", gotNum, gotOK, tt.wantNum, tt.wantOK)
+			}
+		})
+	}
+}
+
+// ownerDeathGHServer is a small router for the owner-death test matrix: it
+// serves canned Issue bodies by number, and records label/comment writes so
+// tests can assert on the reaction that fired.
+type ownerDeathGHServer struct {
+	mu sync.Mutex
+
+	issues map[int]*github.Issue // GET /issues/{n}
+
+	addLabelCalls    []string // "issue:label"
+	removeLabelCalls []string // "issue:label"
+	comments         []string // "issue:body"
+}
+
+func newOwnerDeathGHServer() *ownerDeathGHServer {
+	return &ownerDeathGHServer{issues: map[int]*github.Issue{}}
+}
+
+func (s *ownerDeathGHServer) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/issues/") && !strings.HasSuffix(r.URL.Path, "/labels"):
+			var num int
+			if _, err := fmt.Sscanf(r.URL.Path, "/repos/owner/repo/issues/%d", &num); err == nil {
+				if issue, ok := s.issues[num]; ok {
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(issue)
+					return
+				}
+			}
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels"):
+			var num int
+			_, _ = fmt.Sscanf(r.URL.Path, "/repos/owner/repo/issues/%d/labels", &num)
+			var body struct {
+				Labels []string `json:"labels"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			for _, l := range body.Labels {
+				s.addLabelCalls = append(s.addLabelCalls, fmt.Sprintf("%d:%s", num, l))
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/labels/"):
+			parts := strings.Split(r.URL.Path, "/")
+			label := parts[len(parts)-1]
+			var num int
+			_, _ = fmt.Sscanf(r.URL.Path, "/repos/owner/repo/issues/%d/labels/", &num)
+			s.removeLabelCalls = append(s.removeLabelCalls, fmt.Sprintf("%d:%s", num, label))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/comments"):
+			var num int
+			_, _ = fmt.Sscanf(r.URL.Path, "/repos/owner/repo/issues/%d/comments", &num)
+			var body struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			s.comments = append(s.comments, fmt.Sprintf("%d:%s", num, body.Body))
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(github.Comment{ID: 1, Body: body.Body})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}
+}
+
+func (s *ownerDeathGHServer) hasAddLabel(issue int, label string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	want := fmt.Sprintf("%d:%s", issue, label)
+	for _, c := range s.addLabelCalls {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestController_ReactToDeadFixIssue covers item 2 of GH-4842: react to a
+// dead designated fix issue by either re-arming its source for retry, or
+// escalating to needs-human when the source's retries are already
+// exhausted — in every case exactly one live owner (or an escalation) must
+// result, and an alert must fire.
+func TestController_ReactToDeadFixIssue(t *testing.T) {
+	fixIssueBody := "Fixes CI failure.\n\nDepends on: #100\n\n<!-- autopilot-meta branch:pilot/GH-100 pr:7 iteration:1 -->"
+
+	tests := []struct {
+		name           string
+		sourceIssue    *github.Issue
+		wantRearm      bool
+		wantEscalate   bool
+		wantNoReaction bool
+	}{
+		{
+			name: "source open with pilot-failed and no retry-exhausted — rearmed",
+			sourceIssue: &github.Issue{
+				Number: 100,
+				State:  github.StateOpen,
+				Labels: []github.Label{{Name: github.LabelFailed}},
+			},
+			wantRearm: true,
+		},
+		{
+			name: "source open with pilot-failed and retry-exhausted — escalated",
+			sourceIssue: &github.Issue{
+				Number: 100,
+				State:  github.StateOpen,
+				Labels: []github.Label{{Name: github.LabelFailed}, {Name: github.LabelRetryExhausted}},
+			},
+			wantEscalate: true,
+		},
+		{
+			name: "source already closed — no reaction (avoid double-processing)",
+			sourceIssue: &github.Issue{
+				Number: 100,
+				State:  github.StateClosed,
+				Labels: []github.Label{{Name: github.LabelDone}},
+			},
+			wantNoReaction: true,
+		},
+		{
+			name: "source not currently designated to this fix issue — no reaction",
+			sourceIssue: &github.Issue{
+				Number: 100,
+				State:  github.StateOpen,
+				Labels: []github.Label{{Name: github.LabelRetryReady}},
+			},
+			wantNoReaction: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newOwnerDeathGHServer()
+			srv.issues[100] = tt.sourceIssue
+			ts := httptest.NewServer(srv.handler())
+			defer ts.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, ts.URL)
+			cfg := DefaultConfig()
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+			sink := &fakeAlertSink{}
+			c.SetAlertsEngine(sink)
+
+			deadIssue := &github.Issue{Number: 200, State: github.StateClosed, Body: fixIssueBody}
+			c.reactToDeadFixIssue(context.Background(), deadIssue, "closed without shipping")
+
+			switch {
+			case tt.wantRearm:
+				if !srv.hasAddLabel(100, github.LabelRetryReady) {
+					t.Errorf("expected pilot-retry-ready to be added to source #100, calls=%v", srv.addLabelCalls)
+				}
+				if len(sink.events) != 1 {
+					t.Errorf("expected exactly 1 alert, got %d", len(sink.events))
+				}
+			case tt.wantEscalate:
+				if !srv.hasAddLabel(100, labelNeedsHuman) {
+					t.Errorf("expected %s to be added to source #100, calls=%v", labelNeedsHuman, srv.addLabelCalls)
+				}
+				if srv.hasAddLabel(100, github.LabelRetryReady) {
+					t.Error("retry-exhausted source must not be re-armed with retry-ready")
+				}
+				if len(sink.events) != 1 {
+					t.Errorf("expected exactly 1 alert, got %d", len(sink.events))
+				}
+			case tt.wantNoReaction:
+				if len(srv.addLabelCalls) != 0 {
+					t.Errorf("expected no label writes, got %v", srv.addLabelCalls)
+				}
+				if len(sink.events) != 0 {
+					t.Errorf("expected no alerts, got %d", len(sink.events))
+				}
+			}
+		})
+	}
+}
+
+// TestFeedbackLoop_CreateFailureIssue_DedupOwnerHealth covers item 3 of
+// GH-4842 end-to-end through FeedbackLoop.CreateFailureIssue's dedup path:
+// a closed-unmerged (dead) previously-designated fix issue must never be
+// handed back out as the live owner — it must fall through and mint a
+// replacement. A closed-and-shipped (pilot-done) or still-open issue is NOT
+// death and must still be returned as-is (existing dedup behavior).
+func TestFeedbackLoop_CreateFailureIssue_DedupOwnerHealth(t *testing.T) {
+	tests := []struct {
+		name           string
+		existingIssue  *github.Issue
+		wantCreateCall bool
+		wantReturned   int
+	}{
+		{
+			name:           "existing fix issue open — alive, dedup returns it unchanged",
+			existingIssue:  &github.Issue{Number: 999, State: github.StateOpen},
+			wantCreateCall: false,
+			wantReturned:   999,
+		},
+		{
+			name:           "existing fix issue closed+pilot-done — shipped, not death, dedup returns it unchanged",
+			existingIssue:  &github.Issue{Number: 999, State: github.StateClosed, Labels: []github.Label{{Name: github.LabelDone}}},
+			wantCreateCall: false,
+			wantReturned:   999,
+		},
+		{
+			name:           "existing fix issue closed without shipping — dead, dedup falls through to create a replacement",
+			existingIssue:  &github.Issue{Number: 999, State: github.StateClosed, Labels: []github.Label{{Name: github.LabelRetryExhausted}}},
+			wantCreateCall: true,
+			wantReturned:   555,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			createCalls := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.URL.Path == "/repos/owner/repo/issues/999" && r.Method == http.MethodGet:
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(tt.existingIssue)
+				case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodGet:
+					// GH-4309 belt-and-suspenders search — no match, let dedup
+					// logic (not this fallback) drive the outcome.
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode([]*github.Issue{})
+				case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+					createCalls++
+					resp := github.Issue{Number: 555}
+					w.WriteHeader(http.StatusCreated)
+					_ = json.NewEncoder(w).Encode(resp)
+				default:
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("{}"))
+				}
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+
+			fl := NewFeedbackLoop(ghClient, "owner", "repo", cfg)
+			store := newTestStateStore(t)
+			fl.SetStateStore(store)
+			sink := &fakeAlertSink{}
+			fl.SetAlertsEngine(sink)
+
+			dedupRepo := "owner/repo"
+			dedupKey := spawnedFixDedupKey(42, FailureCIPostMerge, []string{"epic-lifecycle / run"})
+			if _, err := store.ClaimSpawnedFix(dedupRepo, dedupKey); err != nil {
+				t.Fatalf("seed ClaimSpawnedFix failed: %v", err)
+			}
+			if err := store.RecordSpawnedFixIssue(dedupRepo, dedupKey, 999); err != nil {
+				t.Fatalf("seed RecordSpawnedFixIssue failed: %v", err)
+			}
+
+			prState := &PRState{PRNumber: 42, HeadSHA: "abc1234"}
+			got, err := fl.CreateFailureIssue(context.Background(), prState, FailureCIPostMerge, []string{"epic-lifecycle / run"}, "", 1)
+			if err != nil {
+				t.Fatalf("CreateFailureIssue() error = %v", err)
+			}
+			if got != tt.wantReturned {
+				t.Errorf("CreateFailureIssue() = %d, want %d", got, tt.wantReturned)
+			}
+			if (createCalls > 0) != tt.wantCreateCall {
+				t.Errorf("createCalls = %d, wantCreateCall = %v", createCalls, tt.wantCreateCall)
+			}
+
+			if tt.wantCreateCall {
+				// The dead issue's dedup row must be overwritten with the
+				// replacement so future ticks resolve to the live owner.
+				stored, err := store.GetSpawnedFixIssue(dedupRepo, dedupKey)
+				if err != nil {
+					t.Fatalf("GetSpawnedFixIssue error = %v", err)
+				}
+				if stored != 555 {
+					t.Errorf("dedup row after replacement = %d, want 555 (overwritten, not stuck on the dead issue)", stored)
+				}
+				if len(sink.events) != 1 {
+					t.Errorf("expected exactly 1 owner-death alert, got %d", len(sink.events))
+				}
+			} else if len(sink.events) != 0 {
+				t.Errorf("expected no owner-death alert for a live/shipped owner, got %d", len(sink.events))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

After PR#4840 (GH-4826), a CI-failure close designates exactly one recovery owner (the spawned fix issue) via `prState.TerminalLabel`. If that owner itself dies — declined at preflight before dispatch, or closed without ever shipping a merged PR — nothing re-armed the source or escalated it, stranding the source permanently as `pilot-failed` with zero live owners.

Two reactive seams cover both death modes without a new poller:

- `storeExecutionSaver.SaveDeclinedExecution` (`cmd/pilot/main.go`) is called synchronously by the SDK poller on every preflight decline; it now reacts via `Controller.ReactToDeclinedFixIssue` when the declined task is a Pilot-spawned fix issue.
- `FeedbackLoop.CreateFailureIssue`'s dedup path (`feedback_loop.go`) now checks the previously-designated fix issue's open/shipped/dead state before handing it back out, and falls through to mint a replacement (overwriting the dead issue's dedup row) instead of re-designating a closed-unmerged owner.

Both paths trace the dead fix issue back to its source via the existing `Depends on: #N` body convention (no new persistence, per scope) and either re-arm the source with `pilot-retry-ready` or escalate to `pilot-needs-human` when retries are exhausted, firing an alert through the existing alerts engine either way.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/autopilot/... ./cmd/pilot/...`
- [x] Table-driven matrix: preflight-declined → rearm/escalate, source-already-closed → no-op, dedup-returns-open/shipped (not death) vs dedup-returns-closed-unmerged (death → replacement minted, dedup row overwritten, exactly one alert)

Closes GH-4842.