### PR TITLE
fix(linear): pass project_ids through to the SDK poller

### DIFF
--- a/cmd/pilot/poller_linear.go
+++ b/cmd/pilot/poller_linear.go
@@ -13,6 +13,21 @@ import (
 	"github.com/qf-studio/pilot/internal/logging"
 )
 
+func newSDKLinearWorkspace(name, apiKey, teamID, triggerLabel string, projectIDs, projects []string, interval time.Duration) *linearSDK.WorkspaceConfig {
+	return &linearSDK.WorkspaceConfig{
+		Name:         name,
+		APIKey:       apiKey,
+		TeamID:       teamID,
+		TriggerLabel: triggerLabel,
+		ProjectIDs:   projectIDs,
+		Projects:     projects,
+		Polling: &linearSDK.PollingConfig{
+			Enabled:  true,
+			Interval: interval,
+		},
+	}
+}
+
 func linearPollerRegistration() PollerRegistration {
 	return PollerRegistration{
 		Name: "linear",
@@ -44,16 +59,7 @@ func linearPollerRegistration() PollerRegistration {
 				if ws.Polling != nil && ws.Polling.Interval > 0 {
 					wsInterval = ws.Polling.Interval
 				}
-				sdkWorkspaces = append(sdkWorkspaces, &linearSDK.WorkspaceConfig{
-					Name:         ws.Name,
-					APIKey:       ws.APIKey,
-					TeamID:       ws.TeamID,
-					TriggerLabel: triggerLabel,
-					Polling: &linearSDK.PollingConfig{
-						Enabled:  true,
-						Interval: wsInterval,
-					},
-				})
+				sdkWorkspaces = append(sdkWorkspaces, newSDKLinearWorkspace(ws.Name, ws.APIKey, ws.TeamID, triggerLabel, ws.ProjectIDs, ws.Projects, wsInterval))
 				notifiersByTeamID[ws.TeamID] = linearSDK.NewNotifier(linearSDK.NewClient(ws.APIKey))
 			}
 

--- a/cmd/pilot/poller_linear_test.go
+++ b/cmd/pilot/poller_linear_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	sdkcore "github.com/qf-studio/studio-sdk/sdk/core"
 
@@ -201,5 +202,84 @@ func TestLinearHandlerSubIssueCreatorDirectInject(t *testing.T) {
 	}
 	if !strings.Contains(string(content), "SetSubIssueCreator(linear.NewClient") {
 		t.Error("handlers.go must call runner.SetSubIssueCreator(linear.NewClient(...))")
+	}
+}
+
+func TestNewSDKLinearWorkspace(t *testing.T) {
+	tests := []struct {
+		name           string
+		ws             *linear.WorkspaceConfig
+		triggerLabel   string
+		interval       time.Duration
+		wantProjectIDs []string
+		wantProjects   []string
+	}{
+		{
+			name: "project filter is handed to the SDK",
+			ws: &linear.WorkspaceConfig{
+				Name:       "acme",
+				APIKey:     "test-linear-key",
+				TeamID:     "ENG",
+				ProjectIDs: []string{"proj-a", "proj-b"},
+				Projects:   []string{"pilot"},
+			},
+			triggerLabel:   "llm-pilot",
+			interval:       30 * time.Second,
+			wantProjectIDs: []string{"proj-a", "proj-b"},
+			wantProjects:   []string{"pilot"},
+		},
+		{
+			name: "unset filter stays nil so the unfiltered path is unchanged",
+			ws: &linear.WorkspaceConfig{
+				Name:   "acme",
+				APIKey: "test-linear-key",
+				TeamID: "ENG",
+			},
+			triggerLabel:   "pilot",
+			interval:       time.Minute,
+			wantProjectIDs: nil,
+			wantProjects:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newSDKLinearWorkspace(tt.ws.Name, tt.ws.APIKey, tt.ws.TeamID, tt.triggerLabel, tt.ws.ProjectIDs, tt.ws.Projects, tt.interval)
+
+			if got.ProjectIDs == nil && tt.wantProjectIDs != nil {
+				t.Fatalf("ProjectIDs = nil, want %v", tt.wantProjectIDs)
+			}
+			if tt.wantProjectIDs == nil && got.ProjectIDs != nil {
+				t.Errorf("ProjectIDs = %v, want nil", got.ProjectIDs)
+			}
+			if len(got.ProjectIDs) != len(tt.wantProjectIDs) {
+				t.Fatalf("ProjectIDs = %v, want %v", got.ProjectIDs, tt.wantProjectIDs)
+			}
+			for i, want := range tt.wantProjectIDs {
+				if got.ProjectIDs[i] != want {
+					t.Errorf("ProjectIDs[%d] = %q, want %q", i, got.ProjectIDs[i], want)
+				}
+			}
+
+			if tt.wantProjects == nil && got.Projects != nil {
+				t.Errorf("Projects = %v, want nil", got.Projects)
+			}
+			if len(got.Projects) != len(tt.wantProjects) {
+				t.Fatalf("Projects = %v, want %v", got.Projects, tt.wantProjects)
+			}
+
+			if got.Name != tt.ws.Name {
+				t.Errorf("Name = %q, want %q", got.Name, tt.ws.Name)
+			}
+			if got.TeamID != tt.ws.TeamID {
+				t.Errorf("TeamID = %q, want %q", got.TeamID, tt.ws.TeamID)
+			}
+			if got.TriggerLabel != tt.triggerLabel {
+				t.Errorf("TriggerLabel = %q, want %q", got.TriggerLabel, tt.triggerLabel)
+			}
+			if got.Polling == nil || got.Polling.Interval != tt.interval {
+				t.Errorf("Polling interval = %v, want %v", got.Polling, tt.interval)
+			}
+		})
 	}
 }


### PR DESCRIPTION
`project_ids` is documented as a hard filter and had no effect — dropped at the `linearSDK.WorkspaceConfig` translation literal, failing open. Translation moves into `newSDKLinearWorkspace` so the assignment itself is asserted by a regression guard (the bug class is a silently dropped field, so the guard belongs on the translation, not downstream behavior).

Fixes #4883

Single commit; full audit of sibling pollers in the commit message. Verified: build/vet/test clean, `--new-from-rev=main` 0 issues, filter confirmed live (in-project issue dispatched, project-less ignored).