### PR TITLE
fix(alerts): dead-man streak alerts can never fire (GH-4866)

### DIFF
--- a/cmd/pilot/adapters.go
+++ b/cmd/pilot/adapters.go
@@ -175,60 +175,13 @@ func wireProjectAccessChecker(runner *executor.Runner, cfg *config.Config) func(
 	return func() { _ = db.Close() }
 }
 
-// getAlertsConfig extracts alerts configuration from the main config
+// getAlertsConfig extracts alerts configuration from the main config.
+// GH-4866: delegates to config.AlertsConfig.ToAlertConfig so this
+// conversion has exactly one implementation, shared with internal/health's
+// doctor rule-coverage check (which can't reach this function directly —
+// cmd/pilot imports internal/health, not the reverse).
 func getAlertsConfig(cfg *config.Config) *alerts.AlertConfig {
-	if cfg.Alerts == nil {
-		return nil
-	}
-
-	alertsCfg := cfg.Alerts
-
-	// Convert to alerts package types (channel configs are shared types, passed directly)
-	channels := make([]alerts.ChannelConfigInput, 0, len(alertsCfg.Channels))
-	for _, ch := range alertsCfg.Channels {
-		channels = append(channels, alerts.ChannelConfigInput{
-			Name:       ch.Name,
-			Type:       ch.Type,
-			Enabled:    ch.Enabled,
-			Severities: ch.Severities,
-			Slack:      ch.Slack,     // Same type, direct pass-through
-			Telegram:   ch.Telegram,  // Same type, direct pass-through
-			Email:      ch.Email,     // Same type, direct pass-through
-			Webhook:    ch.Webhook,   // Same type, direct pass-through
-			PagerDuty:  ch.PagerDuty, // Same type, direct pass-through
-		})
-	}
-
-	rules := make([]alerts.RuleConfigInput, 0, len(alertsCfg.Rules))
-	for _, r := range alertsCfg.Rules {
-		rules = append(rules, alerts.RuleConfigInput{
-			Name:        r.Name,
-			Type:        r.Type,
-			Enabled:     r.Enabled,
-			Severity:    r.Severity,
-			Channels:    r.Channels,
-			Cooldown:    r.Cooldown,
-			Description: r.Description,
-			Condition: alerts.ConditionConfigInput{
-				ProgressUnchangedFor: r.Condition.ProgressUnchangedFor,
-				ConsecutiveFailures:  r.Condition.ConsecutiveFailures,
-				DailySpendThreshold:  r.Condition.DailySpendThreshold,
-				BudgetLimit:          r.Condition.BudgetLimit,
-				UsageSpikePercent:    r.Condition.UsageSpikePercent,
-				Pattern:              r.Condition.Pattern,
-				FilePattern:          r.Condition.FilePattern,
-				Paths:                r.Condition.Paths,
-			},
-		})
-	}
-
-	defaults := alerts.DefaultsConfigInput{
-		Cooldown:           alertsCfg.Defaults.Cooldown,
-		DefaultSeverity:    alertsCfg.Defaults.DefaultSeverity,
-		SuppressDuplicates: alertsCfg.Defaults.SuppressDuplicates,
-	}
-
-	return alerts.FromConfigAlerts(alertsCfg.Enabled, channels, rules, defaults)
+	return cfg.Alerts.ToAlertConfig()
 }
 
 // qualityCheckerWrapper adapts quality.Executor to executor.QualityChecker interface

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -832,7 +832,7 @@ func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkco
 		// zero attempts already are (Stale) instead of hiding behind an
 		// error-only counter.
 		labelTracker := alertsEngine.RegisterDeadManTracker(
-			labelLifecycleDeadManTrackerName,
+			labelLifecycleDeadManTrackerName(repoOwner+"/"+repoName),
 			alerts.AlertTypeLabelLifecycleFailureStreak,
 			alerts.DefaultDeadManFailureThreshold,
 			alerts.DefaultDeadManWindow,
@@ -935,11 +935,29 @@ func fetchGithubIssueForSDKTask(ctx context.Context, client *githubSDK.Client, o
 	return issue
 }
 
-// labelLifecycleDeadManTrackerName is the alerts.DeadManTracker registration
-// name (TASK-441 L2, GH-4709) for the notifyTaskStartedSDK call site above —
-// global (not per-repo) since the GH-4687 incident it guards was the whole
-// label-lifecycle path going silent, not a single repo's.
-const labelLifecycleDeadManTrackerName = "label_lifecycle"
+// labelLifecycleDeadManTrackerPrefix is the alerts.DeadManTracker
+// registration name prefix (TASK-441 L2, GH-4709) for the
+// notifyTaskStartedSDK call site above. GH-4866: per-repo, not global — a
+// global shared counter let one repo's real, sustained label-lifecycle
+// failures get diluted by every other (healthy) repo's RecordSuccess calls
+// on the same tracker, so a single broken repo's streak could take far
+// longer to reach threshold (or never reach it at all, on a large
+// multi-repo fleet) than the DefaultDeadManFailureThreshold consecutive
+// failures the tracker is supposed to guarantee. Mirrors
+// sdkPreFlightJudge's per-repo "intent_judge:"+repoFullName keying
+// (poller_github.go) for the same reason.
+const labelLifecycleDeadManTrackerPrefix = "label_lifecycle:"
+
+// labelLifecycleDeadManTrackerName returns the per-repo tracker name for
+// repoFullName ("owner/repo"). Registered once per repo poller at startup
+// (startGithubSDKPollerForRepo, poller_github.go — mirroring the self-review
+// tracker registered there) and resolved again here by the same name on
+// every event, relying on RegisterDeadManTracker's memoize-by-name so both
+// call sites share one set of counters per repo instead of the startup
+// registration and the event-time registration racing to create two.
+func labelLifecycleDeadManTrackerName(repoFullName string) string {
+	return labelLifecycleDeadManTrackerPrefix + repoFullName
+}
 
 // notifyTaskStartedSDK applies the pilot-in-progress label and posts the
 // task-started comment via studio-sdk's tested Notifier (GH-4687). Extracted

--- a/cmd/pilot/label_lifecycle_deadman_test.go
+++ b/cmd/pilot/label_lifecycle_deadman_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLabelLifecycleDeadManTrackerName_PerRepo verifies GH-4866's per-repo
+// keying: two different repos must resolve to two different tracker names,
+// and the same repo must always resolve to the same name (so
+// alerts.Engine.RegisterDeadManTracker's memoize-by-name shares one set of
+// counters for it across the startup registration in poller_github.go and
+// the event-time lookup in handlers.go).
+func TestLabelLifecycleDeadManTrackerName_PerRepo(t *testing.T) {
+	nameA := labelLifecycleDeadManTrackerName("qf-studio/pilot")
+	nameB := labelLifecycleDeadManTrackerName("qf-studio/other-repo")
+
+	if nameA == nameB {
+		t.Fatalf("expected distinct tracker names for distinct repos, got %q for both", nameA)
+	}
+	if got := labelLifecycleDeadManTrackerName("qf-studio/pilot"); got != nameA {
+		t.Errorf("expected stable tracker name for the same repo, got %q want %q", got, nameA)
+	}
+	if !strings.Contains(nameA, "qf-studio/pilot") {
+		t.Errorf("expected tracker name to embed the repo, got %q", nameA)
+	}
+}
+
+// TestGithubHandlerSDK_LabelLifecycleTrackerPerRepo is a source-level guard
+// (mirrors TestGithubHandlerSDK_NotifyTaskStartedWired's established pattern
+// for this otherwise-unexercisable function): handleGithubIssueEventSDK must
+// register the label-lifecycle dead-man tracker under the per-repo name
+// (labelLifecycleDeadManTrackerName(repoOwner+"/"+repoName)), not a bare
+// global name — GH-4866 found the prior global tracker let one repo's real
+// failures get diluted by every other repo's successes on the same counter.
+func TestGithubHandlerSDK_LabelLifecycleTrackerPerRepo(t *testing.T) {
+	body := githubFuncBody(t, "handlers.go", "func handleGithubIssueEventSDK(")
+
+	if !strings.Contains(body, "labelLifecycleDeadManTrackerName(repoOwner+\"/\"+repoName)") {
+		t.Error("handleGithubIssueEventSDK must register the label-lifecycle dead-man tracker under the per-repo name labelLifecycleDeadManTrackerName(repoOwner+\"/\"+repoName), not a global name (GH-4866)")
+	}
+}
+
+// TestStartGithubSDKPollerForRepo_RegistersPerRepoLabelLifecycleTracker is a
+// source-level guard: startGithubSDKPollerForRepo must register the
+// label-lifecycle tracker at poller startup (hoisted, mirroring the
+// self-review tracker registered in the same function) using the per-repo
+// name keyed off target.repoFullName, so the tracker exists (and is
+// discoverable, e.g. via `pilot doctor`) before the first event ever lands.
+func TestStartGithubSDKPollerForRepo_RegistersPerRepoLabelLifecycleTracker(t *testing.T) {
+	body := githubFuncBody(t, "poller_github.go", "func startGithubSDKPollerForRepo(")
+
+	if !strings.Contains(body, "labelLifecycleDeadManTrackerName(target.repoFullName)") {
+		t.Error("startGithubSDKPollerForRepo must register the label-lifecycle dead-man tracker at startup under labelLifecycleDeadManTrackerName(target.repoFullName), mirroring the self-review tracker registration in the same function (GH-4866)")
+	}
+
+	selfReviewIdx := strings.Index(body, "executor.SelfReviewDeadManTrackerName")
+	labelLifecycleIdx := strings.Index(body, "labelLifecycleDeadManTrackerName(target.repoFullName)")
+	if selfReviewIdx < 0 || labelLifecycleIdx < 0 {
+		t.Fatal("expected both the self-review and label-lifecycle tracker registrations in startGithubSDKPollerForRepo")
+	}
+}

--- a/cmd/pilot/poller_github.go
+++ b/cmd/pilot/poller_github.go
@@ -366,6 +366,57 @@ func startGithubSDKPollerForRepo(ctx context.Context, deps *PollerDeps, log *slo
 		alerts.DefaultDeadManWindow,
 	)
 
+	// TASK-441 L2 (GH-4709), per-repo (GH-4866): register the label-lifecycle
+	// dead-man tracker here too, mirroring the self-review registration just
+	// above — unlike self-review, this one is keyed per-repo
+	// (labelLifecycleDeadManTrackerName, handlers.go) so one repo's real,
+	// sustained label-lifecycle failures can't get diluted by every other
+	// repo's successes sharing the same counter. The actual
+	// attempt/success/failure recording happens inline in
+	// handleGithubIssueEventSDK (handlers.go), which resolves this same
+	// per-repo name and relies on RegisterDeadManTracker's memoize-by-name to
+	// share this registration's counters rather than racing to create a
+	// second tracker at first-event time.
+	deps.AlertsEngine.RegisterDeadManTracker(
+		labelLifecycleDeadManTrackerName(target.repoFullName),
+		alerts.AlertTypeLabelLifecycleFailureStreak,
+		alerts.DefaultDeadManFailureThreshold,
+		alerts.DefaultDeadManWindow,
+	)
+
+	// GH-4866: register the label-strip dead-man tracker here too — the
+	// removal-side counterpart of the label-lifecycle tracker just above.
+	// Unlike that one, this stays global (executor.LabelStripDeadManTrackerName,
+	// not per-repo): the recording site (stripInProgressLabelOnTerminalFailure,
+	// internal/executor/lifecycle.go) runs off an ExecutionLifecycle that has
+	// no live repo-owner context to key on, only ProjectPath/TaskID. It
+	// shares alerts.AlertTypeLabelLifecycleFailureStreak with the apply-side
+	// tracker (mirrors the four finish-tripwire trackers sharing one
+	// AlertType) since both are the same "label lifecycle silently broken"
+	// incident class, just counted independently by name.
+	deps.AlertsEngine.RegisterDeadManTracker(
+		executor.LabelStripDeadManTrackerName,
+		alerts.AlertTypeLabelLifecycleFailureStreak,
+		alerts.DefaultDeadManFailureThreshold,
+		alerts.DefaultDeadManWindow,
+	)
+
+	// GH-4866: register the push-retry-exhausted dead-man tracker here as
+	// well — the actual attempt/success/failure recording happens inline in
+	// Runner.executeWithOptions's push-retry loop (runner.go), which relays
+	// through the AlertEventTypeDeadMan{Attempt,Success,Failure} events the
+	// same way runSelfReview does (runner.go cannot import internal/alerts
+	// directly). Global, not per-repo, for the same reason as label-strip
+	// above — the push-retry loop has no repo-owner context in scope, only
+	// task.Branch/task.SourceRepo (SourceRepo is only ever set for
+	// GitHub-dispatched tasks, and this loop runs for every adapter).
+	deps.AlertsEngine.RegisterDeadManTracker(
+		executor.PushRetryExhaustedDeadManTrackerName,
+		alerts.AlertTypePushRetryExhaustedFailureStreak,
+		alerts.DefaultDeadManFailureThreshold,
+		alerts.DefaultDeadManWindow,
+	)
+
 	// Determine interval (shared adapter polling config; projects have no per-repo interval).
 	interval := 30 * time.Second
 	if ghCfg.Polling != nil && ghCfg.Polling.Interval > 0 {

--- a/cmd/pilot/wiring_test.go
+++ b/cmd/pilot/wiring_test.go
@@ -438,6 +438,54 @@ func TestGetAlertsConfig_WithChannelsAndRules(t *testing.T) {
 	}
 }
 
+// TestGetAlertsConfig_LegacyFiveRuleConfig_YieldsFullCoverage is the GH-4866
+// acceptance-criteria table test: even when the input config carries only
+// the legacy 5-rule list (config.defaultAlertRules — task_stuck/task_failed/
+// consecutive_failures/daily_spend/budget_depleted, predating every
+// dead-man/intent-judge/dispatch-loop-breaker rule), the daemon-path config
+// (getAlertsConfig, which now delegates to config.AlertsConfig.
+// ToAlertConfig -> alerts.FromConfigAlerts) must still yield an enabled rule
+// for every AlertType an engine handler can emit — the exact gap the
+// kill-drill found (TASK-441 kill-drill A): the daemon's rule set omitted
+// every dead-man rule, so 57 minutes of continuous seam failures produced
+// zero dead-man output.
+func TestGetAlertsConfig_LegacyFiveRuleConfig_YieldsFullCoverage(t *testing.T) {
+	cfg := &config.Config{
+		Alerts: &config.AlertsConfig{
+			Enabled: true,
+			Rules:   defaultAlertRulesForTest(),
+			Defaults: config.AlertDefaultsConfig{
+				Cooldown:        5 * time.Minute,
+				DefaultSeverity: "warning",
+			},
+		},
+	}
+
+	result := getAlertsConfig(cfg)
+	if result == nil {
+		t.Fatal("expected non-nil AlertConfig")
+	}
+
+	gaps := alerts.CoverageGaps(result)
+	if len(gaps) != 0 {
+		t.Errorf("legacy 5-rule config left these handler-emitted alert types with no enabled rule: %v", gaps)
+	}
+}
+
+// defaultAlertRulesForTest reproduces config.defaultAlertRules()'s legacy
+// 5-rule list (the function itself is unexported) for the coverage table
+// test above — same Types/Enabled values, since only those two fields
+// matter for alerts.CoverageGaps.
+func defaultAlertRulesForTest() []config.AlertRuleConfig {
+	return []config.AlertRuleConfig{
+		{Name: "task_stuck", Type: "task_stuck", Enabled: true},
+		{Name: "task_failed", Type: "task_failed", Enabled: true},
+		{Name: "consecutive_failures", Type: "consecutive_failures", Enabled: true},
+		{Name: "daily_spend", Type: "daily_spend_exceeded", Enabled: false},
+		{Name: "budget_depleted", Type: "budget_depleted", Enabled: false},
+	}
+}
+
 // =============================================================================
 // GH-2134: resolveOwnerRepo tests
 // =============================================================================

--- a/internal/alerts/config.go
+++ b/internal/alerts/config.go
@@ -29,6 +29,32 @@ func FromConfigAlerts(enabled bool, channels []ChannelConfigInput, rules []RuleC
 		alertCfg.Rules = append(alertCfg.Rules, convertRule(r))
 	}
 
+	// GH-4866 (TASK-441 kill-drill A): union in any default rule Type absent
+	// from the caller's list. The daemon path's config-sourced rules
+	// (internal/config/config.go's defaultAlertRules, or a persisted
+	// alerts.rules: list that predates a Type added since) can omit Types
+	// added after that list was authored — dead-man streaks
+	// (label_lifecycle/self_review/finish_tripwire), the intent-judge
+	// streak, and the GitHub side-effect audit all exist only in
+	// defaultRules(), whose sole caller used to be the one-shot `--alerts`
+	// CLI (DefaultConfig()). There is no migration path for a persisted
+	// config, so config.Load's "replace defaults wholesale with any
+	// persisted list" behavior would otherwise silently drop these Types
+	// forever. Every default AlertType is therefore load-bearing here: this
+	// is the single point both production callers (cmd/pilot/adapters.go's
+	// getAlertsConfig and internal/pilot/pilot.go's initAlerts) go through,
+	// so a rule the caller's list already covers (by Type) is left
+	// untouched — only a genuinely missing Type gets the default appended.
+	seenTypes := make(map[AlertType]bool, len(alertCfg.Rules))
+	for _, r := range alertCfg.Rules {
+		seenTypes[r.Type] = true
+	}
+	for _, defaultRule := range defaultRules() {
+		if !seenTypes[defaultRule.Type] {
+			alertCfg.Rules = append(alertCfg.Rules, defaultRule)
+		}
+	}
+
 	return alertCfg
 }
 

