### PR TITLE
fix(autopilot): confirm-poll CI status before declaring wait timeout on adopted PRs

### DIFF
--- a/.agent/tasks/gh-4851.md
+++ b/.agent/tasks/gh-4851.md
@@ -1,0 +1,42 @@
+# GH-4851
+
+**Created:** 2026-08-11
+
+## Problem
+
+GitHub Issue GH-4851: fix(autopilot): CI wait fires timeout blind on adopted PRs — confirm-poll before deadline, evidence-seeded clock, TerminalLabel on timeout
+
+## Context
+
+2026-08-11 incident: the reconciler adopted open PR#4846 (sha fe0f1d5) at 14:35Z; all 7 checks completed green by 14:43Z; the CI wait clock started at 14:57Z; at 15:27Z the daemon declared "CI timeout after 30m0s" and set stage=failed without ever recording a CI read (persisted ci_status=pending is the fingerprint — controller.go:2239 overwrites it on any successful poll). New variant of the GH-4384 family (green checks + 30m timeout), one layer above the #4408 fix: that fix corrected what a poll computes; here no poll result was ever consulted.
+
+Mechanism:
+
+- `handlePRCreated` (internal/autopilot/controller.go:2104-2132) never looks at CI: it unconditionally sets `Stage=StageWaitingCI` and `CIWaitStartedAt=time.Now()` (:2129-2130). For adopted PRs (reconciler `reconcileOrphanPRs` :6126-6180 and startup `ScanExistingPRs` :6042-6105 → `OnPRCreated` :1859-1945, always `StagePRCreated`+`CIPending` :1876-1877) the 30-minute clock starts at adoption time, not CI time.
+- `handleWaitingCI` (controller.go:2137-2280) evaluates the deadline (:2152-2157) BEFORE the only CI read (`c.ciMonitor.CheckCI` :2206). The timeout branch performs no confirming status check, writes stage=failed (:2154) + Error (:2155), never updates ci_status, and sets no TerminalLabel.
+- Any poll-suppressing window leaves the wall clock running with zero reads, so the next evaluation past the deadline fails blind. Candidate suppressors in the incident window: rate-limit cooldown (:6794-6807, skips all of processAllPRs, capped 20m — matches the observed 22-min gap) · per-PR circuit breaker (:2019-2023) · `GetPullRequest` error `continue` (:6850-6873) · persist-failure loop (GH-4053 precedent documented at :1243) · restart re-zeroing the clock (:2139-2141).
+- Close asymmetry: because no TerminalLabel is set, a later human CLOSE of the stranded PR routes `notifyExternalClose` (:7318) to reclassify the completed execution as failed and default the issue to `pilot-retry-ready` — re-dispatching shipped work. (Manual MERGE is safe: :7022-7108 clears retry labels.)
+
+## Implementation
+
+1. **Confirm-poll before declaring timeout.** In `handleWaitingCI`, do not honor the deadline until at least one `CheckCI` read for the current head SHA has been evaluated in the same tick — either move the deadline check after the status read, or perform one confirming `CheckCI` inside the timeout branch and only fail if it does not return success. A deadline-exceeded tick whose read returns CISuccess must proceed to StageCIPassed.
+2. **Seed the wait clock from evidence on the adoption path.** When `OnPRCreated` adopts an existing PR (both reconciler and startup-scan callers), either seed `CIWaitStartedAt` from observable evidence (e.g. PR updated_at), or have `handlePRCreated` resolve CI once inline before entering StageWaitingCI. State the chosen approach in the PR description.
+3. **Stamp a TerminalLabel on the timeout branch** so an external close after a bogus timeout cannot default to `pilot-retry-ready` (see existing TerminalLabel sites at controller.go:2619/:3002 for idiom).
+4. **Persist what was read**: the timeout branch must record the last-known ci_status (or an explicit never-read marker) instead of leaving the adoption-time `CIPending` default — the persisted row must distinguish "polled and pending" from "never successfully polled".
+
+Out of scope: the unguarded `execution_events` append (controller.go:1701) that recorded a bogus terminal failed rung on a completed execution — separate residue, do not widen scope.
+
+## Acceptance
+
+- Regression test: a PR adopted with all checks already completed green, first `handleWaitingCI` evaluation occurring after the deadline has elapsed → reaches StageCIPassed, not StageFailed (drive with deadline exceeded + CheckCI returning success; must fail on current main).
+- Timeout can only be declared after a same-tick CI read that did not return success.
+- Timeout branch sets a TerminalLabel; test that an external close after timeout does not arm `pilot-retry-ready`.
+- GH-4384 / GH-4415 / GH-4478 / GH-4646 family tests unchanged and passing.
+
+## Refs
+
+- Incident: PR#4846 strand (TASK-467) — adopted 14:35Z, checks green 14:43Z, wait started 14:57Z, bogus timeout 15:27Z, ci_status=pending fingerprint.
+- Prior family: GH-4384 (#4408 fix, ci_monitor.go:451-487) · GH-4478 · GH-4646 · GH-4415 restart variant · GH-4053 reconciler-loop precedent (controller.go:1243 comment).
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1944,6 +1944,41 @@ func (c *Controller) OnPRCreated(prNumber int, prURL string, issueNumber int, he
 	}
 }
 
