### PR TITLE
GH-4859: fix(autopilot): reset CI-wait clock when the head SHA changes mid-wait — fourth re-entry vector

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2234,6 +2234,21 @@ func (c *Controller) handleWaitingCI(ctx context.Context, prState *PRState, ghPR
 				"old", ShortSHA(sha),
 				"new", ShortSHA(ghPR.Head.SHA),
 			)
+			// GH-4859: a changed HeadSHA means a new CI run — reset the wait
+			// clock so the deadline measures the new run, not the original
+			// StageWaitingCI entry. PR#4857 reset CIWaitStartedAt at the three
+			// Stage=StageWaitingCI assignment sites, but this refresh happens
+			// on every tick without a stage transition, so it was the fourth
+			// re-entry vector PR#4857's post-merge review flagged: a PR could
+			// sit past deadline, pick up a post-creation commit (self-review
+			// or human push), and get an instant CONFIRMED timeout against a
+			// brand-new, still-pending CI run purely because deadlineExceeded
+			// (line ~2208) was computed against the stale CIWaitStartedAt
+			// before this refresh ran. Clearing deadlineExceeded here keeps
+			// the GH-4851 same-tick-success-wins ordering intact: applyCIOutcome
+			// below still short-circuits on CISuccess regardless of this flag.
+			prState.CIWaitStartedAt = time.Now()
+			deadlineExceeded = false
 		} else if sha == "" {
 			c.log.Info("refreshed empty HeadSHA from GitHub",
 				"pr", prState.PRNumber,

--- a/internal/autopilot/gh4859_ci_wait_sha_change_test.go
+++ b/internal/autopilot/gh4859_ci_wait_sha_change_test.go
@@ -1,0 +1,148 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GH-4859 regression tests.
+//
+// Post-merge review of PR#4857 (GH-4855) found a fourth CI-wait re-entry
+// vector the fix's three Stage=StageWaitingCI assignment sites could not
+// see: handleWaitingCI (controller.go) computes deadlineExceeded from the
+// PR's existing CIWaitStartedAt BEFORE the same-tick GH-419/GH-457 HeadSHA
+// refresh runs. That refresh does not change Stage — the PR was already in
+// StageWaitingCI and stays there — so it is not a re-entry site at all, and
+// PR#4857 never reset the clock there. Scenario: a PR sits in
+// StageWaitingCI past its deadline; a post-creation commit (self-review
+// push, human push) lands on the branch and kicks off a fresh CI run; the
+// next tick refreshes HeadSHA to the new commit and CheckCI correctly
+// reads the new run as pending — but deadlineExceeded, measured from the
+// ORIGINAL wait entry, is already true, producing an instant CONFIRMED
+// timeout (StageFailed, TerminalLabel=pilot-failed) against a CI run that
+// had not had any chance to complete. These tests cover: (1) a changed
+// HeadSHA whose new run is still pending must NOT time out, and the clock
+// must be reset to measure the new run; (2) the GH-4851 same-tick-success-
+// wins ordering must still hold when the SHA also changed this tick.
+
+func gh4859CheckRunsHandler(sha string, run github.CheckRun) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/commits/"+sha+"/check-runs" {
+			resp := github.CheckRunsResponse{TotalCount: 1, CheckRuns: []github.CheckRun{run}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}
+}
+
+// TestHandleWaitingCI_HeadSHAChangeMidWait_ResetsDeadline_GH4859 is the
+// primary acceptance test: a PR whose wait clock is already 45m stale (past
+// the 30m default deadline) picks up a new HeadSHA this tick whose CI run
+// is still in_progress. It must stay in StageWaitingCI (not be declared a
+// confirmed timeout), and CIWaitStartedAt must be reset to at/after the SHA
+// change so the new run gets a full timeout window.
+func TestHandleWaitingCI_HeadSHAChangeMidWait_ResetsDeadline_GH4859(t *testing.T) {
+	const oldSHA = "gh4859old0001"
+	const newSHA = "gh4859new0001"
+	server := httptest.NewServer(gh4859CheckRunsHandler(newSHA, github.CheckRun{
+		Name: "ci", Status: github.CheckRunInProgress,
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	before := time.Now()
+	c.mu.Lock()
+	c.activePRs[4859] = &PRState{
+		PRNumber: 4859,
+		HeadSHA:  oldSHA,
+		Stage:    StageWaitingCI,
+		CIStatus: CIPending,
+		// Deadline already exceeded against the ORIGINAL sha's wait entry —
+		// mirrors a PR that sat in StageWaitingCI for 45m before a
+		// post-creation commit landed.
+		CIWaitStartedAt: time.Now().Add(-45 * time.Minute),
+	}
+	c.mu.Unlock()
+
+	// GitHub now reports a new HeadSHA — the branch moved mid-wait.
+	ghPR := &github.PullRequest{Number: 4859, Head: github.PRRef{SHA: newSHA}, Base: github.PRRef{Ref: "main"}}
+
+	if err := c.ProcessPR(context.Background(), 4859, ghPR); err != nil {
+		t.Fatalf("ProcessPR returned unexpected error: %v", err)
+	}
+
+	pr, ok := c.GetPRState(4859)
+	if !ok {
+		t.Fatal("PR 4859 no longer tracked")
+	}
+	if pr.Stage != StageWaitingCI {
+		t.Fatalf("Stage = %s, want %s — a changed HeadSHA whose new CI run is still pending must not be declared a timeout (error=%q)", pr.Stage, StageWaitingCI, pr.Error)
+	}
+	if pr.TerminalLabel == github.LabelFailed {
+		t.Errorf("TerminalLabel = %q, want unset — this PR did not time out", pr.TerminalLabel)
+	}
+	if pr.HeadSHA != newSHA {
+		t.Errorf("HeadSHA = %q, want %q — must refresh to the new commit", pr.HeadSHA, newSHA)
+	}
+	if pr.CIWaitStartedAt.Before(before) {
+		t.Fatalf("CIWaitStartedAt = %v, want reset to >= SHA-change time %v — a changed head means a new CI run and must get a full timeout window, not carry over the stale original clock", pr.CIWaitStartedAt, before)
+	}
+}
+
+// TestHandleWaitingCI_HeadSHAChangeMidWait_ConfirmedSuccessSameTick_GH4859
+// guards the GH-4851 ordering: even when the SHA also changed this tick,
+// a same-tick CheckCI read that resolves CISuccess on the new SHA must
+// still win and land the PR in StageCIPassed, not fall through to a
+// timeout evaluation.
+func TestHandleWaitingCI_HeadSHAChangeMidWait_ConfirmedSuccessSameTick_GH4859(t *testing.T) {
+	const oldSHA = "gh4859old0002"
+	const newSHA = "gh4859new0002"
+	server := httptest.NewServer(gh4859CheckRunsHandler(newSHA, github.CheckRun{
+		Name: "ci", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess,
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	c.mu.Lock()
+	c.activePRs[4860] = &PRState{
+		PRNumber:        4860,
+		HeadSHA:         oldSHA,
+		Stage:           StageWaitingCI,
+		CIStatus:        CIPending,
+		CIWaitStartedAt: time.Now().Add(-45 * time.Minute),
+	}
+	c.mu.Unlock()
+
+	ghPR := &github.PullRequest{Number: 4860, Head: github.PRRef{SHA: newSHA}, Base: github.PRRef{Ref: "main"}}
+
+	if err := c.ProcessPR(context.Background(), 4860, ghPR); err != nil {
+		t.Fatalf("ProcessPR returned unexpected error: %v", err)
+	}
+
+	pr, ok := c.GetPRState(4860)
+	if !ok {
+		t.Fatal("PR 4860 no longer tracked")
+	}
+	if pr.Stage != StageCIPassed {
+		t.Fatalf("Stage = %s, want %s — a same-tick CheckCI success on the new SHA must win in the same tick the SHA changed", pr.Stage, StageCIPassed)
+	}
+	if pr.HeadSHA != newSHA {
+		t.Errorf("HeadSHA = %q, want %q", pr.HeadSHA, newSHA)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4859.

Closes #4859

## Changes

GitHub Issue GH-4859: fix(autopilot): reset CI-wait clock when the head SHA changes mid-wait — fourth re-entry vector

## Context

PR#4857 (GH-4855) reset the CI-wait clock at the three stage re-entry sites, but its post-merge review (verdict on the PR) found a fourth re-entry vector the spec didn't enumerate — one where the stage never changes, so it is not a `Stage = StageWaitingCI` assignment site:

- `handleWaitingCI` computes `deadlineExceeded` from `CIWaitStartedAt` (internal/autopilot/controller.go:2208) BEFORE the same tick's head-SHA refresh (:2233-2251, the GH-419/457 logic that updates `HeadSHA` when the branch moved).
- Scenario: PR sits in `StageWaitingCI` for 29m; a post-creation commit lands on the branch (self-review push, human push) and triggers a fresh CI run; next tick refreshes `HeadSHA`, `CheckCI(newSHA)` correctly reads the new run as pending, but `deadlineExceeded` — measured from the ORIGINAL wait entry — is true → instant CONFIRMED timeout, `TerminalLabel=pilot-failed`, permanent strand. The exact class PR#4857 fixed, via the one vector it could not see.

## Implementation

1. Reset `CIWaitStartedAt = time.Now()` inside the `sha != ghPR.Head.SHA` branch of `handleWaitingCI` (controller.go:~2234) — a changed head means a new CI run, so the deadline must measure the new run. Ensure the reset happens before the deadline is honored in the same tick (the confirm-poll ordering from PR#4853/#4857 must keep winning: a same-tick success on the new SHA proceeds to CIPassed regardless).

## Acceptance

- Test: PR in `StageWaitingCI` past the deadline with a changed head SHA whose new CI run is `in_progress` → NOT a timeout; stays `StageWaitingCI`; the new run gets a full timeout window measured from the SHA change.
- Test (guard the ordering): same scenario but the new SHA's read returns success → `StageCIPassed` in the same tick.
- GH-4855 suite (5 tests) + GH-4851 suite + GH-4384/4415/4478/4646 family pass unchanged.

## Refs

- PR#4857 post-merge review verdict (comment on the PR) — D1 medium.
- Lineage: GH-4855 ← PR#4853 review ← GH-4851 incident (PR#4846 strand, TASK-467).