### PR TITLE
GH-4860: fix(autopilot): seeded-claim test for the review guard; dedup reuse-don't-replace for clarification owners; CI-path claim release

### DIFF
--- a/internal/autopilot/feedback_loop.go
+++ b/internal/autopilot/feedback_loop.go
@@ -298,6 +298,7 @@ func (f *FeedbackLoop) CreateFailureIssue(ctx context.Context, prState *PRState,
 	// fix issue for it. The claim lives in the shared SQLite store so it
 	// holds even across process boundaries.
 	var dedupRepo, dedupKey string
+	var ownFailureClaim bool
 	if f.stateStore != nil {
 		dedupRepo = f.owner + "/" + f.repo
 		dedupKey = spawnedFixDedupKey(prState.PRNumber, failureType, failedChecks)
@@ -321,13 +322,30 @@ func (f *FeedbackLoop) CreateFailureIssue(ctx context.Context, prState *PRState,
 				// must never be re-designated as the recovery owner via
 				// dedup; fall through and mint a replacement instead.
 				existingIssue, err := f.ghClient.GetIssue(ctx, f.owner, f.repo, existing)
+				health := classifyOwnerHealth(existingIssue)
 				switch {
 				case err != nil:
 					f.log.Warn("owner-health check failed, returning existing fix issue unverified",
 						"pr", prState.PRNumber, "failure", failureType, "existing_issue", existing, "error", err)
 					return existing, nil
-				case classifyOwnerHealth(existingIssue) != ownerDead:
+				case health != ownerDead:
 					f.log.Info("duplicate fix-issue creation suppressed",
+						"pr", prState.PRNumber, "failure", failureType, "existing_issue", existing)
+					return existing, nil
+				case existingIssue.State != github.StateClosed:
+					// GH-4860 D2: open + pilot-needs-clarification reads as
+					// ownerDead (it will never ship) but is NOT abandoned —
+					// it's the documented-resumable preflight-decline state
+					// (notifier.go, epic.go). A transient ClosePullRequest
+					// failure or crash-before-close can re-enter this create
+					// path while a human is mid-clarification; minting a
+					// replacement here would move the claim, leave the
+					// declined issue open as a zombie, and — once the human
+					// removes the label — dispatch BOTH issues against the
+					// same branch: meta, clobbering each other. Reuse
+					// instead: hand back the existing (still-resumable)
+					// owner, leave the claim row untouched, fire no alert.
+					f.log.Info("existing owner open + needs-clarification (resumable) — reusing, not replacing",
 						"pr", prState.PRNumber, "failure", failureType, "existing_issue", existing)
 					return existing, nil
 				}
@@ -337,6 +355,8 @@ func (f *FeedbackLoop) CreateFailureIssue(ctx context.Context, prState *PRState,
 				// fall through: dedupKey stays set so RecordSpawnedFixIssue
 				// below overwrites this dead issue's row with the replacement.
 			}
+		} else {
+			ownFailureClaim = true
 		}
 	}
 
@@ -382,6 +402,22 @@ func (f *FeedbackLoop) CreateFailureIssue(ctx context.Context, prState *PRState,
 	// explicit sentinel encodes that intent (vs a nil-means-skip default). TASK-286 / GH-3027 / TASK-347.
 	issue, err := ghissue.CreatePilotIssue(ctx, f.ghClient, ghissue.AllowAllIssueRepos(), f.owner, f.repo, title, body, f.issueLabels)
 	if err != nil {
+		// GH-4860 N1: mirror CreateReviewIssue's claim release (GH-4856,
+		// feedback_loop.go ~679) — without this, a transient create error on
+		// the CI path leaves the claim row surviving with issue_number=0
+		// forever (RecordSpawnedFixIssue below is only reached on the
+		// success path), so every future attempt for this PR hits the
+		// dedup-hit "existing <= 0: return existing, nil" branch and
+		// permanently escalates per the GH-4459 guard, with no way to ever
+		// record a real issue number. Only release a claim this call
+		// actually took — a claim-check failure above (proceeding without
+		// the guard) never took one.
+		if ownFailureClaim {
+			if relErr := f.stateStore.ReleaseSpawnedFix(dedupRepo, dedupKey); relErr != nil {
+				f.log.Warn("failed to release spawned fix claim after create failure",
+					"pr", prState.PRNumber, "failure", failureType, "error", relErr)
+			}
+		}
 		return 0, fmt.Errorf("failed to create issue: %w", err)
 	}
 
@@ -603,13 +639,26 @@ func (f *FeedbackLoop) CreateReviewIssue(ctx context.Context, prState *PRState, 
 				// spawnReviewIssue would set TerminalLabel pointing at a
 				// corpse.
 				existingIssue, err := f.ghClient.GetIssue(ctx, f.owner, f.repo, existing)
+				health := classifyOwnerHealth(existingIssue)
 				switch {
 				case err != nil:
 					f.log.Warn("owner-health check failed, returning existing review issue unverified",
 						"pr", prState.PRNumber, "existing_issue", existing, "error", err)
 					return existing, nil
-				case classifyOwnerHealth(existingIssue) != ownerDead:
+				case health != ownerDead:
 					f.log.Info("duplicate review-issue creation suppressed", "pr", prState.PRNumber, "existing_issue", existing)
+					return existing, nil
+				case existingIssue.State != github.StateClosed:
+					// GH-4860 D2: mirror CreateFailureIssue's reuse-don't-
+					// replace for an open + pilot-needs-clarification owner
+					// (see the matching comment there). Minting a
+					// replacement here while a human is mid-clarification
+					// would move the claim and leave a zombie review issue
+					// open — review issues additionally share `branch:`
+					// meta with the source PR, so a later duplicate
+					// dispatch clobbers the same branch.
+					f.log.Info("existing review owner open + needs-clarification (resumable) — reusing, not replacing",
+						"pr", prState.PRNumber, "existing_issue", existing)
 					return existing, nil
 				}
 				f.log.Warn("designated review issue is dead (closed without shipping) — minting a replacement",

--- a/internal/autopilot/gh4860_test.go
+++ b/internal/autopilot/gh4860_test.go
@@ -1,0 +1,279 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GH-4860: post-merge review of PR#4858 (GH-4856) found three remaining
+// gaps. These tests cover the fixes named in the review verdict:
+//
+//  1. D1: the "(0, nil)" half of handleReviewRequested's guard
+//     (`if err != nil || issueNum <= 0`, controller.go:3145) was unreachable
+//     by the suite — a seeded claim with no recorded issue number is the
+//     real-world producer of that shape (crash between CreatePilotIssue
+//     succeeding and RecordSpawnedFixIssue landing, or a concurrent claim in
+//     flight).
+//  2. N1: CreateFailureIssue's create-error path must release its claim on
+//     the CI path too, mirroring CreateReviewIssue's GH-4856 fix, so a
+//     transient create error doesn't poison the dedup key forever.
+
+// TestHandleReviewRequested_SeededClaimWithoutRecord_EscalatesAndHolds
+// reproduces D1's real-world (0, nil) producer directly: a claim landed
+// (ClaimSpawnedFix succeeded) but no issue number was ever recorded — the
+// exact shape left behind by a crash between CreatePilotIssue succeeding and
+// RecordSpawnedFixIssue, or a concurrent claim still in flight. Mutating
+// controller.go:3145's `if err != nil || issueNum <= 0` down to `if err !=
+// nil` must fail this test: CreateReviewIssue returns (0, nil) for this
+// shape (feedback_loop.go's "existing <= 0: return existing, nil" branch),
+// so the mutated guard would fall through and close the PR / delete the
+// branch, discarding the review round — the original GH-4856 bug.
+func TestHandleReviewRequested_SeededClaimWithoutRecord_EscalatesAndHolds(t *testing.T) {
+	var prClosed, branchDeleted atomic.Bool
+	var createCalls atomic.Int64
+	var labelsAdded []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/91/reviews" && r.Method == http.MethodGet:
+			resp := []*github.PullRequestReview{{ID: 1, User: github.User{Login: "alice"}, Body: "Fix this", State: "CHANGES_REQUESTED"}}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls/91/comments") && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			// Must never be called: the claim above already landed, so
+			// CreateReviewIssue's dedup-hit "existing <= 0" branch must
+			// return (0, nil) without ever attempting a create.
+			createCalls.Add(1)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, github.Issue{Number: 701}))
+		case r.URL.Path == "/repos/owner/repo/issues/40/labels" && r.Method == http.MethodPost:
+			var body map[string][]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			labelsAdded = append(labelsAdded, body["labels"]...)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Label{})
+		case r.URL.Path == "/repos/owner/repo/pulls/91" && r.Method == http.MethodPatch:
+			prClosed.Store(true)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/git/refs/heads/") && r.Method == http.MethodDelete:
+			branchDeleted.Store(true)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	store := newTestStateStore(t)
+	c.SetStateStore(store)
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	prState := &PRState{
+		PRNumber:    91,
+		IssueNumber: 40,
+		BranchName:  "pilot/GH-40",
+		Stage:       StageReviewRequested,
+	}
+
+	// Seed the durable claim WITHOUT recording an issue number — the shape
+	// left by a crash between CreatePilotIssue succeeding and
+	// RecordSpawnedFixIssue landing, or a concurrent claim still in flight.
+	dedupRepo := "owner/repo"
+	dedupKey := spawnedFixDedupKey(prState.PRNumber, FailureReviewRequested, nil)
+	if _, err := store.ClaimSpawnedFix(dedupRepo, dedupKey); err != nil {
+		t.Fatalf("seed ClaimSpawnedFix failed: %v", err)
+	}
+
+	if err := c.handleReviewRequested(context.Background(), prState); err != nil {
+		t.Fatalf("handleReviewRequested returned unexpected error: %v", err)
+	}
+
+	if createCalls.Load() != 0 {
+		t.Errorf("expected no issue creation attempt (dedup-hit existing<=0 branch), got %d create calls", createCalls.Load())
+	}
+	if prClosed.Load() {
+		t.Error("PR must NOT be closed when the review-issue owner is a poisoned (0, nil) claim — hold via escalateAndHold instead (GH-4860 D1)")
+	}
+	if branchDeleted.Load() {
+		t.Error("branch must NOT be deleted when the PR is held via escalateAndHold")
+	}
+	if prState.Stage != StageFailed {
+		t.Errorf("Stage = %s, want %s", prState.Stage, StageFailed)
+	}
+	if prState.TerminalLabel != "" {
+		t.Errorf("TerminalLabel = %q, want empty — no review issue was ever created", prState.TerminalLabel)
+	}
+	found := false
+	for _, l := range labelsAdded {
+		if l == labelNeedsHuman {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected pilot-needs-human label on the issue (escalate-and-hold), got labels: %v", labelsAdded)
+	}
+	if len(sink.events) == 0 {
+		t.Error("expected an escalation alert to fire")
+	}
+}
+
+// TestCreateReviewIssue_DedupHit_ClarificationOwner_ReusesExisting covers
+// GH-4860 D2 for the review path: an open + pilot-needs-clarification
+// previously-designated review issue is the documented-resumable
+// preflight-decline state (notifier.go, epic.go), not abandonment. The
+// dedup re-check must reuse it, not mint a replacement — replacing here
+// would move the claim, leave the declined issue open as a zombie, and once
+// the clarification label is removed, dispatch both issues against review
+// issues' shared `branch:` meta, clobbering each other.
+func TestCreateReviewIssue_DedupHit_ClarificationOwner_ReusesExisting(t *testing.T) {
+	createCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues/102" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Issue{
+				Number: 102,
+				State:  github.StateOpen,
+				Labels: []github.Label{{Name: github.LabelNeedsClarification}},
+			})
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			createCalls++
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(github.Issue{Number: 999})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	fl := NewFeedbackLoop(ghClient, "owner", "repo", cfg)
+	store := newTestStateStore(t)
+	fl.SetStateStore(store)
+	sink := &fakeAlertSink{}
+	fl.SetAlertsEngine(sink)
+
+	prState := &PRState{PRNumber: 79, IssueNumber: 14, BranchName: "pilot/GH-14"}
+
+	dedupRepo := "owner/repo"
+	dedupKey := spawnedFixDedupKey(prState.PRNumber, FailureReviewRequested, nil)
+	if _, err := store.ClaimSpawnedFix(dedupRepo, dedupKey); err != nil {
+		t.Fatalf("seed ClaimSpawnedFix failed: %v", err)
+	}
+	if err := store.RecordSpawnedFixIssue(dedupRepo, dedupKey, 102); err != nil {
+		t.Fatalf("seed RecordSpawnedFixIssue failed: %v", err)
+	}
+
+	got, err := fl.CreateReviewIssue(context.Background(), prState, nil, nil, 1)
+	if err != nil {
+		t.Fatalf("CreateReviewIssue error: %v", err)
+	}
+	if got != 102 {
+		t.Errorf("CreateReviewIssue() = %d, want 102 (resumable clarification owner reused, not replaced)", got)
+	}
+	if createCalls != 0 {
+		t.Errorf("createCalls = %d, want 0 (must not mint a replacement for a resumable clarification owner)", createCalls)
+	}
+	if len(sink.events) != 0 {
+		t.Errorf("expected no owner-death alert (reuse, not replace), got %d: %v", len(sink.events), sink.events)
+	}
+
+	recorded, err := store.GetSpawnedFixIssue(dedupRepo, dedupKey)
+	if err != nil {
+		t.Fatalf("GetSpawnedFixIssue: %v", err)
+	}
+	if recorded != 102 {
+		t.Errorf("claim row = %d, want unchanged at 102 (no replace)", recorded)
+	}
+}
+
+// TestCreateFailureIssue_CreateError_ReleasesClaimForRetry covers GH-4860
+// N1: the CI path's create-error branch must release the claim it took, not
+// leave it poisoned at issue_number=0 forever — mirroring CreateReviewIssue's
+// GH-4856 fix. Without the release, every subsequent tick for this PR would
+// hit the dedup-hit "existing <= 0" branch and return (0, nil) permanently,
+// with no way to ever record a real issue number.
+func TestCreateFailureIssue_CreateError_ReleasesClaimForRetry(t *testing.T) {
+	var failCreate atomic.Bool
+	failCreate.Store(true)
+	var createdIssueNum atomic.Int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodGet:
+			// GH-4309 belt-and-suspenders search — no match.
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.Issue{})
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			if failCreate.Load() {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"message":"internal server error"}`))
+				return
+			}
+			createdIssueNum.Store(801)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(github.Issue{Number: 801})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	fl := NewFeedbackLoop(ghClient, "owner", "repo", cfg)
+	store := newTestStateStore(t)
+	fl.SetStateStore(store)
+
+	prState := &PRState{PRNumber: 92, HeadSHA: "def5678"}
+	failedChecks := []string{"test"}
+
+	// First attempt: CreatePilotIssue fails transiently.
+	got, err := fl.CreateFailureIssue(context.Background(), prState, FailureCIPreMerge, failedChecks, "", 0)
+	if err == nil {
+		t.Fatalf("CreateFailureIssue() error = nil, want create-error to propagate")
+	}
+	if got != 0 {
+		t.Errorf("CreateFailureIssue() = %d, want 0 on create error", got)
+	}
+
+	dedupRepo := "owner/repo"
+	dedupKey := spawnedFixDedupKey(prState.PRNumber, FailureCIPreMerge, failedChecks)
+	if stored, lookupErr := store.GetSpawnedFixIssue(dedupRepo, dedupKey); lookupErr == nil && stored != 0 {
+		t.Errorf("claim row should have been released after create failure, got stored=%d", stored)
+	}
+
+	// Second attempt: the transient failure clears. The claim must have been
+	// released so this retry can claim fresh and create successfully instead
+	// of hitting a poisoned dedup-hit branch.
+	failCreate.Store(false)
+	got, err = fl.CreateFailureIssue(context.Background(), prState, FailureCIPreMerge, failedChecks, "", 0)
+	if err != nil {
+		t.Fatalf("CreateFailureIssue() retry error = %v", err)
+	}
+	if got != 801 || createdIssueNum.Load() != 801 {
+		t.Errorf("CreateFailureIssue() retry = %d, want 801 (clean retry after claim release)", got)
+	}
+}

--- a/internal/autopilot/owner_death_test.go
+++ b/internal/autopilot/owner_death_test.go
@@ -323,6 +323,18 @@ func TestFeedbackLoop_CreateFailureIssue_DedupOwnerHealth(t *testing.T) {
 			wantCreateCall: true,
 			wantReturned:   555,
 		},
+		{
+			// GH-4860 D2: open + pilot-needs-clarification reads as ownerDead
+			// (classifyOwnerHealth, GH-4856) but is the documented-resumable
+			// preflight-decline state, not abandonment — a transient close
+			// failure or crash-before-close must not mint a replacement and
+			// strand the declined issue as an open zombie while a human is
+			// mid-clarification.
+			name:           "existing fix issue open+pilot-needs-clarification — dead but resumable, dedup reuses it unchanged",
+			existingIssue:  &github.Issue{Number: 999, State: github.StateOpen, Labels: []github.Label{{Name: github.LabelNeedsClarification}}},
+			wantCreateCall: false,
+			wantReturned:   999,
+		},
 	}
 
 	for _, tt := range tests {
@@ -393,8 +405,19 @@ func TestFeedbackLoop_CreateFailureIssue_DedupOwnerHealth(t *testing.T) {
 				if len(sink.events) != 1 {
 					t.Errorf("expected exactly 1 owner-death alert, got %d", len(sink.events))
 				}
-			} else if len(sink.events) != 0 {
-				t.Errorf("expected no owner-death alert for a live/shipped owner, got %d", len(sink.events))
+			} else {
+				if len(sink.events) != 0 {
+					t.Errorf("expected no owner-death alert for a live/shipped/resumable owner, got %d", len(sink.events))
+				}
+				// GH-4860 D2: the claim row must stay pointed at the reused
+				// owner, not be silently overwritten or cleared.
+				stored, err := store.GetSpawnedFixIssue(dedupRepo, dedupKey)
+				if err != nil {
+					t.Fatalf("GetSpawnedFixIssue error = %v", err)
+				}
+				if stored != 999 {
+					t.Errorf("dedup row = %d, want unchanged at 999 (no replace)", stored)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4860.

Closes #4860

## Changes

GitHub Issue GH-4860: fix(autopilot): seeded-claim test for the review guard; dedup reuse-don't-replace for clarification owners; CI-path claim release

## Context

PR#4858 (GH-4856) post-merge review (verdict on the PR) — the ship stands, three gaps remain:

- **D1 (major, test gap)**: the `(0, nil)` half of the review guard (`if err != nil || issueNum <= 0`, internal/autopilot/controller.go:3145) is unreachable by the suite — neutering it to `if err != nil` survives every test. Real producers of `(0, nil)` from `CreateReviewIssue` (feedback_loop.go:584-587): crash between `CreatePilotIssue` success and `RecordSpawnedFixIssue`; a concurrent claim in flight; the `lookupErr` fail-open returning `existing == 0`. The untested branch's failure mode is the original GH-4856 bug: PR closed, branch deleted, review round discarded.
- **D2 (minor, new false-positive window)**: owner_death.go:51 now classifies open + `pilot-needs-clarification` as dead, and BOTH dedup re-checks consume that as a REPLACE signal (`CreateFailureIssue` feedback_loop.go:329, `CreateReviewIssue` feedback_loop.go:611). But the label is documented resumable (notifier.go:151, epic.go:777): a transient `ClosePullRequest` failure or crash-before-close re-enters the create path, dedup classifies the declined-but-open owner dead, mints a replacement, moves the claim, fires a "replaced" alert — while a human is mid-clarification. Human removes the label → both issues dispatch → duplicate executors; review issues share `branch:` meta → branch clobbering. The replaced owner is left open (zombie), and every re-entry fires another alert. NOTE: the `notifyExternalClose` fallback's use of the widened classification is a strict improvement — do NOT revert it there.
- **N1 (parity)**: `CreateFailureIssue`'s create-error path (feedback_loop.go:~385) still does not release its claim — a transient create error on the CI path poisons `fix:pr<N>:ci_failure_pre_merge` forever (every re-drive re-escalates per the GH-4459 comment). The review path self-heals since PR#4858; mirror it.

## Implementation

1. **Seeded-claim regression test**: seed `ClaimSpawnedFix` WITHOUT `RecordSpawnedFixIssue`, drive `handleReviewRequested`, assert PR open + branch intact + escalate-and-hold (`pilot-needs-human`, alert). Must kill the `if err != nil`-only mutation of controller.go:3145.
2. **Reuse-don't-replace in the dedup re-checks**: in `CreateFailureIssue` (feedback_loop.go:329) and `CreateReviewIssue` (:611), treat an open + `pilot-needs-clarification` owner as REUSE (return the existing issue), not replace — or, if replacement is kept, comment-and-close the zombie and dedup the "replaced" alert. Leave `classifyOwnerHealth` itself and the `notifyExternalClose` fallback behavior unchanged (GH-4852 acceptance scenarios must keep passing).
3. **Release the CI-path claim on create failure**: add the `ReleaseSpawnedFix` treatment to `CreateFailureIssue`'s create-error path, mirroring the review path (feedback_loop.go:679-680), gated on claim ownership the same way.

Optional nits if in the area: `fireOwnerDeathAlert("rearmed")` fires before the `issueAlreadyClosed` gate (controller.go:7614 vs :7627) — false alert for closed sources; decline reaction + external-close fallback can double-fire the owner-death alert for the same source (no dedup).

## Acceptance

- Mutation `if err != nil || issueNum <= 0` → `if err != nil` at controller.go:3145 fails at least one test.
- Test: dedup-hit where the existing owner is open + `pilot-needs-clarification` → reused (no new issue, claim row unchanged, no "replaced" alert) — or, if replace-with-cleanup chosen, the zombie is closed with a comment and only one alert fires.
- Test: transient `CreatePilotIssue` error on the CI path → claim released; next tick creates cleanly (no permanent escalate loop).
- GH-4852 / GH-4856 / GH-4841 / GH-4826 / owner-death suites pass unchanged.

## Refs

- PR#4858 post-merge review verdict (comment on the PR) — D1 major, D2 minor, N1 parity.
- GH-4459 guard precedent · GH-4842 · PR#4854/PR#4858 lineage (TASK-468/TASK-473).