+// seedAdoptedCIWaitClock seeds CIWaitStartedAt for a just-adopted PR (see
+// reconcileOrphanPRs / ScanExistingPRs) from GitHub's own last-activity
+// timestamp instead of letting handlePRCreated default it to time.Now() once
+// the pipeline reaches StageWaitingCI.
+//
+// GH-4851: an adopted PR can have every check long completed by the time
+// OnPRCreated fires — starting the clock at "now" instead of the PR's own
+// last-known-activity time means a suppressed processing window (rate-limit
+// cooldown, circuit breaker, restart) that delays the first handleWaitingCI
+// tick makes the CIWaitTimeout deadline look freshly exceeded, when CI in
+// reality finished the moment the PR stopped changing (PR#4846: adopted
+// 14:35Z, checks green by 14:43Z). This is a lower-bound approximation, not
+// a CI timestamp itself — the deadline-confirmation logic added to
+// handleWaitingCI in the same fix is what actually prevents a false timeout;
+// this just makes the clock (and CIWaitDuration metrics) reflect reality
+// more closely. Only applied while the PR is still sitting in StagePRCreated
+// with a zero CIWaitStartedAt, so it never clobbers a wait already in
+// progress (e.g. a concurrent registration that raced ahead of this call).
+func (c *Controller) seedAdoptedCIWaitClock(prNumber int, updatedAt time.Time) {
+	if updatedAt.IsZero() {
+		return
+	}
+	c.mu.RLock()
+	prState, ok := c.activePRs[prNumber]
+	c.mu.RUnlock()
+	if !ok {
+		return
+	}
+	prState.mu.Lock()
+	if prState.Stage == StagePRCreated && prState.CIWaitStartedAt.IsZero() {
+		prState.CIWaitStartedAt = updatedAt
+	}
+	prState.mu.Unlock()
+}
+
 // OnReviewRequested handles PR review events from GitHub webhooks.
 // For changes_requested reviews on tracked PRs, it transitions the PR to StageReviewRequested
 // so the next processAllPRs tick will create a revision issue.
@@ -2125,15 +2160,37 @@ func (c *Controller) handlePRCreated(ctx context.Context, prState *PRState, ghPR
 		}
 	}
 
-	// All environments wait for CI - no skipping
+	// All environments wait for CI - no skipping.
+	// GH-4851: an adopted PR (reconciler/startup-scan, see
+	// seedAdoptedCIWaitClock) may already have CIWaitStartedAt seeded from
+	// GitHub's own last-activity evidence rather than "now" — preserve that
+	// seed instead of clobbering it, so the wait clock reflects when CI
+	// activity plausibly started, not when Pilot happened to notice the PR.
 	prState.Stage = StageWaitingCI
-	prState.CIWaitStartedAt = time.Now()
+	if prState.CIWaitStartedAt.IsZero() {
+		prState.CIWaitStartedAt = time.Now()
+	}
 	return nil
 }
 
 // handleWaitingCI checks CI status once (non-blocking) and updates state.
 // Uses CheckCI instead of WaitForCI to prevent blocking the processing loop.
 // Accepts optional cached ghPR to avoid redundant API calls.
