### PR TITLE
fix(telegram): accept commands carrying the @botname suffix

### DIFF
--- a/internal/adapters/telegram/commands.go
+++ b/internal/adapters/telegram/commands.go
@@ -33,7 +33,10 @@ func (c *CommandHandler) HandleCommand(ctx context.Context, chatID, text string)
 		return
 	}
 
-	cmd := strings.ToLower(parts[0])
+	cmd, addressed := splitCommandMention(parts[0], c.handler.botUsername)
+	if !addressed {
+		return
+	}
 	args := parts[1:]
 
 	switch cmd {
@@ -675,4 +678,16 @@ func truncateForDisplay(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen-3] + "..."
+}
+
+func splitCommandMention(token, botUsername string) (string, bool) {
+	cmd, mention, found := strings.Cut(token, "@")
+	cmd = strings.ToLower(cmd)
+	if !found || mention == "" {
+		return cmd, true
+	}
+	if botUsername == "" || strings.EqualFold(mention, botUsername) {
+		return cmd, true
+	}
+	return cmd, false
 }

--- a/internal/adapters/telegram/commands_test.go
+++ b/internal/adapters/telegram/commands_test.go
@@ -472,3 +472,33 @@ func TestCommandRouting(t *testing.T) {
 		})
 	}
 }
+
+func TestSplitCommandMention(t *testing.T) {
+	tests := []struct {
+		name          string
+		token         string
+		botUsername   string
+		wantCmd       string
+		wantAddressed bool
+	}{
+		{name: "bare command", token: "/status", botUsername: "pilotbot", wantCmd: "/status", wantAddressed: true},
+		{name: "suffixed with our name", token: "/status@pilotbot", botUsername: "pilotbot", wantCmd: "/status", wantAddressed: true},
+		{name: "suffix case-insensitive", token: "/Status@PilotBot", botUsername: "pilotbot", wantCmd: "/status", wantAddressed: true},
+		{name: "addressed to another bot", token: "/status@otherbot", botUsername: "pilotbot", wantCmd: "/status", wantAddressed: false},
+		{name: "unknown bot username accepts any suffix", token: "/status@pilotbot", botUsername: "", wantCmd: "/status", wantAddressed: true},
+		{name: "uppercase bare command", token: "/STATUS", botUsername: "pilotbot", wantCmd: "/status", wantAddressed: true},
+		{name: "empty mention", token: "/status@", botUsername: "pilotbot", wantCmd: "/status", wantAddressed: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, addressed := splitCommandMention(tt.token, tt.botUsername)
+			if cmd != tt.wantCmd {
+				t.Errorf("cmd = %q, want %q", cmd, tt.wantCmd)
+			}
+			if addressed != tt.wantAddressed {
+				t.Errorf("addressed = %v, want %v", addressed, tt.wantAddressed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Telegram appends `@botname` to commands in groups, so `/status` arrives as `/status@yourbot` and matched no case — every command answered "Unknown command" in groups. Strips the suffix for our own bot; a suffix naming a different bot returns without replying.

Fixes #4880

Single commit; full rationale in the commit message. Verified: build/vet/test clean, `--new-from-rev=main` 0 issues, running in production on a fork build.