### PR TITLE
fix(telegram): make the task confirmation buttons work

### DIFF
--- a/internal/adapters/telegram/callback_test.go
+++ b/internal/adapters/telegram/callback_test.go
@@ -1,7 +1,15 @@
 package telegram
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
+
+	"github.com/qf-studio/pilot/internal/comms"
+	"github.com/qf-studio/pilot/internal/testutil"
 )
 
 // TestCallbackQueryData tests callback query data parsing
@@ -396,5 +404,58 @@ func TestChatFields(t *testing.T) {
 				t.Errorf("Type = %q, want %q", tt.chat.Type, tt.wantType)
 			}
 		})
+	}
+}
+
+func TestHandleCallbackAcceptsConfirmationButtonData(t *testing.T) {
+	for _, data := range []string{
+		"execute_task:TG-1786801033",
+		"cancel_task:TG-1786801033",
+		"execute",
+		"cancel",
+		"voice_check_status",
+		"",
+	} {
+		t.Run(data, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(`{"ok":true,"result":{"message_id":1}}`))
+			}))
+			defer srv.Close()
+
+			h := &Handler{
+				client: NewClientWithBaseURL(testutil.FakeTelegramBotToken, srv.URL),
+				commsHandler: comms.NewHandler(&comms.HandlerConfig{
+					Messenger:    &noopMessenger{},
+					TaskIDPrefix: "TG",
+				}),
+			}
+
+			h.handleCallback(context.Background(), &CallbackQuery{
+				ID:      "cb-1",
+				From:    &User{ID: 55},
+				Data:    data,
+				Message: &Message{MessageID: 7, Chat: &Chat{ID: -100123}},
+			})
+		})
+	}
+}
+
+func TestConfirmationCallbackDataMatchesHandler(t *testing.T) {
+	messenger, err := os.ReadFile("messenger.go")
+	if err != nil {
+		t.Fatalf("read messenger.go: %v", err)
+	}
+	handler, err := os.ReadFile("handler.go")
+	if err != nil {
+		t.Fatalf("read handler.go: %v", err)
+	}
+
+	for _, prefix := range []string{"execute_task:", "cancel_task:"} {
+		if !strings.Contains(string(messenger), prefix) {
+			t.Fatalf("messenger no longer emits %q; update this guard", prefix)
+		}
+		if !strings.Contains(string(handler), prefix) {
+			t.Errorf("handleCallback does not match %q — confirmation buttons silently do nothing", prefix)
+		}
 	}
 }

--- a/internal/adapters/telegram/handler.go
+++ b/internal/adapters/telegram/handler.go
@@ -390,7 +390,7 @@ func (h *Handler) handleCallback(ctx context.Context, callback *CallbackQuery) {
 	_ = h.client.AnswerCallback(ctx, callback.ID, "")
 
 	switch {
-	case data == "execute":
+	case data == "execute" || strings.HasPrefix(data, "execute_task:"):
 		if h.commsHandler != nil {
 			senderID := ""
 			if callback.From != nil {
@@ -405,7 +405,7 @@ func (h *Handler) handleCallback(ctx context.Context, callback *CallbackQuery) {
 				ActionID:   "execute",
 			})
 		}
-	case data == "cancel":
+	case data == "cancel" || strings.HasPrefix(data, "cancel_task:"):
 		if h.commsHandler != nil {
 			senderID := ""
 			if callback.From != nil {


### PR DESCRIPTION
Buttons send `execute_task:<id>`/`cancel_task:<id>`; `handleCallback` matched only bare `execute`/`cancel` — both branches unreachable, every tap silently dropped. Now matches the prefixed payloads (bare forms kept for the SDK bridge). Includes a guard test asserting producer and consumer prefixes match so they can't drift again.

Fixes #4881

Single commit; verified: build/vet/test clean, `--new-from-rev=main` 0 issues, fix confirmed live (tap → task started → completed).