### PR TITLE
fix(autopilot): owner-death hardening — health-check durable-claim fallback, gate decline reaction on claim (GH-4852)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -7583,8 +7583,39 @@ func (c *Controller) notifyExternalClose(ctx context.Context, prState *PRState) 
 				c.log.Warn("durable spawned-fix lookup failed, falling back to retry-ready",
 					"pr", prState.PRNumber, "error", err)
 			} else if fixIssue > 0 {
-				issueLabel = github.LabelFailed
-				nextSteps = fmt.Sprintf("This issue will not be retried automatically under its own number — fix issue #%d already owns this work.", fixIssue)
+				// GH-4852: the claim only records that a fix issue was
+				// spawned — it says nothing about whether that issue is
+				// still alive. A human can close it during daemon downtime
+				// (no race needed); trusting the claim blindly here labels
+				// the source pilot-failed pointing at a corpse, and GH-4842's
+				// reactions are event-driven only (preflight-decline hook,
+				// dedup-path re-check inside CreateFailureIssue) so they
+				// cannot fire for an already-closed, untracked issue —
+				// permanent strand. Health-check before trusting it.
+				fixGH, ghErr := c.ghClient.GetIssue(ctx, c.owner, c.repo, fixIssue)
+				switch {
+				case ghErr != nil:
+					// Fail open: trust the claim, mirroring the GH-4842
+					// dedup path's "owner-health check failed, returning
+					// existing fix issue unverified" behavior in
+					// CreateFailureIssue.
+					c.log.Warn("owner-health check on claimed fix issue failed, trusting claim",
+						"pr", prState.PRNumber, "fix_issue", fixIssue, "error", ghErr)
+					issueLabel = github.LabelFailed
+					nextSteps = fmt.Sprintf("This issue will not be retried automatically under its own number — fix issue #%d already owns this work.", fixIssue)
+				case classifyOwnerHealth(fixGH) == ownerDead:
+					// Dead owner: fall through to the default retry-ready
+					// label/nextSteps set above instead of stranding the
+					// source on pilot-failed, and surface it the same way
+					// the other owner-death reactions do.
+					reasonMsg := fmt.Sprintf("its designated fix issue #%d died (closed without shipping, discovered during external-close scan)", fixIssue)
+					c.log.Warn("owner-death: claimed fix issue is dead, re-arming source instead of stranding it",
+						"pr", prState.PRNumber, "fix_issue", fixIssue, "source", prState.IssueNumber)
+					c.fireOwnerDeathAlert(prState.IssueNumber, reasonMsg, "rearmed")
+				default:
+					issueLabel = github.LabelFailed
+					nextSteps = fmt.Sprintf("This issue will not be retried automatically under its own number — fix issue #%d already owns this work.", fixIssue)
+				}
 			}
 		}
 

