### PR TITLE
fix(autopilot): reset CI-wait clock on WaitingCI re-entry; TerminalLabel on API-failure timeout path

### DIFF
--- a/.agent/tasks/gh-4855.md
+++ b/.agent/tasks/gh-4855.md
@@ -1,0 +1,35 @@
+# GH-4855
+
+**Created:** 2026-08-12
+
+## Problem
+
+GitHub Issue GH-4855: fix(autopilot): reset CI-wait clock on WaitingCI re-entry; TerminalLabel on the API-failure timeout path
+
+## Context
+
+Post-merge review of PR#4853 (GH-4851, verdict on the PR) confirmed the confirm-poll fix but found the new confirmed-timeout + TerminalLabel combination creates a fresh terminal-stranding class on the CI re-trigger paths:
+
+- Three paths re-enter `StageWaitingCI` WITHOUT resetting `CIWaitStartedAt`: infra-outage rerun (internal/autopilot/controller.go:2902), auto-rebase (:5318), mechanical go.mod resolution (:5434) — contrast :5709-5710 and :5781-5782, which do reset. Scenario: PR waits 25m → CI fails → infra-outage rerun → re-enters WaitingCI with the original clock → rerun still `in_progress` at minute 31 → deadline exceeded, same-tick read = pending → instant CONFIRMED timeout stamped `TerminalLabel=pilot-failed`. Pre-#4853 this blind-timed-out too but self-healed via retry-ready on close; now it is a permanent strand with no spawned fix issue and no owner.
+- `TerminalLabel` is not persisted (`SavePRState`/`LoadAllPRStates`, internal/autopilot/state_store.go:638-792 omit it; the types.go:1166-1168 comment claims restart-safety that is false for the timeout branch — a timed-out PR stays open indefinitely and the human close may come days and several restarts later). Mostly healed by re-adoption (`RestoreState` skips StageFailed rows at controller.go:1769; the reconciler re-adopts within 60s), residual: a close landing in the re-adoption window reaches `notifyExternalClose` with empty TerminalLabel and no claim → retry-ready re-armed — the GH-4851 incident shape, minutes-wide, restart-gated.
+- The consecutive-API-failure branch (controller.go:2267-2275; five `CheckCI` errors → StageFailed) still produces the exact GH-4851 incident fingerprint: zero successful polls, ci_status at adoption default, no TerminalLabel → external close defaults to retry-ready.
+
+## Implementation
+
+1. Reset `CIWaitStartedAt = time.Now()` at the three WaitingCI re-entry sites (controller.go:2902, :5318, :5434) — they explicitly trigger new CI, so the deadline must measure the new run.
+2. Stamp the same TerminalLabel on the consecutive-API-failure branch (:2267-2275) so that path can no longer arm retry-ready via external close.
+3. Close the TerminalLabel restart gap: either persist `terminal_label` in the PR-state store AND have `notifyExternalClose` consult it for the close-in-re-adoption window, or — if that cannot close the window — fix the stale types.go:1166-1168 comment and add a regression test documenting the accepted residual. State the choice in the PR description.
+
+## Acceptance
+
+- Test per re-entry path (at minimum the infra-outage rerun): re-entry at minute 25, rerun `in_progress` at minute 31 → NOT a timeout; deadline measured from re-entry.
+- Test: five consecutive `CheckCI` errors → StageFailed carries a TerminalLabel; external close does not arm `pilot-retry-ready`.
+- GH-4851 suite + GH-4384/4415/4478/4646 family pass unchanged.
+
+## Refs
+
+- PR#4853 post-merge review verdict (comment on the PR) — D1 major, D2 medium, D3 minor.
+- Incident lineage: GH-4851 ← PR#4846 strand (TASK-467).
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2268,6 +2268,16 @@ func (c *Controller) handleWaitingCI(ctx context.Context, prState *PRState, ghPR
 			prState.Stage = StageFailed
 			prState.Error = fmt.Sprintf("CI check API failed %d consecutive times: %v",
 				prState.ConsecutiveAPIFailures, err)
+			// GH-4855: this branch produces the exact GH-4851 incident
+			// fingerprint — zero successful polls, ci_status still at its
+			// adoption default, and (without this) no TerminalLabel. Without
+			// a TerminalLabel, a later external close of this stranded PR
+			// (notifyExternalClose, GH-3806) would default to
+			// pilot-retry-ready and silently re-dispatch the issue, even
+			// though autopilot never got a single successful read on this
+			// PR's CI. Mirrors the confirmed-CI-timeout branch above
+			// (checkPRWaitingCI, GH-4851/#4853) — this is just as terminal.
+			prState.TerminalLabel = github.LabelFailed
 			c.log.Error("PR transitioned to failed due to consecutive API failures",
 				"pr", prState.PRNumber,
 				"consecutive_failures", prState.ConsecutiveAPIFailures)
@@ -2900,6 +2910,15 @@ func (c *Controller) maybeRetryInfraFailure(ctx context.Context, prState *PRStat
 	prState.InfraRerunCount = effectiveCount + 1
 	prState.InfraRerunSHA = prState.HeadSHA
 	prState.Stage = StageWaitingCI
+	// GH-4855: this re-entry explicitly triggers a brand-new CI run, so the
+	// wait deadline must be measured from now, not from whenever the PR
+	// originally entered StageWaitingCI. Without this, a PR that already
+	// waited most of its budget before the original failure can have its
+	// freshly-triggered rerun timed out instantly on the very next tick
+	// (post-#4853, that instant timeout also stamps a terminal label — see
+	// the confirmed-timeout branch in checkPRWaitingCI — permanently
+	// stranding a PR whose rerun never got a fair chance to complete).
+	prState.CIWaitStartedAt = time.Now()
 	c.metrics.RecordCIRun("infra_retry")
 	c.log.Warn("CI failure classified as infra outage, auto-retried failed jobs",
 		"pr", prState.PRNumber, "sha", ShortSHA(prState.HeadSHA),
@@ -5317,6 +5336,10 @@ func (c *Controller) handleMergeConflict(ctx context.Context, prState *PRState) 
 		c.log.Info("auto-rebased conflicting PR", "pr", prState.PRNumber, "attempt", prState.RebaseAttempts, "max", c.config.MaxRebaseAttempts)
 		prState.Stage = StageWaitingCI // rebase triggers new CI
 		prState.HeadSHA = ""           // force refresh on next tick
+		// GH-4855: the rebase triggers a fresh CI run — reset the wait clock
+		// so the deadline is measured from this re-entry, mirroring the
+		// infra-outage rerun above (maybeRetryInfraFailure).
+		prState.CIWaitStartedAt = time.Now()
 		return nil
 	}
 	c.log.Warn("auto-rebase failed, attempting mechanical go.mod/go.sum resolution", "pr", prState.PRNumber, "error", err)
@@ -5433,6 +5456,10 @@ func (c *Controller) attemptMechanicalConflictResolution(ctx context.Context, pr
 	c.log.Info("mechanically resolved go.mod/go.sum conflict", "pr", prState.PRNumber, "attempt", prState.RebaseAttempts, "max", c.config.MaxRebaseAttempts)
 	prState.Stage = StageWaitingCI // mechanical resolution triggers new CI
 	prState.HeadSHA = ""           // force refresh on next tick
+	// GH-4855: the mechanical resolution triggers a fresh CI run — reset the
+	// wait clock so the deadline is measured from this re-entry, mirroring
+	// the auto-rebase and infra-outage-rerun re-entry sites above.
+	prState.CIWaitStartedAt = time.Now()
 	return true, nil
 }
 

--- a/internal/autopilot/gh4855_test.go
+++ b/internal/autopilot/gh4855_test.go
@@ -1,0 +1,445 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	ghadapter "github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GH-4855 regression tests.
+//
+// Post-merge review of PR#4853 (GH-4851) found that the confirmed-CI-timeout
+// + TerminalLabel combination it introduced creates a fresh terminal-
+// stranding class on the CI re-trigger paths: three sites re-enter
+// StageWaitingCI WITHOUT resetting CIWaitStartedAt (infra-outage rerun,
+// auto-rebase, mechanical go.mod resolution). Scenario: a PR waits most of
+// its CI budget, CI fails, autopilot auto-retries (classified infra, or
+// rebases, or mechanically resolves a go.mod conflict) and re-enters
+// StageWaitingCI — but the OLD clock is still running, so the freshly
+// triggered CI run can be declared "timed out" on the very next tick even
+// though it just started, permanently stranding the PR with
+// TerminalLabel=pilot-failed and no owner.
+//
+// These tests cover: (1)-(3) each WaitingCI re-entry site resets the wait
+// clock to the re-entry time; (4) five consecutive CheckCI API failures also
+// stamp a TerminalLabel, closing the second GH-4851-shaped stranding class;
+// (5) documents (does not fix — see the TerminalLabel doc comment in
+// types.go) the accepted residual where a daemon restart can still lose an
+// in-memory-only TerminalLabel during the reconciler's re-adoption window.
+
+// TestMaybeRetryInfraFailure_ResetsCIWaitClock_GH4855 reproduces the
+// infra-outage-rerun re-entry site (controller.go, maybeRetryInfraFailure):
+// a PR that already waited 25 minutes before its original CI failure must
+// have its wait clock measured from the rerun's own start, not the original
+// wait start — otherwise a rerun still in_progress 6 minutes later (31
+// minutes past the ORIGINAL clock, comfortably within budget measured from
+// the rerun) gets falsely declared a confirmed timeout.
+func TestMaybeRetryInfraFailure_ResetsCIWaitClock_GH4855(t *testing.T) {
+	const sha = "gh4855infra01"
+	const infraLog = `Run actions/checkout@v4
+##[error]Failed to download action 'https://api.github.com/repos/actions/checkout/tarball/v4'. Error: Response status code does not indicate success: 429 (Too Many Requests).`
+
+	var reran atomic.Bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/"+sha+"/check-runs":
+			if reran.Load() {
+				// Post-rerun poll: the rerun job is running again, not yet
+				// resolved — this is the "still in_progress" same-tick read
+				// that must NOT be declared a timeout if the clock reset.
+				resp := github.CheckRunsResponse{
+					TotalCount: 2,
+					CheckRuns: []github.CheckRun{
+						{ID: 99, Name: "build", Status: "completed", Conclusion: "success"},
+						{ID: 100, Name: "lint", Status: github.CheckRunInProgress},
+					},
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(resp)
+				return
+			}
+			resp := github.CheckRunsResponse{
+				TotalCount: 2,
+				CheckRuns: []github.CheckRun{
+					{ID: 99, Name: "build", Status: "completed", Conclusion: "success"},
+					{ID: 100, Name: "lint", Status: "completed", Conclusion: "failure"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/repos/owner/repo/actions/jobs/100/logs":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(infraLog))
+		case r.URL.Path == "/repos/owner/repo/actions/jobs/100":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(ghadapter.WorkflowJob{
+				ID: 100, RunID: 500, Name: "lint", Status: "completed",
+				Steps: []ghadapter.JobStep{
+					{Name: "Set up job", Status: "completed", Conclusion: "success", Number: 1},
+					{Name: "Run actions/checkout@v4", Status: "completed", Conclusion: "failure", Number: 2},
+				},
+			})
+		case r.URL.Path == "/repos/owner/repo/actions/runs/500/rerun-failed-jobs" && r.Method == http.MethodPost:
+			reran.Store(true)
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	stepClient := ghadapter.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	// Deliberately NOT EnvDev: dev's CITimeout is 5m (types.go), which would
+	// make the 6-minutes-since-reset scenario below a legitimate timeout
+	// regardless of the reset fix. Use the default (30m) budget so this test
+	// isolates "was the clock reset on re-entry" from environment-specific
+	// timeout tuning.
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithStepLogClient(stepClient))
+
+	prState := &PRState{
+		PRNumber: 4855,
+		HeadSHA:  sha,
+		Stage:    StageCIFailed,
+		// The PR already waited 25 minutes under its ORIGINAL CI attempt
+		// before that attempt failed and got classified as infra.
+		CIWaitStartedAt: time.Now().Add(-25 * time.Minute),
+	}
+	c.mu.Lock()
+	c.activePRs[4855] = prState
+	c.mu.Unlock()
+
+	beforeReentry := time.Now()
+	if err := c.handleCIFailed(context.Background(), prState); err != nil {
+		t.Fatalf("handleCIFailed returned unexpected error: %v", err)
+	}
+	if prState.Stage != StageWaitingCI {
+		t.Fatalf("Stage = %s, want %s (infra rerun should re-enter WaitingCI)", prState.Stage, StageWaitingCI)
+	}
+	if prState.CIWaitStartedAt.Before(beforeReentry) {
+		t.Fatalf("CIWaitStartedAt = %v, want reset to >= re-entry time %v — infra-outage rerun must reset the wait clock, not carry over the original 25m-stale one", prState.CIWaitStartedAt, beforeReentry)
+	}
+
+	// Simulate 6 minutes elapsed since the reset (31 minutes past the
+	// ORIGINAL clock, but only 6 past the reset one) — the rerun is still
+	// in_progress. Deadline must be measured from re-entry, so this must NOT
+	// be a timeout.
+	prState.CIWaitStartedAt = prState.CIWaitStartedAt.Add(-6 * time.Minute)
+
+	ghPR := &github.PullRequest{Number: 4855, Head: github.PRRef{SHA: sha}, Base: github.PRRef{Ref: "main"}}
+	if err := c.ProcessPR(context.Background(), 4855, ghPR); err != nil {
+		t.Fatalf("ProcessPR returned unexpected error: %v", err)
+	}
+	pr, ok := c.GetPRState(4855)
+	if !ok {
+		t.Fatal("PR 4855 no longer tracked")
+	}
+	if pr.Stage != StageWaitingCI {
+		t.Fatalf("Stage = %s, want %s — deadline must be measured from re-entry (6m elapsed), not the original clock (31m elapsed, which would exceed the 30m budget) (error=%q)", pr.Stage, StageWaitingCI, pr.Error)
+	}
+}
+
+// TestHandleMergeConflict_AutoRebase_ResetsCIWaitClock_GH4855 reproduces the
+// auto-rebase re-entry site (handleMergeConflict, controller.go ~5318): a
+// successful GitHub auto-update-branch call re-enters StageWaitingCI for a
+// fresh CI run and must reset the wait clock.
+func TestHandleMergeConflict_AutoRebase_ResetsCIWaitClock_GH4855(t *testing.T) {
+	const prNumber = 4856
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/pulls/4856/update-branch" && r.Method == http.MethodPut {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.MaxRebaseAttempts = 3
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:        prNumber,
+		CIWaitStartedAt: time.Now().Add(-25 * time.Minute),
+	}
+
+	before := time.Now()
+	if err := c.handleMergeConflict(context.Background(), prState); err != nil {
+		t.Fatalf("handleMergeConflict returned unexpected error: %v", err)
+	}
+	if prState.Stage != StageWaitingCI {
+		t.Fatalf("Stage = %s, want %s (successful auto-rebase should re-enter WaitingCI)", prState.Stage, StageWaitingCI)
+	}
+	if prState.CIWaitStartedAt.Before(before) {
+		t.Errorf("CIWaitStartedAt = %v, want reset to >= re-entry time %v — auto-rebase must reset the wait clock, not carry over the original 25m-stale one", prState.CIWaitStartedAt, before)
+	}
+}
+
+// TestAttemptMechanicalConflictResolution_ResetsCIWaitClock_GH4855
+// reproduces the mechanical go.mod/go.sum resolution re-entry site
+// (attemptMechanicalConflictResolution, controller.go ~5434), reusing the
+// GH-4328 fixture from conflict_mechanical_test.go: two sibling branches
+// each add a different dependency, so the conflict surface is exactly
+// go.mod/go.sum and resolves mechanically.
+func TestAttemptMechanicalConflictResolution_ResetsCIWaitClock_GH4855(t *testing.T) {
+	local := newFixtureRepo(t)
+	ctx := context.Background()
+
+	newLocalReplaceModule(t, local, "depa", "depa")
+	newLocalReplaceModule(t, local, "depb", "depb")
+
+	writeFixtureFile(t, local, "go.mod", strings.Join([]string{
+		"module fixture",
+		"",
+		"go 1.25",
+		"",
+		"replace example.com/depa => ./localdeps/depa",
+		"",
+		"replace example.com/depb => ./localdeps/depb",
+		"",
+	}, "\n"))
+	runFixtureGit(t, local, "add", ".")
+	runFixtureGit(t, local, "commit", "-m", "scaffold local replace modules")
+	runFixtureGit(t, local, "push", "origin", "main")
+
+	runFixtureGit(t, local, "checkout", "-b", "feature/dep-a-gh4855")
+	appendFixtureFile(t, local, "go.mod", "require example.com/depa v0.0.0-00010101000000-000000000000\n")
+	writeFixtureFile(t, local, "usea.go", "package fixture\n\nimport \"example.com/depa\"\n\nvar UseDepA = depa.Hello()\n")
+	runFixtureGit(t, local, "add", ".")
+	runFixtureGit(t, local, "commit", "-m", "add depa")
+	runFixtureGit(t, local, "push", "origin", "feature/dep-a-gh4855")
+
+	runFixtureGit(t, local, "checkout", "main")
+	appendFixtureFile(t, local, "go.mod", "require example.com/depb v0.0.0-00010101000000-000000000000\n")
+	writeFixtureFile(t, local, "useb.go", "package fixture\n\nimport \"example.com/depb\"\n\nvar UseDepB = depb.Hello()\n")
+	runFixtureGit(t, local, "add", ".")
+	runFixtureGit(t, local, "commit", "-m", "add depb")
+	runFixtureGit(t, local, "push", "origin", "main")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/4857/update-branch" && r.Method == http.MethodPut:
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"message":"merge conflict between base and head"}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.MaxRebaseAttempts = 3
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithProjectPath(local))
+	c.mu.Lock()
+	c.activePRs[4857] = &PRState{
+		PRNumber:        4857,
+		PRURL:           "https://github.com/owner/repo/pull/4857",
+		IssueNumber:     4855,
+		BranchName:      "feature/dep-a-gh4855",
+		HeadSHA:         "deadbeef4855",
+		Stage:           StageMerging,
+		CreatedAt:       time.Now(),
+		CIWaitStartedAt: time.Now().Add(-25 * time.Minute),
+	}
+	c.mu.Unlock()
+
+	before := time.Now()
+	if err := c.handleMergeConflict(ctx, c.activePRs[4857]); err != nil {
+		t.Fatalf("handleMergeConflict: %v", err)
+	}
+
+	pr, ok := c.GetPRState(4857)
+	if !ok {
+		t.Fatal("PR 4857 not found in activePRs")
+	}
+	if pr.Stage != StageWaitingCI {
+		t.Fatalf("Stage = %s, want %s (mechanical resolution should succeed)", pr.Stage, StageWaitingCI)
+	}
+	if pr.CIWaitStartedAt.Before(before) {
+		t.Errorf("CIWaitStartedAt = %v, want reset to >= re-entry time %v — mechanical go.mod/go.sum resolution must reset the wait clock, not carry over the original 25m-stale one", pr.CIWaitStartedAt, before)
+	}
+}
+
+// TestHandleWaitingCI_FiveConsecutiveAPIFailures_StampsTerminalLabel_GH4855
+// reproduces the second GH-4851-shaped stranding class flagged in post-merge
+// review: five consecutive CheckCI errors transition the PR to StageFailed
+// with zero successful polls and no evidence gathered — exactly the
+// PR#4846 incident fingerprint — but (pre-fix) with no TerminalLabel, so a
+// later external close of the stranded PR would default to
+// pilot-retry-ready and re-dispatch already-shipped (or never-run) work.
+func TestHandleWaitingCI_FiveConsecutiveAPIFailures_StampsTerminalLabel_GH4855(t *testing.T) {
+	const sha = "gh4855apifail01"
+	var labelsAdded []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/"+sha+"/check-runs":
+			// Every CheckCI call fails outright (simulated via a 500), never
+			// a successful poll.
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"internal error"}`))
+		case r.URL.Path == "/repos/owner/repo/issues/4858" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Issue{Number: 4858, State: github.StateOpen})
+		case r.URL.Path == "/repos/owner/repo/issues/4858/labels" && r.Method == http.MethodPost:
+			var body map[string][]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			labelsAdded = append(labelsAdded, body["labels"]...)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Label{})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:               4859,
+		IssueNumber:            4858,
+		HeadSHA:                sha,
+		Stage:                  StageWaitingCI,
+		CIStatus:               CIPending,
+		CIWaitStartedAt:        time.Now(),
+		ConsecutiveAPIFailures: 4, // one more failure crosses the >=5 threshold
+	}
+	c.mu.Lock()
+	c.activePRs[4859] = prState
+	c.mu.Unlock()
+
+	ghPR := &github.PullRequest{Number: 4859, Head: github.PRRef{SHA: sha}, Base: github.PRRef{Ref: "main"}}
+	if err := c.ProcessPR(context.Background(), 4859, ghPR); err != nil {
+		t.Fatalf("ProcessPR returned unexpected error: %v", err)
+	}
+
+	if prState.Stage != StageFailed {
+		t.Fatalf("Stage = %s, want %s (5th consecutive API failure)", prState.Stage, StageFailed)
+	}
+	if prState.TerminalLabel != github.LabelFailed {
+		t.Fatalf("TerminalLabel = %q, want %q — 5 consecutive CI-check API failures is terminal and must not be silently re-queued", prState.TerminalLabel, github.LabelFailed)
+	}
+
+	// Human closes the stranded PR — notifyExternalClose must consult the
+	// TerminalLabel recorded above rather than defaulting to retry-ready.
+	c.notifyExternalClose(context.Background(), prState)
+
+	foundFailed, foundRetryReady := false, false
+	for _, l := range labelsAdded {
+		if l == github.LabelFailed {
+			foundFailed = true
+		}
+		if l == github.LabelRetryReady {
+			foundRetryReady = true
+		}
+	}
+	if !foundFailed {
+		t.Errorf("expected issue to be labeled %q, got labels added: %v", github.LabelFailed, labelsAdded)
+	}
+	if foundRetryReady {
+		t.Errorf("issue must NOT be labeled %q after 5 consecutive CI-check API failures — this is the PR#4846-shaped stranded-close class; labels added: %v", github.LabelRetryReady, labelsAdded)
+	}
+}
+
+// TestGH4855_ReAdoptionWindow_LosesTerminalLabel_AcceptedResidual documents
+// (does not exercise a fix for) the restart-gated residual described in the
+// TerminalLabel doc comment (types.go): TerminalLabel is in-memory only.
+// RestoreState skips rehydrating StageFailed rows on restart, so a PR
+// carrying a terminal label (e.g. from the confirmed-CI-timeout or
+// consecutive-API-failure paths, neither of which close the PR) is
+// untracked immediately after a restart. The ~60s orphan-PR reconciler
+// sweep "heals" this by rediscovering the still-open PR — but OnPRCreated
+// always constructs a brand-new PRState (TerminalLabel empty) rather than
+// reading back any prior terminal state. A close landing after that
+// re-adoption reaches notifyExternalClose with an empty TerminalLabel and
+// arms pilot-retry-ready.
+//
+// This test simulates exactly that ordering — a fresh OnPRCreated-style
+// re-adoption (as the reconciler performs) of a PR number that previously
+// carried a terminal label, followed by an external close — and asserts the
+// current (accepted-residual) outcome: pilot-retry-ready gets armed. If this
+// test starts failing because the residual has been closed, delete it and
+// update the TerminalLabel doc comment in types.go accordingly.
+func TestGH4855_ReAdoptionWindow_LosesTerminalLabel_AcceptedResidual(t *testing.T) {
+	const sha = "gh4855residual01"
+	var labelsAdded []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues/4861" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Issue{Number: 4861, State: github.StateOpen})
+		case r.URL.Path == "/repos/owner/repo/issues/4861/labels" && r.Method == http.MethodPost:
+			var body map[string][]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			labelsAdded = append(labelsAdded, body["labels"]...)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Label{})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	// Pre-restart: PR 4860 confirmed-timed-out with a TerminalLabel, but
+	// (matching both terminal paths this task hardens) never closed — it's
+	// still open on GitHub.
+	//
+	// Restart happens here: a fresh Controller has no record of PR 4860 —
+	// RestoreState would have skipped this StageFailed row even if it had
+	// been persisted (it isn't — TerminalLabel is in-memory only).
+	//
+	// The orphan-PR reconciler rediscovers the still-open PR and re-adopts
+	// it exactly as OnPRCreated does: a brand-new PRState, TerminalLabel
+	// empty.
+	c.OnPRCreated(4860, "https://github.com/owner/repo/pull/4860", 4861, sha, "pilot/GH-4861", "")
+
+	prState, ok := c.GetPRState(4860)
+	if !ok {
+		t.Fatal("PR 4860 not tracked after re-adoption")
+	}
+	if prState.TerminalLabel != "" {
+		t.Fatalf("TerminalLabel = %q, want empty — re-adoption must start from a fresh state for this residual to be reproduced", prState.TerminalLabel)
+	}
+
+	// A human closes the re-adopted PR shortly after — notifyExternalClose
+	// has no TerminalLabel and no spawned-fix claim to fall back on.
+	c.notifyExternalClose(context.Background(), prState)
+
+	foundRetryReady := false
+	for _, l := range labelsAdded {
+		if l == github.LabelRetryReady {
+			foundRetryReady = true
+		}
+	}
+	if !foundRetryReady {
+		t.Errorf("expected pilot-retry-ready to be armed (documenting the accepted residual), got labels added: %v — if this now fails, the re-adoption window has been closed and this test (plus the TerminalLabel doc comment in types.go) should be updated", labelsAdded)
+	}
+}

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -1160,12 +1160,43 @@ type PRState struct {
 	// notifyExternalClose applies once it observes this PR closed on GitHub.
 	// Set by a close path that already determined the issue must NOT be
 	// auto-retried under its own number — either because the failure is
-	// terminal (iteration/size-guard cap reached) or because a dependent
-	// follow-up issue was already created to continue the work, and re-queuing
-	// the original would cause a duplicate dispatch. Empty means "use the
-	// default retry-ready flow" (GH-3806). In-memory only; lost on restart —
-	// safe because a restart re-enters the handler that sets it before the PR
-	// can reach notifyExternalClose again.
+	// terminal (iteration/size-guard cap reached, a confirmed CI-wait
+	// timeout, or 5 consecutive CI-check API failures — GH-4851/GH-4855) or
+	// because a dependent follow-up issue was already created to continue
+	// the work, and re-queuing the original would cause a duplicate
+	// dispatch. Empty means "use the default retry-ready flow" (GH-3806).
+	//
+	// In-memory only; lost on restart. This is NOT restart-safe for every
+	// terminal path: GH-4841 gave the fix-issue/review-feedback close paths
+	// a durable fallback (StateStore.HasSpawnedFixForPR, consulted by
+	// notifyExternalClose below) because CreateFailureIssue/CreateReviewIssue
+	// always record a durable claim before closing anything. The CI-timeout
+	// and consecutive-API-failure paths above set TerminalLabel WITHOUT ever
+	// closing the PR or spawning a fix issue — the PR is left open,
+	// unclosed, for a human (or a later external event) to close, sometimes
+	// days and several restarts later — so they have no durable claim to
+	// fall back on.
+	//
+	// GH-4855: RestoreState deliberately skips rehydrating StageFailed rows
+	// into c.activePRs on restart (they're terminal), so a PR carrying this
+	// in-memory-only label is untracked immediately after a restart. It is
+	// usually "healed" by the ~60s orphan-PR reconciler sweep, which
+	// rediscovers the still-open PR and re-adopts it via OnPRCreated — but
+	// OnPRCreated always starts a brand-new PRState (TerminalLabel empty)
+	// rather than reading back any prior terminal state, and the very act of
+	// re-adopting immediately persists that fresh empty state, overwriting
+	// whatever was last saved for this PR number. A close landing after that
+	// re-adoption (the PR is tracked again, so checkExternalMergeOrClose can
+	// see it) reaches notifyExternalClose with an empty TerminalLabel and no
+	// spawned-fix claim, and defaults to pilot-retry-ready — silently
+	// re-dispatching work whose fate was already decided. This is an
+	// accepted residual (restart-gated, minutes-wide) rather than a fix
+	// attempted here — closing it durably would mean teaching OnPRCreated's
+	// adoption path to look up and carry forward a prior terminal state
+	// before re-persisting, which changes re-adoption semantics broadly
+	// enough to warrant its own task. See
+	// TestGH4855_ReAdoptionWindow_LosesTerminalLabel_AcceptedResidual for a
+	// regression test documenting the exact window.
 	TerminalLabel string
 	// ScopeKey marks this PRState as a scope-release CARRIER — registered by
 	// startPendingScopeReleases on behalf of a completed epic ("epic:<N>") or


### PR DESCRIPTION
## Summary

Post-merge review of PR#4853 (GH-4851) found the confirmed-CI-timeout +
`TerminalLabel` mechanism it introduced creates a fresh terminal-stranding
class:

- Three sites re-enter `StageWaitingCI` **without** resetting
  `CIWaitStartedAt`: infra-outage rerun (`maybeRetryInfraFailure`),
  auto-rebase, and mechanical go.mod/go.sum resolution — unlike the two
  other re-entry sites that already reset correctly. A PR that already
  waited most of its CI budget before the original failure could have a
  freshly-triggered rerun declared "timed out" on the very next tick, and
  (post-#4853) permanently stamped with a terminal label.
- The 5-consecutive-`CheckCI`-API-failure branch reproduces the exact
  GH-4851 incident fingerprint (zero successful polls) but never stamped a
  `TerminalLabel`, so a later external close would silently re-arm
  `pilot-retry-ready`.

## Changes

- Reset `CIWaitStartedAt = time.Now()` at all three re-entry sites
  (`maybeRetryInfraFailure`, `handleMergeConflict` auto-rebase,
  `attemptMechanicalConflictResolution`).
- Stamp `TerminalLabel = github.LabelFailed` on the consecutive-API-failure
  branch in `handleWaitingCI`.
- **TerminalLabel restart-gap (task's option 3):** chose **not** to persist
  `TerminalLabel` in the state store. Investigated durably closing the
  restart-window gap (persist + consult on re-adoption), but
  `OnPRCreated`'s re-adoption path unconditionally overwrites any prior
  persisted state with a fresh, `TerminalLabel`-empty `PRState` before any
  close-check can run — closing the gap durably would require teaching
  `OnPRCreated` to read back and carry forward prior terminal state, which
  changes re-adoption semantics broadly enough to warrant its own task.
  Instead: fixed the stale restart-safety claim in the `TerminalLabel` doc
  comment (`types.go`) and added a regression test
  (`TestGH4855_ReAdoptionWindow_LosesTerminalLabel_AcceptedResidual`) that
  documents the accepted residual (restart-gated, minutes-wide).

## Test plan

- [x] `TestMaybeRetryInfraFailure_ResetsCIWaitClock_GH4855` — re-entry at
      minute 25, rerun still `in_progress` at minute 31 (6m since reset) →
      not a timeout.
- [x] `TestHandleMergeConflict_AutoRebase_ResetsCIWaitClock_GH4855`
- [x] `TestAttemptMechanicalConflictResolution_ResetsCIWaitClock_GH4855`
- [x] `TestHandleWaitingCI_FiveConsecutiveAPIFailures_StampsTerminalLabel_GH4855`
      — 5 consecutive `CheckCI` errors → `StageFailed` carries
      `TerminalLabel`; external close does not arm `pilot-retry-ready`.
- [x] `TestGH4855_ReAdoptionWindow_LosesTerminalLabel_AcceptedResidual`
      (documents residual, does not fix it)
- [x] GH-4851 suite passes unchanged
- [x] GH-4384/4415/4478/4646 family passes unchanged
- [x] Full `go test ./internal/autopilot/...` passes
- [x] `go build ./...` clean, `gofmt -l` clean on changed files