+//
+// GH-4851: the CI-wait deadline is a lower bound on "how long has this PR
+// waited", not a promise that a poll ever actually ran during that window —
+// a suppressed processing tick (rate-limit cooldown, circuit breaker, a
+// restart) can leave the wall clock running with zero CI reads while CI
+// itself genuinely finished (even green) minutes or hours earlier. The
+// deadline is therefore only ever honored AFTER a same-tick CheckCI read
+// comes back — and only if that read is CIPending/CIRunning ("still
+// genuinely unresolved"); a read that resolves CISuccess/CIFailure/
+// CIConfigMismatch always takes priority over an expired clock, via
+// applyCIOutcome below. Incident: PR#4846 was adopted 14:35Z, all checks
+// went green by 14:43Z, the wait clock started (blind) at 14:57Z, and the
+// first-ever evaluation of this function — at 15:27Z, after a suppressed
+// window — declared "CI timeout" without ever having consulted CI, leaving
+// the persisted ci_status at its adoption-time CIPending default.
 func (c *Controller) handleWaitingCI(ctx context.Context, prState *PRState, ghPR *github.PullRequest) error {
 	// Initialize CIWaitStartedAt if not set (backwards compatibility)
 	if prState.CIWaitStartedAt.IsZero() {
@@ -2148,13 +2205,7 @@ func (c *Controller) handleWaitingCI(ctx context.Context, prState *PRState, ghPR
 	if envCITimeout > 0 && (ciTimeout == 0 || envCITimeout < ciTimeout) {
 		ciTimeout = envCITimeout
 	}
-
-	if time.Since(prState.CIWaitStartedAt) > ciTimeout {
-		c.log.Warn("CI timeout", "pr", prState.PRNumber, "waited", time.Since(prState.CIWaitStartedAt))
-		prState.Stage = StageFailed
-		prState.Error = fmt.Sprintf("CI timeout after %v", ciTimeout)
-		return nil
-	}
+	deadlineExceeded := time.Since(prState.CIWaitStartedAt) > ciTimeout
 
 	// GH-419, GH-457: Always refresh HeadSHA from GitHub before checking CI.
 	// Self-review or other post-creation commits can change the HEAD,
@@ -2245,6 +2296,37 @@ func (c *Controller) handleWaitingCI(ctx context.Context, prState *PRState, ghPR
 		"status", status,
 	)
 
+	// GH-4851: a same-tick read that resolves CISuccess/CIFailure/
+	// CIConfigMismatch always wins over an expired deadline — only a read
+	// that comes back CIPending/CIRunning ("still genuinely unresolved")
+	// falls through to the confirmed-timeout check below.
+	if c.applyCIOutcome(prState, sha, status) {
+		return nil
+	}
+
+	if deadlineExceeded {
+		waited := time.Since(prState.CIWaitStartedAt)
+		c.log.Warn("CI timeout confirmed by same-tick poll",
+			"pr", prState.PRNumber, "waited", waited, "last_status", status)
+		prState.Stage = StageFailed
+		prState.Error = fmt.Sprintf("CI timeout after %v (last confirmed status: %s)", ciTimeout, status)
+		// GH-4851: without a TerminalLabel here, a later external close of
+		// this stranded PR (notifyExternalClose, GH-3806) would default to
+		// pilot-retry-ready and silently re-dispatch the issue's already-
+		// shipped work. Mirrors the iteration-limit idiom at handleCIFailed
+		// (controller.go:2619) — this branch is just as terminal.
+		prState.TerminalLabel = github.LabelFailed
+	}
+
+	return nil
+}
+
+// applyCIOutcome transitions prState based on a freshly-read, same-tick CI
+// status. Returns true if the PR left StageWaitingCI for a terminal or
+// passed stage (CISuccess/CIFailure/CIConfigMismatch); false if status is
+// still CIPending/CIRunning, in which case the caller decides whether to
+// keep waiting or — GH-4851 — declare a deadline-confirmed timeout.
+func (c *Controller) applyCIOutcome(prState *PRState, sha string, status CIStatus) bool {
 	switch status {
 	case CISuccess:
 		c.log.Info("CI passed", "pr", prState.PRNumber, "sha", ShortSHA(sha))
@@ -2253,12 +2335,14 @@ func (c *Controller) handleWaitingCI(ctx context.Context, prState *PRState, ghPR
 		if !prState.CIWaitStartedAt.IsZero() {
 			c.metrics.RecordCIWaitDuration(time.Since(prState.CIWaitStartedAt))
 		}
+		return true
 	case CIFailure:
 		c.log.Warn("CI failed", "pr", prState.PRNumber, "sha", ShortSHA(sha))
 		prState.Stage = StageCIFailed
 		if !prState.CIWaitStartedAt.IsZero() {
 			c.metrics.RecordCIWaitDuration(time.Since(prState.CIWaitStartedAt))
 		}
+		return true
 	case CIConfigMismatch:
 		// GH-4646: required_checks/ci_checks.required names a check this repo's
 		// CI will never post — a config error, not a code failure. Fail the PR
@@ -2271,12 +2355,13 @@ func (c *Controller) handleWaitingCI(ctx context.Context, prState *PRState, ghPR
 			"missing_required_checks", missing, "discovered_checks", discovered)
 		prState.Stage = StageFailed
 		prState.Error = fmt.Sprintf("CI required-checks config mismatch: required check(s) %v never posted on this SHA (discovered checks: %v) — fix required_checks/ci_checks.required, then retry (GH-4646)", missing, discovered)
+		return true
 	case CIPending, CIRunning:
 		// Stay in StageWaitingCI, will be checked next poll cycle
 		c.log.Debug("CI still running", "pr", prState.PRNumber, "status", status)
+		return false
 	}
-
-	return nil
+	return false
 }
 
 // requiredCheckMismatchDetail computes, from sha's already-discovered check
@@ -6116,6 +6201,9 @@ func (c *Controller) ScanExistingPRs(ctx context.Context) error {
 
 		// Register PR via existing mechanism
 		c.OnPRCreated(pr.Number, pr.HTMLURL, issueNum, pr.Head.SHA, pr.Head.Ref, "")
+		if updatedAt, err := time.Parse(time.RFC3339, pr.UpdatedAt); err == nil {
+			c.seedAdoptedCIWaitClock(pr.Number, updatedAt)
+		}
 		c.metrics.RecordOrphanPRRegistered("startup_scan")
 		restored++
 	}
@@ -6195,6 +6283,9 @@ func (c *Controller) reconcileOrphanPRs(ctx context.Context) {
 			"issue", issueNum,
 		)
 		c.OnPRCreated(pr.Number, pr.HTMLURL, issueNum, pr.Head.SHA, pr.Head.Ref, "")
+		if updatedAt, err := time.Parse(time.RFC3339, pr.UpdatedAt); err == nil {
+			c.seedAdoptedCIWaitClock(pr.Number, updatedAt)
+		}
 		c.metrics.RecordOrphanPRRegistered("reconciler")
 	}
 }

--- a/internal/autopilot/gh4851_ci_wait_confirm_poll_test.go
+++ b/internal/autopilot/gh4851_ci_wait_confirm_poll_test.go
@@ -1,0 +1,449 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GH-4851 regression tests.
+//
+// 2026-08-11 incident: the reconciler adopted open PR#4846 (sha fe0f1d5) at
+// 14:35Z; all 7 checks completed green by 14:43Z; the CI wait clock started
+// at 14:57Z; a suppressed processing window (rate-limit cooldown/breaker)
+// delayed the first-ever handleWaitingCI evaluation until 15:27Z, which
+// declared "CI timeout after 30m0s" and set Stage=failed WITHOUT ever
+// consulting CI — the deadline check ran before the only CI read in the
+// function, so a same-tick CheckCI never happened. The persisted
+// ci_status=pending fingerprint is the adoption-time CIPending default,
+// never overwritten by a real poll. Closing the stranded PR afterward routed
+// through notifyExternalClose with no TerminalLabel recorded, defaulting the
+// issue to pilot-retry-ready and re-dispatching already-shipped work.
+//
+// These tests cover: (1) a deadline-exceeded tick must consult CI before
+// declaring timeout, and success wins over an expired clock; (2) a
+// same-tick read that resolves failure also wins over the deadline, so it
+// is never mislabeled a "CI timeout"; (3) only a same-tick CIPending/
+// CIRunning read can confirm a timeout, and that branch records a
+// TerminalLabel plus the real polled status (not the blind default); (4)
+// external close after a confirmed timeout does not arm pilot-retry-ready;
+// (5)/(6) the adoption paths (reconciler, startup scan) seed the wait clock
+// from GitHub's own last-activity evidence instead of "now"; (7) an
+// end-to-end reproduction of the PR#4846 shape.
+
+func gh4851CheckRunsHandler(sha string, run github.CheckRun) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/commits/"+sha+"/check-runs" {
+			resp := github.CheckRunsResponse{TotalCount: 1, CheckRuns: []github.CheckRun{run}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}
+}
+
+// TestHandleWaitingCI_DeadlineExceeded_ConfirmedSuccess_GH4851 is the primary
+// acceptance test: a PR whose CI already resolved CISuccess, evaluated for
+// the first time only after the wait deadline has already elapsed, must
+// reach StageCIPassed — not StageFailed. This fails on pre-fix main, where
+// the deadline check ran unconditionally before any CheckCI call.
+func TestHandleWaitingCI_DeadlineExceeded_ConfirmedSuccess_GH4851(t *testing.T) {
+	const sha = "gh4851pass01"
+	server := httptest.NewServer(gh4851CheckRunsHandler(sha, github.CheckRun{
+		Name: "ci", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess,
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	c.mu.Lock()
+	c.activePRs[4846] = &PRState{
+		PRNumber: 4846,
+		HeadSHA:  sha,
+		Stage:    StageWaitingCI,
+		CIStatus: CIPending, // adoption-time blind default, never yet confirmed
+		// Deadline already exceeded before this tick's CheckCI ever runs —
+		// mirrors the suppressed-window gap between adoption and first poll.
+		CIWaitStartedAt: time.Now().Add(-45 * time.Minute),
+	}
+	c.mu.Unlock()
+
+	ghPR := &github.PullRequest{Number: 4846, Head: github.PRRef{SHA: sha}, Base: github.PRRef{Ref: "main"}}
+
+	if err := c.ProcessPR(context.Background(), 4846, ghPR); err != nil {
+		t.Fatalf("ProcessPR returned unexpected error: %v", err)
+	}
+
+	pr, ok := c.GetPRState(4846)
+	if !ok {
+		t.Fatal("PR 4846 no longer tracked")
+	}
+	if pr.Stage != StageCIPassed {
+		t.Fatalf("Stage = %s, want %s — a same-tick CheckCI success must win over an already-expired deadline (error=%q)", pr.Stage, StageCIPassed, pr.Error)
+	}
+}
+
+// TestHandleWaitingCI_DeadlineExceeded_ConfirmedFailure_GH4851 verifies the
+// symmetric case: a same-tick read that resolves CIFailure also takes
+// priority over the deadline, so a genuinely-failed PR routes into the
+// normal CI-fix cascade (StageCIFailed) rather than being misdiagnosed as a
+// bare "CI timeout" with no failing-check evidence attached.
+func TestHandleWaitingCI_DeadlineExceeded_ConfirmedFailure_GH4851(t *testing.T) {
+	const sha = "gh4851fail01"
+	server := httptest.NewServer(gh4851CheckRunsHandler(sha, github.CheckRun{
+		Name: "ci", Status: github.CheckRunCompleted, Conclusion: github.ConclusionFailure,
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	c.mu.Lock()
+	c.activePRs[4847] = &PRState{
+		PRNumber:        4847,
+		HeadSHA:         sha,
+		Stage:           StageWaitingCI,
+		CIStatus:        CIPending,
+		CIWaitStartedAt: time.Now().Add(-45 * time.Minute),
+	}
+	c.mu.Unlock()
+
+	ghPR := &github.PullRequest{Number: 4847, Head: github.PRRef{SHA: sha}, Base: github.PRRef{Ref: "main"}}
+
+	if err := c.ProcessPR(context.Background(), 4847, ghPR); err != nil {
+		t.Fatalf("ProcessPR returned unexpected error: %v", err)
+	}
+
+	pr, ok := c.GetPRState(4847)
+	if !ok {
+		t.Fatal("PR 4847 no longer tracked")
+	}
+	if pr.Stage != StageCIFailed {
+		t.Fatalf("Stage = %s, want %s — a same-tick CheckCI failure must win over an expired deadline instead of being folded into a bare timeout", pr.Stage, StageCIFailed)
+	}
+	if strings.Contains(pr.Error, "CI timeout") {
+		t.Errorf("Error = %q should not mention CI timeout — this PR failed CI, it did not time out", pr.Error)
+	}
+}
+
+// TestHandleWaitingCI_DeadlineExceeded_ConfirmedPending_DeclaresTimeout_GH4851
+// covers the genuine-timeout branch: only when the same-tick read comes back
+// CIPending/CIRunning (still unresolved) may the deadline fire. That branch
+// must (a) set a TerminalLabel so a later external close can't default to
+// pilot-retry-ready, and (b) leave behind a persisted-state fingerprint that
+// proves a real poll happened — CIStatus reflects the just-read status (not
+// the adoption-time CIPending default) and LastChecked is freshly non-zero.
+func TestHandleWaitingCI_DeadlineExceeded_ConfirmedPending_DeclaresTimeout_GH4851(t *testing.T) {
+	const sha = "gh4851pend01"
+	server := httptest.NewServer(gh4851CheckRunsHandler(sha, github.CheckRun{
+		Name: "ci", Status: github.CheckRunInProgress,
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	before := time.Now()
+	c.mu.Lock()
+	c.activePRs[4848] = &PRState{
+		PRNumber:        4848,
+		HeadSHA:         sha,
+		Stage:           StageWaitingCI,
+		CIStatus:        CIPending,
+		CIWaitStartedAt: time.Now().Add(-45 * time.Minute),
+	}
+	c.mu.Unlock()
+
+	ghPR := &github.PullRequest{Number: 4848, Head: github.PRRef{SHA: sha}, Base: github.PRRef{Ref: "main"}}
+
+	if err := c.ProcessPR(context.Background(), 4848, ghPR); err != nil {
+		t.Fatalf("ProcessPR returned unexpected error: %v", err)
+	}
+
+	pr, ok := c.GetPRState(4848)
+	if !ok {
+		t.Fatal("PR 4848 no longer tracked")
+	}
+	if pr.Stage != StageFailed {
+		t.Fatalf("Stage = %s, want %s — CI is still genuinely unresolved past the deadline, this must time out", pr.Stage, StageFailed)
+	}
+	if pr.TerminalLabel != github.LabelFailed {
+		t.Errorf("TerminalLabel = %q, want %q — a confirmed CI timeout is terminal and must not be silently re-queued", pr.TerminalLabel, github.LabelFailed)
+	}
+	// checkAutoDiscoveredRuns aggregates any still-pending/running check run into
+	// CIPending at the aggregate level (ci_monitor.go) — CIRunning is a per-run,
+	// not an aggregate, value. What matters here is that this is the *freshly
+	// read* same-tick status, not the adoption-time CIPending default carried
+	// over unread — which LastChecked (below) is what actually proves.
+	if pr.CIStatus != CIPending {
+		t.Errorf("CIStatus = %q, want %q — must record the real same-tick poll result", pr.CIStatus, CIPending)
+	}
+	if pr.LastChecked.Before(before) {
+		t.Errorf("LastChecked = %v, want a timestamp at/after %v — proves a real CI read happened this tick, distinguishing 'polled and pending' from 'never successfully polled'", pr.LastChecked, before)
+	}
+	if !strings.Contains(pr.Error, "CI timeout") {
+		t.Errorf("Error = %q, want it to mention CI timeout", pr.Error)
+	}
+}
+
+// TestNotifyExternalClose_AfterConfirmedTimeout_DoesNotArmRetryReady_GH4851
+// reproduces the PR#4846 close asymmetry: once handleWaitingCI has declared
+// a confirmed timeout (and recorded TerminalLabel), a human closing the
+// stranded PR must route the source issue to pilot-failed, never
+// pilot-retry-ready — re-dispatching work that (in the real incident) had
+// already shipped.
+func TestNotifyExternalClose_AfterConfirmedTimeout_DoesNotArmRetryReady_GH4851(t *testing.T) {
+	const sha = "gh4851close01"
+	var labelsAdded []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/"+sha+"/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns:  []github.CheckRun{{Name: "ci", Status: github.CheckRunInProgress}},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/repos/owner/repo/issues/4849" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Issue{Number: 4849, State: github.StateOpen})
+		case r.URL.Path == "/repos/owner/repo/issues/4849/labels" && r.Method == http.MethodPost:
+			var body map[string][]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			labelsAdded = append(labelsAdded, body["labels"]...)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Label{})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:        4846,
+		IssueNumber:     4849,
+		HeadSHA:         sha,
+		Stage:           StageWaitingCI,
+		CIStatus:        CIPending,
+		CIWaitStartedAt: time.Now().Add(-45 * time.Minute),
+	}
+	c.mu.Lock()
+	c.activePRs[4846] = prState
+	c.mu.Unlock()
+
+	ghPR := &github.PullRequest{Number: 4846, Head: github.PRRef{SHA: sha}, Base: github.PRRef{Ref: "main"}}
+	if err := c.ProcessPR(context.Background(), 4846, ghPR); err != nil {
+		t.Fatalf("ProcessPR returned unexpected error: %v", err)
+	}
+	if prState.Stage != StageFailed || prState.TerminalLabel != github.LabelFailed {
+		t.Fatalf("setup failed: Stage=%s TerminalLabel=%q, want StageFailed with TerminalLabel=pilot-failed", prState.Stage, prState.TerminalLabel)
+	}
+
+	// Human closes the stranded PR — notifyExternalClose must consult the
+	// TerminalLabel recorded above.
+	c.notifyExternalClose(context.Background(), prState)
+
+	foundFailed, foundRetryReady := false, false
+	for _, l := range labelsAdded {
+		if l == github.LabelFailed {
+			foundFailed = true
+		}
+		if l == github.LabelRetryReady {
+			foundRetryReady = true
+		}
+	}
+	if !foundFailed {
+		t.Errorf("expected issue to be labeled %q, got labels added: %v", github.LabelFailed, labelsAdded)
+	}
+	if foundRetryReady {
+		t.Errorf("issue must NOT be labeled %q after a confirmed CI timeout — this is the PR#4846 stranded-close shape; labels added: %v", github.LabelRetryReady, labelsAdded)
+	}
+}
+
+// TestReconcileOrphanPRs_SeedsCIWaitClockFromUpdatedAt_GH4851 verifies that
+// adopting an orphan PR seeds CIWaitStartedAt from GitHub's own UpdatedAt
+// evidence rather than leaving it zero (to later default to time.Now() in
+// handlePRCreated) — the reconciler-adoption half of the PR#4846 incident,
+// where the clock started at PR-notice time (14:57Z) rather than reflecting
+// when the PR had actually last changed.
+func TestReconcileOrphanPRs_SeedsCIWaitClockFromUpdatedAt_GH4851(t *testing.T) {
+	staleUpdatedAt := time.Now().Add(-22 * time.Minute).Truncate(time.Second)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/pulls" {
+			prs := []*github.PullRequest{
+				{
+					Number:    4846,
+					HTMLURL:   "https://github.com/owner/repo/pull/4846",
+					Head:      github.PRRef{Ref: "pilot/GH-4840", SHA: "fe0f1d5"},
+					Base:      github.PRRef{Ref: "main"},
+					UpdatedAt: staleUpdatedAt.Format(time.RFC3339),
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(prs)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	c.reconcileOrphanPRs(context.Background())
+
+	pr, ok := c.GetPRState(4846)
+	if !ok {
+		t.Fatal("reconciler did not register PR 4846")
+	}
+	if pr.CIWaitStartedAt.IsZero() {
+		t.Fatal("CIWaitStartedAt was not seeded from adoption evidence")
+	}
+	if diff := pr.CIWaitStartedAt.Sub(staleUpdatedAt); diff < -time.Second || diff > time.Second {
+		t.Errorf("CIWaitStartedAt = %v, want ~%v (PR's own UpdatedAt) — must not be seeded to time.Now()", pr.CIWaitStartedAt, staleUpdatedAt)
+	}
+}
+
+// TestScanExistingPRs_SeedsCIWaitClockFromUpdatedAt_GH4851 is the
+// startup-scan counterpart to the reconciler test above.
+func TestScanExistingPRs_SeedsCIWaitClockFromUpdatedAt_GH4851(t *testing.T) {
+	staleUpdatedAt := time.Now().Add(-40 * time.Minute).Truncate(time.Second)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/pulls" {
+			prs := []*github.PullRequest{
+				{
+					Number:    4850,
+					HTMLURL:   "https://github.com/owner/repo/pull/4850",
+					Head:      github.PRRef{Ref: "pilot/GH-4845", SHA: "abc9999"},
+					Base:      github.PRRef{Ref: "main"},
+					UpdatedAt: staleUpdatedAt.Format(time.RFC3339),
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(prs)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	if err := c.ScanExistingPRs(context.Background()); err != nil {
+		t.Fatalf("ScanExistingPRs returned unexpected error: %v", err)
+	}
+
+	pr, ok := c.GetPRState(4850)
+	if !ok {
+		t.Fatal("scan did not register PR 4850")
+	}
+	if diff := pr.CIWaitStartedAt.Sub(staleUpdatedAt); diff < -time.Second || diff > time.Second {
+		t.Errorf("CIWaitStartedAt = %v, want ~%v (PR's own UpdatedAt) — must not be seeded to time.Now()", pr.CIWaitStartedAt, staleUpdatedAt)
+	}
+}
+
+// TestGH4851_EndToEnd_AdoptedGreenPR_PastDeadline_ReachesCIPassed reproduces
+// the full PR#4846 shape in one flow: the reconciler adopts an orphan PR
+// whose UpdatedAt is already older than the CI wait timeout (the suppressed-
+// window gap), and the very first ProcessPR tick — where CheckCI reports the
+// checks are already green — must resolve straight to StageCIPassed rather
+// than declaring a blind timeout.
+func TestGH4851_EndToEnd_AdoptedGreenPR_PastDeadline_ReachesCIPassed(t *testing.T) {
+	const sha = "fe0f1d5end2end"
+	staleUpdatedAt := time.Now().Add(-45 * time.Minute).Truncate(time.Second)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/pulls":
+			prs := []*github.PullRequest{
+				{
+					Number:    4846,
+					HTMLURL:   "https://github.com/owner/repo/pull/4846",
+					Head:      github.PRRef{Ref: "pilot/GH-4840", SHA: sha},
+					Base:      github.PRRef{Ref: "main"},
+					UpdatedAt: staleUpdatedAt.Format(time.RFC3339),
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(prs)
+		case "/repos/owner/repo/commits/" + sha + "/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "ci", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	// Reconciler adopts the orphan PR — CIWaitStartedAt is seeded from its
+	// stale UpdatedAt, already past the 30m deadline.
+	c.reconcileOrphanPRs(context.Background())
+
+	ghPR := &github.PullRequest{Number: 4846, Head: github.PRRef{SHA: sha}, Base: github.PRRef{Ref: "main"}}
+
+	// First tick: StagePRCreated -> StageWaitingCI (must preserve the seeded
+	// clock, not reset it to time.Now()).
+	if err := c.ProcessPR(context.Background(), 4846, ghPR); err != nil {
+		t.Fatalf("first ProcessPR (pr_created) error = %v", err)
+	}
+	pr, ok := c.GetPRState(4846)
+	if !ok {
+		t.Fatal("PR 4846 no longer tracked after first tick")
+	}
+	if pr.Stage != StageWaitingCI {
+		t.Fatalf("stage after first tick = %s, want %s", pr.Stage, StageWaitingCI)
+	}
+	if diff := pr.CIWaitStartedAt.Sub(staleUpdatedAt); diff < -time.Second || diff > time.Second {
+		t.Fatalf("handlePRCreated clobbered the seeded CIWaitStartedAt: got %v, want ~%v", pr.CIWaitStartedAt, staleUpdatedAt)
+	}
+
+	// Second tick: handleWaitingCI evaluates with the deadline already
+	// exceeded — must consult CI (green) before declaring timeout.
+	if err := c.ProcessPR(context.Background(), 4846, ghPR); err != nil {
+		t.Fatalf("second ProcessPR (waiting_ci) error = %v", err)
+	}
+	pr, ok = c.GetPRState(4846)
+	if !ok {
+		t.Fatal("PR 4846 no longer tracked after second tick")
+	}
+	if pr.Stage != StageCIPassed {
+		t.Fatalf("final stage = %s, want %s (error=%q) — the PR#4846 shape: adopted PR with green checks must not time out blind", pr.Stage, StageCIPassed, pr.Error)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes GH-4851: autopilot's CI-wait logic was declaring "CI timeout" on adopted PRs without ever polling CI.

**Incident (PR#4846, 2026-08-11):** the reconciler adopted an open PR whose checks had already gone green; the wait clock started blind via `time.Now()` at adoption time; a suppressed processing window delayed the first `handleWaitingCI` evaluation until after the 30-minute deadline had already elapsed. The deadline check ran unconditionally *before* the function's only CI read, so it declared timeout without ever consulting CI — leaving the persisted `ci_status` stuck at its adoption-time `CIPending` default and no `TerminalLabel` set. A later external close of the stranded PR then defaulted the issue to `pilot-retry-ready`, re-dispatching already-shipped work.

## Changes

1. **Confirm-poll before declaring timeout.** `handleWaitingCI` no longer honors an expired deadline until at least one same-tick `CheckCI` read has been evaluated. A read that resolves `CISuccess`/`CIFailure`/`CIConfigMismatch` always wins over an expired clock — extracted into `applyCIOutcome`, which the deadline branch now falls through to only when the read is still `CIPending`/`CIRunning` ("genuinely unresolved").
2. **Seed the wait clock from evidence on adoption.** Chosen approach: seed `CIWaitStartedAt` from the PR's own `updated_at` (via new `seedAdoptedCIWaitClock`, called from both `reconcileOrphanPRs` and `ScanExistingPRs`) rather than resolving CI inline in `handlePRCreated`. Rejected the inline-resolve option because it would add an unconditional extra `CheckCI` call to every PR-creation path (not just adopted ones), risking regressions across the many existing tests that don't mock CI endpoints for arbitrary SHAs. The evidence-seed approach is scoped only to the two adoption call sites and needs no change to `OnPRCreated`'s public signature (which is bound as a callback type by the Linear and Azure DevOps pollers).
3. **TerminalLabel on confirmed timeout**, mirroring the existing idiom in `handleCIFailed` — prevents a later external close from defaulting the issue to `pilot-retry-ready`.
4. **Persist what was actually read.** Because the timeout branch is now only reachable after a confirmed same-tick poll, `CIStatus`/`LastChecked` are always freshly set before a timeout is declared — distinguishing "polled and pending" from "never successfully polled" for free.

Out of scope (per issue): the unguarded `execution_events` append at controller.go:1701 — separate residue, not widened here.

## Test plan

- [x] New regression tests in `internal/autopilot/gh4851_ci_wait_confirm_poll_test.go`:
  - deadline-exceeded + same-tick success → `StageCIPassed` (fails on main)
  - deadline-exceeded + same-tick failure → `StageCIFailed`
  - deadline-exceeded + same-tick still-pending → confirmed `StageFailed`, `TerminalLabel` set, real `ci_status`/`LastChecked` persisted
  - external close after a confirmed timeout does not arm `pilot-retry-ready`
  - reconciler / startup scan seed `CIWaitStartedAt` from PR `updated_at`, not `time.Now()`
  - full end-to-end repro of the PR#4846 shape: adopt stale-but-green PR past deadline → `StageCIPassed`
- [x] `go build ./...`
- [x] `go test ./internal/autopilot/...` (full package, includes GH-4384/GH-4415/GH-4478/GH-4646/GH-4826 families)
- [x] `go vet ./...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues