### PR TITLE
GH-4856: fix(autopilot): guard handleReviewRequested against poisoned review claims; owner-health gaps in dedup + declined classification

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -3131,8 +3131,29 @@ func (c *Controller) handleReviewRequested(ctx context.Context, prState *PRState
 	// directly, so prState.TerminalLabel is designated the moment the issue
 	// exists — strictly before the ClosePullRequest call below.
 	issueNum, err := c.spawnReviewIssue(ctx, prState, reviews, comments, iteration+1)
-	if err != nil {
-		return fmt.Errorf("failed to create review issue: %w", err)
+	// GH-4856/GH-4459: the PR must never be closed unless the revision issue
+	// actually cleared preflight admission — CreateReviewIssue's dedup guard
+	// can legitimately return (0, nil) when a claim is in flight but not yet
+	// recorded (GH-4852's claim-before-create ordering), and a create error
+	// leaves nothing to continue the work either way. Closing the PR (and
+	// deleting the branch) on either shape discards the review round: the
+	// external-close fallback finds no live claim to fall back to and
+	// re-arms retry-ready, so the source re-runs from scratch instead of
+	// addressing the feedback. Mirror the CI path's guard (controller.go
+	// handleCIFailed, GH-4459) — escalate and hold instead, PR and branch
+	// intact, rather than looping silently.
+	if err != nil || issueNum <= 0 {
+		if err != nil {
+			c.log.Warn("review-fix continuation declined at preflight: failed to create review issue",
+				"pr", prState.PRNumber, "error", err)
+		} else {
+			c.log.Warn("review-fix continuation declined at preflight: no review issue number returned",
+				"pr", prState.PRNumber)
+		}
+		comment := "Could not create a continuation review issue for this feedback round — holding this PR for manual review instead of closing it with no follow-up."
+		c.escalateAndHold(ctx, prState, "review-fix continuation declined at preflight", []string{labelNeedsHuman}, comment)
+		c.metrics.RecordPRFailed()
+		return nil
 	}
 
 	// Learn from review (self-improvement)

--- a/internal/autopilot/feedback_loop.go
+++ b/internal/autopilot/feedback_loop.go
@@ -559,13 +559,17 @@ func (f *FeedbackLoop) CreateReviewIssue(ctx context.Context, prState *PRState, 
 	// for the same review round (PR#4846 pre-merge review, D4). Claiming
 	// first closes that window: a retry after any crash finds the claim
 	// already taken and reuses whatever issue number (if any) was recorded,
-	// instead of creating a duplicate. No owner-health re-check is needed
-	// here unlike CreateFailureIssue's dedup path — a fresh review round
-	// always carries a new PR number (dedupKey is PR-scoped), so the "existing
-	// owner might be dead" question never arises for a *repeat* claim of the
-	// same key; the same key is only ever reused across restarts/re-ticks
-	// still processing the same review round.
+	// instead of creating a duplicate.
+	//
+	// GH-4856: the "existing owner might be dead" question DOES arise here
+	// too, despite dedupKey being PR-scoped — a crash between claim and
+	// record (existing == 0, handled below) isn't the only poisoned shape; a
+	// *recorded* existing issue can also die (closed without shipping) while
+	// the daemon is down, and dedup would otherwise hand it straight back to
+	// spawnReviewIssue, which sets TerminalLabel pointing at a corpse. Mirror
+	// CreateFailureIssue's GH-4842 dedup-path re-check below.
 	var dedupRepo, dedupKey string
+	var ownReviewClaim bool
 	if f.stateStore != nil {
 		dedupRepo = f.owner + "/" + f.repo
 		dedupKey = spawnedFixDedupKey(prState.PRNumber, FailureReviewRequested, nil)
@@ -575,19 +579,47 @@ func (f *FeedbackLoop) CreateReviewIssue(ctx context.Context, prState *PRState, 
 				"pr", prState.PRNumber, "error", claimErr)
 		} else if !claimed {
 			existing, lookupErr := f.stateStore.GetSpawnedFixIssue(dedupRepo, dedupKey)
-			if lookupErr != nil {
+			switch {
+			case lookupErr != nil:
 				f.log.Warn("duplicate review-issue creation suppressed but issue lookup failed",
 					"pr", prState.PRNumber, "error", lookupErr)
 				return existing, nil
+			case existing <= 0:
+				// The claim landed but the prior attempt crashed before
+				// recording an issue number (create failed, or crashed
+				// between create and record) — narrow, accepted window,
+				// mirrors CreateFailureIssue's identical "existing <= 0:
+				// return existing, nil" branch. handleReviewRequested's
+				// issueNum<=0 guard (GH-4856) escalates-and-holds instead of
+				// closing the PR on this shape.
+				return existing, nil
+			default:
+				// GH-4856: verify the previously-designated review issue is
+				// still a live owner before handing it back out, mirroring
+				// CreateFailureIssue's GH-4842 dedup-path re-check
+				// (:317-338). A revision issue that closed without shipping
+				// (human closed it during a crash/downtime window) must
+				// never be re-designated as the recovery owner via dedup —
+				// spawnReviewIssue would set TerminalLabel pointing at a
+				// corpse.
+				existingIssue, err := f.ghClient.GetIssue(ctx, f.owner, f.repo, existing)
+				switch {
+				case err != nil:
+					f.log.Warn("owner-health check failed, returning existing review issue unverified",
+						"pr", prState.PRNumber, "existing_issue", existing, "error", err)
+					return existing, nil
+				case classifyOwnerHealth(existingIssue) != ownerDead:
+					f.log.Info("duplicate review-issue creation suppressed", "pr", prState.PRNumber, "existing_issue", existing)
+					return existing, nil
+				}
+				f.log.Warn("designated review issue is dead (closed without shipping) — minting a replacement",
+					"pr", prState.PRNumber, "dead_issue", existing)
+				f.fireOwnerDeathAlert(existing, fmt.Sprintf("review issue #%d closed without shipping, replacing via dedup path", existing), "replaced")
+				// fall through: dedupKey stays set so RecordSpawnedFixIssue
+				// below overwrites this dead issue's row with the replacement.
 			}
-			// existing > 0: a review issue already exists for this exact PR;
-			// reuse it instead of minting a duplicate. existing == 0: the
-			// claim landed but the prior attempt crashed before recording an
-			// issue number (create failed, or crashed between create and
-			// record) — narrow, accepted window, mirrors CreateFailureIssue's
-			// identical "existing <= 0: return existing, nil" branch.
-			f.log.Info("duplicate review-issue creation suppressed", "pr", prState.PRNumber, "existing_issue", existing)
-			return existing, nil
+		} else {
+			ownReviewClaim = true
 		}
 	}
 
@@ -636,6 +668,20 @@ func (f *FeedbackLoop) CreateReviewIssue(ctx context.Context, prState *PRState, 
 	// sentinel encodes intent vs a nil-means-skip default (TASK-286 / GH-3027 / TASK-347).
 	issue, err := ghissue.CreatePilotIssue(ctx, f.ghClient, ghissue.AllowAllIssueRepos(), f.owner, f.repo, title, body, f.issueLabels)
 	if err != nil {
+		// GH-4856: release the claim row taken above so a transient create
+		// failure doesn't poison the dedup key forever. Without this, the
+		// row survives with issue_number=0 (RecordSpawnedFixIssue below is
+		// only ever reached on the success path) and every future attempt
+		// for this PR hits the dedup-hit branch above, permanently getting
+		// back (0, nil) with no way to ever record a real issue number.
+		// Only release a claim this call actually took — a claim-check
+		// failure above (proceeding without the guard) never took one.
+		if ownReviewClaim {
+			if relErr := f.stateStore.ReleaseSpawnedFix(dedupRepo, dedupKey); relErr != nil {
+				f.log.Warn("failed to release spawned review-issue claim after create failure",
+					"pr", prState.PRNumber, "error", relErr)
+			}
+		}
 		return 0, fmt.Errorf("failed to create review issue: %w", err)
 	}
 

--- a/internal/autopilot/gh4856_test.go
+++ b/internal/autopilot/gh4856_test.go
@@ -1,0 +1,398 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GH-4856: post-merge review of PR#4854 (GH-4852) found a regression at an
+// unguarded caller plus two owner-health gaps. These tests cover the three
+// fixes named in the review verdict:
+//
+//  1. handleReviewRequested must not close the PR/delete the branch when
+//     CreateReviewIssue returns (0, nil) or an error — it must escalate and
+//     hold instead (mirroring GH-4459's CI-path guard), and the claim row
+//     must not stay poisoned forever after a transient create failure.
+//  2. CreateReviewIssue's dedup-hit branch must re-check owner health before
+//     handing back an existing review issue, mirroring CreateFailureIssue's
+//     GH-4842 dedup-path re-check.
+//  3. classifyOwnerHealth must treat an open, pilot-needs-clarification fix
+//     issue (preflight-declined) as dead, not alive.
+
+// TestHandleReviewRequested_CreateIssueErrors_EscalatesInsteadOfClosing covers
+// a transient CreatePilotIssue error on a review round: the PR must not be
+// closed or the branch deleted, and the tick must escalate-and-hold instead.
+// A later successful create (once the transient failure clears) must then
+// proceed normally — the claim row must not be left poisoned by the first
+// failed attempt.
+func TestHandleReviewRequested_CreateIssueErrors_EscalatesInsteadOfClosing(t *testing.T) {
+	var prClosed, branchDeleted atomic.Bool
+	var failCreate atomic.Bool
+	failCreate.Store(true)
+	var labelsAdded []string
+	var createdIssueNum atomic.Int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/91/reviews" && r.Method == http.MethodGet:
+			resp := []*github.PullRequestReview{{ID: 1, User: github.User{Login: "alice"}, Body: "Fix this", State: "CHANGES_REQUESTED"}}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls/91/comments") && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			if failCreate.Load() {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"message":"internal server error"}`))
+				return
+			}
+			resp := github.Issue{Number: 701}
+			createdIssueNum.Store(701)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/issues/40/labels" && r.Method == http.MethodPost:
+			var body map[string][]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			labelsAdded = append(labelsAdded, body["labels"]...)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Label{})
+		case r.URL.Path == "/repos/owner/repo/pulls/91" && r.Method == http.MethodPatch:
+			prClosed.Store(true)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/git/refs/heads/") && r.Method == http.MethodDelete:
+			branchDeleted.Store(true)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	store := newTestStateStore(t)
+	c.SetStateStore(store)
+
+	prState := &PRState{
+		PRNumber:    91,
+		IssueNumber: 40,
+		BranchName:  "pilot/GH-40",
+		Stage:       StageReviewRequested,
+	}
+
+	// First tick: CreatePilotIssue fails transiently.
+	if err := c.handleReviewRequested(context.Background(), prState); err != nil {
+		t.Fatalf("handleReviewRequested returned unexpected error: %v", err)
+	}
+
+	if prClosed.Load() {
+		t.Error("PR must NOT be closed when the review issue fails to create — hold via escalateAndHold instead (GH-4856/GH-4459)")
+	}
+	if branchDeleted.Load() {
+		t.Error("branch must NOT be deleted when the PR is held via escalateAndHold")
+	}
+	if c.consumeSelfClosedMarker(91) {
+		t.Error("escalateAndHold must never stamp a self-close marker — the PR was never closed")
+	}
+	if prState.Stage != StageFailed {
+		t.Errorf("Stage = %s, want %s", prState.Stage, StageFailed)
+	}
+	if prState.Error != "review-fix continuation declined at preflight" {
+		t.Errorf("Error = %q, want %q", prState.Error, "review-fix continuation declined at preflight")
+	}
+	if prState.TerminalLabel != "" {
+		t.Errorf("TerminalLabel = %q, want empty — no review issue was ever created", prState.TerminalLabel)
+	}
+	found := false
+	for _, l := range labelsAdded {
+		if l == labelNeedsHuman {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected pilot-needs-human label on the issue, got labels: %v", labelsAdded)
+	}
+
+	// Second tick: the transient failure clears. The claim row from the first
+	// attempt must have been released, not left poisoned at issue_number=0
+	// forever — otherwise this retry would hit the dedup-hit branch and get
+	// back (0, nil) again, looping on escalateAndHold indefinitely.
+	failCreate.Store(false)
+	prState.Stage = StageReviewRequested
+	prState.Error = ""
+
+	if err := c.handleReviewRequested(context.Background(), prState); err != nil {
+		t.Fatalf("handleReviewRequested (retry) returned unexpected error: %v", err)
+	}
+
+	if createdIssueNum.Load() != 701 {
+		t.Fatalf("expected retry to successfully create issue #701, got %d", createdIssueNum.Load())
+	}
+	if !prClosed.Load() {
+		t.Error("expected PR to be closed once the review issue was successfully created on retry")
+	}
+	if !branchDeleted.Load() {
+		t.Error("expected branch to be deleted once the review issue was successfully created on retry")
+	}
+	if prState.TerminalLabel != github.LabelFailed {
+		t.Errorf("TerminalLabel = %q, want %q after a successful review-issue create", prState.TerminalLabel, github.LabelFailed)
+	}
+}
+
+// TestCreateReviewIssue_DedupHit_DeadOwner_MintsReplacement covers the
+// dedup-hit branch of CreateReviewIssue: a durably-claimed review issue that
+// has since closed without shipping (a human closed it during a crash/
+// downtime window) must not be handed back out unverified — dedup must
+// re-check owner health (mirroring CreateFailureIssue's GH-4842 path) and
+// mint a replacement instead, so spawnReviewIssue never points TerminalLabel
+// at a corpse.
+func TestCreateReviewIssue_DedupHit_DeadOwner_MintsReplacement(t *testing.T) {
+	createCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues/100" && r.Method == http.MethodGet:
+			// The previously-designated review issue: closed without ever
+			// shipping (no pilot-done label) — dead.
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Issue{Number: 100, State: github.StateClosed})
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			createCalls++
+			resp := github.Issue{Number: 200}
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	fl := NewFeedbackLoop(ghClient, "owner", "repo", cfg)
+	store := newTestStateStore(t)
+	fl.SetStateStore(store)
+	sink := &fakeAlertSink{}
+	fl.SetAlertsEngine(sink)
+
+	prState := &PRState{PRNumber: 77, IssueNumber: 12, BranchName: "pilot/GH-12"}
+
+	// Seed a durable claim naming the now-dead review issue #100, simulating
+	// a prior review round whose designated owner has since died.
+	dedupRepo := "owner/repo"
+	dedupKey := spawnedFixDedupKey(prState.PRNumber, FailureReviewRequested, nil)
+	if _, err := store.ClaimSpawnedFix(dedupRepo, dedupKey); err != nil {
+		t.Fatalf("seed ClaimSpawnedFix failed: %v", err)
+	}
+	if err := store.RecordSpawnedFixIssue(dedupRepo, dedupKey, 100); err != nil {
+		t.Fatalf("seed RecordSpawnedFixIssue failed: %v", err)
+	}
+
+	got, err := fl.CreateReviewIssue(context.Background(), prState, nil, nil, 1)
+	if err != nil {
+		t.Fatalf("CreateReviewIssue error: %v", err)
+	}
+	if got != 200 {
+		t.Errorf("CreateReviewIssue() = %d, want 200 (dead owner #100 replaced with a fresh issue)", got)
+	}
+	if createCalls != 1 {
+		t.Errorf("createCalls = %d, want 1 (a replacement must be minted for the dead owner)", createCalls)
+	}
+	if len(sink.events) != 1 {
+		t.Errorf("expected exactly 1 owner-death alert for the replaced dead owner, got %d: %v", len(sink.events), sink.events)
+	}
+
+	recorded, err := store.GetSpawnedFixIssue(dedupRepo, dedupKey)
+	if err != nil {
+		t.Fatalf("GetSpawnedFixIssue: %v", err)
+	}
+	if recorded != 200 {
+		t.Errorf("claim row after replacement = %d, want 200 (overwritten with the replacement)", recorded)
+	}
+}
+
+// TestCreateReviewIssue_DedupHit_AliveOwner_ReusesExisting is the control
+// case for the health re-check above: an open (still-alive) previously
+// designated review issue must still be reused, not replaced.
+func TestCreateReviewIssue_DedupHit_AliveOwner_ReusesExisting(t *testing.T) {
+	createCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues/101" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Issue{Number: 101, State: github.StateOpen})
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			createCalls++
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(github.Issue{Number: 999})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	fl := NewFeedbackLoop(ghClient, "owner", "repo", cfg)
+	store := newTestStateStore(t)
+	fl.SetStateStore(store)
+
+	prState := &PRState{PRNumber: 78, IssueNumber: 13, BranchName: "pilot/GH-13"}
+
+	dedupRepo := "owner/repo"
+	dedupKey := spawnedFixDedupKey(prState.PRNumber, FailureReviewRequested, nil)
+	if _, err := store.ClaimSpawnedFix(dedupRepo, dedupKey); err != nil {
+		t.Fatalf("seed ClaimSpawnedFix failed: %v", err)
+	}
+	if err := store.RecordSpawnedFixIssue(dedupRepo, dedupKey, 101); err != nil {
+		t.Fatalf("seed RecordSpawnedFixIssue failed: %v", err)
+	}
+
+	got, err := fl.CreateReviewIssue(context.Background(), prState, nil, nil, 1)
+	if err != nil {
+		t.Fatalf("CreateReviewIssue error: %v", err)
+	}
+	if got != 101 {
+		t.Errorf("CreateReviewIssue() = %d, want 101 (alive owner reused)", got)
+	}
+	if createCalls != 0 {
+		t.Errorf("createCalls = %d, want 0 (must not mint a duplicate for a still-alive owner)", createCalls)
+	}
+}
+
+// TestClassifyOwnerHealth_PreflightDeclined_IsDead covers the third gap: a
+// fix/review issue declined at preflight stays OPEN carrying
+// pilot-needs-clarification (GH-2768) and never dispatches. classifyOwnerHealth
+// must classify it as ownerDead, not ownerAlive, so callers that re-check
+// health (dedup paths, notifyExternalClose's durable-claim fallback) don't
+// re-designate the zombie after ReactToDeclinedFixIssue has already re-armed
+// its source.
+func TestClassifyOwnerHealth_PreflightDeclined_IsDead(t *testing.T) {
+	issue := &github.Issue{
+		Number: 500,
+		State:  github.StateOpen,
+		Labels: []github.Label{{Name: github.LabelNeedsClarification}},
+	}
+	if got := classifyOwnerHealth(issue); got != ownerDead {
+		t.Errorf("classifyOwnerHealth(open+needs-clarification) = %v, want ownerDead", got)
+	}
+}
+
+// TestClassifyOwnerHealth_OpenWithoutLabel_IsAlive is the control case: an
+// ordinary open issue with no needs-clarification label must still read as
+// alive.
+func TestClassifyOwnerHealth_OpenWithoutLabel_IsAlive(t *testing.T) {
+	issue := &github.Issue{Number: 501, State: github.StateOpen}
+	if got := classifyOwnerHealth(issue); got != ownerAlive {
+		t.Errorf("classifyOwnerHealth(open, no label) = %v, want ownerAlive", got)
+	}
+}
+
+// TestNotifyExternalClose_DurableClaimFallback_PreflightDeclinedOwner_RearmsNotFails
+// reproduces the exact TASK-468 D1 ordering the issue describes: the SDK's
+// preflight-decline hook fires first and correctly re-arms the source via
+// ReactToDeclinedFixIssue (simulated here by seeding the source already
+// pilot-retry-ready), then the external-close fallback runs minutes later
+// and must NOT re-designate the still-open, still-declined fix issue as the
+// recovery owner (pilot-failed) — it must recognize the declined owner as
+// dead and leave the source on its rearmed retry-ready path.
+func TestNotifyExternalClose_DurableClaimFallback_PreflightDeclinedOwner_RearmsNotFails(t *testing.T) {
+	const (
+		prNumber    = 5301
+		issueNumber = 5302
+		fixIssueNum = 5303
+	)
+
+	var issueLabelsAdded []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues/5302" && r.Method == http.MethodGet:
+			// Source issue: open, already re-armed with pilot-retry-ready by
+			// the earlier preflight-decline reaction.
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Issue{Number: issueNumber, State: github.StateOpen})
+		case r.URL.Path == "/repos/owner/repo/issues/5303" && r.Method == http.MethodGet:
+			// The claimed fix issue: still open, declined at preflight.
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Issue{
+				Number: fixIssueNum,
+				State:  github.StateOpen,
+				Labels: []github.Label{{Name: github.LabelNeedsClarification}},
+			})
+		case r.URL.Path == "/repos/owner/repo/issues/5302/labels" && r.Method == http.MethodPost:
+			var body map[string][]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			issueLabelsAdded = append(issueLabelsAdded, body["labels"]...)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Label{})
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/5302/labels/") && r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	store := newTestStateStore(t)
+	dedupRepo := "owner/repo"
+	dedupKey := spawnedFixDedupKey(prNumber, FailureReviewRequested, nil)
+	if _, err := store.ClaimSpawnedFix(dedupRepo, dedupKey); err != nil {
+		t.Fatalf("seed ClaimSpawnedFix failed: %v", err)
+	}
+	if err := store.RecordSpawnedFixIssue(dedupRepo, dedupKey, fixIssueNum); err != nil {
+		t.Fatalf("seed RecordSpawnedFixIssue failed: %v", err)
+	}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.SetStateStore(store)
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	prState := &PRState{
+		PRNumber:    prNumber,
+		PRURL:       "https://github.com/owner/repo/pull/5301",
+		IssueNumber: issueNumber,
+		// TerminalLabel intentionally empty — in-memory designation lost to
+		// a restart, forcing the durable-claim fallback.
+	}
+
+	c.notifyExternalClose(context.Background(), prState)
+
+	foundFailed := false
+	foundRetryReady := false
+	for _, l := range issueLabelsAdded {
+		if l == github.LabelFailed {
+			foundFailed = true
+		}
+		if l == github.LabelRetryReady {
+			foundRetryReady = true
+		}
+	}
+	if foundFailed {
+		t.Errorf("source issue must NOT be re-designated %q pointing at a preflight-declined owner, labels added: %v", github.LabelFailed, issueLabelsAdded)
+	}
+	if !foundRetryReady {
+		t.Errorf("expected source issue to stay/be re-armed with %q, labels added: %v", github.LabelRetryReady, issueLabelsAdded)
+	}
+}