--- a/internal/autopilot/feedback_loop.go
+++ b/internal/autopilot/feedback_loop.go
@@ -550,6 +550,47 @@ func (f *FeedbackLoop) generateBody(prState *PRState, failureType FailureType, f
 // iteration tracks how many review-fix attempts have been chained.
 // Returns the issue number on success.
 func (f *FeedbackLoop) CreateReviewIssue(ctx context.Context, prState *PRState, reviews []*github.PullRequestReview, comments []*github.PRReviewComment, iteration int) (int, error) {
+	// GH-4852: claim the durable dedup row BEFORE creating the issue, not
+	// after (the ordering CreateFailureIssue already uses for the same
+	// reason, GH-4307). The old after-create ordering left a window where a
+	// crash between CreatePilotIssue succeeding and this claim landing loses
+	// the claim entirely — a restart re-enters handleReviewRequested for the
+	// same still-open PR, finds no claim, and mints a second revision issue
+	// for the same review round (PR#4846 pre-merge review, D4). Claiming
+	// first closes that window: a retry after any crash finds the claim
+	// already taken and reuses whatever issue number (if any) was recorded,
+	// instead of creating a duplicate. No owner-health re-check is needed
+	// here unlike CreateFailureIssue's dedup path — a fresh review round
+	// always carries a new PR number (dedupKey is PR-scoped), so the "existing
+	// owner might be dead" question never arises for a *repeat* claim of the
+	// same key; the same key is only ever reused across restarts/re-ticks
+	// still processing the same review round.
+	var dedupRepo, dedupKey string
+	if f.stateStore != nil {
+		dedupRepo = f.owner + "/" + f.repo
+		dedupKey = spawnedFixDedupKey(prState.PRNumber, FailureReviewRequested, nil)
+		claimed, claimErr := f.stateStore.ClaimSpawnedFix(dedupRepo, dedupKey)
+		if claimErr != nil {
+			f.log.Warn("review-issue durable claim check failed, proceeding without guard",
+				"pr", prState.PRNumber, "error", claimErr)
+		} else if !claimed {
+			existing, lookupErr := f.stateStore.GetSpawnedFixIssue(dedupRepo, dedupKey)
+			if lookupErr != nil {
+				f.log.Warn("duplicate review-issue creation suppressed but issue lookup failed",
+					"pr", prState.PRNumber, "error", lookupErr)
+				return existing, nil
+			}
+			// existing > 0: a review issue already exists for this exact PR;
+			// reuse it instead of minting a duplicate. existing == 0: the
+			// claim landed but the prior attempt crashed before recording an
+			// issue number (create failed, or crashed between create and
+			// record) — narrow, accepted window, mirrors CreateFailureIssue's
+			// identical "existing <= 0: return existing, nil" branch.
+			f.log.Info("duplicate review-issue creation suppressed", "pr", prState.PRNumber, "existing_issue", existing)
+			return existing, nil
+		}
+	}
+
 	title := f.generateTitle(prState, FailureReviewRequested)
 
 	var sb strings.Builder
@@ -598,20 +639,13 @@ func (f *FeedbackLoop) CreateReviewIssue(ctx context.Context, prState *PRState, 
 		return 0, fmt.Errorf("failed to create review issue: %w", err)
 	}
 
-	// GH-4841: mirror CreateFailureIssue's durable claim (GH-4307), minus the
-	// dedup gate on creation — a repeat review round must still create a new
-	// issue, but a durable row naming its number must exist before
-	// handleReviewRequested's caller (spawnReviewIssue) ever closes the PR, so
-	// notifyExternalClose's HasSpawnedFixForPR fallback can find it even if a
-	// daemon restart loses prState.TerminalLabel. failedChecks is nil (review
-	// feedback has no check-run concept); the dedup key namespace only needs
-	// the PR number to be found by HasSpawnedFixForPR's prefix match.
-	if f.stateStore != nil {
-		dedupRepo := f.owner + "/" + f.repo
-		dedupKey := spawnedFixDedupKey(prState.PRNumber, FailureReviewRequested, nil)
-		if _, claimErr := f.stateStore.ClaimSpawnedFix(dedupRepo, dedupKey); claimErr != nil {
-			f.log.Warn("review-issue durable claim failed", "pr", prState.PRNumber, "error", claimErr)
-		} else if recErr := f.stateStore.RecordSpawnedFixIssue(dedupRepo, dedupKey, issue.Number); recErr != nil {
+	// GH-4841/GH-4852: backfill the issue number onto the claim taken above
+	// (or, if stateStore is nil, this is a no-op). A durable row naming this
+	// issue must exist before handleReviewRequested's caller (spawnReviewIssue)
+	// ever closes the PR, so notifyExternalClose's HasSpawnedFixForPR fallback
+	// can find it even if a daemon restart loses prState.TerminalLabel.
+	if f.stateStore != nil && dedupKey != "" {
+		if recErr := f.stateStore.RecordSpawnedFixIssue(dedupRepo, dedupKey, issue.Number); recErr != nil {
 			f.log.Warn("failed to record spawned review issue number", "issue", issue.Number, "pr", prState.PRNumber, "error", recErr)
 		}
 	}

--- a/internal/autopilot/gh4852_test.go
+++ b/internal/autopilot/gh4852_test.go
@@ -1,0 +1,352 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GH-4852: PR#4846 (GH-4841) made recovery-owner designation durable by
+// consulting the autopilot_spawned_fixes claim in notifyExternalClose's
+// fallback, but the fallback trusted `issue_number > 0` without ever
+// checking whether that fix issue was still alive. A fix issue closed by a
+// human during daemon downtime (no race needed) meant the fallback labeled
+// the source pilot-failed pointing at a corpse — GH-4842's reactions are
+// event-driven only and cannot fire for an already-closed, untracked issue,
+// so the source was permanently stranded. These tests cover the two
+// specific gaps named in the pre-merge review (D1 major, D3): the fallback
+// must health-check the claim before trusting it, and the decline-reaction
+// gate must accept the durable claim as an alternate designation source
+// (not just the pilot-failed label) so a decline that races ahead of the
+// external-close tick doesn't consume the one-shot reaction for nothing.
+
+// TestNotifyExternalClose_DurableClaimFallback_HealthChecksDeadOwner covers
+// the "dead owner, no race needed" scenario: a durable claim names a fix
+// issue that is now closed without shipping. Before this fix,
+// notifyExternalClose's fallback would trust `fixIssue > 0` blindly and
+// label the source pilot-failed forever. After this fix, it must detect the
+// dead owner, fall through to pilot-retry-ready instead, and emit an
+// owner-death alert so the strand doesn't go unnoticed.
+func TestNotifyExternalClose_DurableClaimFallback_HealthChecksDeadOwner(t *testing.T) {
+	const (
+		prNumber    = 5201
+		issueNumber = 5202
+		fixIssueNum = 5203
+	)
+
+	var issueLabelsAdded []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues/5202" && r.Method == http.MethodGet:
+			// Source issue: open, not yet pilot-done.
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Issue{Number: issueNumber, State: github.StateOpen})
+		case r.URL.Path == "/repos/owner/repo/issues/5203" && r.Method == http.MethodGet:
+			// The claimed fix issue: closed by a human during daemon
+			// downtime, without ever shipping (no pilot-done label) — dead.
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Issue{Number: fixIssueNum, State: github.StateClosed})
+		case r.URL.Path == "/repos/owner/repo/issues/5202/labels" && r.Method == http.MethodPost:
+			var body map[string][]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			issueLabelsAdded = append(issueLabelsAdded, body["labels"]...)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Label{})
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/5202/labels/") && r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	store := newTestStateStore(t)
+	dedupRepo := "owner/repo"
+	dedupKey := spawnedFixDedupKey(prNumber, FailureCIPreMerge, []string{"lint"})
+	if _, err := store.ClaimSpawnedFix(dedupRepo, dedupKey); err != nil {
+		t.Fatalf("seed ClaimSpawnedFix failed: %v", err)
+	}
+	if err := store.RecordSpawnedFixIssue(dedupRepo, dedupKey, fixIssueNum); err != nil {
+		t.Fatalf("seed RecordSpawnedFixIssue failed: %v", err)
+	}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.SetStateStore(store)
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	prState := &PRState{
+		PRNumber:    prNumber,
+		PRURL:       "https://github.com/owner/repo/pull/5201",
+		IssueNumber: issueNumber,
+		// TerminalLabel intentionally empty — this is the in-memory
+		// designation lost to a restart that GH-4841's durable fallback
+		// exists to recover from.
+	}
+
+	c.notifyExternalClose(context.Background(), prState)
+
+	foundFailed := false
+	foundRetryReady := false
+	for _, l := range issueLabelsAdded {
+		if l == github.LabelFailed {
+			foundFailed = true
+		}
+		if l == github.LabelRetryReady {
+			foundRetryReady = true
+		}
+	}
+	if foundFailed {
+		t.Errorf("source issue must NOT be labeled %q pointing at a dead fix issue, labels added: %v", github.LabelFailed, issueLabelsAdded)
+	}
+	if !foundRetryReady {
+		t.Errorf("expected source issue to be re-armed with %q after the claimed fix issue was found dead, labels added: %v", github.LabelRetryReady, issueLabelsAdded)
+	}
+	if len(sink.events) != 1 {
+		t.Errorf("expected exactly 1 owner-death alert, got %d: %v", len(sink.events), sink.events)
+	}
+}
+
+// TestReactToDeadFixIssue_DeclineBeforeDesignation_ClaimGatesReaction covers
+// the TASK-468 D1 ordering race: a daemon restart lands in the
+// close→persist window, and the SDK poller's preflight-decline hook fires
+// on the freshly-spawned fix issue BEFORE the external-close tick lands
+// pilot-failed on the source. Before this fix, reactToDeadFixIssue's
+// label-only designation check would see no pilot-failed label and skip —
+// consuming the one-shot reaction — while the durable spawned-fix claim
+// already designates this fix issue as the source's recovery owner. After
+// this fix, the claim itself is an accepted alternate designation source, so
+// the reaction still fires.
+func TestReactToDeadFixIssue_DeclineBeforeDesignation_ClaimGatesReaction(t *testing.T) {
+	// Matches the body shape FeedbackLoop.generateBody embeds: source #100,
+	// originating PR 7.
+	fixIssueBody := "Fixes CI failure.\n\nDepends on: #100\n\n<!-- autopilot-meta branch:pilot/GH-100 pr:7 iteration:1 -->"
+
+	var issueLabelsAdded []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues/100" && r.Method == http.MethodGet:
+			// Source issue: open, NOT yet labeled pilot-failed — the
+			// external-close tick that would normally add it hasn't landed
+			// yet in this race.
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Issue{Number: 100, State: github.StateOpen})
+		case r.URL.Path == "/repos/owner/repo/issues/100/labels" && r.Method == http.MethodPost:
+			var body map[string][]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			issueLabelsAdded = append(issueLabelsAdded, body["labels"]...)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Label{})
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/100/labels/") && r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+
+	store := newTestStateStore(t)
+	dedupRepo := "owner/repo"
+	// The durable claim CreateFailureIssue recorded synchronously before the
+	// PR was ever closed — this is what survives the restart, unlike the
+	// pilot-failed label which is only written by the later external-close
+	// tick.
+	dedupKey := spawnedFixDedupKey(7, FailureCIPreMerge, []string{"lint"})
+	if _, err := store.ClaimSpawnedFix(dedupRepo, dedupKey); err != nil {
+		t.Fatalf("seed ClaimSpawnedFix failed: %v", err)
+	}
+	if err := store.RecordSpawnedFixIssue(dedupRepo, dedupKey, 200); err != nil {
+		t.Fatalf("seed RecordSpawnedFixIssue failed: %v", err)
+	}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.SetStateStore(store)
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	deadIssue := &github.Issue{Number: 200, State: github.StateClosed, Body: fixIssueBody}
+	c.reactToDeadFixIssue(context.Background(), deadIssue, "declined at preflight: no fix issue number returned")
+
+	if !containsLabel(issueLabelsAdded, github.LabelRetryReady) {
+		t.Errorf("expected source #100 to be re-armed via the durable-claim designation fallback, labels added: %v", issueLabelsAdded)
+	}
+	if len(sink.events) != 1 {
+		t.Errorf("expected exactly 1 owner-death alert (the reaction must not be silently consumed), got %d", len(sink.events))
+	}
+}
+
+// TestReactToDeadFixIssue_NoClaimNoLabel_StillSkips confirms the new
+// claim-based designation check doesn't loosen the existing "avoid
+// double-processing" guard: with no durable claim at all (nil stateStore,
+// matching every pre-GH-4852 caller/test) and no pilot-failed label, the
+// reaction must still skip exactly as before.
+func TestReactToDeadFixIssue_NoClaimNoLabel_StillSkips(t *testing.T) {
+	fixIssueBody := "Fixes CI failure.\n\nDepends on: #100\n\n<!-- autopilot-meta branch:pilot/GH-100 pr:7 iteration:1 -->"
+
+	var issueLabelsAdded []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues/100" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Issue{Number: 100, State: github.StateOpen})
+		case r.URL.Path == "/repos/owner/repo/issues/100/labels" && r.Method == http.MethodPost:
+			var body map[string][]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			issueLabelsAdded = append(issueLabelsAdded, body["labels"]...)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Label{})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	// No SetStateStore call — mirrors every existing owner-death test.
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	deadIssue := &github.Issue{Number: 200, State: github.StateClosed, Body: fixIssueBody}
+	c.reactToDeadFixIssue(context.Background(), deadIssue, "declined at preflight: no fix issue number returned")
+
+	if len(issueLabelsAdded) != 0 {
+		t.Errorf("expected no label writes with no claim and no label designating this fix issue, got %v", issueLabelsAdded)
+	}
+	if len(sink.events) != 0 {
+		t.Errorf("expected no alerts, got %d", len(sink.events))
+	}
+}
+
+func containsLabel(labels []string, want string) bool {
+	for _, l := range labels {
+		if l == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestCreateReviewIssue_DurableClaim_PreventsDuplicateOnRetick covers the
+// review-path claim-window fix: CreateReviewIssue now claims the durable
+// dedup row BEFORE creating the GitHub issue (mirroring CreateFailureIssue),
+// instead of after. A re-tick or restart that calls CreateReviewIssue again
+// for the same still-open PR before it's closed must reuse the already-
+// created issue instead of minting a second revision issue.
+func TestCreateReviewIssue_DurableClaim_PreventsDuplicateOnRetick(t *testing.T) {
+	createCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			createCalls++
+			resp := github.Issue{Number: 100}
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	fl := NewFeedbackLoop(ghClient, "owner", "repo", cfg)
+	store := newTestStateStore(t)
+	fl.SetStateStore(store)
+
+	prState := &PRState{PRNumber: 55, IssueNumber: 10, BranchName: "pilot/GH-10"}
+	reviews := []*github.PullRequestReview{{ID: 1, User: github.User{Login: "alice"}, Body: "Fix this", State: "CHANGES_REQUESTED"}}
+
+	first, err := fl.CreateReviewIssue(context.Background(), prState, reviews, nil, 1)
+	if err != nil {
+		t.Fatalf("first CreateReviewIssue error: %v", err)
+	}
+	if first != 100 {
+		t.Fatalf("first CreateReviewIssue = %d, want 100", first)
+	}
+	if createCalls != 1 {
+		t.Fatalf("createCalls after first call = %d, want 1", createCalls)
+	}
+
+	second, err := fl.CreateReviewIssue(context.Background(), prState, reviews, nil, 1)
+	if err != nil {
+		t.Fatalf("second CreateReviewIssue error: %v", err)
+	}
+	if second != 100 {
+		t.Errorf("second CreateReviewIssue = %d, want 100 (reused, not a duplicate)", second)
+	}
+	if createCalls != 1 {
+		t.Errorf("createCalls after second call = %d, want 1 (no duplicate issue created)", createCalls)
+	}
+}
+
+// TestCreateReviewIssue_ClaimWithoutRecordedIssue_NoDuplicateCreated covers
+// the narrow residual window this fix accepts (mirroring CreateFailureIssue's
+// identical trade-off): a claim row exists but was never backfilled with an
+// issue number (the crash landed between ClaimSpawnedFix and
+// CreatePilotIssue). The retry must NOT mint a second issue purely because
+// the first attempt never got far enough to create one under the old
+// create-then-claim ordering, this exact case free-ran into a duplicate.
+func TestCreateReviewIssue_ClaimWithoutRecordedIssue_NoDuplicateCreated(t *testing.T) {
+	createCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			createCalls++
+			resp := github.Issue{Number: 100}
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	fl := NewFeedbackLoop(ghClient, "owner", "repo", cfg)
+	store := newTestStateStore(t)
+	fl.SetStateStore(store)
+
+	prState := &PRState{PRNumber: 66, IssueNumber: 11, BranchName: "pilot/GH-11"}
+
+	dedupRepo := "owner/repo"
+	dedupKey := spawnedFixDedupKey(prState.PRNumber, FailureReviewRequested, nil)
+	if _, err := store.ClaimSpawnedFix(dedupRepo, dedupKey); err != nil {
+		t.Fatalf("seed ClaimSpawnedFix failed: %v", err)
+	}
+	// Deliberately no RecordSpawnedFixIssue call — simulates a crash after
+	// the claim landed but before/during CreatePilotIssue.
+
+	got, err := fl.CreateReviewIssue(context.Background(), prState, nil, nil, 1)
+	if err != nil {
+		t.Fatalf("CreateReviewIssue error: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("CreateReviewIssue() = %d, want 0 (claim already taken, no recorded issue to reuse)", got)
+	}
+	if createCalls != 0 {
+		t.Errorf("createCalls = %d, want 0 (must not mint a duplicate issue while the claim is contended)", createCalls)
+	}
+}

--- a/internal/autopilot/owner_death.go
+++ b/internal/autopilot/owner_death.go
@@ -73,6 +73,29 @@ func parseFixIssueSource(body string) (int, bool) {
 	return n, true
 }
 
+// fixIssuePRRe extracts the originating PR number embedded by
+// FeedbackLoop.generateBody/CreateReviewIssue's autopilot-meta comment
+// ("pr:123"), mirroring controller.go's iterationRe for the same comment.
+var fixIssuePRRe = regexp.MustCompile(`<!-- autopilot-meta.*?pr:(\d+).*?-->`)
+
+// parseFixIssuePR recovers the originating PR number from a spawned fix
+// issue's body. Companion to parseFixIssueSource: the source issue is named
+// via "Depends on: #N", the PR via "pr:N" in the same autopilot-meta comment.
+// Used by reactToDeadFixIssue (GH-4852) to re-check the durable spawned-fix
+// claim as an alternate designation source when the pilot-failed label
+// hasn't landed yet.
+func parseFixIssuePR(body string) (int, bool) {
+	m := fixIssuePRRe.FindStringSubmatch(body)
+	if len(m) < 2 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
+}
+
 // emitOwnerDeathAlert fires an alerts.Event for an owner-death reaction
 // (rearm/escalate/replace). Shared by Controller and FeedbackLoop, which
 // each hold their own optional alertSink. Logs (rather than drops silently)
@@ -141,7 +164,31 @@ func (c *Controller) reactToDeadFixIssue(ctx context.Context, deadIssue *github.
 		c.log.Info("owner-death: source issue already closed, nothing to re-arm", "fix_issue", deadIssue.Number, "source", sourceNum)
 		return
 	}
-	if !github.HasLabel(source, github.LabelFailed) {
+	designated := github.HasLabel(source, github.LabelFailed)
+	if !designated && c.stateStore != nil {
+		// GH-4852: the pilot-failed label is written by notifyExternalClose,
+		// which only runs once the external-close poll tick observes the PR
+		// closed. The SDK poller's preflight-decline hook (ReactToDeclinedFixIssue)
+		// can fire on a freshly-spawned fix issue BEFORE that tick lands the
+		// label (TASK-468 D1 ordering race: restart in the close→persist
+		// window). Without this fallback the label-only check below would
+		// skip — consuming this one-shot reaction — while the durable
+		// spawned-fix claim already designates deadIssue as this source's
+		// recovery owner; PR#4846's controller.go fallback then re-designates
+		// the already-declined owner from that still-live claim, permanently
+		// stranding the source. Re-check the claim (recorded synchronously
+		// before either handler closes the PR) as an alternate designation
+		// source before giving up.
+		if prNum, ok := parseFixIssuePR(deadIssue.Body); ok {
+			if claimedIssue, cerr := c.stateStore.HasSpawnedFixForPR(c.repoKey(), prNum); cerr != nil {
+				c.log.Warn("owner-death: durable claim lookup failed while checking designation",
+					"fix_issue", deadIssue.Number, "source", sourceNum, "error", cerr)
+			} else {
+				designated = claimedIssue == deadIssue.Number
+			}
+		}
+	}
+	if !designated {
 		// Source isn't currently designated to this fix issue (already
 		// re-armed by something else, or was never in the TerminalLabel
 		// state to begin with) — avoid double-processing.

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -1219,10 +1219,17 @@ func (s *StateStore) GetSpawnedFixIssue(repo, dedupKey string) (int, error) {
 // prState.TerminalLabel.
 func (s *StateStore) HasSpawnedFixForPR(repo string, prNumber int) (int, error) {
 	var issueNumber int
+	// GH-4852 nit: created_at is DATETIME DEFAULT CURRENT_TIMESTAMP, i.e.
+	// second resolution — two claims for the same PR landing within the same
+	// second (fast re-tick, or a CI-fix round immediately followed by a
+	// review round on the replacement PR) would otherwise tie and fall back
+	// to SQLite's undefined row order. rowid is monotonically assigned on
+	// insert for this ordinary (non-WITHOUT ROWID) table, so it's a stable
+	// tiebreaker for "most recently recorded".
 	err := s.db.QueryRow(`
 		SELECT issue_number FROM autopilot_spawned_fixes
 		WHERE repo = ? AND dedup_key LIKE ? AND issue_number > 0
-		ORDER BY created_at DESC LIMIT 1
+		ORDER BY created_at DESC, rowid DESC LIMIT 1
 	`, repo, fmt.Sprintf("fix:pr%d:%%", prNumber)).Scan(&issueNumber)
 	if err == sql.ErrNoRows {
 		return 0, nil


### PR DESCRIPTION
## Summary

Closes GH-4852. Follow-up to PR#4846 (GH-4841)/PR#4849, hardening owner-death handling around the durable spawned-fix claim:

- **Health-check the durable-claim fallback** (`controller.go`, `notifyExternalClose`): before trusting a claimed fix issue and labeling the source `pilot-failed`, fetch the fix issue and run `classifyOwnerHealth`. A dead owner (closed without shipping) now falls through to retry-ready + `emitOwnerDeathAlert` instead of stranding the source pointing at a corpse. API errors fail open (trust the claim), mirroring the GH-4842 dedup path.
- **Gate the decline reaction on the durable claim, not just the label** (`owner_death.go`, `reactToDeadFixIssue`): when the source lacks `pilot-failed` (label not yet landed — TASK-468 D1 ordering race), re-check the durable spawned-fix claim via the fix issue's embedded PR number before skipping. Prevents the one-shot decline reaction from being consumed while a live claim still designates the declined issue, which previously let PR#4846's fallback re-designate the already-dead owner and permanently strand the source.
- **Close the review-path claim window** (`feedback_loop.go`, `CreateReviewIssue`): claim the durable dedup row *before* creating the issue (mirroring `CreateFailureIssue`/GH-4307) instead of after. A crash between issue creation and the old post-create claim could lose the claim entirely; a restart would then mint a duplicate revision issue for the same review round. Claiming first closes that window — a retry after a crash finds the claim already taken and reuses the recorded issue number.
- **Nit**: `HasSpawnedFixForPR` now tiebreaks same-second `created_at` ties with `rowid DESC` for a stable "most recent" ordering.

## Test plan

- [x] `TestNotifyExternalClose_DurableClaimFallback_HealthChecksDeadOwner` — durable claim row exists, fix issue closed → external-close scan arms retry-ready + emits owner-death alert, source NOT labeled `pilot-failed`
- [x] `TestReactToDeadFixIssue_DeclineBeforeDesignation_ClaimGatesReaction` — decline arrives before the `pilot-failed` label lands → recovery still fires via the claim fallback
- [x] `TestReactToDeadFixIssue_NoClaimNoLabel_StillSkips` — no claim and no label → still correctly skips (no regression)
- [x] `TestCreateReviewIssue_DurableClaim_PreventsDuplicateOnRetick` / `TestCreateReviewIssue_ClaimWithoutRecordedIssue_NoDuplicateCreated` — review-path claim-before-create dedup
- [x] `go build ./...` clean
- [x] `go test ./internal/autopilot/...` full suite passes (GH-4841/GH-4826/owner-death suites unaffected)