--- a/internal/alerts/config_test.go
+++ b/internal/alerts/config_test.go
@@ -392,9 +392,15 @@ func TestFromConfigAlerts(t *testing.T) {
 		t.Error("slack channel config incorrect")
 	}
 
-	// Verify rules
-	if len(config.Rules) != 2 {
-		t.Errorf("expected 2 rules, got %d", len(config.Rules))
+	// Verify rules: the 2 caller-supplied rules plus every default AlertType
+	// the caller's list didn't already cover (GH-4866's FromConfigAlerts
+	// union — see that function's doc comment). Both caller-supplied Types
+	// here (task_failed, consecutive_failures) already exist in
+	// defaultRules(), so they aren't duplicated — only the remaining default
+	// Types are unioned in.
+	wantRules := len(defaultRules())
+	if len(config.Rules) != wantRules {
+		t.Errorf("expected %d rules (2 supplied + unioned defaults, no duplicates), got %d", wantRules, len(config.Rules))
 	}
 
 	// Find and verify task-failed rule
@@ -433,8 +439,12 @@ func TestFromConfigAlerts_Empty(t *testing.T) {
 	if len(config.Channels) != 0 {
 		t.Errorf("expected 0 channels, got %d", len(config.Channels))
 	}
-	if len(config.Rules) != 0 {
-		t.Errorf("expected 0 rules, got %d", len(config.Rules))
+	// GH-4866: an empty rule list still gets every default AlertType unioned
+	// in (see FromConfigAlerts) — a caller-supplied empty/truncated rule
+	// list must never leave the daemon with zero dead-man/health rules.
+	wantRules := len(defaultRules())
+	if len(config.Rules) != wantRules {
+		t.Errorf("expected %d unioned default rules, got %d", wantRules, len(config.Rules))
 	}
 }
 

--- a/internal/alerts/deadman.go
+++ b/internal/alerts/deadman.go
@@ -3,9 +3,12 @@ package alerts
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/qf-studio/pilot/internal/logging"
 )
 
 // DefaultDeadManFailureThreshold mirrors judgeFailureStreakAlertThreshold
@@ -63,10 +66,14 @@ const (
 // (memory: poller-labels-removed-log-means-never-applied).
 //
 // A tracker fires its registered AlertType exactly once when its consecutive
-// failure streak reaches threshold (equality, not >=, mirroring
-// fireLoopBreakerAlert/the pre-generalization sdkPreFlightJudge.recordFailure
-// — a dead-open seam pages once, not on every subsequent failure), and
-// resets the streak on the next success.
+// failure streak reaches threshold (>=, gated by a fired-once flag rather
+// than an equality check — GH-4866: a tracker that starts counting mid-streak,
+// e.g. after a process restart or a threshold lowered below an
+// already-elevated streak, would otherwise sail past an exact-match
+// threshold and never fire at all) and resets the streak, and the fired
+// flag, on the next success — a dead-open seam pages once per streak, not on
+// every subsequent failure, and pages again if it dies again after
+// recovering.
 type DeadManTracker struct {
 	engine    *Engine
 	name      string
@@ -79,6 +86,7 @@ type DeadManTracker struct {
 	attempts            uint64
 	successes           uint64
 	consecutiveFailures int
+	fired               bool
 	lastAttemptAt       time.Time
 }
 
@@ -175,9 +183,12 @@ func (t *DeadManTracker) RecordAttempt() {
 	t.mu.Unlock()
 }
 
-// RecordSuccess resets the consecutive-failure streak so failures before and
-// after an intervening success don't compound toward the alert threshold,
-// and increments the success counter exposed by Successes().
+// RecordSuccess resets the consecutive-failure streak (and the fired-once
+// gate — see RecordFailure) so failures before and after an intervening
+// success don't compound toward the alert threshold, and a seam that dies
+// again after recovering pages again instead of staying silenced by its
+// first streak's fired flag. Increments the success counter exposed by
+// Successes().
 func (t *DeadManTracker) RecordSuccess() {
 	if t == nil {
 		return
@@ -185,14 +196,23 @@ func (t *DeadManTracker) RecordSuccess() {
 	t.mu.Lock()
 	t.successes++
 	t.consecutiveFailures = 0
+	t.fired = false
 	t.mu.Unlock()
 }
 
-// RecordFailure increments the consecutive-failure streak and fires exactly
-// one alert when it reaches threshold — an equality check, not >=, so a seam
-// that never recovers pages once instead of on every failure thereafter.
-// extraMetadata is merged into the fired event alongside the tracker's own
-// name/consecutive_failures (e.g. repo, task_id).
+// RecordFailure increments the consecutive-failure streak and, at the
+// threshold crossing, logs an unconditional WARN — greppable (`alerts.deadman`
+// component) whether or not an alerts engine is even wired up, since GH-4866
+// found the daemon can silently run without a single dead-man rule
+// registered at all. The crossing also fires exactly one alert event per
+// streak, gated by a fired-once flag rather than an equality check (see the
+// DeadManTracker doc comment for why) so a seam that never recovers pages
+// once instead of on every failure thereafter, and pages again on the next
+// streak past threshold after an intervening RecordSuccess. Both the WARN
+// log and the alert event share the same shouldFire gate, so the log line is
+// always present when (and only when) an alert would have fired had an
+// engine been wired. extraMetadata is merged into the fired event alongside
+// the tracker's own name/consecutive_failures (e.g. repo, task_id).
 func (t *DeadManTracker) RecordFailure(extraMetadata map[string]string) {
 	if t == nil {
 		return
@@ -200,9 +220,24 @@ func (t *DeadManTracker) RecordFailure(extraMetadata map[string]string) {
 	t.mu.Lock()
 	t.consecutiveFailures++
 	consecutive := t.consecutiveFailures
+	shouldFire := consecutive >= t.threshold && !t.fired
+	if shouldFire {
+		t.fired = true
+	}
 	t.mu.Unlock()
 
-	if consecutive != t.threshold || t.engine == nil {
+	if !shouldFire {
+		return
+	}
+
+	logging.WithComponent("alerts.deadman").Warn("dead-man tracker reached failure threshold",
+		slog.String("tracker", t.name),
+		slog.String("alert_type", string(t.alertType)),
+		slog.Int("consecutive_failures", consecutive),
+		slog.Int("threshold", t.threshold),
+	)
+
+	if t.engine == nil {
 		return
 	}
 
@@ -307,16 +342,31 @@ func (e *Engine) handleDeadManFailure(event Event) {
 // counting happens here).
 func (e *Engine) handleDeadManStreak(ctx context.Context, event Event) {
 	alertType := AlertType(event.Metadata["alert_type"])
+	matched := false
 	for _, rule := range e.config.Rules {
-		if !rule.Enabled || rule.Type != alertType {
+		if rule.Type != alertType {
 			continue
 		}
-		if !e.shouldFire(rule) {
+		matched = true
+		if !rule.Enabled || !e.shouldFire(rule) {
 			continue
 		}
 		message := fmt.Sprintf("Dead-man tracker %q has failed %s consecutive times without a success",
 			event.Metadata["tracker"], event.Metadata["consecutive_failures"])
 		alert := e.createAlert(rule, event, message)
 		e.fireAlert(ctx, rule, alert)
+	}
+	// RecordFailure already logs an unconditional WARN at the threshold
+	// crossing (greppable regardless of rule coverage), so this only needs
+	// to flag the additional, more specific failure mode: the streak
+	// crossed threshold but no configured rule can ever deliver it as a
+	// channel alert — the same class of gap FromConfigAlerts' default-rule
+	// union (GH-4866) closes for a fresh/persisted config, surfaced here as
+	// a runtime backstop for any rule set that still slips through it.
+	if !matched {
+		e.logger.Warn("dead-man streak event has no matching rule — alert dropped silently",
+			slog.String("tracker", event.Metadata["tracker"]),
+			slog.String("alert_type", string(alertType)),
+			slog.String("consecutive_failures", event.Metadata["consecutive_failures"]))
 	}
 }

--- a/internal/alerts/deadman_test.go
+++ b/internal/alerts/deadman_test.go
@@ -117,6 +117,129 @@ func TestDeadManTracker_SuccessResetsStreak(t *testing.T) {
 	}
 }
 
+// TestDeadManTracker_FiresAgainAfterRecoveryAndRelapse verifies GH-4866's
+// >=-threshold + fired-once-flag semantics: a tracker fires once at
+// threshold, stays silent through further failures in the same streak (the
+// pre-existing "fires once" guarantee), but — unlike a bare equality check —
+// fires again on a second streak that crosses threshold after an
+// intervening RecordSuccess. This also covers a tracker built with an
+// already-elevated consecutiveFailures relative to a lowered threshold: an
+// equality check could sail past a threshold if the streak somehow started
+// above it, whereas >= always catches it on the very next failure.
+func TestDeadManTracker_FiresAgainAfterRecoveryAndRelapse(t *testing.T) {
+	config := &AlertConfig{
+		Enabled: true,
+		Channels: []ChannelConfig{
+			{Name: "test-channel", Type: "webhook", Enabled: true},
+		},
+		Rules: []AlertRule{
+			{
+				Name:     "self_review_failure_streak",
+				Type:     AlertTypeSelfReviewFailureStreak,
+				Enabled:  true,
+				Severity: SeverityCritical,
+				Channels: []string{"test-channel"},
+				Cooldown: 0,
+			},
+		},
+	}
+	mockCh := newMockChannel("test-channel", "webhook")
+	dispatcher := NewDispatcher(config)
+	dispatcher.RegisterChannel(mockCh)
+	engine := NewEngine(config, WithDispatcher(dispatcher))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = engine.Start(ctx)
+
+	tracker := engine.RegisterDeadManTracker("relapse-tracker", AlertTypeSelfReviewFailureStreak, 3, DefaultDeadManWindow)
+
+	// First streak: fires exactly once at threshold, stays silent past it.
+	for i := 0; i < 5; i++ {
+		tracker.RecordFailure(nil)
+	}
+	waitForAlerts(t, mockCh, 1, 2*time.Second)
+	time.Sleep(20 * time.Millisecond)
+	if got := len(mockCh.getAlerts()); got != 1 {
+		t.Fatalf("expected exactly 1 alert after first streak, got %d", got)
+	}
+
+	// Recovery resets the fired gate.
+	tracker.RecordSuccess()
+
+	// Second streak crosses threshold again — must fire again, not stay
+	// silenced by the first streak's fired flag. waitForAlerts drains
+	// signals already consumed above, so only 1 more is expected here.
+	for i := 0; i < 3; i++ {
+		tracker.RecordFailure(nil)
+	}
+	waitForAlerts(t, mockCh, 1, 2*time.Second)
+	time.Sleep(20 * time.Millisecond)
+	if got := len(mockCh.getAlerts()); got != 2 {
+		t.Fatalf("expected exactly 2 alerts after relapse streak, got %d", got)
+	}
+}
+
+// TestDeadManTracker_WarnLogsEvenWithNilEngine verifies RecordFailure's WARN
+// log fires at the threshold crossing unconditionally — including when the
+// tracker has no engine wired (engine=nil) — so a streak is greppable via
+// the `alerts.deadman` component even when no alerts engine exists to
+// deliver a channel alert. This can't assert on log output directly (no
+// logger injection point), but it does assert the crossing doesn't panic
+// and the fired-once gate still applies with a nil engine, matching the
+// non-nil-engine behavior in TestDeadManTracker_StreakFiresOnceAtThreshold.
+func TestDeadManTracker_WarnLogsEvenWithNilEngine(t *testing.T) {
+	tracker := NewDeadManTracker(nil, "standalone-warn", AlertTypeSelfReviewFailureStreak, 2, DefaultDeadManWindow)
+
+	tracker.RecordFailure(nil)
+	tracker.RecordFailure(nil) // crosses threshold; must log WARN, must not panic with nil engine
+	tracker.RecordFailure(nil) // past threshold; fired-once gate still applies
+
+	if got := tracker.ConsecutiveFailures(); got != 3 {
+		t.Errorf("expected streak of 3, got %d", got)
+	}
+}
+
+// TestHandleDeadManStreak_NoMatchingRule verifies GH-4866's no-match WARN
+// path: a dead-man streak reaching threshold with zero configured rules for
+// its AlertType must not panic and must not fire a channel alert — the
+// runtime backstop for the same "config declares no rule for this Type"
+// class of bug FromConfigAlerts' default-rule union closes for the on-disk
+// config.
+func TestHandleDeadManStreak_NoMatchingRule(t *testing.T) {
+	config := &AlertConfig{
+		Enabled: true,
+		Channels: []ChannelConfig{
+			{Name: "test-channel", Type: "webhook", Enabled: true},
+		},
+		Rules: []AlertRule{
+			{
+				Name:     "unrelated_rule",
+				Type:     AlertTypeTaskFailed,
+				Enabled:  true,
+				Severity: SeverityWarning,
+				Channels: []string{"test-channel"},
+			},
+		},
+	}
+	mockCh := newMockChannel("test-channel", "webhook")
+	dispatcher := NewDispatcher(config)
+	dispatcher.RegisterChannel(mockCh)
+	engine := NewEngine(config, WithDispatcher(dispatcher))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = engine.Start(ctx)
+
+	tracker := engine.RegisterDeadManTracker("no-rule-tracker", AlertTypeSelfReviewFailureStreak, 1, DefaultDeadManWindow)
+	tracker.RecordFailure(nil) // crosses threshold; no rule declares AlertTypeSelfReviewFailureStreak
+	engine.flushForTest()
+
+	if got := len(mockCh.getAlerts()); got != 0 {
+		t.Errorf("expected 0 alerts (no matching rule), got %d", got)
+	}
+}
+
 // TestDeadManTracker_ZeroAttemptsDetection covers the half of the
 // silent-death class a pure failure counter can never observe (GH-4687,
 // GH-4702): a tracker nothing calls produces zero failures too, so Stale

--- a/internal/alerts/engine.go
+++ b/internal/alerts/engine.go
@@ -722,16 +722,23 @@ func (e *Engine) handleLaneStarvation(ctx context.Context, event Event) {
 // gated on the exact threshold before emitting this event, so — like
 // handleReleaseMissing — no Condition-based counting happens here.
 func (e *Engine) handleDispatchLoopBreaker(ctx context.Context, event Event) {
+	matched := false
 	for _, rule := range e.config.Rules {
-		if !rule.Enabled {
+		if rule.Type != AlertTypeDispatchLoopBreaker {
 			continue
 		}
-		if rule.Type == AlertTypeDispatchLoopBreaker && e.shouldFire(rule) {
+		matched = true
+		if rule.Enabled && e.shouldFire(rule) {
 			message := fmt.Sprintf("Task %s has been dispatched-and-rejected %s consecutive times without completing — stopping until operator action or backoff expiry",
 				event.TaskID, event.Metadata["consecutive_drops"])
 			alert := e.createAlert(rule, event, message)
 			e.fireAlert(ctx, rule, alert)
 		}
+	}
+	if !matched {
+		e.logger.Warn("dispatch loop breaker threshold event has no matching rule — alert dropped silently",
+			slog.String("task_id", event.TaskID),
+			slog.String("consecutive_drops", event.Metadata["consecutive_drops"]))
 	}
 }
 
@@ -742,16 +749,23 @@ func (e *Engine) handleDispatchLoopBreaker(ctx context.Context, event Event) {
 // threshold before emitting this event — mirroring handleDispatchLoopBreaker
 // — so no Condition-based counting happens here.
 func (e *Engine) handleIntentJudgeFailureStreak(ctx context.Context, event Event) {
+	matched := false
 	for _, rule := range e.config.Rules {
-		if !rule.Enabled {
+		if rule.Type != AlertTypeIntentJudgeFailureStreak {
 			continue
 		}
-		if rule.Type == AlertTypeIntentJudgeFailureStreak && e.shouldFire(rule) {
+		matched = true
+		if rule.Enabled && e.shouldFire(rule) {
 			message := fmt.Sprintf("Pre-flight intent judge for %s has failed open %s consecutive times — judge is not producing verdicts",
 				event.Metadata["repo"], event.Metadata["consecutive_failures"])
 			alert := e.createAlert(rule, event, message)
 			e.fireAlert(ctx, rule, alert)
 		}
+	}
+	if !matched {
+		e.logger.Warn("intent judge failure streak event has no matching rule — alert dropped silently",
+			slog.String("repo", event.Metadata["repo"]),
+			slog.String("consecutive_failures", event.Metadata["consecutive_failures"]))
 	}
 }
 

--- a/internal/alerts/engine_test.go
+++ b/internal/alerts/engine_test.go
@@ -1536,6 +1536,53 @@ func TestHandleDispatchLoopBreaker(t *testing.T) {
 			t.Errorf("expected 0 alerts (rule disabled), got %d", got)
 		}
 	})
+
+	// GH-4866: an event that matches zero configured rules (not merely a
+	// disabled one) must not panic and must not fire — this is the runtime
+	// no-match WARN path (see handleDispatchLoopBreaker's "matched" flag),
+	// the backstop for the class of bug FromConfigAlerts' default-rule
+	// union closes for the on-disk config.
+	t.Run("no matching rule does not fire and does not panic", func(t *testing.T) {
+		config := &AlertConfig{
+			Enabled: true,
+			Channels: []ChannelConfig{
+				{Name: "test-channel", Type: "webhook", Enabled: true},
+			},
+			Rules: []AlertRule{
+				{
+					Name:     "unrelated_rule",
+					Type:     AlertTypeTaskFailed,
+					Enabled:  true,
+					Severity: SeverityWarning,
+					Channels: []string{"test-channel"},
+				},
+			},
+		}
+
+		mockCh := newMockChannel("test-channel", "webhook")
+		dispatcher := NewDispatcher(config)
+		dispatcher.RegisterChannel(mockCh)
+
+		engine := NewEngine(config, WithDispatcher(dispatcher))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = engine.Start(ctx)
+
+		engine.ProcessEvent(Event{
+			Type:   EventTypeDispatchLoopBreaker,
+			TaskID: "GH-4391",
+			Metadata: map[string]string{
+				"consecutive_drops": "10",
+			},
+			Timestamp: time.Now(),
+		})
+		engine.flushForTest()
+
+		if got := len(mockCh.getAlerts()); got != 0 {
+			t.Errorf("expected 0 alerts (no matching rule), got %d", got)
+		}
+	})
 }
 
 // TestHandleIntentJudgeFailureStreak covers the GH-4669 intent-judge
@@ -1636,6 +1683,50 @@ func TestHandleIntentJudgeFailureStreak(t *testing.T) {
 
 		if got := len(mockCh.getAlerts()); got != 0 {
 			t.Errorf("expected 0 alerts (rule disabled), got %d", got)
+		}
+	})
+
+	// GH-4866: mirrors TestHandleDispatchLoopBreaker's no-match subtest —
+	// an event with zero matching rules must not panic and must not fire.
+	t.Run("no matching rule does not fire and does not panic", func(t *testing.T) {
+		config := &AlertConfig{
+			Enabled: true,
+			Channels: []ChannelConfig{
+				{Name: "test-channel", Type: "webhook", Enabled: true},
+			},
+			Rules: []AlertRule{
+				{
+					Name:     "unrelated_rule",
+					Type:     AlertTypeTaskFailed,
+					Enabled:  true,
+					Severity: SeverityWarning,
+					Channels: []string{"test-channel"},
+				},
+			},
+		}
+
+		mockCh := newMockChannel("test-channel", "webhook")
+		dispatcher := NewDispatcher(config)
+		dispatcher.RegisterChannel(mockCh)
+
+		engine := NewEngine(config, WithDispatcher(dispatcher))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = engine.Start(ctx)
+
+		engine.ProcessEvent(Event{
+			Type: EventTypeIntentJudgeFailureStreak,
+			Metadata: map[string]string{
+				"repo":                 "qf-studio/pilot",
+				"consecutive_failures": "10",
+			},
+			Timestamp: time.Now(),
+		})
+		engine.flushForTest()
+
+		if got := len(mockCh.getAlerts()); got != 0 {
+			t.Errorf("expected 0 alerts (no matching rule), got %d", got)
 		}
 	})
 }

--- a/internal/alerts/types.go
+++ b/internal/alerts/types.go
@@ -83,7 +83,12 @@ const (
 	// (handleDeadManStreak) rather than a pre-existing dedicated handler.
 	// Label-lifecycle: the post-GH-4692 notifyTaskStartedSDK path has gone
 	// silent for 19 days (GH-4687) with zero errors surfaced. Self-review:
-	// runSelfReview has gone silent for months (GH-4702) the same way.
+	// runSelfReview has gone silent for months (GH-4702) the same way. GH-4866
+	// added a second tracker under this same AlertType — executor.
+	// LabelStripDeadManTrackerName, the removal-side counterpart wired into
+	// stripInProgressLabelOnTerminalFailure (lifecycle.go) — mirroring how
+	// AlertTypeFinishTripwireFailureStreak below already covers four
+	// independently-counted trackers under one rule.
 	AlertTypeLabelLifecycleFailureStreak AlertType = "label_lifecycle_failure_streak"
 	AlertTypeSelfReviewFailureStreak     AlertType = "self_review_failure_streak"
 
@@ -97,7 +102,61 @@ const (
 	// (DeadManTracker instances are per-name); this only selects which rule
 	// fires when any one of them reaches its threshold.
 	AlertTypeFinishTripwireFailureStreak AlertType = "finish_tripwire_failure_streak"
+
+	// AlertTypePushRetryExhaustedFailureStreak (GH-4866): the git-push retry
+	// loop (Runner.executeWithOptions, runner.go) exhausted every retry
+	// attempt N+ consecutive times without a success — committed work left
+	// stranded with no PR. Previously observable only as isolated "Push
+	// failed, retrying" WARN lines with no dead-man coverage at all (the
+	// GH-4866 kill-drill's unwired-seam finding).
+	AlertTypePushRetryExhaustedFailureStreak AlertType = "push_retry_exhausted_failure_streak"
 )
+
+// HandlerEmittedAlertTypes lists every AlertType whose handler
+// (handleDispatchLoopBreaker, handleIntentJudgeFailureStreak,
+// handleDeadManStreak — engine.go/deadman.go) fires without any
+// Condition-based counting of its own: the caller already computed and
+// gated on the exact threshold before emitting the event, so if no enabled
+// rule exists for one of these types by the time the event arrives, the
+// alert is dropped silently no matter what — each of those handlers WARNs
+// on that no-match case (GH-4866), but the WARN only fires after the fact.
+// CheckAlertRuleCoverage (internal/health/subsystems.go) and
+// TestHandlerEmittedAlertTypesHaveCoverage (types_test.go) both key off
+// this list so the doctor coverage check catches the gap before the
+// runtime WARN ever needs to. Adding a new caller-gated handler means
+// adding its AlertType here too.
+var HandlerEmittedAlertTypes = []AlertType{
+	AlertTypeDispatchLoopBreaker,
+	AlertTypeIntentJudgeFailureStreak,
+	AlertTypeLabelLifecycleFailureStreak,
+	AlertTypeSelfReviewFailureStreak,
+	AlertTypeFinishTripwireFailureStreak,
+	AlertTypePushRetryExhaustedFailureStreak,
+}
+
+// CoverageGaps returns the subset of HandlerEmittedAlertTypes that cfg has
+// no enabled rule for. An empty, non-nil cfg (Rules == nil/empty) reports
+// every handler-emitted type as a gap, matching the "engine never delivers
+// any of these alerts" reality of that config. A nil cfg is treated the
+// same way (alerts subsystem entirely absent).
+func CoverageGaps(cfg *AlertConfig) []AlertType {
+	covered := make(map[AlertType]bool)
+	if cfg != nil {
+		for _, r := range cfg.Rules {
+			if r.Enabled {
+				covered[r.Type] = true
+			}
+		}
+	}
+
+	var gaps []AlertType
+	for _, t := range HandlerEmittedAlertTypes {
+		if !covered[t] {
+			gaps = append(gaps, t)
+		}
+	}
+	return gaps
+}
 
 // Alert represents an alert event
 type Alert struct {
@@ -520,6 +579,20 @@ func defaultRules() []AlertRule {
 			Channels:    []string{},
 			Cooldown:    30 * time.Minute,
 			Description: "Alert when a post-task invariant sweep check fails N+ consecutive times without a success",
+		},
+		// Push-retry-exhausted dead-man tracker (GH-4866): same shape as
+		// label_lifecycle_failure_streak/self_review_failure_streak, guarding
+		// a sustained run of exhausted git-push retries (stranded commits,
+		// no PR) — the GH-4866 kill-drill's unwired-seam finding.
+		{
+			Name:        "push_retry_exhausted_failure_streak",
+			Type:        AlertTypePushRetryExhaustedFailureStreak,
+			Enabled:     true,
+			Condition:   RuleCondition{},
+			Severity:    SeverityCritical,
+			Channels:    []string{},
+			Cooldown:    30 * time.Minute,
+			Description: "Alert when the git-push retry loop exhausts all attempts N+ consecutive times without a success",
 		},
 	}
 }

--- a/internal/alerts/types_test.go
+++ b/internal/alerts/types_test.go
@@ -77,6 +77,8 @@ func TestDefaultRules(t *testing.T) {
 		AlertTypeSelfReviewFailureStreak:     {"self_review_failure_streak", true},
 		// Finish tripwire sweep failure streak (TASK-441 L5, GH-4716)
 		AlertTypeFinishTripwireFailureStreak: {"finish_tripwire_failure_streak", true},
+		// Push-retry-exhausted dead-man tracker (GH-4866)
+		AlertTypePushRetryExhaustedFailureStreak: {"push_retry_exhausted_failure_streak", true},
 	}
 
 	if len(rules) != len(expectedRules) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -454,6 +454,68 @@ type AlertDefaultsConfig struct {
 	SuppressDuplicates bool          `yaml:"suppress_duplicates"`
 }
 
+// ToAlertConfig converts the YAML-facing AlertsConfig into the alerts
+// package's runtime AlertConfig, routing through alerts.FromConfigAlerts so
+// the union-with-defaultRules() logic (GH-4866) always applies here too.
+// This is the single conversion cmd/pilot's daemon start path
+// (getAlertsConfig) and internal/health's doctor coverage check both need —
+// internal/health cannot import cmd/pilot (reverse import direction), and
+// internal/alerts cannot import internal/config (config already imports
+// alerts for the channel-config types above), so this method is the only
+// place both callers can reach without a cycle. Returns nil if a is nil,
+// mirroring the pre-existing nil-config handling in getAlertsConfig.
+func (a *AlertsConfig) ToAlertConfig() *alerts.AlertConfig {
+	if a == nil {
+		return nil
+	}
+
+	channels := make([]alerts.ChannelConfigInput, 0, len(a.Channels))
+	for _, ch := range a.Channels {
+		channels = append(channels, alerts.ChannelConfigInput{
+			Name:       ch.Name,
+			Type:       ch.Type,
+			Enabled:    ch.Enabled,
+			Severities: ch.Severities,
+			Slack:      ch.Slack,
+			Telegram:   ch.Telegram,
+			Email:      ch.Email,
+			Webhook:    ch.Webhook,
+			PagerDuty:  ch.PagerDuty,
+		})
+	}
+
+	rules := make([]alerts.RuleConfigInput, 0, len(a.Rules))
+	for _, r := range a.Rules {
+		rules = append(rules, alerts.RuleConfigInput{
+			Name:        r.Name,
+			Type:        r.Type,
+			Enabled:     r.Enabled,
+			Severity:    r.Severity,
+			Channels:    r.Channels,
+			Cooldown:    r.Cooldown,
+			Description: r.Description,
+			Condition: alerts.ConditionConfigInput{
+				ProgressUnchangedFor: r.Condition.ProgressUnchangedFor,
+				ConsecutiveFailures:  r.Condition.ConsecutiveFailures,
+				DailySpendThreshold:  r.Condition.DailySpendThreshold,
+				BudgetLimit:          r.Condition.BudgetLimit,
+				UsageSpikePercent:    r.Condition.UsageSpikePercent,
+				Pattern:              r.Condition.Pattern,
+				FilePattern:          r.Condition.FilePattern,
+				Paths:                r.Condition.Paths,
+			},
+		})
+	}
+
+	defaults := alerts.DefaultsConfigInput{
+		Cooldown:           a.Defaults.Cooldown,
+		DefaultSeverity:    a.Defaults.DefaultSeverity,
+		SuppressDuplicates: a.Defaults.SuppressDuplicates,
+	}
+
+	return alerts.FromConfigAlerts(a.Enabled, channels, rules, defaults)
+}
+
 // DefaultConfig returns a new Config instance with sensible default values.
 // The gateway binds to localhost:9090, recording is enabled, and common
 // alert rules are pre-configured but disabled.
@@ -539,7 +601,28 @@ func DefaultConfig() *Config {
 	}
 }
 
-// defaultAlertRules returns the default alert rules
+// defaultAlertRules returns the default alert rules for a fresh config.
+// This list is intentionally NOT fully delegated to alerts.DefaultConfig()
+// (GH-4866 considered it): "service_unhealthy" exists only here (no
+// alerts.defaultRules() entry), and several autopilot-health rules there
+// (failed_queue_high, api_error_rate_high, pr_stuck_waiting_ci) key off
+// RuleCondition fields (FailedQueueThreshold, APIErrorRatePerMin,
+// PRStuckTimeout) that AlertConditionConfig below has no field for and
+// whose handlers (engine.go's handleAutopilotMetrics) have no zero-value
+// fallback — round-tripping those through this narrower struct would
+// silently zero the threshold and permanently disable the rule. This list
+// is deliberately kept small and self-contained instead.
+//
+// The actual GH-4866 fix (the daemon rule set omitting every dead-man
+// rule) lives one layer down: alerts.FromConfigAlerts unions in any
+// alerts.defaultRules() Type absent from the caller's list — including
+// every type this list doesn't carry (the four dead-man streaks, the
+// intent-judge/lane-starvation/dispatch-loop-breaker/deadlock/escalation/
+// release-monitoring rules, etc.) — using the RICH alerts.AlertRule value
+// directly (no truncation), so those rules' extra Condition fields survive
+// intact regardless of what's authored here. This function only needs to
+// keep covering the handful of types (documented in the original list)
+// that predate or fall outside that union's default set.
 func defaultAlertRules() []AlertRuleConfig {
 	return []AlertRuleConfig{
 		{

--- a/internal/executor/alerts.go
+++ b/internal/executor/alerts.go
@@ -88,3 +88,25 @@ const (
 // startup) — guards the GH-4702 incident class (self-review silently dead
 // for months).
 const SelfReviewDeadManTrackerName = "self_review"
+
+// LabelStripDeadManTrackerName is the alerts.DeadManTracker registration
+// name (GH-4866) for stripInProgressLabelOnTerminalFailure (lifecycle.go) —
+// the removal-side counterpart of the apply-side label_lifecycle tracker
+// (labelLifecycleDeadManTrackerName, cmd/pilot/handlers.go). It routes
+// through the same alerts.AlertTypeLabelLifecycleFailureStreak rule as the
+// apply-side tracker (mirrors how the four finish-tripwire trackers all
+// share one AlertType): both are the same "label lifecycle silently broken"
+// incident class, just counted separately by name. Global rather than
+// per-repo — unlike the apply-side call site, ExecutionLifecycle has no
+// live repo-owner context to key on here (only ProjectPath/TaskID), and the
+// kill-drill gap this closes (GH-4866) was "wired to nothing at all," not
+// dilution across repos.
+const LabelStripDeadManTrackerName = "label_strip"
+
+// PushRetryExhaustedDeadManTrackerName is the alerts.DeadManTracker
+// registration name (GH-4866) for the git-push retry loop in
+// Runner.executeWithOptions (runner.go): a sustained run of pushes that
+// exhaust every gitPushRetryAttempts attempt leaves committed work stranded
+// with no PR, and the kill-drill found this producing zero dead-man signal
+// despite repeated occurrences during the drill window.
+const PushRetryExhaustedDeadManTrackerName = "push_retry_exhausted"

--- a/internal/executor/lifecycle.go
+++ b/internal/executor/lifecycle.go
@@ -441,6 +441,25 @@ func (l *ExecutionLifecycle) stripInProgressLabelOnTerminalFailure(execID string
 	defer cancel()
 
 	log := logging.WithComponent("executor.lifecycle")
+
+	// GH-4866: dead-man tracker for this seam — the kill-drill's box found
+	// this exact path producing `failed to strip pilot-in-progress label`
+	// ERRORs for 57 minutes straight with zero dead-man signal, because
+	// nothing here ever recorded into a tracker at all (the "wired to
+	// nothing" shape, same class as GH-4687/GH-4702). RecordAttempt fires
+	// right before the actual ghEditLabels call, not before the skip checks
+	// above — those are legitimate "nothing to strip here" decisions
+	// (non-GitHub adapter, unparseable issue number), not failures. Relayed
+	// via emitTripwireAlertEvent (finish_tripwires.go), the same nil-safe
+	// AlertEventProcessor send the finish-tripwire sweep above already uses.
+	now := time.Now()
+	emitTripwireAlertEvent(l.alertProcessor, AlertEvent{
+		Type:      AlertEventTypeDeadManAttempt,
+		TaskID:    exec.TaskID,
+		Metadata:  map[string]string{"tracker": LabelStripDeadManTrackerName},
+		Timestamp: now,
+	})
+
 	if err := ghEditLabels(ctx, exec.ProjectPath, issueNum, nil, []string{"pilot-in-progress"}); err != nil {
 		// GH-4692 lesson (studio-sdk's "labels removed" log line fired on
 		// labels that were never applied at all): log this failure loudly —
@@ -449,10 +468,23 @@ func (l *ExecutionLifecycle) stripInProgressLabelOnTerminalFailure(execID string
 		// inert marker with no visible signal that anything went wrong.
 		log.Error("failed to strip pilot-in-progress label after terminal execution — issue may stay stuck behind the marker",
 			"execution_id", execID, "task_id", exec.TaskID, "issue", parsed, "status", string(status), "error", err)
+		emitTripwireAlertEvent(l.alertProcessor, AlertEvent{
+			Type:      AlertEventTypeDeadManFailure,
+			TaskID:    exec.TaskID,
+			Error:     err.Error(),
+			Metadata:  map[string]string{"tracker": LabelStripDeadManTrackerName},
+			Timestamp: time.Now(),
+		})
 		return
 	}
 	log.Info("stripped pilot-in-progress label after terminal execution",
 		"execution_id", execID, "task_id", exec.TaskID, "issue", parsed, "status", string(status))
+	emitTripwireAlertEvent(l.alertProcessor, AlertEvent{
+		Type:      AlertEventTypeDeadManSuccess,
+		TaskID:    exec.TaskID,
+		Metadata:  map[string]string{"tracker": LabelStripDeadManTrackerName},
+		Timestamp: time.Now(),
+	})
 }
 
 // Finish terminates execID in one call: Classify followed by Persist.

--- a/internal/executor/lifecycle_test.go
+++ b/internal/executor/lifecycle_test.go
@@ -874,3 +874,123 @@ func TestExecutionLifecycle_Finish_Completed_DoesNotStripInProgressLabel(t *test
 		t.Error("expected no gh CLI invocation for a completed execution")
 	}
 }
+
+// setupFailingFakeGHForLifecycleTest mirrors setupFakeGHForLifecycleTest but
+// the fake `gh` always exits non-zero, simulating the strip call itself
+// failing (e.g. a revoked token or 403'd repo — the GH-4866 kill-drill's
+// sandbox-repo-archived scenario).
+func setupFailingFakeGHForLifecycleTest(t *testing.T) {
+	t.Helper()
+	fakeBin := t.TempDir()
+	script := filepath.Join(fakeBin, "gh")
+	content := "#!/bin/sh\necho 'gh: 403 Forbidden' >&2\nexit 1\n"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+os.Getenv("PATH"))
+}
+
+// TestExecutionLifecycle_Finish_FailedGitHubTask_RecordsLabelStripDeadManEvents
+// is GH-4866's seam test for the label-strip dead-man tracker: the
+// kill-drill found stripInProgressLabelOnTerminalFailure logging `failed to
+// strip pilot-in-progress label` ERRORs for 57 minutes straight with zero
+// dead-man signal, because nothing here ever recorded into a tracker at all
+// (the same "wired to nothing" shape already fixed for self-review/
+// label-lifecycle). Exercises the real seam — a real *ExecutionLifecycle
+// crossing into a real fakeAlertProcessor via SetAlertProcessor, not an
+// argument-discarding mock (TASK-441 L1) — for both the failure and success
+// outcomes of the strip call itself.
+func TestExecutionLifecycle_Finish_FailedGitHubTask_RecordsLabelStripDeadManEvents(t *testing.T) {
+	t.Run("strip call fails: records attempt+failure", func(t *testing.T) {
+		setupFailingFakeGHForLifecycleTest(t)
+
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+
+		task := &Task{ID: "GH-4866-STRIP-FAIL", ProjectPath: t.TempDir(), SourceAdapter: "github", SourceIssueID: "4866"}
+		lifecycle := NewExecutionLifecycle(store)
+		processor := &fakeAlertProcessor{}
+		lifecycle.SetAlertProcessor(processor)
+		execID, err := lifecycle.Begin(task, ExecStatusRunning)
+		if err != nil {
+			t.Fatalf("Begin failed: %v", err)
+		}
+
+		result := &ExecutionResult{TaskID: task.ID, Success: false, Error: "boom"}
+		if _, err := lifecycle.Finish(execID, result, errors.New("boom"), time.Second); err != nil {
+			t.Fatalf("Finish failed: %v", err)
+		}
+
+		var attempts, failures, successes int
+		for _, event := range processor.events {
+			if event.Metadata["tracker"] != LabelStripDeadManTrackerName {
+				continue
+			}
+			switch event.Type {
+			case AlertEventTypeDeadManAttempt:
+				attempts++
+			case AlertEventTypeDeadManFailure:
+				failures++
+				if event.Error == "" {
+					t.Error("expected DeadManFailure event to carry the underlying gh error, got empty Error")
+				}
+			case AlertEventTypeDeadManSuccess:
+				successes++
+			}
+		}
+		if attempts != 1 {
+			t.Errorf("expected exactly 1 DeadManAttempt event, got %d", attempts)
+		}
+		if failures != 1 {
+			t.Errorf("expected exactly 1 DeadManFailure event, got %d", failures)
+		}
+		if successes != 0 {
+			t.Errorf("expected 0 DeadManSuccess events, got %d", successes)
+		}
+	})
+
+	t.Run("strip call succeeds: records attempt+success", func(t *testing.T) {
+		setupFakeGHForLifecycleTest(t)
+
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+
+		task := &Task{ID: "GH-4866-STRIP-OK", ProjectPath: t.TempDir(), SourceAdapter: "github", SourceIssueID: "4867"}
+		lifecycle := NewExecutionLifecycle(store)
+		processor := &fakeAlertProcessor{}
+		lifecycle.SetAlertProcessor(processor)
+		execID, err := lifecycle.Begin(task, ExecStatusRunning)
+		if err != nil {
+			t.Fatalf("Begin failed: %v", err)
+		}
+
+		result := &ExecutionResult{TaskID: task.ID, Success: false, Error: "boom"}
+		if _, err := lifecycle.Finish(execID, result, errors.New("boom"), time.Second); err != nil {
+			t.Fatalf("Finish failed: %v", err)
+		}
+
+		var attempts, failures, successes int
+		for _, event := range processor.events {
+			if event.Metadata["tracker"] != LabelStripDeadManTrackerName {
+				continue
+			}
+			switch event.Type {
+			case AlertEventTypeDeadManAttempt:
+				attempts++
+			case AlertEventTypeDeadManFailure:
+				failures++
+			case AlertEventTypeDeadManSuccess:
+				successes++
+			}
+		}
+		if attempts != 1 {
+			t.Errorf("expected exactly 1 DeadManAttempt event, got %d", attempts)
+		}
+		if successes != 1 {
+			t.Errorf("expected exactly 1 DeadManSuccess event, got %d", successes)
+		}
+		if failures != 0 {
+			t.Errorf("expected 0 DeadManFailure events, got %d", failures)
+		}
+	})
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -4859,6 +4859,22 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 			// Push branch — retry transient failures before declaring the work
 			// stranded (GH-3785: a single failed push previously produced a
 			// silent "committed work but no PR" report with no detail).
+			//
+			// GH-4866: dead-man tracker for this seam — the kill-drill found
+			// push-retry exhaustion producing zero dead-man signal despite
+			// repeated occurrences during the drill window, the exact
+			// "wired to nothing" shape already fixed for self-review/
+			// label-lifecycle. RecordAttempt covers the whole retry loop (one
+			// push operation, not one per internal retry); only exhausting
+			// every attempt counts as a tracker failure — a retry that
+			// eventually succeeds, or a chdir false-positive resolved via
+			// RemoteBranchExists below, is a success.
+			r.emitAlertEvent(AlertEvent{
+				Type:      AlertEventTypeDeadManAttempt,
+				TaskID:    task.ID,
+				Metadata:  map[string]string{"tracker": PushRetryExhaustedDeadManTrackerName},
+				Timestamp: time.Now(),
+			})
 			var pushErr error
 			for attempt := 1; attempt <= gitPushRetryAttempts; attempt++ {
 				pushErr = git.Push(ctx, task.Branch)
@@ -4886,11 +4902,24 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 				}
 			}
 			if pushErr != nil {
+				r.emitAlertEvent(AlertEvent{
+					Type:      AlertEventTypeDeadManFailure,
+					TaskID:    task.ID,
+					Error:     pushErr.Error(),
+					Metadata:  map[string]string{"tracker": PushRetryExhaustedDeadManTrackerName},
+					Timestamp: time.Now(),
+				})
 				result.Success = false
 				result.Error = formatGitStepFailureWithRecovery(ctx, git, "push", gitPushRetryAttempts, pushErr, task.ID, task.Branch, result.CommitSHA)
 				r.reportProgress(task.ID, "PR Failed", 100, result.Error)
 				return result, nil
 			}
+			r.emitAlertEvent(AlertEvent{
+				Type:      AlertEventTypeDeadManSuccess,
+				TaskID:    task.ID,
+				Metadata:  map[string]string{"tracker": PushRetryExhaustedDeadManTrackerName},
+				Timestamp: time.Now(),
+			})
 
 			// GH-457: Use actual pushed HEAD as CommitSHA source of truth.
 			// Self-review or quality retries may push new commits after

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -4202,6 +4202,75 @@ func TestRunner_PRCreate_HasCommits_ProceedsToCreate(t *testing.T) {
 	}
 }
 
+// TestRunner_PushRetryExhausted_RecordsDeadManEvents is GH-4866's seam test
+// for the push-retry-exhaustion dead-man tracker: the kill-drill found this
+// exact path (git push exhausting every gitPushRetryAttempts attempt)
+// producing zero dead-man signal despite repeated occurrences during the
+// drill window. Reuses the same no-remote repo setup as
+// TestRunner_PRCreate_HasCommits_ProceedsToCreate (every push attempt fails
+// identically, exhausting retries) but asserts on the alert-processor relay
+// instead of the returned error string — a real *Runner crossing the
+// executor→alerts seam via emitAlertEvent, not an argument-discarding mock
+// (TASK-441 L1).
+func TestRunner_PushRetryExhausted_RecordsDeadManEvents(t *testing.T) {
+	const branch = "pilot/GH-9997"
+	dir := setupPRGuardRepo(t, branch, true) // one commit on branch, no remote configured
+
+	backend := &mockFixedBackend{
+		result: &BackendResult{Success: true, Output: "implementation complete"},
+	}
+	runner := NewRunnerWithBackend(backend)
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+	processor := &fakeAlertProcessor{}
+	runner.SetAlertProcessor(processor)
+
+	task := &Task{
+		ID:          "GH-9997",
+		Title:       "fix(executor): push-retry-exhaustion dead-man wiring test",
+		Description: "Verify push-retry exhaustion records a dead-man attempt+failure",
+		ProjectPath: dir,
+		Branch:      branch,
+		CreatePR:    true,
+	}
+
+	result, err := runner.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+	if result.Success {
+		t.Fatal("expected failure (push has no remote), got success")
+	}
+
+	var attempts, failures, successes int
+	for _, event := range processor.events {
+		if event.Metadata["tracker"] != PushRetryExhaustedDeadManTrackerName {
+			continue
+		}
+		switch event.Type {
+		case AlertEventTypeDeadManAttempt:
+			attempts++
+		case AlertEventTypeDeadManFailure:
+			failures++
+			if event.Error == "" {
+				t.Error("expected DeadManFailure event to carry the underlying push error, got empty Error")
+			}
+		case AlertEventTypeDeadManSuccess:
+			successes++
+		}
+	}
+	if attempts != 1 {
+		t.Errorf("expected exactly 1 DeadManAttempt event (one push operation, not one per internal retry), got %d", attempts)
+	}
+	if failures != 1 {
+		t.Errorf("expected exactly 1 DeadManFailure event, got %d", failures)
+	}
+	if successes != 0 {
+		t.Errorf("expected 0 DeadManSuccess events, got %d", successes)
+	}
+}
+
 // TestParseDeclinedReason verifies the DECLINED:<reason> marker extraction. GH-2777.
 func TestParseDeclinedReason(t *testing.T) {
 	tests := []struct {

--- a/internal/health/subsystems.go
+++ b/internal/health/subsystems.go
@@ -3,7 +3,9 @@ package health
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 
+	"github.com/qf-studio/pilot/internal/alerts"
 	"github.com/qf-studio/pilot/internal/config"
 	"github.com/qf-studio/pilot/internal/executor"
 )
@@ -53,6 +55,9 @@ func CheckDisabledSubsystems(cfg *config.Config) []SubsystemCheck {
 	wired, reason = checkApprovalChannelDeliverable(cfg)
 	checks = append(checks, SubsystemCheck{Name: "approval channel deliverable", Wired: wired, Reason: reason})
 
+	wired, reason = checkAlertRuleCoverage(cfg)
+	checks = append(checks, SubsystemCheck{Name: "alert rule coverage", Wired: wired, Reason: reason})
+
 	return checks
 }
 
@@ -69,23 +74,27 @@ func checkAlertEngineStarted(cfg *config.Config) (bool, string) {
 }
 
 // checkAlertProcessorWiredOnRunner reports whether cmd/pilot's active start
-// path calls executor.Runner.SetAlertProcessor. GH-394 makes runPollingMode
-// (cmd/pilot/main.go) the default whenever GitHub or Telegram polling is
-// enabled, and that path never calls SetAlertProcessor — alertsEngine is only
-// passed into individual issue-handler calls for one-off ProcessEvent
-// invocations, never wired onto the runner itself. That means task-lifecycle
-// events (stagnation/OOM/retry/escalation, emitted via Runner.emitAlertEvent)
-// are dropped silently even when the alert engine is healthy and running.
-// This is a build-time fact about the current start path, not a config
-// toggle — update this check if cmd/pilot/main.go is changed to wire
-// SetAlertProcessor there (internal/pilot's gateway-only path already does,
-// via orchestrator.SetAlertProcessor, but that path is not the default once
-// any polling adapter is enabled).
+// path calls executor.Runner.SetAlertProcessor once the alert engine starts.
+// GH-394 originally left runPollingMode (cmd/pilot/main.go) — the default
+// path whenever GitHub or Telegram polling is enabled — never calling
+// SetAlertProcessor, so task-lifecycle events (stagnation/OOM/retry/
+// escalation/dead-man, emitted via Runner.emitAlertEvent) were dropped
+// silently even with a healthy, running alert engine. GH-4716 fixed that:
+// main.go now calls runner.SetAlertProcessor immediately after
+// alertsEngine.Start succeeds (main.go:3058), and internal/pilot's
+// gateway/orchestrator path wires the equivalent
+// orchestrator.SetAlertProcessor the same way (pilot.go's initAlerts). GH-4866
+// found this check still hardcoded to `return false` long after that fix
+// landed — a permanently-red doctor line trains operators to ignore doctor
+// entirely, which is worse than no check at all. This is a build-time fact
+// about the current start paths, not a config toggle — update this (not just
+// flip the literal) if a start path is ever added that starts the alert
+// engine without also wiring the processor.
 func checkAlertProcessorWiredOnRunner(cfg *config.Config) (bool, string) {
 	if cfg.Alerts == nil || !cfg.Alerts.Enabled {
 		return false, "alert engine not started (see \"alert engine started\")"
 	}
-	return false, "runner.SetAlertProcessor is not called on the polling-mode start path (cmd/pilot/main.go runPollingMode) — task lifecycle alerts (stagnation/OOM/retry) are dropped even though the alert engine is running"
+	return true, "runner.SetAlertProcessor is called once the alert engine starts (cmd/pilot/main.go runPollingMode; internal/pilot/pilot.go initAlerts for the gateway/orchestrator path)"
 }
 
 // checkReleaserResolved mirrors autopilot.resolveRelease's env-scoped-wins-
@@ -185,4 +194,34 @@ func checkApprovalChannelDeliverable(cfg *config.Config) (bool, string) {
 		return false, "approval.enabled=false"
 	}
 	return true, "inbound processing active"
+}
+
+// checkAlertRuleCoverage reports whether every AlertType an engine handler
+// can emit without its own Condition-based counting (alerts.
+// HandlerEmittedAlertTypes — dispatch-loop-breaker, intent-judge streak, and
+// every generic dead-man tracker: label-lifecycle, self-review, finish-
+// tripwire, push-retry-exhausted) actually has an enabled rule once this
+// config runs through the same union-with-defaults conversion the daemon
+// start path uses (config.AlertsConfig.ToAlertConfig, which wraps
+// alerts.FromConfigAlerts). GH-4866: a persisted config carrying only the
+// legacy 5-rule list (task_stuck/task_failed/consecutive_failures/
+// daily_spend/budget_depleted, predating the dead-man trackers) used to
+// mean every one of those alerts was silently unreachable — the kill-drill's
+// central finding. ToAlertConfig's union logic already closes that gap for
+// any config going through the real conversion, so this check should read
+// as wired=true for any config using that path; a false here means either a
+// gap in FromConfigAlerts' union list or a rule explicitly disabled by the
+// operator.
+func checkAlertRuleCoverage(cfg *config.Config) (bool, string) {
+	acfg := cfg.Alerts.ToAlertConfig()
+	gaps := alerts.CoverageGaps(acfg)
+	if len(gaps) == 0 {
+		return true, fmt.Sprintf("all %d handler-emitted alert types have an enabled rule", len(alerts.HandlerEmittedAlertTypes))
+	}
+
+	names := make([]string, len(gaps))
+	for i, t := range gaps {
+		names[i] = string(t)
+	}
+	return false, fmt.Sprintf("no enabled rule for: %s — these alerts can never fire", strings.Join(names, ", "))
 }

--- a/internal/health/subsystems_test.go
+++ b/internal/health/subsystems_test.go
@@ -1,6 +1,7 @@
 package health
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/qf-studio/pilot/internal/adapters/telegram"
@@ -65,19 +66,28 @@ func TestCheckAlertEngineStarted(t *testing.T) {
 	}
 }
 
-func TestCheckAlertProcessorWiredOnRunner_AlwaysFalse(t *testing.T) {
-	// GH-3839: the poller's alertProcessor (this issue's B4) is a different
-	// wire than the runner's task-lifecycle alertProcessor — cmd/pilot's
-	// polling-mode start path never calls Runner.SetAlertProcessor, so this
-	// check must report false regardless of how alerts are configured.
-	cfg := &config.Config{
-		Alerts: &config.AlertsConfig{
-			Enabled:  true,
-			Channels: []config.AlertChannelConfig{{Name: "ops", Type: "slack", Enabled: true}},
-		},
-	}
+func TestCheckAlertProcessorWiredOnRunner(t *testing.T) {
+	// GH-4866: GH-4716 fixed the underlying gap (cmd/pilot/main.go:3058 now
+	// calls runner.SetAlertProcessor right after alertsEngine.Start succeeds),
+	// but this check kept hardcoding false — a permanently-red doctor line.
+	// Engine.Start (engine.go) never errors on zero channels — it only
+	// no-ops when config.Enabled is false — so main.go's SetAlertProcessor
+	// call is gated on alerts.enabled alone, not on channels being
+	// configured too (that's "alert engine started"'s concern, a distinct
+	// question from whether the processor gets wired).
+	cfg := &config.Config{}
 	if wired, reason := checkAlertProcessorWiredOnRunner(cfg); wired {
-		t.Errorf("wired=true, want false (reason=%q)", reason)
+		t.Errorf("nil alerts config: wired=true, want false (reason=%q)", reason)
+	}
+
+	cfg.Alerts = &config.AlertsConfig{Enabled: false}
+	if wired, reason := checkAlertProcessorWiredOnRunner(cfg); wired {
+		t.Errorf("alerts.enabled=false: wired=true, want false (reason=%q)", reason)
+	}
+
+	cfg.Alerts.Enabled = true
+	if wired, reason := checkAlertProcessorWiredOnRunner(cfg); !wired {
+		t.Errorf("alerts.enabled=true: wired=false, want true (reason=%q)", reason)
 	}
 }
 
@@ -201,6 +211,55 @@ func TestCheckIntentClassifier(t *testing.T) {
 	}
 	if !wired && reason == "" {
 		t.Error("wired=false but empty reason")
+	}
+}
+
+// TestCheckAlertRuleCoverage covers the GH-4866 doctor gap: a persisted
+// alerts.rules: list that predates the dead-man/intent-judge/dispatch-
+// loop-breaker AlertTypes (the "legacy 5-rule" config.defaultAlertRules
+// list) used to mean every one of those alerts was silently unreachable —
+// the kill-drill's central finding. config.AlertsConfig.ToAlertConfig
+// unions in alerts.defaultRules() for any missing Type, so this check
+// should report wired=true through that path; this test also proves the
+// check actually looks at rule coverage (not just cfg.Alerts.Enabled) by
+// deliberately disabling the one rule GH-4866 cares about most and
+// confirming it's named in the reason string.
+func TestCheckAlertRuleCoverage(t *testing.T) {
+	cfg := &config.Config{}
+	if wired, reason := checkAlertRuleCoverage(cfg); wired {
+		t.Errorf("nil alerts config: wired=true, want false (no rules exist at all — nothing can fire) (reason=%q)", reason)
+	}
+
+	// Legacy 5-rule list, same as config.defaultAlertRules(): predates every
+	// dead-man/intent-judge/dispatch-loop-breaker rule.
+	cfg.Alerts = &config.AlertsConfig{
+		Enabled: true,
+		Rules: []config.AlertRuleConfig{
+			{Name: "task_stuck", Type: "task_stuck", Enabled: true},
+			{Name: "task_failed", Type: "task_failed", Enabled: true},
+			{Name: "consecutive_failures", Type: "consecutive_failures", Enabled: true},
+			{Name: "daily_spend", Type: "daily_spend_exceeded", Enabled: false},
+			{Name: "budget_depleted", Type: "budget_depleted", Enabled: false},
+		},
+	}
+	wired, reason := checkAlertRuleCoverage(cfg)
+	if !wired {
+		t.Errorf("legacy 5-rule config: wired=false, want true (ToAlertConfig's union should still cover every handler-emitted type) (reason=%q)", reason)
+	}
+
+	// Now explicitly disable the label_lifecycle rule the union added —
+	// coverage must report the gap.
+	cfg.Alerts.Rules = append(cfg.Alerts.Rules, config.AlertRuleConfig{
+		Name:    "label_lifecycle_failure_streak",
+		Type:    "label_lifecycle_failure_streak",
+		Enabled: false,
+	})
+	wired, reason = checkAlertRuleCoverage(cfg)
+	if wired {
+		t.Errorf("label_lifecycle_failure_streak explicitly disabled: wired=true, want false (reason=%q)", reason)
+	}
+	if !strings.Contains(reason, "label_lifecycle_failure_streak") {
+		t.Errorf("reason %q does not name the missing rule label_lifecycle_failure_streak", reason)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixes GH-4866: TASK-441 kill-drill A found the daemon's `alerts.rules` config omitted every dead-man rule, so 57 minutes of continuous seam failures (label-strip, push-retry exhaustion, notify-task-started) during a sandboxed-repo drill produced zero dead-man output.
- `alerts.FromConfigAlerts` now unions in any `alerts.defaultRules()` Type missing from the caller's rule list — a persisted or legacy config can no longer silently drop a Type added after it was authored.
- `DeadManTracker.RecordFailure` now logs an unconditional WARN at the threshold crossing (regardless of rule/engine wiring) and fires on a `>=`/fired-once gate instead of exact equality, so trackers that start counting mid-streak still fire; `handleDeadManStreak`/`handleIntentJudgeFailureStreak`/`handleDispatchLoopBreaker` WARN when a streak event has no matching rule at all.
- `label_lifecycle` dead-man tracking is now keyed per-repo (`"label_lifecycle:"+owner/repo`) instead of one global counter, so one broken repo's failures aren't diluted by every other healthy repo's successes.
- Wired the two previously-silent seams the kill-drill exercised: the `pilot-in-progress` label-strip path (`lifecycle.go`) and git-push retry exhaustion (`runner.go`) now emit dead-man attempt/success/failure events through the existing nil-safe `AlertEventProcessor` relay.
- `pilot doctor`: `checkAlertProcessorWiredOnRunner` no longer hardcodes `false` (GH-4716 already fixed the underlying gap); added a new rule-coverage check that flags any handler-emitted `AlertType` with no enabled rule, built on a new shared `config.AlertsConfig.ToAlertConfig` conversion so both the daemon start path and the doctor check go through one implementation.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./...` — full suite green
- [x] New table test: `getAlertsConfig` yields full AlertType coverage even from the legacy 5-rule config (`cmd/pilot/wiring_test.go`)
- [x] New doctor coverage-check test (`internal/health/subsystems_test.go`)
- [x] New seam tests for lifecycle label-strip and push-retry-exhaustion dead-man events, using real fake-`gh`/no-remote-repo fixtures (no argument-discarding mocks)
- [x] `make check-secrets` clean