--- a/internal/autopilot/owner_death.go
+++ b/internal/autopilot/owner_death.go
@@ -33,8 +33,24 @@ const (
 // whether its closure represents a completed hand-off (ownerShipped), no
 // closure at all (ownerAlive), or an owner-death event (ownerDead) that
 // must trigger source re-arm/escalation.
+//
+// GH-4856: a fix issue declined at preflight stays OPEN carrying
+// pilot-needs-clarification (GH-2768) and never dispatches — it reads as
+// ownerAlive by the closed-only check below even though it will never ship.
+// ReactToDeclinedFixIssue already reacts to this exact event and re-arms the
+// source, but any caller that re-checks health afterward (the dedup path
+// here, or notifyExternalClose's durable-claim fallback) must agree it's
+// dead too, or it re-designates the already-declined zombie as the recovery
+// owner — the TASK-468 D1 shape where the reaction's re-arm is immediately
+// clobbered by a fallback that still thinks the zombie is alive.
 func classifyOwnerHealth(issue *github.Issue) ownerHealth {
-	if issue == nil || issue.State != github.StateClosed {
+	if issue == nil {
+		return ownerAlive
+	}
+	if issue.State != github.StateClosed {
+		if github.HasLabel(issue, github.LabelNeedsClarification) {
+			return ownerDead
+		}
 		return ownerAlive
 	}
 	if github.HasLabel(issue, github.LabelDone) {

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -1185,6 +1185,22 @@ func (s *StateStore) RecordSpawnedFixIssue(repo, dedupKey string, issueNumber in
 	return err
 }
 
+// ReleaseSpawnedFix deletes the claim row for (repo, dedupKey) taken by
+// ClaimSpawnedFix. GH-4856: call this when the create-issue call that
+// followed a successful claim fails synchronously (e.g. a transient
+// CreatePilotIssue error) — without it, the row survives with
+// issue_number=0 forever (RecordSpawnedFixIssue is only ever reached on the
+// success path), permanently poisoning the dedup key: every future attempt
+// hits the dedup-hit branch and gets back (0, nil) with no way to ever
+// record a real issue number. Deleting the row lets the next attempt
+// re-claim and retry cleanly.
+func (s *StateStore) ReleaseSpawnedFix(repo, dedupKey string) error {
+	_, err := s.db.Exec(`
+		DELETE FROM autopilot_spawned_fixes WHERE repo = ? AND dedup_key = ?
+	`, repo, dedupKey)
+	return err
+}
+
 // GetSpawnedFixIssue returns the issue number recorded for (repo, dedupKey),
 // or 0 if the claim row exists but RecordSpawnedFixIssue hasn't landed yet
 // (a create is still in flight) or the row doesn't exist.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4856.

Closes #4856

## Changes

GitHub Issue GH-4856: fix(autopilot): guard handleReviewRequested against poisoned review claims; owner-health gaps in dedup + declined classification

## Context

Post-merge review of PR#4854 (GH-4852, verdict on the PR): both headline strand fixes hold (mutation-verified), but the review-path claim-before-create ordering introduced a regression at an unguarded caller, plus two owner-health gaps:

- **Claim poisoning meets an unguarded caller**: `CreateReviewIssue` (internal/autopilot/feedback_loop.go:577-593) can return `(0, nil)` when the claim row exists with no recorded issue — the common case is a transient `CreatePilotIssue` error on the first attempt, which leaves the claim taken with `issue_number=0` forever (nothing releases it). `handleReviewRequested` (controller.go:3114-3117) checks only `err != nil` → proceeds with issueNum=0: closes the reviewed PR (:3157), deletes the branch (:3161-3164), review round discarded; `notifyExternalClose`'s fallback finds no `issue_number>0` row → retry-ready → the source re-runs FROM SCRATCH instead of addressing review feedback. The CI path guards this exact shape (GH-4459, controller.go:2761-2784, escalate-and-hold). Regression vs pre-#4854: create errors were simply retried next tick.
- **Dedup-hit branch skips the owner-health re-check** its `CreateFailureIssue` twin performs (feedback_loop.go:584-592 returns `existing` unverified; compare :317-338): crash-in-window + human closes the revision issue during downtime → dedup returns the dead issue → `spawnReviewIssue` sets TerminalLabel (controller.go:3053-3055) → `notifyExternalClose` takes the TerminalLabel branch (:7571-7573), bypassing the health-checked fallback → `pilot-failed` toward a corpse.
- **Preflight-declined owner reads as alive**: `classifyOwnerHealth` (owner_death.go:36-44) counts only closed-without-pilot-done as dead; a preflight-declined fix issue stays OPEN with `pilot-needs-clarification` and never dispatches. In the exact TASK-468 D1 ordering: the reaction correctly re-arms retry-ready, then the fallback re-designates the declined zombie with `pilot-failed` minutes later — contradictory audit trail + a burned retry rung.

## Implementation

1. **GH-4459-style guard in `handleReviewRequested`**: on `issueNum <= 0` with nil error, escalate-and-hold (PR + branch intact), mirroring controller.go:2761-2784. Also release (or complete) the claim row when `CreatePilotIssue` fails so a transient error cannot poison the claim forever.
2. **Health re-check on the dedup-hit branch** of `CreateReviewIssue` — mirror the `CreateFailureIssue` twin (feedback_loop.go:317-338).
3. **Classify preflight-declined owners as dead**: treat open + `pilot-needs-clarification` as ownerDead in `classifyOwnerHealth`, or skip fallback designation when the source already carries retry-ready.

Optional nits if in the area: the false "rearmed" alert fires before the issueAlreadyClosed gate (controller.go:7606-7629); the decline reaction and external-close fallback can double-fire `emitOwnerDeathAlert` for the same source (no dedup).

## Acceptance

- Test: transient `CreatePilotIssue` error on a review round → next tick does NOT close the PR or delete the branch; escalates and holds; a later successful create proceeds normally (claim not poisoned).
- Test: dedup-hit returning a closed revision issue → health re-check prevents TerminalLabel toward the corpse.
- Test: preflight-declined (open + `pilot-needs-clarification`) owner → classified dead; no re-designation after the reaction re-arms the source.
- GH-4841 / GH-4852 / GH-4826 / owner-death suites pass unchanged.

## Refs

- PR#4854 post-merge review verdict (comment on the PR) — D1 major, D2/D3 minor, D4/D5 nits.
- GH-4459 guard precedent (controller.go:2761-2784) · TASK-468 D1 · GH-4842.