### PR TITLE
feat(telegram): route notifications, approvals and alerts into a forum topic

### DIFF
--- a/cmd/pilot/adapters.go
+++ b/cmd/pilot/adapters.go
@@ -29,7 +29,7 @@ type telegramBriefAdapter struct {
 }
 
 func (a *telegramBriefAdapter) SendBriefMessage(ctx context.Context, chatID, text, parseMode string) (*briefs.TelegramMessageResponse, error) {
-	resp, err := a.client.SendMessage(ctx, chatID, text, parseMode)
+	resp, err := a.client.SendMessage(ctx, chatID, text, parseMode, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -44,8 +44,8 @@ type telegramApprovalAdapter struct {
 	client *telegram.Client
 }
 
-func (a *telegramApprovalAdapter) SendMessageWithKeyboard(ctx context.Context, chatID, text, parseMode string, keyboard [][]approval.InlineKeyboardButton) (*approval.MessageResponse, error) {
-	resp, err := a.client.SendMessageWithKeyboard(ctx, chatID, text, parseMode, convertKeyboardToTelegram(keyboard))
+func (a *telegramApprovalAdapter) SendMessageWithKeyboard(ctx context.Context, chatID, text, parseMode string, keyboard [][]approval.InlineKeyboardButton, messageThreadID int64) (*approval.MessageResponse, error) {
+	resp, err := a.client.SendMessageWithKeyboard(ctx, chatID, text, parseMode, convertKeyboardToTelegram(keyboard), messageThreadID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -688,7 +688,7 @@ Examples:
 					telegramClient := telegram.NewClient(cfg.Adapters.Telegram.BotToken)
 					for _, ch := range alertsCfg.Channels {
 						if ch.Type == "telegram" && ch.Telegram != nil {
-							telegramChannel := alerts.NewTelegramChannel(ch.Name, telegramClient, ch.Telegram.ChatID)
+							telegramChannel := alerts.NewTelegramChannel(ch.Name, telegramClient, ch.Telegram.ChatID, ch.Telegram.MessageThreadID)
 							dispatcher.RegisterChannel(telegramChannel)
 						}
 					}

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -816,7 +816,7 @@ Examples:
 				if cfg.Adapters.Telegram != nil && cfg.Adapters.Telegram.Enabled && cfg.Adapters.Telegram.BotToken != "" &&
 					(cfg.Adapters.Telegram.Approval == nil || cfg.Adapters.Telegram.Approval.Enabled) {
 					tgClient := telegram.NewClient(cfg.Adapters.Telegram.BotToken)
-					gwTgApprovalHandler = approval.NewTelegramHandler(&telegramApprovalAdapter{client: tgClient}, cfg.Adapters.Telegram.ChatID)
+					gwTgApprovalHandler = approval.NewTelegramHandler(&telegramApprovalAdapter{client: tgClient}, cfg.Adapters.Telegram.ChatID, cfg.Adapters.Telegram.MessageThreadID)
 					// GH-3825: persist decisions directly to PRState via the manager so a
 					// button tap on a Rehydrate-restored request isn't lost when no
 					// waiter goroutine survived the restart.
@@ -993,7 +993,7 @@ Examples:
 						telegramClient := telegram.NewClient(cfg.Adapters.Telegram.BotToken)
 						for _, ch := range alertsCfg.Channels {
 							if ch.Type == "telegram" && ch.Telegram != nil {
-								telegramChannel := alerts.NewTelegramChannel(ch.Name, telegramClient, ch.Telegram.ChatID)
+								telegramChannel := alerts.NewTelegramChannel(ch.Name, telegramClient, ch.Telegram.ChatID, ch.Telegram.MessageThreadID)
 								alertsDispatcher.RegisterChannel(telegramChannel)
 							}
 						}
@@ -2147,7 +2147,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 	if cfg.Adapters.Telegram != nil && cfg.Adapters.Telegram.Enabled && cfg.Adapters.Telegram.BotToken != "" &&
 		(cfg.Adapters.Telegram.Approval == nil || cfg.Adapters.Telegram.Approval.Enabled) {
 		tgApprovalClient := telegram.NewClient(cfg.Adapters.Telegram.BotToken)
-		tgApprovalHandlerImpl = approval.NewTelegramHandler(&telegramApprovalAdapter{client: tgApprovalClient}, cfg.Adapters.Telegram.ChatID)
+		tgApprovalHandlerImpl = approval.NewTelegramHandler(&telegramApprovalAdapter{client: tgApprovalClient}, cfg.Adapters.Telegram.ChatID, cfg.Adapters.Telegram.MessageThreadID)
 		// GH-3825: persist decisions directly to PRState via the manager so a
 		// button tap on a Rehydrate-restored request isn't lost when no waiter
 		// goroutine survived the restart.
@@ -3035,7 +3035,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			telegramClient := telegram.NewClient(cfg.Adapters.Telegram.BotToken)
 			for _, ch := range alertsCfg.Channels {
 				if ch.Type == "telegram" && ch.Telegram != nil {
-					telegramChannel := alerts.NewTelegramChannel(ch.Name, telegramClient, ch.Telegram.ChatID)
+					telegramChannel := alerts.NewTelegramChannel(ch.Name, telegramClient, ch.Telegram.ChatID, ch.Telegram.MessageThreadID)
 					alertsDispatcher.RegisterChannel(telegramChannel)
 				}
 			}

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -64,6 +64,13 @@ adapters:
     enabled: false
     bot_token: "${TELEGRAM_BOT_TOKEN}"
     chat_id: "${TELEGRAM_CHAT_ID}"    # Your user/chat ID for notifications
+    # Forum supergroups only (groups with Topics enabled): post task lifecycle
+    # notifications and approval prompts into one topic instead of General.
+    # The id is the topic's message_thread_id — the middle segment of a topic
+    # message link (https://t.me/c/<chat>/<topic>/<msg>). Omit or 0 for
+    # non-forum chats. Approval prompts addressed to an individual approver
+    # (approvers[0] is a chat id) ignore this and go to that chat directly.
+    # message_thread_id: 12
     transcription:
       provider: openai
       openai_key: "${OPENAI_API_KEY}"  # For voice message transcription
@@ -470,6 +477,30 @@ briefs:
     include_metrics: true
     include_errors: true
     max_items_per_section: 10
+
+# Alerting
+# alerts:
+#   enabled: true
+#   channels:
+#     # Two channels can share one chat_id and split by topic + severity.
+#     # message_thread_id applies to forum supergroups only (Topics enabled);
+#     # it is the topic's message_thread_id — the middle segment of a topic
+#     # message link (https://t.me/c/<chat>/<topic>/<msg>). Omit or 0 for
+#     # non-forum chats.
+#     - name: telegram-critical
+#       type: telegram
+#       enabled: true
+#       severities: [critical]
+#       telegram:
+#         chat_id: -1001234567890
+#         message_thread_id: 12
+#     - name: telegram-routine
+#       type: telegram
+#       enabled: true
+#       severities: [warning, info]
+#       telegram:
+#         chat_id: -1001234567890
+#         message_thread_id: 34
 
 # Memory settings
 memory:

--- a/docs/content/features/alerts.mdx
+++ b/docs/content/features/alerts.mdx
@@ -144,6 +144,7 @@ Sends MarkdownV2 formatted messages with emoji indicators.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `chat_id` | integer | Yes | Telegram chat or group ID |
+| `message_thread_id` | integer | No | Forum topic to post into. Forum supergroups only |
 
 **Formatting:**
 - Severity emoji header (🚨 critical, ⚠️ warning, ℹ️ info)
@@ -158,6 +159,27 @@ Sends MarkdownV2 formatted messages with emoji indicators.
   severities: [critical, warning]
   telegram:
     chat_id: -1001234567890
+```
+
+**Splitting severities across forum topics:** in a supergroup with Topics
+enabled, several channels can share one `chat_id` and differ only by
+`message_thread_id`, keeping critical alerts out of the routine feed.
+
+```yaml
+- name: telegram-critical
+  type: telegram
+  enabled: true
+  severities: [critical]
+  telegram:
+    chat_id: -1001234567890
+    message_thread_id: 12
+- name: telegram-routine
+  type: telegram
+  enabled: true
+  severities: [warning, info]
+  telegram:
+    chat_id: -1001234567890
+    message_thread_id: 34
 ```
 
 ### Email (SMTP)

--- a/docs/content/integrations/telegram.mdx
+++ b/docs/content/integrations/telegram.mdx
@@ -54,6 +54,7 @@ Always set `allowed_ids` to restrict who can trigger Pilot via Telegram. Without
 | `enabled` | bool | `false` | Enable the Telegram adapter |
 | `bot_token` | string | required | Bot token from @BotFather |
 | `chat_id` | string | — | Default chat ID for outbound notifications |
+| `message_thread_id` | int64 | — | Forum topic for outbound notifications and approval prompts. Forum supergroups only |
 | `allowed_ids` | []int64 | — | User/chat IDs authorized to send tasks |
 | `project_path` | string | — | Default project path for tasks |
 | `polling` | bool | `false` | Enable inbound message polling |
@@ -69,6 +70,27 @@ Always set `allowed_ids` to restrict who can trigger Pilot via Telegram. Without
 | `llm_classifier.timeout_seconds` | int | `2` | Classification timeout |
 | `llm_classifier.history_size` | int | `10` | Messages to keep per chat |
 | `llm_classifier.history_ttl` | duration | `30m` | Conversation history TTL |
+
+## Forum Topics
+
+Supergroups with Topics enabled route every message to a topic. Set
+`message_thread_id` to post notifications and approval prompts into one topic
+instead of General:
+
+```yaml
+adapters:
+  telegram:
+    chat_id: "-1001234567890"
+    message_thread_id: 12
+```
+
+The id is the middle segment of a link to any message in that topic —
+`https://t.me/c/<chat>/<topic>/<msg>`. Leave it unset for chats without Topics;
+sending a topic id to a non-forum chat is rejected by the Bot API.
+
+Approval prompts addressed to an individual approver (where `approvers[0]` is a
+chat ID) go to that chat directly and ignore this setting. Alert channels take
+their own `message_thread_id` — see [Alerts](/features/alerts).
 
 ## Chat Modes
 

--- a/internal/adapters/telegram/client.go
+++ b/internal/adapters/telegram/client.go
@@ -45,10 +45,11 @@ func NewClientWithBaseURL(botToken, baseURL string) *Client {
 
 // SendMessageRequest represents a Telegram sendMessage request
 type SendMessageRequest struct {
-	ChatID      string                `json:"chat_id"`
-	Text        string                `json:"text"`
-	ParseMode   string                `json:"parse_mode,omitempty"`
-	ReplyMarkup *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
+	ChatID          string                `json:"chat_id"`
+	Text            string                `json:"text"`
+	ParseMode       string                `json:"parse_mode,omitempty"`
+	MessageThreadID int64                 `json:"message_thread_id,omitempty"`
+	ReplyMarkup     *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
 }
 
 // SendMessageResponse represents the response from sending a message
@@ -283,11 +284,12 @@ func (c *Client) Verify(ctx context.Context) error {
 }
 
 // SendMessage sends a message to a chat
-func (c *Client) SendMessage(ctx context.Context, chatID, text, parseMode string) (*SendMessageResponse, error) {
+func (c *Client) SendMessage(ctx context.Context, chatID, text, parseMode string, messageThreadID int64) (*SendMessageResponse, error) {
 	req := SendMessageRequest{
-		ChatID:    chatID,
-		Text:      text,
-		ParseMode: parseMode,
+		ChatID:          chatID,
+		Text:            text,
+		ParseMode:       parseMode,
+		MessageThreadID: messageThreadID,
 	}
 
 	body, err := json.Marshal(req)
@@ -327,11 +329,12 @@ func (c *Client) SendMessage(ctx context.Context, chatID, text, parseMode string
 }
 
 // SendMessageWithKeyboard sends a message with an inline keyboard
-func (c *Client) SendMessageWithKeyboard(ctx context.Context, chatID, text, parseMode string, keyboard [][]InlineKeyboardButton) (*SendMessageResponse, error) {
+func (c *Client) SendMessageWithKeyboard(ctx context.Context, chatID, text, parseMode string, keyboard [][]InlineKeyboardButton, messageThreadID int64) (*SendMessageResponse, error) {
 	req := SendMessageRequest{
-		ChatID:    chatID,
-		Text:      text,
-		ParseMode: parseMode,
+		ChatID:          chatID,
+		Text:            text,
+		ParseMode:       parseMode,
+		MessageThreadID: messageThreadID,
 		ReplyMarkup: &InlineKeyboardMarkup{
 			InlineKeyboard: keyboard,
 		},
@@ -526,7 +529,7 @@ type BriefMessageResponse struct {
 // SendBriefMessage sends a message and returns a simplified response for brief delivery.
 // This method satisfies the briefs.TelegramSender interface.
 func (c *Client) SendBriefMessage(ctx context.Context, chatID, text, parseMode string) (*BriefMessageResponse, error) {
-	resp, err := c.SendMessage(ctx, chatID, text, parseMode)
+	resp, err := c.SendMessage(ctx, chatID, text, parseMode, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapters/telegram/client_test.go
+++ b/internal/adapters/telegram/client_test.go
@@ -305,7 +305,7 @@ func TestClientSendMessage(t *testing.T) {
 			// Test verifies method signature exists
 			client := NewClient(testutil.FakeTelegramBotToken)
 			ctx := context.Background()
-			_, _ = client.SendMessage(ctx, tt.chatID, tt.text, tt.parseMode)
+			_, _ = client.SendMessage(ctx, tt.chatID, tt.text, tt.parseMode, 0)
 		})
 	}
 }
@@ -348,7 +348,7 @@ func TestClientSendMessageWithKeyboard(t *testing.T) {
 
 	client := NewClient(testutil.FakeTelegramBotToken)
 	ctx := context.Background()
-	_, _ = client.SendMessageWithKeyboard(ctx, "123456", "Choose:", "", keyboard)
+	_, _ = client.SendMessageWithKeyboard(ctx, "123456", "Choose:", "", keyboard, 0)
 }
 
 // TestClientEditMessage tests message editing
@@ -634,5 +634,99 @@ func TestCallbackQueryStructure(t *testing.T) {
 	}
 	if callback.Message.MessageID != 200 {
 		t.Errorf("Message.MessageID = %d, want 200", callback.Message.MessageID)
+	}
+}
+
+func TestSendMessageRequestMessageThreadID(t *testing.T) {
+	tests := []struct {
+		name            string
+		messageThreadID int64
+		wantKey         bool
+		wantValue       float64
+	}{
+		{
+			name:            "unset omits the field",
+			messageThreadID: 0,
+			wantKey:         false,
+		},
+		{
+			name:            "forum topic is serialized",
+			messageThreadID: 42,
+			wantKey:         true,
+			wantValue:       42,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, err := json.Marshal(SendMessageRequest{
+				ChatID:          "123456",
+				Text:            "hello",
+				MessageThreadID: tt.messageThreadID,
+			})
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+
+			var raw map[string]interface{}
+			if err := json.Unmarshal(body, &raw); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+
+			got, ok := raw["message_thread_id"]
+			if ok != tt.wantKey {
+				t.Fatalf("message_thread_id present = %v, want %v (body: %s)", ok, tt.wantKey, body)
+			}
+			if tt.wantKey && got != tt.wantValue {
+				t.Errorf("message_thread_id = %v, want %v", got, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestClientSendsMessageThreadID(t *testing.T) {
+	tests := []struct {
+		name            string
+		withKeyboard    bool
+		messageThreadID int64
+		wantKey         bool
+	}{
+		{name: "sendMessage without topic", messageThreadID: 0, wantKey: false},
+		{name: "sendMessage with topic", messageThreadID: 77, wantKey: true},
+		{name: "keyboard without topic", withKeyboard: true, messageThreadID: 0, wantKey: false},
+		{name: "keyboard with topic", withKeyboard: true, messageThreadID: 88, wantKey: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var raw map[string]interface{}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewDecoder(r.Body).Decode(&raw)
+				_ = json.NewEncoder(w).Encode(SendMessageResponse{OK: true, Result: &Result{MessageID: 1}})
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeTelegramBotToken, server.URL)
+			ctx := context.Background()
+
+			var err error
+			if tt.withKeyboard {
+				keyboard := [][]InlineKeyboardButton{{{Text: "OK", CallbackData: "ok"}}}
+				_, err = client.SendMessageWithKeyboard(ctx, "123456", "hi", "", keyboard, tt.messageThreadID)
+			} else {
+				_, err = client.SendMessage(ctx, "123456", "hi", "", tt.messageThreadID)
+			}
+			if err != nil {
+				t.Fatalf("send: %v", err)
+			}
+
+			got, ok := raw["message_thread_id"]
+			if ok != tt.wantKey {
+				t.Fatalf("message_thread_id present = %v, want %v", ok, tt.wantKey)
+			}
+			if tt.wantKey && got != float64(tt.messageThreadID) {
+				t.Errorf("message_thread_id = %v, want %d", got, tt.messageThreadID)
+			}
+		})
 	}
 }

--- a/internal/adapters/telegram/commands.go
+++ b/internal/adapters/telegram/commands.go
@@ -66,7 +66,7 @@ func (c *CommandHandler) HandleCommand(ctx context.Context, chatID, text string)
 		if len(args) > 0 {
 			c.handler.handleRunCommand(ctx, chatID, args[0])
 		} else {
-			_, _ = c.handler.client.SendMessage(ctx, chatID, "Usage: /run <task-id>\nExample: /run 07", "")
+			_, _ = c.handler.client.SendMessage(ctx, chatID, "Usage: /run <task-id>\nExample: /run 07", "", 0)
 		}
 	case "/stop":
 		c.handleStop(ctx, chatID)
@@ -78,16 +78,16 @@ func (c *CommandHandler) HandleCommand(ctx context.Context, chatID, text string)
 		if len(args) > 0 {
 			c.handleNoPR(ctx, chatID, strings.Join(args, " "))
 		} else {
-			_, _ = c.handler.client.SendMessage(ctx, chatID, "Usage: /nopr <task description>\nExecutes task without creating a PR.", "")
+			_, _ = c.handler.client.SendMessage(ctx, chatID, "Usage: /nopr <task description>\nExecutes task without creating a PR.", "", 0)
 		}
 	case "/pr":
 		if len(args) > 0 {
 			c.handleForcePR(ctx, chatID, strings.Join(args, " "))
 		} else {
-			_, _ = c.handler.client.SendMessage(ctx, chatID, "Usage: /pr <task description>\nForces PR creation even for ephemeral-looking tasks.", "")
+			_, _ = c.handler.client.SendMessage(ctx, chatID, "Usage: /pr <task description>\nForces PR creation even for ephemeral-looking tasks.", "", 0)
 		}
 	default:
-		_, _ = c.handler.client.SendMessage(ctx, chatID, "Unknown command. Use /help for available commands.", "")
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "Unknown command. Use /help for available commands.", "", 0)
 	}
 }
 
@@ -164,7 +164,7 @@ I execute tasks and answer questions about your codebase.
 _Note: Ephemeral commands (serve, run, etc.) auto-skip PR creation._`
 	}
 
-	_, _ = c.handler.client.SendMessage(ctx, chatID, helpText, c.handler.getParseMode())
+	_, _ = c.handler.client.SendMessage(ctx, chatID, helpText, c.handler.getParseMode(), 0)
 }
 
 // handleStatus shows current status with running/pending/queue info
@@ -232,40 +232,39 @@ func (c *CommandHandler) handleStatus(ctx context.Context, chatID string) {
 		sb.WriteString("\n✅ Ready for tasks")
 	}
 
-	_, _ = c.handler.client.SendMessage(ctx, chatID, sb.String(), c.handler.getParseMode())
+	_, _ = c.handler.client.SendMessage(ctx, chatID, sb.String(), c.handler.getParseMode(), 0)
 }
 
 // handleCancel cancels pending or running task
 func (c *CommandHandler) handleCancel(ctx context.Context, chatID string) {
 	if c.handler.commsHandler != nil {
 		if err := c.handler.commsHandler.CancelTask(ctx, chatID); err != nil {
-			_, _ = c.handler.client.SendMessage(ctx, chatID, "No task to cancel.", "")
+			_, _ = c.handler.client.SendMessage(ctx, chatID, "No task to cancel.", "", 0)
 		}
 		return
 	}
-	_, _ = c.handler.client.SendMessage(ctx, chatID, "No task to cancel.", "")
+	_, _ = c.handler.client.SendMessage(ctx, chatID, "No task to cancel.", "", 0)
 }
 
 // handleQueue shows queued tasks
 func (c *CommandHandler) handleQueue(ctx context.Context, chatID string) {
 	if c.store == nil {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, "📋 Queue not available (no memory store)", "")
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "📋 Queue not available (no memory store)", "", 0)
 		return
 	}
 
 	queued, err := c.store.GetQueuedTasks(10)
 	if err != nil {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, "❌ Failed to fetch queue", "")
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "❌ Failed to fetch queue", "", 0)
 		return
 	}
 
 	if len(queued) == 0 {
 		// Show pending task as fallback
 		if c.handler.commsHandler != nil && c.handler.commsHandler.GetPendingTask(chatID) != nil {
-			_, _ = c.handler.client.SendMessage(ctx, chatID,
-				"📋 No queued tasks\n⏳ 1 pending confirmation", "")
+			_, _ = c.handler.client.SendMessage(ctx, chatID, "📋 No queued tasks\n⏳ 1 pending confirmation", "", 0)
 		} else {
-			_, _ = c.handler.client.SendMessage(ctx, chatID, "📋 Queue is empty", "")
+			_, _ = c.handler.client.SendMessage(ctx, chatID, "📋 Queue is empty", "", 0)
 		}
 		return
 	}
@@ -289,21 +288,19 @@ func (c *CommandHandler) handleQueue(ctx context.Context, chatID string) {
 		sb.WriteString(fmt.Sprintf("   📁 %s • ⏱ %s ago\n\n", filepath.Base(task.ProjectPath), age))
 	}
 
-	_, _ = c.handler.client.SendMessage(ctx, chatID, sb.String(), c.handler.getParseMode())
+	_, _ = c.handler.client.SendMessage(ctx, chatID, sb.String(), c.handler.getParseMode(), 0)
 }
 
 // handleProjects lists configured projects
 func (c *CommandHandler) handleProjects(ctx context.Context, chatID string) {
 	if c.handler.projects == nil {
-		_, _ = c.handler.client.SendMessage(ctx, chatID,
-			"📁 No projects configured.\n\nAdd projects to ~/.pilot/config.yaml", "")
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "📁 No projects configured.\n\nAdd projects to ~/.pilot/config.yaml", "", 0)
 		return
 	}
 
 	projects := c.handler.projects.ListProjects()
 	if len(projects) == 0 {
-		_, _ = c.handler.client.SendMessage(ctx, chatID,
-			"📁 No projects configured.\n\nAdd projects to ~/.pilot/config.yaml", "")
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "📁 No projects configured.\n\nAdd projects to ~/.pilot/config.yaml", "", 0)
 		return
 	}
 
@@ -346,9 +343,9 @@ func (c *CommandHandler) handleProjects(ctx context.Context, chatID string) {
 	}
 
 	if len(keyboard) > 0 {
-		_, _ = c.handler.client.SendMessageWithKeyboard(ctx, chatID, sb.String(), c.handler.getParseMode(), keyboard)
+		_, _ = c.handler.client.SendMessageWithKeyboard(ctx, chatID, sb.String(), c.handler.getParseMode(), keyboard, 0)
 	} else {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, sb.String(), c.handler.getParseMode())
+		_, _ = c.handler.client.SendMessage(ctx, chatID, sb.String(), c.handler.getParseMode(), 0)
 	}
 }
 
@@ -367,8 +364,7 @@ func (c *CommandHandler) handleSwitch(ctx context.Context, chatID, projectName s
 		}
 
 		if err != nil {
-			_, _ = c.handler.client.SendMessage(ctx, chatID,
-				fmt.Sprintf("❌ Project '%s' not found\n\nUse /projects to see available projects", projectName), "")
+			_, _ = c.handler.client.SendMessage(ctx, chatID, fmt.Sprintf("❌ Project '%s' not found\n\nUse /projects to see available projects", projectName), "", 0)
 			return
 		}
 	}
@@ -383,7 +379,7 @@ func (c *CommandHandler) handleSwitch(ctx context.Context, chatID, projectName s
 	} else {
 		text = fmt.Sprintf("✅ Switched to *%s*%s\n`%s`", escapeMarkdown(proj.Name), nav, proj.Path)
 	}
-	_, _ = c.handler.client.SendMessage(ctx, chatID, text, c.handler.getParseMode())
+	_, _ = c.handler.client.SendMessage(ctx, chatID, text, c.handler.getParseMode(), 0)
 }
 
 // handleCurrentProject shows current active project
@@ -408,24 +404,24 @@ func (c *CommandHandler) handleCurrentProject(ctx context.Context, chatID string
 	} else {
 		text = fmt.Sprintf("📁 Active: *%s*%s\n`%s`\n\nUse /projects to see all", escapeMarkdown(projName), nav, activeProjectPath)
 	}
-	_, _ = c.handler.client.SendMessage(ctx, chatID, text, c.handler.getParseMode())
+	_, _ = c.handler.client.SendMessage(ctx, chatID, text, c.handler.getParseMode(), 0)
 }
 
 // handleHistory shows recent task history
 func (c *CommandHandler) handleHistory(ctx context.Context, chatID string) {
 	if c.store == nil {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, "📜 History not available (no memory store)", "")
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "📜 History not available (no memory store)", "", 0)
 		return
 	}
 
 	executions, err := c.store.GetRecentExecutions(10, "")
 	if err != nil {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, "❌ Failed to fetch history", "")
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "❌ Failed to fetch history", "", 0)
 		return
 	}
 
 	if len(executions) == 0 {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, "📜 No task history yet", "")
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "📜 No task history yet", "", 0)
 		return
 	}
 
@@ -478,13 +474,13 @@ func (c *CommandHandler) handleHistory(ctx context.Context, chatID string) {
 		sb.WriteString("\n")
 	}
 
-	_, _ = c.handler.client.SendMessage(ctx, chatID, sb.String(), c.handler.getParseMode())
+	_, _ = c.handler.client.SendMessage(ctx, chatID, sb.String(), c.handler.getParseMode(), 0)
 }
 
 // handleBudget shows usage and costs
 func (c *CommandHandler) handleBudget(ctx context.Context, chatID string) {
 	if c.store == nil {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, "💰 Budget not available (no memory store)", "")
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "💰 Budget not available (no memory store)", "", 0)
 		return
 	}
 
@@ -497,7 +493,7 @@ func (c *CommandHandler) handleBudget(ctx context.Context, chatID string) {
 		End:   now,
 	})
 	if err != nil {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, "❌ Failed to fetch usage data", "")
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "❌ Failed to fetch usage data", "", 0)
 		return
 	}
 
@@ -554,14 +550,14 @@ func (c *CommandHandler) handleBudget(ctx context.Context, chatID string) {
 		sb.WriteString(fmt.Sprintf("\n_Period: %s - %s_", monthStart.Format("Jan 2"), now.Format("Jan 2")))
 	}
 
-	_, _ = c.handler.client.SendMessage(ctx, chatID, sb.String(), c.handler.getParseMode())
+	_, _ = c.handler.client.SendMessage(ctx, chatID, sb.String(), c.handler.getParseMode(), 0)
 }
 
 // handleTasks shows task backlog
 func (c *CommandHandler) handleTasks(ctx context.Context, chatID string) {
 	taskList := c.handler.fastListTasks()
 	if taskList == "" {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, "📋 No tasks found in .agent/tasks/", "")
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "📋 No tasks found in .agent/tasks/", "", 0)
 		return
 	}
 	var text string
@@ -570,7 +566,7 @@ func (c *CommandHandler) handleTasks(ctx context.Context, chatID string) {
 	} else {
 		text = "📋 *Task Backlog*\n\n" + taskList
 	}
-	_, _ = c.handler.client.SendMessage(ctx, chatID, text, c.handler.getParseMode())
+	_, _ = c.handler.client.SendMessage(ctx, chatID, text, c.handler.getParseMode(), 0)
 }
 
 // handleStop stops a running task
@@ -578,7 +574,7 @@ func (c *CommandHandler) handleStop(ctx context.Context, chatID string) {
 	if c.handler.commsHandler != nil {
 		running := c.handler.commsHandler.GetRunningTask(chatID)
 		if running == nil {
-			_, _ = c.handler.client.SendMessage(ctx, chatID, "No task is currently running.", "")
+			_, _ = c.handler.client.SendMessage(ctx, chatID, "No task is currently running.", "", 0)
 			return
 		}
 		_ = c.handler.commsHandler.CancelTask(ctx, chatID)
@@ -588,26 +584,25 @@ func (c *CommandHandler) handleStop(ctx context.Context, chatID string) {
 		} else {
 			text = fmt.Sprintf("🛑 Stopped task `%s`", running.TaskID)
 		}
-		_, _ = c.handler.client.SendMessage(ctx, chatID, text, c.handler.getParseMode())
+		_, _ = c.handler.client.SendMessage(ctx, chatID, text, c.handler.getParseMode(), 0)
 		return
 	}
-	_, _ = c.handler.client.SendMessage(ctx, chatID, "No task is currently running.", "")
+	_, _ = c.handler.client.SendMessage(ctx, chatID, "No task is currently running.", "", 0)
 }
 
 // handleBrief generates and sends a daily brief on demand
 func (c *CommandHandler) handleBrief(ctx context.Context, chatID string) {
 	if c.store == nil {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, "📋 Brief not available (no memory store)", "")
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "📋 Brief not available (no memory store)", "", 0)
 		return
 	}
 
-	_, _ = c.handler.client.SendMessage(ctx, chatID, "📊 Generating brief...", "")
+	_, _ = c.handler.client.SendMessage(ctx, chatID, "📊 Generating brief...", "", 0)
 
 	generator := briefs.NewGenerator(c.store, nil)
 	brief, err := generator.GenerateDaily()
 	if err != nil {
-		_, _ = c.handler.client.SendMessage(ctx, chatID,
-			fmt.Sprintf("❌ Failed to generate brief: %s", err.Error()), "")
+		_, _ = c.handler.client.SendMessage(ctx, chatID, fmt.Sprintf("❌ Failed to generate brief: %s", err.Error()), "", 0)
 		return
 	}
 
@@ -615,12 +610,11 @@ func (c *CommandHandler) handleBrief(ctx context.Context, chatID string) {
 	formatter := briefs.NewPlainTextFormatter()
 	text, err := formatter.Format(brief)
 	if err != nil {
-		_, _ = c.handler.client.SendMessage(ctx, chatID,
-			fmt.Sprintf("❌ Failed to format brief: %s", err.Error()), "")
+		_, _ = c.handler.client.SendMessage(ctx, chatID, fmt.Sprintf("❌ Failed to format brief: %s", err.Error()), "", 0)
 		return
 	}
 
-	_, _ = c.handler.client.SendMessage(ctx, chatID, text, "")
+	_, _ = c.handler.client.SendMessage(ctx, chatID, text, "", 0)
 }
 
 // formatTimeAgo formats a time as relative (e.g., "2h ago", "3d ago")
@@ -649,8 +643,7 @@ func (c *CommandHandler) HandleCallbackSwitch(ctx context.Context, chatID, proje
 // handleNoPR executes a task without creating a PR
 func (c *CommandHandler) handleNoPR(ctx context.Context, chatID, description string) {
 	taskID := fmt.Sprintf("TG-%d", time.Now().Unix())
-	_, _ = c.handler.client.SendMessage(ctx, chatID,
-		fmt.Sprintf("🚀 Executing without PR: %s", truncateForDisplay(description, 50)), "")
+	_, _ = c.handler.client.SendMessage(ctx, chatID, fmt.Sprintf("🚀 Executing without PR: %s", truncateForDisplay(description, 50)), "", 0)
 	if c.handler.commsHandler != nil {
 		forcePR := false
 		c.handler.commsHandler.ExecuteDirectTask(ctx, chatID, "", taskID, description, &comms.DirectTaskOpts{
@@ -662,8 +655,7 @@ func (c *CommandHandler) handleNoPR(ctx context.Context, chatID, description str
 // handleForcePR executes a task and forces PR creation
 func (c *CommandHandler) handleForcePR(ctx context.Context, chatID, description string) {
 	taskID := fmt.Sprintf("TG-%d", time.Now().Unix())
-	_, _ = c.handler.client.SendMessage(ctx, chatID,
-		fmt.Sprintf("🚀 Executing with PR: %s", truncateForDisplay(description, 50)), "")
+	_, _ = c.handler.client.SendMessage(ctx, chatID, fmt.Sprintf("🚀 Executing with PR: %s", truncateForDisplay(description, 50)), "", 0)
 	if c.handler.commsHandler != nil {
 		forcePR := true
 		c.handler.commsHandler.ExecuteDirectTask(ctx, chatID, "", taskID, description, &comms.DirectTaskOpts{

--- a/internal/adapters/telegram/handler.go
+++ b/internal/adapters/telegram/handler.go
@@ -471,8 +471,7 @@ func (h *Handler) handleRunCommand(ctx context.Context, chatID, taskIDInput stri
 	if h.commsHandler != nil {
 		if running := h.commsHandler.GetRunningTask(chatID); running != nil {
 			elapsed := time.Since(running.StartedAt).Round(time.Second)
-			_, _ = h.client.SendMessage(ctx, chatID,
-				fmt.Sprintf("⚠️ Already running %s (%s)\n\nUse /stop to cancel it first.", running.TaskID, elapsed), "")
+			_, _ = h.client.SendMessage(ctx, chatID, fmt.Sprintf("⚠️ Already running %s (%s)\n\nUse /stop to cancel it first.", running.TaskID, elapsed), "", 0)
 			return
 		}
 	}
@@ -480,22 +479,19 @@ func (h *Handler) handleRunCommand(ctx context.Context, chatID, taskIDInput stri
 	// Resolve task ID
 	taskInfo := h.resolveTaskID(taskIDInput)
 	if taskInfo == nil {
-		_, _ = h.client.SendMessage(ctx, chatID,
-			fmt.Sprintf("❌ Task %s not found\n\nUse /tasks to see available tasks.", taskIDInput), "")
+		_, _ = h.client.SendMessage(ctx, chatID, fmt.Sprintf("❌ Task %s not found\n\nUse /tasks to see available tasks.", taskIDInput), "", 0)
 		return
 	}
 
 	// Load task description
 	description := h.loadTaskDescription(taskInfo)
 	if description == "" {
-		_, _ = h.client.SendMessage(ctx, chatID,
-			fmt.Sprintf("❌ Could not load task %s", taskInfo.FullID), "")
+		_, _ = h.client.SendMessage(ctx, chatID, fmt.Sprintf("❌ Could not load task %s", taskInfo.FullID), "", 0)
 		return
 	}
 
 	// Notify user
-	_, _ = h.client.SendMessage(ctx, chatID,
-		fmt.Sprintf("🚀 Starting task\n\n%s: %s", taskInfo.FullID, taskInfo.Title), "")
+	_, _ = h.client.SendMessage(ctx, chatID, fmt.Sprintf("🚀 Starting task\n\n%s: %s", taskInfo.FullID, taskInfo.Title), "", 0)
 
 	// Execute directly via commsHandler
 	if h.commsHandler != nil {
@@ -524,13 +520,13 @@ func (h *Handler) handlePhoto(ctx context.Context, chatID string, msg *Message) 
 		slog.String("chat_id", chatID), slog.Int("width", photo.Width), slog.Int("height", photo.Height))
 
 	// Send acknowledgment
-	_, _ = h.client.SendMessage(ctx, chatID, "📷 Processing image...", "")
+	_, _ = h.client.SendMessage(ctx, chatID, "📷 Processing image...", "", 0)
 
 	// Download the image
 	imagePath, err := h.downloadImage(ctx, photo.FileID)
 	if err != nil {
 		logging.WithComponent("telegram").Warn("Failed to download image", slog.Any("error", err))
-		_, _ = h.client.SendMessage(ctx, chatID, "❌ Failed to download image. Please try again.", "")
+		_, _ = h.client.SendMessage(ctx, chatID, "❌ Failed to download image. Please try again.", "", 0)
 		return
 	}
 	defer func() {
@@ -572,7 +568,7 @@ func (h *Handler) handleVoice(ctx context.Context, chatID string, msg *Message) 
 	if h.transcriber == nil {
 		logging.WithComponent("telegram").Debug("Voice message received but transcription not configured")
 		msg := h.voiceNotAvailableMessage()
-		_, _ = h.client.SendMessage(ctx, chatID, msg, "")
+		_, _ = h.client.SendMessage(ctx, chatID, msg, "", 0)
 		return
 	}
 
@@ -581,13 +577,13 @@ func (h *Handler) handleVoice(ctx context.Context, chatID string, msg *Message) 
 		slog.String("chat_id", chatID), slog.Int("duration", voice.Duration))
 
 	// Send acknowledgment
-	_, _ = h.client.SendMessage(ctx, chatID, "🎤 Transcribing voice message...", "")
+	_, _ = h.client.SendMessage(ctx, chatID, "🎤 Transcribing voice message...", "", 0)
 
 	// Download the voice file
 	audioPath, err := h.downloadAudio(ctx, voice.FileID)
 	if err != nil {
 		logging.WithComponent("telegram").Warn("Failed to download voice", slog.Any("error", err))
-		_, _ = h.client.SendMessage(ctx, chatID, "❌ Failed to download voice message. Please try again.", "")
+		_, _ = h.client.SendMessage(ctx, chatID, "❌ Failed to download voice message. Please try again.", "", 0)
 		return
 	}
 	defer func() {
@@ -601,14 +597,12 @@ func (h *Handler) handleVoice(ctx context.Context, chatID string, msg *Message) 
 	result, err := h.transcriber.Transcribe(transcribeCtx, audioPath)
 	if err != nil {
 		logging.WithComponent("telegram").Warn("Transcription failed", slog.Any("error", err))
-		_, _ = h.client.SendMessage(ctx, chatID,
-			"❌ Failed to transcribe voice message. Please try again or send as text.", "")
+		_, _ = h.client.SendMessage(ctx, chatID, "❌ Failed to transcribe voice message. Please try again or send as text.", "", 0)
 		return
 	}
 
 	if result.Text == "" {
-		_, _ = h.client.SendMessage(ctx, chatID,
-			"🤷 Couldn't understand the voice message. Please try again or send as text.", "")
+		_, _ = h.client.SendMessage(ctx, chatID, "🤷 Couldn't understand the voice message. Please try again or send as text.", "", 0)
 		return
 	}
 
@@ -619,7 +613,7 @@ func (h *Handler) handleVoice(ctx context.Context, chatID string, msg *Message) 
 	}
 
 	transcriptMsg := fmt.Sprintf("🎤 Transcribed%s:\n%s", langInfo, result.Text)
-	_, _ = h.client.SendMessage(ctx, chatID, transcriptMsg, "")
+	_, _ = h.client.SendMessage(ctx, chatID, transcriptMsg, "", 0)
 
 	// Delegate transcribed text to commsHandler
 	text := strings.TrimSpace(result.Text)
@@ -1212,7 +1206,7 @@ func (h *Handler) sendVoiceSetupPrompt(ctx context.Context, chatID string) {
 	if status.OpenAIKeySet {
 		sb.WriteString("✅ Voice transcription is ready!\n")
 		sb.WriteString("Backend: Whisper API")
-		_, _ = h.client.SendMessage(ctx, chatID, sb.String(), "")
+		_, _ = h.client.SendMessage(ctx, chatID, sb.String(), "", 0)
 		return
 	}
 
@@ -1225,5 +1219,5 @@ func (h *Handler) sendVoiceSetupPrompt(ctx context.Context, chatID string) {
 		{Text: "🔍 Check Status", CallbackData: "voice_check_status"},
 	})
 
-	_, _ = h.client.SendMessageWithKeyboard(ctx, chatID, sb.String(), "", buttons)
+	_, _ = h.client.SendMessageWithKeyboard(ctx, chatID, sb.String(), "", buttons, 0)
 }

--- a/internal/adapters/telegram/messenger.go
+++ b/internal/adapters/telegram/messenger.go
@@ -33,9 +33,17 @@ func (m *TelegramMessenger) parseMode() string {
 	return "Markdown"
 }
 
+func parseThreadID(threadID string) int64 {
+	id, err := strconv.ParseInt(threadID, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return id
+}
+
 // SendText sends a plain text message to the given chat.
 func (m *TelegramMessenger) SendText(ctx context.Context, contextID, text string) error {
-	_, err := m.client.SendMessage(ctx, contextID, text, m.parseMode())
+	_, err := m.client.SendMessage(ctx, contextID, text, m.parseMode(), 0)
 	return err
 }
 
@@ -51,7 +59,7 @@ func (m *TelegramMessenger) SendConfirmation(ctx context.Context, contextID, thr
 		},
 	}
 
-	resp, err := m.client.SendMessageWithKeyboard(ctx, contextID, text, m.parseMode(), keyboard)
+	resp, err := m.client.SendMessageWithKeyboard(ctx, contextID, text, m.parseMode(), keyboard, parseThreadID(threadID))
 	if err != nil {
 		return "", fmt.Errorf("send confirmation: %w", err)
 	}
@@ -100,7 +108,7 @@ func (m *TelegramMessenger) SendResult(ctx context.Context, contextID, threadID,
 		text += fmt.Sprintf("\n\n🔗 PR: %s", prURL)
 	}
 
-	_, err := m.client.SendMessage(ctx, contextID, text, m.parseMode())
+	_, err := m.client.SendMessage(ctx, contextID, text, m.parseMode(), parseThreadID(threadID))
 	return err
 }
 
@@ -112,7 +120,7 @@ func (m *TelegramMessenger) SendChunked(ctx context.Context, contextID, threadID
 		if prefix != "" && i == 0 {
 			text = prefix + "\n\n" + chunk
 		}
-		if _, err := m.client.SendMessage(ctx, contextID, text, m.parseMode()); err != nil {
+		if _, err := m.client.SendMessage(ctx, contextID, text, m.parseMode(), parseThreadID(threadID)); err != nil {
 			return fmt.Errorf("send chunk %d: %w", i, err)
 		}
 	}

--- a/internal/adapters/telegram/messenger_test.go
+++ b/internal/adapters/telegram/messenger_test.go
@@ -211,3 +211,53 @@ func TestTelegramMessenger_MaxMessageLength(t *testing.T) {
 		t.Errorf("expected 4000, got %d", got)
 	}
 }
+
+func TestTelegramMessenger_ForwardsThreadID(t *testing.T) {
+	sends := map[string]func(m *TelegramMessenger, threadID string) error{
+		"SendConfirmation": func(m *TelegramMessenger, threadID string) error {
+			_, err := m.SendConfirmation(context.Background(), "123", threadID, "TASK-1", "Add feature", "/project")
+			return err
+		},
+		"SendResult": func(m *TelegramMessenger, threadID string) error {
+			return m.SendResult(context.Background(), "123", threadID, "TASK-1", true, "done", "")
+		},
+		"SendChunked": func(m *TelegramMessenger, threadID string) error {
+			return m.SendChunked(context.Background(), "123", threadID, "short content", "")
+		},
+	}
+
+	tests := []struct {
+		name      string
+		threadID  string
+		wantKey   bool
+		wantValue float64
+	}{
+		{name: "forum topic", threadID: "99", wantKey: true, wantValue: 99},
+		{name: "empty thread id", threadID: "", wantKey: false},
+		{name: "unparseable thread id", threadID: "general", wantKey: false},
+	}
+
+	for method, send := range sends {
+		for _, tt := range tests {
+			t.Run(method+"/"+tt.name, func(t *testing.T) {
+				var raw map[string]interface{}
+				m := newTestMessenger(t, func(w http.ResponseWriter, r *http.Request) {
+					_ = json.NewDecoder(r.Body).Decode(&raw)
+					_ = json.NewEncoder(w).Encode(SendMessageResponse{OK: true, Result: &Result{MessageID: 1}})
+				})
+
+				if err := send(m, tt.threadID); err != nil {
+					t.Fatalf("%s returned error: %v", method, err)
+				}
+
+				got, ok := raw["message_thread_id"]
+				if ok != tt.wantKey {
+					t.Fatalf("message_thread_id present = %v, want %v", ok, tt.wantKey)
+				}
+				if tt.wantKey && got != tt.wantValue {
+					t.Errorf("message_thread_id = %v, want %v", got, tt.wantValue)
+				}
+			})
+		}
+	}
+}

--- a/internal/adapters/telegram/notifier.go
+++ b/internal/adapters/telegram/notifier.go
@@ -11,9 +11,11 @@ import (
 
 // Config holds Telegram adapter configuration
 type Config struct {
-	Enabled       bool                   `yaml:"enabled"`
-	BotToken      string                 `yaml:"bot_token"`
-	ChatID        string                 `yaml:"chat_id"`
+	Enabled         bool   `yaml:"enabled"`
+	BotToken        string `yaml:"bot_token"`
+	ChatID          string `yaml:"chat_id"`
+	MessageThreadID int64  `yaml:"message_thread_id"`
+
 	Polling       bool                   `yaml:"polling"`         // Enable inbound polling
 	SDKBridge     bool                   `yaml:"sdk_bridge"`      // GH-3470: drive inbound via the studio-sdk chat bridge instead of the local long-poll loop (opt-in; default off)
 	AllowedIDs    []int64                `yaml:"allowed_ids"`     // User/chat IDs allowed to send tasks
@@ -53,17 +55,19 @@ func DefaultConfig() *Config {
 
 // Notifier sends notifications to Telegram
 type Notifier struct {
-	client        *Client
-	chatID        string
-	plainTextMode bool
+	client          *Client
+	chatID          string
+	messageThreadID int64
+	plainTextMode   bool
 }
 
 // NewNotifier creates a new Telegram notifier
 func NewNotifier(config *Config) *Notifier {
 	return &Notifier{
-		client:        NewClient(config.BotToken),
-		chatID:        config.ChatID,
-		plainTextMode: config.PlainTextMode,
+		client:          NewClient(config.BotToken),
+		chatID:          config.ChatID,
+		messageThreadID: config.MessageThreadID,
+		plainTextMode:   config.PlainTextMode,
 	}
 }
 
@@ -78,7 +82,7 @@ func (n *Notifier) getParseMode() string {
 
 // SendMessage sends a plain text message
 func (n *Notifier) SendMessage(ctx context.Context, text string) error {
-	_, err := n.client.SendMessage(ctx, n.chatID, text, "")
+	_, err := n.client.SendMessage(ctx, n.chatID, text, "", n.messageThreadID)
 	return err
 }
 
@@ -90,7 +94,7 @@ func (n *Notifier) SendTaskStarted(ctx context.Context, taskID, title string) er
 	} else {
 		text = fmt.Sprintf("🚀 *Pilot started task*\n`%s` %s", taskID, escapeMarkdown(title))
 	}
-	_, err := n.client.SendMessage(ctx, n.chatID, text, n.getParseMode())
+	_, err := n.client.SendMessage(ctx, n.chatID, text, n.getParseMode(), n.messageThreadID)
 	return err
 }
 
@@ -108,7 +112,7 @@ func (n *Notifier) SendTaskCompleted(ctx context.Context, taskID, title, prURL s
 			text += fmt.Sprintf("\n\n[PR ready for review](%s)", prURL)
 		}
 	}
-	_, err := n.client.SendMessage(ctx, n.chatID, text, n.getParseMode())
+	_, err := n.client.SendMessage(ctx, n.chatID, text, n.getParseMode(), n.messageThreadID)
 	return err
 }
 
@@ -120,7 +124,7 @@ func (n *Notifier) SendTaskFailed(ctx context.Context, taskID, title, errorMsg s
 	} else {
 		text = fmt.Sprintf("❌ *Pilot task failed*\n`%s` %s\n\n```\n%s\n```", taskID, escapeMarkdown(title), errorMsg)
 	}
-	_, err := n.client.SendMessage(ctx, n.chatID, text, n.getParseMode())
+	_, err := n.client.SendMessage(ctx, n.chatID, text, n.getParseMode(), n.messageThreadID)
 	return err
 }
 
@@ -133,7 +137,7 @@ func (n *Notifier) TaskProgress(ctx context.Context, taskID, status string, prog
 	} else {
 		text = fmt.Sprintf("⏳ *Task Progress*\n`%s` %s\n%s %d%%", taskID, escapeMarkdown(status), progressBar, progress)
 	}
-	_, err := n.client.SendMessage(ctx, n.chatID, text, n.getParseMode())
+	_, err := n.client.SendMessage(ctx, n.chatID, text, n.getParseMode(), n.messageThreadID)
 	return err
 }
 
@@ -145,7 +149,7 @@ func (n *Notifier) PRReady(ctx context.Context, taskID, title, prURL string, fil
 	} else {
 		text = fmt.Sprintf("🔔 *PR Ready for Review*\n`%s` %s\n\n[View PR](%s) • %d files changed", taskID, escapeMarkdown(title), prURL, filesChanged)
 	}
-	_, err := n.client.SendMessage(ctx, n.chatID, text, n.getParseMode())
+	_, err := n.client.SendMessage(ctx, n.chatID, text, n.getParseMode(), n.messageThreadID)
 	return err
 }
 
@@ -190,7 +194,7 @@ func (n *Notifier) SendBudgetWarning(ctx context.Context, alertType, message str
 	} else {
 		text = fmt.Sprintf("%s *%s*\n\n%s", icon, title, escapeMarkdown(message))
 	}
-	_, err := n.client.SendMessage(ctx, n.chatID, text, n.getParseMode())
+	_, err := n.client.SendMessage(ctx, n.chatID, text, n.getParseMode(), n.messageThreadID)
 	return err
 }
 
@@ -202,7 +206,7 @@ func (n *Notifier) SendBudgetPaused(ctx context.Context, reason string) error {
 	} else {
 		text = fmt.Sprintf("🛑 *Task Execution Paused*\n\n%s\n\nNew tasks will not start until limits reset or budget is increased.", escapeMarkdown(reason))
 	}
-	_, err := n.client.SendMessage(ctx, n.chatID, text, n.getParseMode())
+	_, err := n.client.SendMessage(ctx, n.chatID, text, n.getParseMode(), n.messageThreadID)
 	return err
 }
 
@@ -214,7 +218,7 @@ func (n *Notifier) SendTaskBlocked(ctx context.Context, taskID, reason string) e
 	} else {
 		text = fmt.Sprintf("⛔ *Task Blocked*\n`%s`\n\n%s", taskID, escapeMarkdown(reason))
 	}
-	_, err := n.client.SendMessage(ctx, n.chatID, text, n.getParseMode())
+	_, err := n.client.SendMessage(ctx, n.chatID, text, n.getParseMode(), n.messageThreadID)
 	return err
 }
 

--- a/internal/adapters/telegram/notifier_test.go
+++ b/internal/adapters/telegram/notifier_test.go
@@ -478,3 +478,46 @@ func TestNotifierPlainTextModeConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestNotifierSendsConfiguredMessageThreadID(t *testing.T) {
+	tests := []struct {
+		name            string
+		messageThreadID int64
+		wantKey         bool
+		wantValue       float64
+	}{
+		{name: "no topic configured", messageThreadID: 0, wantKey: false},
+		{name: "topic configured", messageThreadID: 321, wantKey: true, wantValue: 321},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var raw map[string]interface{}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewDecoder(r.Body).Decode(&raw)
+				_ = json.NewEncoder(w).Encode(SendMessageResponse{OK: true, Result: &Result{MessageID: 1}})
+			}))
+			defer server.Close()
+
+			notifier := NewNotifier(&Config{
+				BotToken:        testutil.FakeTelegramBotToken,
+				ChatID:          "123456",
+				MessageThreadID: tt.messageThreadID,
+				PlainTextMode:   true,
+			})
+			notifier.client = NewClientWithBaseURL(testutil.FakeTelegramBotToken, server.URL)
+
+			if err := notifier.SendTaskStarted(context.Background(), "TASK-1", "Add feature"); err != nil {
+				t.Fatalf("SendTaskStarted error = %v", err)
+			}
+
+			got, ok := raw["message_thread_id"]
+			if ok != tt.wantKey {
+				t.Fatalf("message_thread_id present = %v, want %v", ok, tt.wantKey)
+			}
+			if tt.wantKey && got != tt.wantValue {
+				t.Errorf("message_thread_id = %v, want %v", got, tt.wantValue)
+			}
+		})
+	}
+}

--- a/internal/alerts/channels.go
+++ b/internal/alerts/channels.go
@@ -132,17 +132,19 @@ func (c *SlackChannel) severityColor(severity Severity) string {
 
 // TelegramChannel sends alerts to Telegram
 type TelegramChannel struct {
-	name   string
-	client *telegram.Client
-	chatID int64
+	name            string
+	client          *telegram.Client
+	chatID          int64
+	messageThreadID int64
 }
 
 // NewTelegramChannel creates a new Telegram alert channel
-func NewTelegramChannel(name string, client *telegram.Client, chatID int64) *TelegramChannel {
+func NewTelegramChannel(name string, client *telegram.Client, chatID, messageThreadID int64) *TelegramChannel {
 	return &TelegramChannel{
-		name:   name,
-		client: client,
-		chatID: chatID,
+		name:            name,
+		client:          client,
+		chatID:          chatID,
+		messageThreadID: messageThreadID,
 	}
 }
 
@@ -156,7 +158,7 @@ func (c *TelegramChannel) Send(ctx context.Context, alert *Alert) error {
 	// MarkdownV2 metacharacter set. Legacy "Markdown" left those escapes as literal
 	// backslashes (e.g. "50\.00") or rejected the entities outright ("can't parse
 	// entities"), silently dropping cost/failure alerts.
-	_, err := c.client.SendMessage(ctx, chatID, text, "MarkdownV2")
+	_, err := c.client.SendMessage(ctx, chatID, text, "MarkdownV2", c.messageThreadID)
 	return err
 }
 

--- a/internal/alerts/channels_test.go
+++ b/internal/alerts/channels_test.go
@@ -585,7 +585,7 @@ func TestTelegramChannel_UsesMarkdownV2_E4(t *testing.T) {
 	defer server.Close()
 
 	client := telegram.NewClientWithBaseURL("test-telegram-token", server.URL)
-	ch := NewTelegramChannel("test", client, 123456789)
+	ch := NewTelegramChannel("test", client, 123456789, 0)
 
 	alert := &Alert{
 		ID:          "a1",
@@ -1072,6 +1072,52 @@ func TestFormatAlertDuration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := formatAlertDuration(tt.d); got != tt.want {
 				t.Errorf("formatAlertDuration(%v) = %q, want %q", tt.d, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTelegramChannelSendsMessageThreadID(t *testing.T) {
+	tests := []struct {
+		name            string
+		messageThreadID int64
+		wantKey         bool
+		wantValue       float64
+	}{
+		{name: "no topic configured", messageThreadID: 0, wantKey: false},
+		{name: "topic configured", messageThreadID: 555, wantKey: true, wantValue: 555},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var raw map[string]interface{}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewDecoder(r.Body).Decode(&raw)
+				_, _ = w.Write([]byte(`{"ok":true,"result":{"message_id":1}}`))
+			}))
+			defer server.Close()
+
+			client := telegram.NewClientWithBaseURL(testutil.FakeTelegramBotToken, server.URL)
+			ch := NewTelegramChannel("test", client, 123456789, tt.messageThreadID)
+
+			alert := &Alert{
+				ID:        "a1",
+				Type:      AlertTypeTaskFailed,
+				Severity:  SeverityCritical,
+				Title:     "Task failed",
+				Message:   "investigate now",
+				CreatedAt: time.Now(),
+			}
+			if err := ch.Send(context.Background(), alert); err != nil {
+				t.Fatalf("Send() error = %v", err)
+			}
+
+			got, ok := raw["message_thread_id"]
+			if ok != tt.wantKey {
+				t.Fatalf("message_thread_id present = %v, want %v", ok, tt.wantKey)
+			}
+			if tt.wantKey && got != tt.wantValue {
+				t.Errorf("message_thread_id = %v, want %v", got, tt.wantValue)
 			}
 		})
 	}

--- a/internal/alerts/types.go
+++ b/internal/alerts/types.go
@@ -270,7 +270,8 @@ type SlackChannelConfig struct {
 
 // TelegramChannelConfig for Telegram alerts
 type TelegramChannelConfig struct {
-	ChatID int64 `yaml:"chat_id"`
+	ChatID          int64 `yaml:"chat_id"`
+	MessageThreadID int64 `yaml:"message_thread_id"`
 }
 
 // EmailChannelConfig for email alerts

--- a/internal/approval/channel_test.go
+++ b/internal/approval/channel_test.go
@@ -92,7 +92,7 @@ func TestRehydrate_MixedChannelScenario(t *testing.T) {
 		Title: "Unknown-channel row", PreferredChannel: "webhook", CreatedAt: time.Now(), ExpiresAt: future,
 	})
 
-	telegramHandler := NewTelegramHandler(&mockTelegramClient{}, "chat123").WithStore(store)
+	telegramHandler := NewTelegramHandler(&mockTelegramClient{}, "chat123", 0).WithStore(store)
 	if err := telegramHandler.Rehydrate(context.Background()); err != nil {
 		t.Fatalf("telegram rehydrate: unexpected error: %v", err)
 	}

--- a/internal/approval/telegram.go
+++ b/internal/approval/telegram.go
@@ -32,7 +32,7 @@ type PendingApprovalStore interface {
 // TelegramClient defines the interface for Telegram operations
 // This allows the approval handler to use the existing Telegram client
 type TelegramClient interface {
-	SendMessageWithKeyboard(ctx context.Context, chatID, text, parseMode string, keyboard [][]InlineKeyboardButton) (*MessageResponse, error)
+	SendMessageWithKeyboard(ctx context.Context, chatID, text, parseMode string, keyboard [][]InlineKeyboardButton, messageThreadID int64) (*MessageResponse, error)
 	EditMessage(ctx context.Context, chatID string, messageID int64, text, parseMode string) error
 	AnswerCallback(ctx context.Context, callbackID, text string) error
 }
@@ -55,14 +55,15 @@ type MessageResult struct {
 
 // TelegramHandler handles approval requests via Telegram
 type TelegramHandler struct {
-	client   TelegramClient
-	chatID   string
-	pending  map[string]*telegramPending  // requestID -> pending state
-	resolved map[string]*telegramResolved // requestID -> approved decision (for a later merge follow-up)
-	mu       sync.RWMutex
-	log      *slog.Logger
-	store    PendingApprovalStore // optional; enables restart persistence
-	recorder DecisionRecorder     // optional; persists decisions directly (restart-safe)
+	client          TelegramClient
+	chatID          string
+	messageThreadID int64
+	pending         map[string]*telegramPending  // requestID -> pending state
+	resolved        map[string]*telegramResolved // requestID -> approved decision (for a later merge follow-up)
+	mu              sync.RWMutex
+	log             *slog.Logger
+	store           PendingApprovalStore // optional; enables restart persistence
+	recorder        DecisionRecorder     // optional; persists decisions directly (restart-safe)
 
 	// warnedInvalidDest dedupes the "Approvers[0] is not a valid Telegram
 	// destination" warning per bad value (GH-4380), so a persistently
@@ -97,10 +98,11 @@ type telegramResolved struct {
 const resolvedRetention = 24 * time.Hour
 
 // NewTelegramHandler creates a new Telegram approval handler
-func NewTelegramHandler(client TelegramClient, chatID string) *TelegramHandler {
+func NewTelegramHandler(client TelegramClient, chatID string, messageThreadID int64) *TelegramHandler {
 	return &TelegramHandler{
 		client:            client,
 		chatID:            chatID,
+		messageThreadID:   messageThreadID,
 		pending:           make(map[string]*telegramPending),
 		resolved:          make(map[string]*telegramResolved),
 		log:               logging.WithComponent("approval.telegram"),
@@ -141,6 +143,13 @@ func (h *TelegramHandler) resolveDestChatID(req *Request) string {
 	}
 	h.warnInvalidDestOnce(req.ID, req.Approvers[0])
 	return h.chatID
+}
+
+func (h *TelegramHandler) threadFor(dest string) int64 {
+	if dest != h.chatID {
+		return 0
+	}
+	return h.messageThreadID
 }
 
 // warnInvalidDestOnce logs the first time a given invalid Approvers[0] value
@@ -264,7 +273,7 @@ func (h *TelegramHandler) resendRehydratedPrompt(ctx context.Context, p *telegra
 	text := h.formatRehydratedMessage(p.Request)
 	keyboard := h.createApprovalKeyboard(p.Request)
 
-	resp, err := h.client.SendMessageWithKeyboard(ctx, p.ChatID, text, "", keyboard)
+	resp, err := h.client.SendMessageWithKeyboard(ctx, p.ChatID, text, "", keyboard, h.threadFor(p.ChatID))
 	if err != nil {
 		h.log.Warn("failed to resend rehydrated approval prompt",
 			slog.String("request_id", p.Request.ID), slog.Any("error", err))
@@ -376,7 +385,7 @@ func (h *TelegramHandler) SendApprovalRequest(ctx context.Context, req *Request)
 	destChatID := h.resolveDestChatID(req)
 
 	// Send message
-	resp, err := h.client.SendMessageWithKeyboard(ctx, destChatID, text, "", keyboard)
+	resp, err := h.client.SendMessageWithKeyboard(ctx, destChatID, text, "", keyboard, h.threadFor(destChatID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to send Telegram message: %w", err)
 	}
@@ -627,7 +636,7 @@ func (h *TelegramHandler) deliverResponseCard(ctx context.Context, chatID string
 		h.log.Warn("failed to edit response message, falling back to a new message",
 			slog.String("chat_id", chatID), slog.Int64("message_id", messageID), slog.Any("error", err))
 	}
-	if _, err := h.client.SendMessageWithKeyboard(ctx, chatID, text, "", nil); err != nil {
+	if _, err := h.client.SendMessageWithKeyboard(ctx, chatID, text, "", nil, h.threadFor(chatID)); err != nil {
 		h.log.Warn("failed to send fallback response message",
 			slog.String("chat_id", chatID), slog.Any("error", err))
 	}
@@ -653,7 +662,7 @@ func (h *TelegramHandler) NotifyMerged(ctx context.Context, requestID, shortSHA 
 	}
 
 	text := fmt.Sprintf("🔀 Merged %s", shortSHA)
-	if _, err := h.client.SendMessageWithKeyboard(ctx, r.ChatID, text, "", nil); err != nil {
+	if _, err := h.client.SendMessageWithKeyboard(ctx, r.ChatID, text, "", nil, h.threadFor(r.ChatID)); err != nil {
 		return fmt.Errorf("notify merged: %w", err)
 	}
 	return nil

--- a/internal/approval/telegram_test.go
+++ b/internal/approval/telegram_test.go
@@ -37,6 +37,7 @@ type mockSentMessage struct {
 	ChatID   string
 	Text     string
 	Keyboard [][]InlineKeyboardButton
+	ThreadID int64
 }
 
 type mockEditedMessage struct {
@@ -50,7 +51,7 @@ type mockAnsweredCallback struct {
 	Text       string
 }
 
-func (m *mockTelegramClient) SendMessageWithKeyboard(ctx context.Context, chatID, text, parseMode string, keyboard [][]InlineKeyboardButton) (*MessageResponse, error) {
+func (m *mockTelegramClient) SendMessageWithKeyboard(ctx context.Context, chatID, text, parseMode string, keyboard [][]InlineKeyboardButton, messageThreadID int64) (*MessageResponse, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -62,6 +63,7 @@ func (m *mockTelegramClient) SendMessageWithKeyboard(ctx context.Context, chatID
 		ChatID:   chatID,
 		Text:     text,
 		Keyboard: keyboard,
+		ThreadID: messageThreadID,
 	})
 
 	m.nextMessageID++
@@ -129,7 +131,7 @@ func (m *mockTelegramClient) getAnsweredCallbacks() []mockAnsweredCallback {
 
 func TestTelegramHandler_Name(t *testing.T) {
 	client := &mockTelegramClient{}
-	handler := NewTelegramHandler(client, "12345")
+	handler := NewTelegramHandler(client, "12345", 0)
 
 	if handler.Name() != "telegram" {
 		t.Errorf("expected name 'telegram', got '%s'", handler.Name())
@@ -172,7 +174,7 @@ func TestTelegramHandler_SendApprovalRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := &mockTelegramClient{}
-			handler := NewTelegramHandler(client, "chat123")
+			handler := NewTelegramHandler(client, "chat123", 0)
 
 			req := &Request{
 				ID:        "req-1",
@@ -221,7 +223,7 @@ func TestTelegramHandler_SendApprovalRequest(t *testing.T) {
 
 func TestTelegramHandler_SendApprovalRequest_WithMetadata(t *testing.T) {
 	client := &mockTelegramClient{}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	req := &Request{
 		ID:          "req-meta",
@@ -260,7 +262,7 @@ func TestTelegramHandler_SendApprovalRequest_Error(t *testing.T) {
 	client := &mockTelegramClient{
 		sendError: errors.New("network error"),
 	}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	req := &Request{
 		ID:        "req-err",
@@ -282,7 +284,7 @@ func TestTelegramHandler_SendApprovalRequest_Error(t *testing.T) {
 
 func TestTelegramHandler_CancelRequest(t *testing.T) {
 	client := &mockTelegramClient{}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	req := &Request{
 		ID:        "req-cancel",
@@ -317,7 +319,7 @@ func TestTelegramHandler_CancelRequest(t *testing.T) {
 
 func TestTelegramHandler_CancelRequest_NotFound(t *testing.T) {
 	client := &mockTelegramClient{}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	// Cancel a request that doesn't exist
 	err := handler.CancelRequest(context.Background(), "nonexistent")
@@ -336,7 +338,7 @@ func TestTelegramHandler_CancelRequest_EditError(t *testing.T) {
 	client := &mockTelegramClient{
 		editError: errors.New("edit failed"),
 	}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	req := &Request{
 		ID:        "req-edit-err",
@@ -360,7 +362,7 @@ func TestTelegramHandler_CancelRequest_EditError(t *testing.T) {
 
 func TestTelegramHandler_HandleCallback_Approve(t *testing.T) {
 	client := &mockTelegramClient{}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	req := &Request{
 		ID:        "req-cb-approve",
@@ -418,7 +420,7 @@ func TestTelegramHandler_HandleCallback_Approve(t *testing.T) {
 
 func TestTelegramHandler_HandleCallback_Reject(t *testing.T) {
 	client := &mockTelegramClient{}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	req := &Request{
 		ID:        "req-cb-reject",
@@ -461,7 +463,7 @@ func TestTelegramHandler_HandleCallback_Reject(t *testing.T) {
 
 func TestTelegramHandler_HandleCallback_InvalidFormat(t *testing.T) {
 	client := &mockTelegramClient{}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	tests := []struct {
 		name string
@@ -486,7 +488,7 @@ func TestTelegramHandler_HandleCallback_InvalidFormat(t *testing.T) {
 
 func TestTelegramHandler_HandleCallback_ExpiredRequest(t *testing.T) {
 	client := &mockTelegramClient{}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	// Handle callback for a request that doesn't exist
 	handled := handler.HandleCallback(context.Background(), "cb123", "approve:nonexistent", "user", "username")
@@ -506,7 +508,7 @@ func TestTelegramHandler_HandleCallback_ExpiredRequest(t *testing.T) {
 
 func TestTelegramHandler_HandleCallback_ExpiredButStillPending(t *testing.T) {
 	client := &mockTelegramClient{}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	req := &Request{
 		ID:        "req-expired-race",
@@ -564,7 +566,7 @@ func TestTelegramHandler_HandleCallback_EditError(t *testing.T) {
 	client := &mockTelegramClient{
 		editError: errors.New("edit failed"),
 	}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	req := &Request{
 		ID:        "req-edit-fail",
@@ -694,7 +696,7 @@ func TestFormatDuration(t *testing.T) {
 
 func TestTelegramHandler_FormatApprovalMessage_Stages(t *testing.T) {
 	client := &mockTelegramClient{}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	tests := []struct {
 		stage     Stage
@@ -731,7 +733,7 @@ func TestTelegramHandler_FormatApprovalMessage_Stages(t *testing.T) {
 
 func TestTelegramHandler_FormatResponseMessage(t *testing.T) {
 	client := &mockTelegramClient{}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	req := &Request{
 		ID:     "test",
@@ -772,7 +774,7 @@ func TestTelegramHandler_FormatResponseMessage(t *testing.T) {
 // control paths, which must fall back to the generic APPROVED/REJECTED card.
 func TestTelegramHandler_FormatResponseMessage_ReleasePlan(t *testing.T) {
 	client := &mockTelegramClient{}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	tests := []struct {
 		name         string
@@ -834,7 +836,7 @@ func TestTelegramHandler_FormatResponseMessage_ReleasePlan(t *testing.T) {
 
 func TestTelegramHandler_CreateApprovalKeyboard(t *testing.T) {
 	client := &mockTelegramClient{}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	tests := []struct {
 		stage       Stage
@@ -882,7 +884,7 @@ func TestTelegramHandler_NilMessageResponse(t *testing.T) {
 	// Create a client that returns nil result
 	client := &mockTelegramClient{}
 	// Modify to return nil result
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	req := &Request{
 		ID:        "req-nil",
@@ -905,7 +907,7 @@ func TestTelegramHandler_NilMessageResponse(t *testing.T) {
 func TestTelegramHandler_CancelWithZeroMessageID(t *testing.T) {
 	// Create handler that tracks a request with message ID 0
 	client := &mockTelegramClient{}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	// Manually add a pending request with 0 message ID
 	handler.mu.Lock()
@@ -935,7 +937,7 @@ func TestTelegramHandler_CancelWithZeroMessageID(t *testing.T) {
 
 func TestTelegramHandler_HandleCallbackWithZeroMessageID(t *testing.T) {
 	client := &mockTelegramClient{}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	// Manually add a pending request with 0 message ID
 	respCh := make(chan *Response, 1)
@@ -981,7 +983,7 @@ func TestTelegramHandler_HandleCallbackWithZeroMessageID(t *testing.T) {
 func TestTelegramHandler_ApproverRouting(t *testing.T) {
 	t.Run("uses approver chat_id when set", func(t *testing.T) {
 		client := &mockTelegramClient{}
-		handler := NewTelegramHandler(client, "constructor-chat")
+		handler := NewTelegramHandler(client, "constructor-chat", 0)
 
 		req := &Request{
 			ID:        "req-approver",
@@ -1008,7 +1010,7 @@ func TestTelegramHandler_ApproverRouting(t *testing.T) {
 
 	t.Run("falls back to constructor chat_id when approvers empty", func(t *testing.T) {
 		client := &mockTelegramClient{}
-		handler := NewTelegramHandler(client, "constructor-chat")
+		handler := NewTelegramHandler(client, "constructor-chat", 0)
 
 		req := &Request{
 			ID:        "req-no-approver",
@@ -1035,7 +1037,7 @@ func TestTelegramHandler_ApproverRouting(t *testing.T) {
 
 	t.Run("uses @channel approver as-is", func(t *testing.T) {
 		client := &mockTelegramClient{}
-		handler := NewTelegramHandler(client, "constructor-chat")
+		handler := NewTelegramHandler(client, "constructor-chat", 0)
 
 		req := &Request{
 			ID:        "req-approver-channel",
@@ -1068,7 +1070,7 @@ func TestTelegramHandler_ApproverRouting(t *testing.T) {
 	// incident's PRs #4373/#4374.
 	t.Run("falls back to constructor chat_id when approver is not a valid telegram destination", func(t *testing.T) {
 		client := &mockTelegramClient{}
-		handler := NewTelegramHandler(client, "constructor-chat")
+		handler := NewTelegramHandler(client, "constructor-chat", 0)
 
 		req := &Request{
 			ID:        "req-invalid-approver",
@@ -1095,7 +1097,7 @@ func TestTelegramHandler_ApproverRouting(t *testing.T) {
 
 	t.Run("edit after callback uses same chat_id as original send", func(t *testing.T) {
 		client := &mockTelegramClient{}
-		handler := NewTelegramHandler(client, "constructor-chat")
+		handler := NewTelegramHandler(client, "constructor-chat", 0)
 
 		req := &Request{
 			ID:        "req-edit-routing",
@@ -1153,7 +1155,7 @@ func TestIsValidTelegramChatID(t *testing.T) {
 // approvers list doesn't spam the log every controller tick (GH-4380).
 func TestTelegramHandler_InvalidApprover_WarnsOnce(t *testing.T) {
 	client := &mockTelegramClient{}
-	handler := NewTelegramHandler(client, "constructor-chat")
+	handler := NewTelegramHandler(client, "constructor-chat", 0)
 	logger, buf := newCapturingLogger()
 	handler.log = logger
 
@@ -1284,7 +1286,7 @@ func (s *mockPendingStore) len() int {
 func TestTelegramHandler_WithStore_PersistOnSend(t *testing.T) {
 	client := &mockTelegramClient{}
 	store := newMockPendingStore()
-	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+	handler := NewTelegramHandler(client, "chat123", 0).WithStore(store)
 
 	req := &Request{
 		ID: "persist-1", TaskID: "T-1", Stage: StagePreMerge,
@@ -1312,7 +1314,7 @@ func TestTelegramHandler_WithStore_PersistOnSend(t *testing.T) {
 func TestTelegramHandler_WithStore_PersistsProject(t *testing.T) {
 	client := &mockTelegramClient{}
 	store := newMockPendingStore()
-	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+	handler := NewTelegramHandler(client, "chat123", 0).WithStore(store)
 
 	req := &Request{
 		ID: "persist-project-1", TaskID: "T-1", Stage: StagePreMerge,
@@ -1334,7 +1336,7 @@ func TestTelegramHandler_WithStore_PersistsProject(t *testing.T) {
 func TestTelegramHandler_WithStore_DeleteOnCallback(t *testing.T) {
 	client := &mockTelegramClient{}
 	store := newMockPendingStore()
-	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+	handler := NewTelegramHandler(client, "chat123", 0).WithStore(store)
 
 	req := &Request{
 		ID: "del-cb-1", TaskID: "T-2", Stage: StagePreMerge,
@@ -1357,7 +1359,7 @@ func TestTelegramHandler_WithStore_DeleteOnCallback(t *testing.T) {
 func TestTelegramHandler_WithStore_DeleteOnCancel(t *testing.T) {
 	client := &mockTelegramClient{}
 	store := newMockPendingStore()
-	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+	handler := NewTelegramHandler(client, "chat123", 0).WithStore(store)
 
 	req := &Request{
 		ID: "del-cancel-1", TaskID: "T-3", Stage: StagePreMerge,
@@ -1392,7 +1394,7 @@ func TestTelegramHandler_Rehydrate_RestoреsNonExpired(t *testing.T) {
 		Title: "Dead", CreatedAt: time.Now(), ExpiresAt: past,
 	})
 
-	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+	handler := NewTelegramHandler(client, "chat123", 0).WithStore(store)
 	if err := handler.Rehydrate(context.Background()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1416,7 +1418,7 @@ func TestTelegramHandler_Rehydrate_RestoреsNonExpired(t *testing.T) {
 
 func TestTelegramHandler_Rehydrate_NoStore(t *testing.T) {
 	client := &mockTelegramClient{}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 	// No store attached — Rehydrate should be a no-op.
 	if err := handler.Rehydrate(context.Background()); err != nil {
 		t.Fatalf("expected no error without store, got: %v", err)
@@ -1431,7 +1433,7 @@ func TestTelegramHandler_Rehydrate_CallbackWorksAfterRehydrate(t *testing.T) {
 		Title: "Rehydrated", CreatedAt: time.Now(), ExpiresAt: time.Now().Add(time.Hour),
 	})
 
-	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+	handler := NewTelegramHandler(client, "chat123", 0).WithStore(store)
 	if err := handler.Rehydrate(context.Background()); err != nil {
 		t.Fatalf("rehydrate error: %v", err)
 	}
@@ -1492,7 +1494,7 @@ func (r *mockDecisionRecorder) getCalls() []struct {
 func TestTelegramHandler_HandleCallback_RecordsDecisionViaRecorder(t *testing.T) {
 	client := &mockTelegramClient{}
 	recorder := &mockDecisionRecorder{}
-	handler := NewTelegramHandler(client, "chat123").WithDecisionRecorder(recorder)
+	handler := NewTelegramHandler(client, "chat123", 0).WithDecisionRecorder(recorder)
 
 	req := &Request{ID: "req-1", TaskID: "T-1", Stage: StagePreMerge, Title: "Test", ExpiresAt: time.Now().Add(time.Hour)}
 	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
@@ -1525,7 +1527,7 @@ func TestTelegramHandler_Rehydrate_CallbackRecordsDecisionDirectly(t *testing.T)
 		Title: "Rehydrated", CreatedAt: time.Now(), ExpiresAt: time.Now().Add(time.Hour),
 	})
 
-	handler := NewTelegramHandler(client, "chat123").WithStore(store).WithDecisionRecorder(recorder)
+	handler := NewTelegramHandler(client, "chat123", 0).WithStore(store).WithDecisionRecorder(recorder)
 	if err := handler.Rehydrate(context.Background()); err != nil {
 		t.Fatalf("rehydrate error: %v", err)
 	}
@@ -1547,7 +1549,7 @@ func TestTelegramHandler_Rehydrate_CallbackRecordsDecisionDirectly(t *testing.T)
 func TestTelegramHandler_HandleCallback_RecorderErrorIsNonFatal(t *testing.T) {
 	client := &mockTelegramClient{}
 	recorder := &mockDecisionRecorder{err: errors.New("db down")}
-	handler := NewTelegramHandler(client, "chat123").WithDecisionRecorder(recorder)
+	handler := NewTelegramHandler(client, "chat123", 0).WithDecisionRecorder(recorder)
 
 	req := &Request{ID: "req-2", TaskID: "T-2", Stage: StagePreMerge, Title: "Test", ExpiresAt: time.Now().Add(time.Hour)}
 	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
@@ -1570,7 +1572,7 @@ func TestTelegramHandler_HandleCallback_RecorderErrorIsNonFatal(t *testing.T) {
 func TestTelegramHandler_HandleCallback_RaceLoss_ShowsAlreadyDecided(t *testing.T) {
 	client := &mockTelegramClient{}
 	recorder := &mockDecisionRecorder{err: memory.ErrApprovalAlreadyDecided}
-	handler := NewTelegramHandler(client, "chat123").WithDecisionRecorder(recorder)
+	handler := NewTelegramHandler(client, "chat123", 0).WithDecisionRecorder(recorder)
 
 	req := &Request{ID: "req-race-loss", TaskID: "T-Race", Stage: StagePreMerge, Title: "Test", ExpiresAt: time.Now().Add(time.Hour)}
 	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
@@ -1636,7 +1638,7 @@ func findSubstring(s, substr string) bool {
 func TestTelegramHandler_HandleCallback_UnknownRequest_LogsInfo(t *testing.T) {
 	client := &mockTelegramClient{}
 	logger, buf := newCapturingLogger()
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 	handler.log = logger
 
 	handled := handler.HandleCallback(context.Background(), "cb-unknown", "approve:ghost-request", "u1", "tester")
@@ -1662,7 +1664,7 @@ func TestTelegramHandler_HandleCallback_UnknownRequest_LogsInfo(t *testing.T) {
 func TestTelegramHandler_HandleCallback_AnswerCallbackError_LogsWarn(t *testing.T) {
 	client := &mockTelegramClient{answerError: errors.New("telegram api down")}
 	logger, buf := newCapturingLogger()
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 	handler.log = logger
 
 	req := &Request{ID: "req-answer-fail", TaskID: "T-1", Stage: StagePreMerge, Title: "Test", ExpiresAt: time.Now().Add(time.Hour)}
@@ -1689,7 +1691,7 @@ func TestTelegramHandler_HandleCallback_AnswerCallbackError_LogsWarn(t *testing.
 func TestTelegramHandler_HandleCallback_UnknownRequest_AnswerCallbackError_LogsWarn(t *testing.T) {
 	client := &mockTelegramClient{answerError: errors.New("telegram api down")}
 	logger, buf := newCapturingLogger()
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 	handler.log = logger
 
 	handled := handler.HandleCallback(context.Background(), "cb-1", "approve:ghost", "u1", "tester")
@@ -1708,7 +1710,7 @@ func TestTelegramHandler_HandleCallback_UnknownRequest_AnswerCallbackError_LogsW
 func TestTelegramHandler_HandleCallback_ExpiredButPending_AnswerCallbackError_LogsWarn(t *testing.T) {
 	client := &mockTelegramClient{answerError: errors.New("telegram api down")}
 	logger, buf := newCapturingLogger()
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 	handler.log = logger
 
 	req := &Request{ID: "req-exp-answer-fail", TaskID: "T-1", Stage: StagePreMerge, Title: "Test", ExpiresAt: time.Now().Add(-time.Minute)}
@@ -1740,7 +1742,7 @@ func TestTelegramHandler_Rehydrate_ResendsFreshPromptPerPendingRequest(t *testin
 		Title: "Rehydrated", CreatedAt: time.Now(), ExpiresAt: time.Now().Add(time.Hour),
 	})
 
-	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+	handler := NewTelegramHandler(client, "chat123", 0).WithStore(store)
 	if err := handler.Rehydrate(context.Background()); err != nil {
 		t.Fatalf("rehydrate error: %v", err)
 	}
@@ -1780,7 +1782,7 @@ func TestTelegramHandler_Rehydrate_NoSpamOnRepeatedCalls(t *testing.T) {
 		Title: "Rehydrated", CreatedAt: time.Now(), ExpiresAt: time.Now().Add(time.Hour),
 	})
 
-	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+	handler := NewTelegramHandler(client, "chat123", 0).WithStore(store)
 	if err := handler.Rehydrate(context.Background()); err != nil {
 		t.Fatalf("first rehydrate error: %v", err)
 	}
@@ -1810,7 +1812,7 @@ func TestTelegramHandler_Rehydrate_ResendFailureIsNonFatal(t *testing.T) {
 		Title: "Rehydrated", CreatedAt: time.Now(), ExpiresAt: time.Now().Add(time.Hour),
 	})
 
-	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+	handler := NewTelegramHandler(client, "chat123", 0).WithStore(store)
 	handler.log = logger
 
 	if err := handler.Rehydrate(context.Background()); err != nil {
@@ -1835,7 +1837,7 @@ func TestTelegramHandler_Rehydrate_ResendFailureIsNonFatal(t *testing.T) {
 func TestTelegramHandler_PruneExpired_EditsMessageAndRemoves(t *testing.T) {
 	client := &mockTelegramClient{}
 	store := newMockPendingStore()
-	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+	handler := NewTelegramHandler(client, "chat123", 0).WithStore(store)
 
 	req := &Request{
 		ID: "exp-1", TaskID: "T-1", Stage: StagePreMerge,
@@ -1876,7 +1878,7 @@ func TestTelegramHandler_PruneExpired_EditsMessageAndRemoves(t *testing.T) {
 func TestTelegramHandler_PruneExpired_LeavesNonExpired(t *testing.T) {
 	client := &mockTelegramClient{}
 	store := newMockPendingStore()
-	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+	handler := NewTelegramHandler(client, "chat123", 0).WithStore(store)
 
 	expired := &Request{ID: "exp-2", TaskID: "T-2", Stage: StagePreMerge, Title: "Old", ExpiresAt: time.Now().Add(-time.Minute)}
 	live := &Request{ID: "live-2", TaskID: "T-3", Stage: StagePreMerge, Title: "Fresh", ExpiresAt: time.Now().Add(time.Hour)}
@@ -1924,7 +1926,7 @@ func TestTelegramHandler_PruneExpired_RehydratedGetsFreshMessageID(t *testing.T)
 		Title: "Rehydrated", CreatedAt: time.Now(), ExpiresAt: time.Now().Add(20 * time.Millisecond),
 	})
 
-	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+	handler := NewTelegramHandler(client, "chat123", 0).WithStore(store)
 	if err := handler.Rehydrate(context.Background()); err != nil {
 		t.Fatalf("rehydrate error: %v", err)
 	}
@@ -1972,7 +1974,7 @@ func TestTelegramHandler_PruneExpired_RehydratedResendFailure_NoMessageID(t *tes
 		Title: "Rehydrated", CreatedAt: time.Now(), ExpiresAt: time.Now().Add(20 * time.Millisecond),
 	})
 
-	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+	handler := NewTelegramHandler(client, "chat123", 0).WithStore(store)
 	if err := handler.Rehydrate(context.Background()); err != nil {
 		t.Fatalf("rehydrate error: %v", err)
 	}
@@ -1997,7 +1999,7 @@ func TestTelegramHandler_PruneExpired_RehydratedResendFailure_NoMessageID(t *tes
 
 func TestTelegramHandler_PruneExpired_NoStore(t *testing.T) {
 	client := &mockTelegramClient{}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	req := &Request{ID: "exp-3", TaskID: "T-4", Stage: StagePreMerge, Title: "Test", ExpiresAt: time.Now().Add(-time.Minute)}
 	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
@@ -2019,7 +2021,7 @@ func TestTelegramHandler_PruneExpired_NoStore(t *testing.T) {
 func TestTelegramHandler_PruneExpired_SweepsOrphanedStoreRows(t *testing.T) {
 	client := &mockTelegramClient{}
 	store := newMockPendingStore()
-	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+	handler := NewTelegramHandler(client, "chat123", 0).WithStore(store)
 
 	// A row with no in-memory pending counterpart — e.g. left behind by a
 	// process that crashed before Rehydrate ran.
@@ -2049,7 +2051,7 @@ func TestTelegramHandler_PruneExpired_SweepsOrphanedStoreRows(t *testing.T) {
 func TestTelegramHandler_HandleCallback_EditFailure_FallsBackToNewMessage(t *testing.T) {
 	client := &mockTelegramClient{editError: errors.New("edit failed")}
 	logger, buf := newCapturingLogger()
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 	handler.log = logger
 
 	req := &Request{ID: "req-fallback", TaskID: "T-1", Stage: StagePreMerge, Title: "Test", ExpiresAt: time.Now().Add(time.Hour)}
@@ -2090,7 +2092,7 @@ func TestTelegramHandler_HandleCallback_EditFailure_FallsBackToNewMessage(t *tes
 // merge-completion follow-up to the same chat the approval card was sent to.
 func TestTelegramHandler_NotifyMerged_SendsFollowUpInSameChat(t *testing.T) {
 	client := &mockTelegramClient{}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	req := &Request{
 		ID: "req-merged", TaskID: "GH-1", Stage: StagePreMerge, Title: "Test",
@@ -2125,7 +2127,7 @@ func TestTelegramHandler_NotifyMerged_SendsFollowUpInSameChat(t *testing.T) {
 // or already notified once — is a silent no-op.
 func TestTelegramHandler_NotifyMerged_UnknownRequestIsNoOp(t *testing.T) {
 	client := &mockTelegramClient{}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	if err := handler.NotifyMerged(context.Background(), "never-approved", "abc1234"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -2140,7 +2142,7 @@ func TestTelegramHandler_NotifyMerged_UnknownRequestIsNoOp(t *testing.T) {
 // tick) does not send a second follow-up.
 func TestTelegramHandler_NotifyMerged_FiresOnceThenNoOp(t *testing.T) {
 	client := &mockTelegramClient{}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	req := &Request{ID: "req-once", TaskID: "GH-1", Stage: StagePreMerge, Title: "Test", ExpiresAt: time.Now().Add(time.Hour)}
 	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
@@ -2166,7 +2168,7 @@ func TestTelegramHandler_NotifyMerged_FiresOnceThenNoOp(t *testing.T) {
 // is dropped from the resolved map so it cannot grow unbounded.
 func TestTelegramHandler_PruneExpired_SweepsStaleResolvedDecisions(t *testing.T) {
 	client := &mockTelegramClient{}
-	handler := NewTelegramHandler(client, "chat123")
+	handler := NewTelegramHandler(client, "chat123", 0)
 
 	req := &Request{ID: "req-stale", TaskID: "GH-1", Stage: StagePreMerge, Title: "Test", ExpiresAt: time.Now().Add(time.Hour)}
 	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
@@ -2187,5 +2189,75 @@ func TestTelegramHandler_PruneExpired_SweepsStaleResolvedDecisions(t *testing.T)
 	handler.mu.RUnlock()
 	if exists {
 		t.Error("expected stale resolved decision to be swept")
+	}
+}
+
+func TestTelegramHandlerMessageThreadID(t *testing.T) {
+	tests := []struct {
+		name            string
+		messageThreadID int64
+		approvers       []string
+		wantChatID      string
+		wantThreadID    int64
+	}{
+		{
+			name:            "topic applied to the configured chat",
+			messageThreadID: 12,
+			approvers:       []string{},
+			wantChatID:      "configured-chat",
+			wantThreadID:    12,
+		},
+		{
+			name:            "topic dropped for an approver override",
+			messageThreadID: 12,
+			approvers:       []string{"99999"},
+			wantChatID:      "99999",
+			wantThreadID:    0,
+		},
+		{
+			name:            "invalid approver falls back to chat and keeps the topic",
+			messageThreadID: 12,
+			approvers:       []string{"#slack-channel"},
+			wantChatID:      "configured-chat",
+			wantThreadID:    12,
+		},
+		{
+			name:            "no topic configured",
+			messageThreadID: 0,
+			approvers:       []string{},
+			wantChatID:      "configured-chat",
+			wantThreadID:    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &mockTelegramClient{}
+			handler := NewTelegramHandler(client, "configured-chat", tt.messageThreadID)
+
+			req := &Request{
+				ID:        "req-thread",
+				TaskID:    "TASK-01",
+				Stage:     StagePreMerge,
+				Title:     "Test",
+				Approvers: tt.approvers,
+				ExpiresAt: time.Now().Add(1 * time.Hour),
+			}
+
+			if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			msgs := client.getSentMessages()
+			if len(msgs) != 1 {
+				t.Fatalf("expected 1 message sent, got %d", len(msgs))
+			}
+			if msgs[0].ChatID != tt.wantChatID {
+				t.Errorf("chat_id = %q, want %q", msgs[0].ChatID, tt.wantChatID)
+			}
+			if msgs[0].ThreadID != tt.wantThreadID {
+				t.Errorf("message_thread_id = %d, want %d", msgs[0].ThreadID, tt.wantThreadID)
+			}
+		})
 	}
 }

--- a/internal/autopilot/restart_approval_integration_test.go
+++ b/internal/autopilot/restart_approval_integration_test.go
@@ -21,7 +21,7 @@ type fakeRestartTelegramClient struct {
 	nextID int64
 }
 
-func (f *fakeRestartTelegramClient) SendMessageWithKeyboard(_ context.Context, _, _, _ string, _ [][]approval.InlineKeyboardButton) (*approval.MessageResponse, error) {
+func (f *fakeRestartTelegramClient) SendMessageWithKeyboard(_ context.Context, _, _, _ string, _ [][]approval.InlineKeyboardButton, _ int64) (*approval.MessageResponse, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.nextID++
@@ -96,7 +96,7 @@ func TestRestartApprovalFlow_WritesExecutionDecisionAndResumesMerge(t *testing.T
 
 	// --- Pre-restart process ---
 	mgr1 := approval.NewManager(approvalCfg)
-	tg1 := approval.NewTelegramHandler(tgClient, "chat-1").WithStore(store)
+	tg1 := approval.NewTelegramHandler(tgClient, "chat-1", 0).WithStore(store)
 	tg1.WithDecisionRecorder(mgr1)
 	mgr1.RegisterHandler(tg1)
 
@@ -144,7 +144,7 @@ func TestRestartApprovalFlow_WritesExecutionDecisionAndResumesMerge(t *testing.T
 	// sharing only the on-disk store/state store. No goroutine or in-memory map
 	// from c1/mgr1/tg1 survives into this section. ---
 	mgr2 := approval.NewManager(approvalCfg)
-	tg2 := approval.NewTelegramHandler(tgClient, "chat-1").WithStore(store)
+	tg2 := approval.NewTelegramHandler(tgClient, "chat-1", 0).WithStore(store)
 	tg2.WithDecisionRecorder(mgr2)
 	mgr2.RegisterHandler(tg2)
 	if err := tg2.Rehydrate(ctx); err != nil {

--- a/internal/autopilot/telegram_notifier.go
+++ b/internal/autopilot/telegram_notifier.go
@@ -52,7 +52,7 @@ func (n *TelegramNotifier) NotifyMerged(ctx context.Context, prState *PRState) e
 		"Method: squash",
 		envPrefix(prState), prState.PRNumber, prDetail(prState))
 
-	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown")
+	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown", 0)
 	return err
 }
 
@@ -71,7 +71,7 @@ func (n *TelegramNotifier) NotifyCIFailed(ctx context.Context, prState *PRState,
 	msg := fmt.Sprintf("%s❌ *CI Failed* for PR #%d%s\n\n%s",
 		envPrefix(prState), prState.PRNumber, prDetail(prState), checks)
 
-	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown")
+	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown", 0)
 	return err
 }
 
@@ -83,7 +83,7 @@ func (n *TelegramNotifier) NotifyApprovalRequired(ctx context.Context, prState *
 		envPrefix(prState), prState.PRNumber, prDetail(prState),
 		prState.PRNumber, prState.PRNumber)
 
-	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown")
+	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown", 0)
 	return err
 }
 
@@ -94,7 +94,7 @@ func (n *TelegramNotifier) NotifyFixIssueCreated(ctx context.Context, prState *P
 		"Pilot will pick this up automatically.",
 		envPrefix(prState), issueNumber, prState.PRNumber)
 
-	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown")
+	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown", 0)
 	return err
 }
 
@@ -103,7 +103,7 @@ func (n *TelegramNotifier) NotifyPipelineComplete(ctx context.Context, prState *
 	msg := fmt.Sprintf("%s🏁 *Pipeline complete* for GH-%d — PR #%d merged%s",
 		envPrefix(prState), prState.IssueNumber, prState.PRNumber, prDetail(prState))
 
-	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown")
+	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown", 0)
 	return err
 }
 
@@ -140,7 +140,7 @@ func (n *TelegramNotifier) NotifyReleased(ctx context.Context, prState *PRState,
 		releaseURL,
 	)
 
-	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown")
+	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown", 0)
 	return err
 }
 

--- a/internal/pilot/pilot.go
+++ b/internal/pilot/pilot.go
@@ -1601,7 +1601,7 @@ func (p *Pilot) initAlerts(cfg *config.Config) {
 		p.telegramClient = telegram.NewClient(cfg.Adapters.Telegram.BotToken)
 		for _, ch := range cfg.Alerts.Channels {
 			if ch.Type == "telegram" && ch.Enabled && ch.Telegram != nil {
-				telegramChannel := alerts.NewTelegramChannel(ch.Name, p.telegramClient, ch.Telegram.ChatID)
+				telegramChannel := alerts.NewTelegramChannel(ch.Name, p.telegramClient, ch.Telegram.ChatID, ch.Telegram.MessageThreadID)
 				dispatcher.RegisterChannel(telegramChannel)
 				log.Info("Registered Telegram alert channel",
 					slog.String("name", ch.Name),


### PR DESCRIPTION
Adds `message_thread_id` support so notifications, approval prompts and alerts land in a configured forum topic instead of General. Non-forum chats are unaffected (`omitempty` guard — verified live).

Fixes #4871

Single commit; full rationale in the commit message. Verified: `go build/vet/test ./...` clean, `golangci-lint run --new-from-rev=main` 0 issues, running in production on a fork build.

Note: two follow-up PRs are stacked on this one (#4887 inbound-topic capture, #4888 SendText threading); I'll open each as its parent merges.