### PR TITLE
fix(github): verify App installation tokens without calling /user

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -1275,13 +1275,24 @@ func (c *Client) GetAuthenticatedUser(ctx context.Context) (*User, error) {
 // dead token can be diagnosed without re-deriving the resolution chain
 // (GH-3718). Pass "" when the source is unknown.
 func (c *Client) Verify(ctx context.Context, tokenSource string) error {
-	if _, err := c.GetAuthenticatedUser(ctx); err != nil {
-		if tokenSource != "" {
-			return fmt.Errorf("github token invalid (source: %s): %w", tokenSource, err)
-		}
-		return fmt.Errorf("github token invalid: %w", err)
+	_, err := c.GetAuthenticatedUser(ctx)
+	if err == nil {
+		return nil
 	}
-	return nil
+	if instErr := c.verifyInstallation(ctx); instErr == nil {
+		return nil
+	}
+	if tokenSource != "" {
+		return fmt.Errorf("github token invalid (source: %s): %w", tokenSource, err)
+	}
+	return fmt.Errorf("github token invalid: %w", err)
+}
+
+func (c *Client) verifyInstallation(ctx context.Context) error {
+	var result struct {
+		TotalCount int `json:"total_count"`
+	}
+	return c.doRequest(ctx, http.MethodGet, "/installation/repositories?per_page=1", nil, &result)
 }
 
 // SearchMergedPRsForIssue checks if any merged PRs exist that reference the given

--- a/internal/adapters/github/verify_test.go
+++ b/internal/adapters/github/verify_test.go
@@ -49,6 +49,11 @@ func TestClientVerify(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.Contains(r.URL.Path, "/installation/repositories") {
+					w.WriteHeader(http.StatusForbidden)
+					_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+					return
+				}
 				if !strings.HasSuffix(r.URL.Path, "/user") {
 					t.Errorf("path = %q, want to end with /user", r.URL.Path)
 				}
@@ -97,5 +102,67 @@ func TestClientVerifyTimeout(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "github token invalid") {
 		t.Errorf("error = %q, want to contain %q", err.Error(), "github token invalid")
+	}
+}
+
+func TestClientVerifyAppInstallationToken(t *testing.T) {
+	tests := []struct {
+		name             string
+		userStatus       int
+		installStatus    int
+		wantErr          bool
+		wantInstallProbe bool
+	}{
+		{
+			name:             "user token verifies without probing the installation",
+			userStatus:       http.StatusOK,
+			installStatus:    http.StatusOK,
+			wantErr:          false,
+			wantInstallProbe: false,
+		},
+		{
+			name:             "installation token rejected by /user is still valid",
+			userStatus:       http.StatusForbidden,
+			installStatus:    http.StatusOK,
+			wantErr:          false,
+			wantInstallProbe: true,
+		},
+		{
+			name:             "dead credential fails both probes",
+			userStatus:       http.StatusUnauthorized,
+			installStatus:    http.StatusUnauthorized,
+			wantErr:          true,
+			wantInstallProbe: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sawInstallProbe bool
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.Contains(r.URL.Path, "/installation/repositories") {
+					sawInstallProbe = true
+					w.WriteHeader(tt.installStatus)
+					_, _ = w.Write([]byte(`{"total_count":3}`))
+					return
+				}
+				w.WriteHeader(tt.userStatus)
+				_, _ = w.Write([]byte(`{"id":1,"login":"pilot-bot"}`))
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			err := client.Verify(context.Background(), "app")
+
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if sawInstallProbe != tt.wantInstallProbe {
+				t.Errorf("installation probe performed = %v, want %v", sawInstallProbe, tt.wantInstallProbe)
+			}
+		})
 	}
 }


### PR DESCRIPTION
`Verify` called `GET /user`, which installation tokens structurally cannot call — every App-auth deployment failed verification and carried a permanent service_unhealthy alert. A /user failure is now inconclusive: re-probe against `GET /installation/repositories`; only failure of both reports an invalid token. User/classic tokens verify on the first call, unchanged behavior and request count.

Fixes #4885

Single commit; verified: build/vet/test clean, `--new-from-rev=main` 0 issues, App-auth deployment verifies clean in production on a fork build.