### PR TITLE
feat(alerts): notify when an alerted condition recovers

### DIFF
--- a/cmd/pilot/adapter_preflight.go
+++ b/cmd/pilot/adapter_preflight.go
@@ -76,6 +76,10 @@ func buildAdapterVerifiers(cfg *config.Config) []verify.Verifiable {
 	return verifiers
 }
 
+func adapterAlertSource(name string) string {
+	return "adapter:" + name
+}
+
 // runAdapterPreflight calls Verify(ctx) on every verifier concurrently,
 // each bounded by preflightVerifyTimeout, and returns the per-adapter
 // result. A failure logs ERROR and emits an alerts.EventTypeConfigError
@@ -110,6 +114,13 @@ func runAdapterPreflight(ctx context.Context, verifiers []verify.Verifiable, ale
 			switch {
 			case err == nil:
 				log.Info("adapter verified", slog.String("adapter", v.Name()))
+				if alertsEngine != nil {
+					alertsEngine.ProcessEvent(alerts.Event{
+						Type:      alerts.EventTypeConfigHealthy,
+						Source:    adapterAlertSource(v.Name()),
+						Timestamp: time.Now(),
+					})
+				}
 			case errors.Is(err, verify.ErrProbeNotImplemented):
 				// No live probe yet — not evidence of a broken credential.
 			default:
@@ -120,6 +131,7 @@ func runAdapterPreflight(ctx context.Context, verifiers []verify.Verifiable, ale
 				if alertsEngine != nil {
 					alertsEngine.ProcessEvent(alerts.Event{
 						Type:      alerts.EventTypeConfigError,
+						Source:    adapterAlertSource(v.Name()),
 						Error:     fmt.Sprintf("%s adapter verification failed: %v", v.Name(), err),
 						Timestamp: time.Now(),
 					})
@@ -130,6 +142,24 @@ func runAdapterPreflight(ctx context.Context, verifiers []verify.Verifiable, ale
 	wg.Wait()
 
 	return results
+}
+
+func startAdapterHealthLoop(ctx context.Context, verifiers []verify.Verifiable, alertsEngine *alerts.Engine, interval time.Duration) {
+	if interval <= 0 || len(verifiers) == 0 || alertsEngine == nil {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				runAdapterPreflight(ctx, verifiers, alertsEngine)
+			}
+		}
+	}()
 }
 
 // registerAdapterReadiness wraps each verifier as a gateway.ReadinessChecker

--- a/cmd/pilot/adapter_preflight_test.go
+++ b/cmd/pilot/adapter_preflight_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/qf-studio/pilot/internal/adapters/linear"
 	"github.com/qf-studio/pilot/internal/adapters/slack"
 	"github.com/qf-studio/pilot/internal/adapters/telegram"
+	"github.com/qf-studio/pilot/internal/alerts"
 	"github.com/qf-studio/pilot/internal/config"
 	"github.com/qf-studio/pilot/internal/gateway"
 	"github.com/qf-studio/pilot/internal/health/verify"
@@ -174,5 +176,64 @@ func TestRegisterAdapterReadiness_ReadyEndpoint(t *testing.T) {
 	}
 	if body.Checks["broken-adapter"] {
 		t.Error("broken-adapter check = true, want false")
+	}
+}
+
+type countingVerifiable struct {
+	name  string
+	err   error
+	mu    sync.Mutex
+	calls int
+	fired chan struct{}
+}
+
+func (c *countingVerifiable) Name() string { return c.name }
+
+func (c *countingVerifiable) Verify(ctx context.Context) error {
+	c.mu.Lock()
+	c.calls++
+	first := c.calls == 1
+	c.mu.Unlock()
+	if first && c.fired != nil {
+		close(c.fired)
+	}
+	return c.err
+}
+
+func TestStartAdapterHealthLoopReverifies(t *testing.T) {
+	v := &countingVerifiable{name: "github", fired: make(chan struct{})}
+	engine := alerts.NewEngine(&alerts.AlertConfig{Enabled: true})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	startAdapterHealthLoop(ctx, []verify.Verifiable{v}, engine, 10*time.Millisecond)
+
+	select {
+	case <-v.fired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("health loop did not re-verify within 2s")
+	}
+}
+
+func TestStartAdapterHealthLoopGuards(t *testing.T) {
+	tests := []struct {
+		name      string
+		interval  time.Duration
+		verifiers []verify.Verifiable
+		engine    *alerts.Engine
+	}{
+		{name: "zero interval disables", interval: 0, verifiers: []verify.Verifiable{&fakeVerifiable{name: "x"}}, engine: alerts.NewEngine(&alerts.AlertConfig{})},
+		{name: "negative interval disables", interval: -time.Minute, verifiers: []verify.Verifiable{&fakeVerifiable{name: "x"}}, engine: alerts.NewEngine(&alerts.AlertConfig{})},
+		{name: "no verifiers", interval: time.Millisecond, verifiers: nil, engine: alerts.NewEngine(&alerts.AlertConfig{})},
+		{name: "nil engine", interval: time.Millisecond, verifiers: []verify.Verifiable{&fakeVerifiable{name: "x"}}, engine: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			startAdapterHealthLoop(ctx, tt.verifiers, tt.engine, tt.interval)
+		})
 	}
 }

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -3184,6 +3184,9 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 	// per-adapter status.
 	adapterVerifiers := buildAdapterVerifiers(cfg)
 	runAdapterPreflight(ctx, adapterVerifiers, alertsEngine)
+	if cfg.Alerts != nil {
+		startAdapterHealthLoop(ctx, adapterVerifiers, alertsEngine, cfg.Alerts.ResolvedHealthCheckInterval())
+	}
 	registerAdapterReadiness(gwServer, adapterVerifiers, verify.DefaultTimeout)
 
 	// GH-929: Start GitHub polling for multiple repos if enabled

--- a/internal/alerts/channels.go
+++ b/internal/alerts/channels.go
@@ -56,12 +56,17 @@ func (c *SlackChannel) formatSlackBlocks(alert *Alert) []slack.Block {
 	emoji := c.severityEmoji(alert.Severity)
 	severityLabel := strings.ToUpper(string(alert.Severity))
 
+	header := fmt.Sprintf("%s %s Alert", emoji, severityLabel)
+	if alert.IsResolution() {
+		header = fmt.Sprintf("✅ Resolved after %s", formatAlertDuration(alert.Duration()))
+	}
+
 	blocks := []slack.Block{
 		{
 			Type: "header",
 			Text: &slack.TextObject{
 				Type: "plain_text",
-				Text: fmt.Sprintf("%s %s Alert", emoji, severityLabel),
+				Text: header,
 			},
 		},
 		{
@@ -160,7 +165,11 @@ func (c *TelegramChannel) formatMessage(alert *Alert) string {
 	severityLabel := strings.ToUpper(string(alert.Severity))
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("%s *%s ALERT*\n\n", emoji, severityLabel))
+	if alert.IsResolution() {
+		fmt.Fprintf(&sb, "✅ *RESOLVED* after %s\n\n", escapeMarkdown(formatAlertDuration(alert.Duration())))
+	} else {
+		fmt.Fprintf(&sb, "%s *%s ALERT*\n\n", emoji, severityLabel)
+	}
 	sb.WriteString(fmt.Sprintf("*%s*\n", escapeMarkdown(alert.Title)))
 	sb.WriteString(fmt.Sprintf("%s\n\n", escapeMarkdown(alert.Message)))
 
@@ -341,6 +350,10 @@ func (c *EmailChannel) formatSubject(alert *Alert) string {
 		emoji = "⚠️"
 	}
 
+	if alert.IsResolution() {
+		return fmt.Sprintf("✅ [RESOLVED after %s] Pilot Alert: %s", formatAlertDuration(alert.Duration()), alert.Title)
+	}
+
 	return fmt.Sprintf("%s [%s] Pilot Alert: %s", emoji, strings.ToUpper(string(alert.Severity)), alert.Title)
 }
 
@@ -485,4 +498,15 @@ func (c *PagerDutyChannel) Send(ctx context.Context, alert *Alert) error {
 	}
 
 	return nil
+}
+
+func formatAlertDuration(d time.Duration) string {
+	switch {
+	case d >= time.Hour:
+		return fmt.Sprintf("%dh%dm", int(d.Hours()), int(d.Minutes())%60)
+	case d >= time.Minute:
+		return fmt.Sprintf("%dm%ds", int(d.Minutes()), int(d.Seconds())%60)
+	default:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
 }

--- a/internal/alerts/channels_test.go
+++ b/internal/alerts/channels_test.go
@@ -1053,3 +1053,66 @@ func TestPagerDutyChannel_Send_Error(t *testing.T) {
 		t.Fatal("expected error for 403 response")
 	}
 }
+
+func TestFormatAlertDuration(t *testing.T) {
+	tests := []struct {
+		name string
+		d    time.Duration
+		want string
+	}{
+		{name: "seconds", d: 45 * time.Second, want: "45s"},
+		{name: "sub-second rounds to zero", d: 200 * time.Millisecond, want: "0s"},
+		{name: "minutes and seconds", d: 3*time.Minute + 7*time.Second, want: "3m7s"},
+		{name: "exact minute", d: time.Minute, want: "1m0s"},
+		{name: "hours and minutes", d: 2*time.Hour + 15*time.Minute, want: "2h15m"},
+		{name: "exact hour", d: time.Hour, want: "1h0m"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatAlertDuration(tt.d); got != tt.want {
+				t.Errorf("formatAlertDuration(%v) = %q, want %q", tt.d, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAlertDurationAndIsResolution(t *testing.T) {
+	created := time.Now().Add(-90 * time.Second)
+	resolved := created.Add(90 * time.Second)
+
+	open := &Alert{CreatedAt: created}
+	if open.IsResolution() {
+		t.Error("unresolved alert reports IsResolution true")
+	}
+	if open.Duration() != 0 {
+		t.Errorf("unresolved Duration = %v, want 0", open.Duration())
+	}
+
+	done := &Alert{CreatedAt: created, ResolvedAt: &resolved}
+	if !done.IsResolution() {
+		t.Error("resolved alert reports IsResolution false")
+	}
+	if got := done.Duration(); got != 90*time.Second {
+		t.Errorf("Duration = %v, want 90s", got)
+	}
+}
+
+func TestTelegramResolutionRendering(t *testing.T) {
+	created := time.Now().Add(-5 * time.Minute)
+	resolved := created.Add(5 * time.Minute)
+	ch := &TelegramChannel{name: "t"}
+
+	firing := ch.formatMessage(&Alert{Severity: SeverityWarning, Title: "x", Message: "y", CreatedAt: created})
+	if strings.Contains(firing, "RESOLVED") {
+		t.Error("firing alert rendered as RESOLVED")
+	}
+
+	recovered := ch.formatMessage(&Alert{Severity: SeverityInfo, Title: "x", Message: "y", CreatedAt: created, ResolvedAt: &resolved})
+	if !strings.Contains(recovered, "RESOLVED") {
+		t.Errorf("resolution not marked RESOLVED: %q", recovered)
+	}
+	if !strings.Contains(recovered, "5m0s") {
+		t.Errorf("resolution missing duration: %q", recovered)
+	}
+}

--- a/internal/alerts/config.go
+++ b/internal/alerts/config.go
@@ -18,6 +18,7 @@ func FromConfigAlerts(enabled bool, channels []ChannelConfigInput, rules []RuleC
 			Cooldown:           defaults.Cooldown,
 			DefaultSeverity:    parseSeverity(defaults.DefaultSeverity),
 			SuppressDuplicates: defaults.SuppressDuplicates,
+			NotifyOnResolve:    defaults.NotifyOnResolve,
 		},
 	}
 
@@ -102,6 +103,7 @@ type DefaultsConfigInput struct {
 	Cooldown           time.Duration
 	DefaultSeverity    string
 	SuppressDuplicates bool
+	NotifyOnResolve    *bool
 }
 
 func convertChannel(in ChannelConfigInput) ChannelConfig {

--- a/internal/alerts/engine.go
+++ b/internal/alerts/engine.go
@@ -28,6 +28,7 @@ type Engine struct {
 	alertHistory        []AlertHistory
 	retryTracker        map[string]int       // source (issue/PR) -> consecutive failure count (GH-848)
 	retryLastSeen       map[string]time.Time // source -> last failure time, for TTL eviction (TASK-357 E7)
+	activeAlerts        map[string]*activeAlert
 
 	// Channels for events. priorityCh carries high-severity events
 	// (escalation / OOM / budget / security) on a dedicated buffer so a flood of
@@ -105,6 +106,7 @@ type Event struct {
 	Phase     string
 	Progress  int
 	Error     string
+	Source    string // e.g. "adapter:github"; keys active-alert state when TaskID is empty
 	Metadata  map[string]string
 	Timestamp time.Time
 	// test-only: set by flushForTest to drain the event queue
@@ -142,6 +144,8 @@ const (
 	// credential (e.g. a GitHub token) fails an authenticated validation
 	// call at startup, so a dead credential doesn't fail silently.
 	EventTypeConfigError EventType = "config_error"
+
+	EventTypeConfigHealthy EventType = "config_healthy"
 
 	// Release missing events (GH-3952): fired when a merged pilot/GH-* PR
 	// did not produce its expected release tag, so a stalled release
@@ -263,6 +267,7 @@ func NewEngine(config *AlertConfig, opts ...EngineOption) *Engine {
 		taskLastProgress:    make(map[string]progressState),
 		alertHistory:        make([]AlertHistory, 0),
 		retryTracker:        make(map[string]int),
+		activeAlerts:        make(map[string]*activeAlert),
 		retryLastSeen:       make(map[string]time.Time),
 		eventCh:             make(chan Event, 100),
 		priorityCh:          make(chan Event, 100),
@@ -438,6 +443,8 @@ func (e *Engine) handleEvent(ctx context.Context, event Event) {
 		e.handleSecurityEvent(ctx, event)
 	case EventTypeConfigError:
 		e.handleConfigError(ctx, event)
+	case EventTypeConfigHealthy:
+		e.handleConfigHealthy(ctx, event)
 	case EventTypeReleaseMissing:
 		e.handleReleaseMissing(ctx, event)
 	case EventTypeLaneStarvation:
@@ -630,6 +637,16 @@ func (e *Engine) handleSecurityEvent(ctx context.Context, event Event) {
 	}
 }
 
+type activeAlert struct {
+	rule     AlertRule
+	alert    *Alert
+	channels []string
+}
+
+func activeAlertKey(ruleName, source string) string {
+	return ruleName + "|" + source
+}
+
 // handleConfigError fires AlertTypeServiceUnhealthy rules when a resolved
 // credential fails validation (GH-3718), e.g. a dead GitHub token detected at
 // startup. Message comes from event.Error, set by the caller.
@@ -640,9 +657,77 @@ func (e *Engine) handleConfigError(ctx context.Context, event Event) {
 		}
 		if rule.Type == AlertTypeServiceUnhealthy && e.shouldFire(rule) {
 			alert := e.createAlert(rule, event, event.Error)
+			e.markActive(rule, alert)
 			e.fireAlert(ctx, rule, alert)
 		}
 	}
+}
+
+func (e *Engine) markActive(rule AlertRule, alert *Alert) {
+	if !e.config.Defaults.ResolveNotificationsEnabled() || alert.Source == "" {
+		return
+	}
+	channels := e.resolveChannels(rule, alert)
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.activeAlerts[activeAlertKey(rule.Name, alert.Source)] = &activeAlert{
+		rule:     rule,
+		alert:    alert,
+		channels: channels,
+	}
+}
+
+func (e *Engine) handleConfigHealthy(ctx context.Context, event Event) {
+	if !e.config.Defaults.ResolveNotificationsEnabled() || event.Source == "" {
+		return
+	}
+	for _, rule := range e.config.Rules {
+		if !rule.Enabled || rule.Type != AlertTypeServiceUnhealthy {
+			continue
+		}
+		key := activeAlertKey(rule.Name, event.Source)
+
+		e.mu.Lock()
+		active, ok := e.activeAlerts[key]
+		if ok {
+			delete(e.activeAlerts, key)
+		}
+		e.mu.Unlock()
+
+		if !ok {
+			continue
+		}
+		e.dispatchResolution(ctx, active)
+	}
+}
+
+func (e *Engine) dispatchResolution(ctx context.Context, active *activeAlert) {
+	now := time.Now()
+	active.alert.ResolvedAt = &now
+
+	resolution := &Alert{
+		ID:          fmt.Sprintf("%s-resolved", active.alert.ID),
+		Type:        active.alert.Type,
+		Severity:    SeverityInfo,
+		Title:       active.alert.Title,
+		Message:     active.alert.Message,
+		Source:      active.alert.Source,
+		ProjectPath: active.alert.ProjectPath,
+		Metadata:    active.alert.Metadata,
+		CreatedAt:   active.alert.CreatedAt,
+		ResolvedAt:  &now,
+	}
+
+	e.metrics.RecordFired(active.rule.Name, string(resolution.Severity))
+	if e.dispatcher == nil {
+		e.logger.Warn("no dispatcher configured, resolution not sent",
+			"rule", active.rule.Name,
+			"alert_id", resolution.ID,
+		)
+		return
+	}
+	e.enqueueDispatch(ctx, active.rule, resolution, active.channels)
 }
 
 // handleReleaseMissing fires AlertTypeReleaseMissing rules when a merged PR
@@ -992,8 +1077,8 @@ func (e *Engine) shouldFire(rule AlertRule) bool {
 
 // createAlert creates an alert from a rule and event
 func (e *Engine) createAlert(rule AlertRule, event Event, message string) *Alert {
-	source := ""
-	if event.TaskID != "" {
+	source := event.Source
+	if source == "" && event.TaskID != "" {
 		source = fmt.Sprintf("task:%s", event.TaskID)
 	}
 
@@ -1068,20 +1153,26 @@ func (e *Engine) fireAlert(ctx context.Context, rule AlertRule, alert *Alert) {
 		return
 	}
 
-	// Determine which channels to send to
-	channels := rule.Channels
-	if len(channels) == 0 {
-		// Send to all channels that accept this severity
-		for _, ch := range e.config.Channels {
-			if ch.Enabled && e.channelAcceptsSeverity(ch, alert.Severity) {
-				channels = append(channels, ch.Name)
-			}
+	e.enqueueDispatch(ctx, rule, alert, e.resolveChannels(rule, alert))
+}
+
+func (e *Engine) resolveChannels(rule AlertRule, alert *Alert) []string {
+	if len(rule.Channels) > 0 {
+		return rule.Channels
+	}
+	var channels []string
+	for _, ch := range e.config.Channels {
+		if ch.Enabled && e.channelAcceptsSeverity(ch, alert.Severity) {
+			channels = append(channels, ch.Name)
 		}
 	}
+	return channels
+}
 
-	// E1: once running, hand delivery to the background worker so a slow/hung
-	// channel can never block the event loop. Before Start() (direct callers /
-	// tests) deliver inline so the path stays synchronous.
+// E1: once running, hand delivery to the background worker so a slow/hung
+// channel can never block the event loop. Before Start() (direct callers /
+// tests) deliver inline so the path stays synchronous.
+func (e *Engine) enqueueDispatch(ctx context.Context, rule AlertRule, alert *Alert, channels []string) {
 	if !e.started.Load() {
 		e.dispatchAndRecord(ctx, rule, alert, channels)
 		return

--- a/internal/alerts/engine_test.go
+++ b/internal/alerts/engine_test.go
@@ -3899,3 +3899,163 @@ func TestParseAlertTypeEvalRegression(t *testing.T) {
 		t.Errorf("parseAlertType(\"eval_regression\") = %s, want %s", result, AlertTypeEvalRegression)
 	}
 }
+
+func newResolutionTestEngine(t *testing.T, severities []Severity, cooldown time.Duration) (*Engine, *mockChannel) {
+	t.Helper()
+	config := &AlertConfig{
+		Enabled: true,
+		Channels: []ChannelConfig{
+			{Name: "test-channel", Type: "webhook", Enabled: true, Severities: severities},
+		},
+		Rules: []AlertRule{
+			{
+				Name:     "config-error",
+				Type:     AlertTypeServiceUnhealthy,
+				Enabled:  true,
+				Severity: SeverityWarning,
+				Cooldown: cooldown,
+			},
+		},
+	}
+
+	mockCh := newMockChannel("test-channel", "webhook")
+	dispatcher := NewDispatcher(config)
+	dispatcher.RegisterChannel(mockCh)
+	return NewEngine(config, WithDispatcher(dispatcher)), mockCh
+}
+
+func fireConfigError(e *Engine, source string) {
+	e.handleConfigError(context.Background(), Event{
+		Type:      EventTypeConfigError,
+		Source:    source,
+		Error:     source + " verification failed",
+		Timestamp: time.Now(),
+	})
+}
+
+func fireConfigHealthy(e *Engine, source string) {
+	e.handleConfigHealthy(context.Background(), Event{
+		Type:      EventTypeConfigHealthy,
+		Source:    source,
+		Timestamp: time.Now(),
+	})
+}
+
+func TestAlertResolution(t *testing.T) {
+	tests := []struct {
+		name       string
+		severities []Severity
+		cooldown   time.Duration
+		run        func(e *Engine)
+		wantAlerts int
+		wantLast   func(t *testing.T, alerts []*Alert)
+	}{
+		{
+			name: "healthy event with no active alert is silent",
+			run: func(e *Engine) {
+				fireConfigHealthy(e, "adapter:github")
+			},
+			wantAlerts: 0,
+		},
+		{
+			name: "fire then resolve emits one resolution carrying ResolvedAt",
+			run: func(e *Engine) {
+				fireConfigError(e, "adapter:github")
+				fireConfigHealthy(e, "adapter:github")
+			},
+			wantAlerts: 2,
+			wantLast: func(t *testing.T, alerts []*Alert) {
+				last := alerts[len(alerts)-1]
+				if last.ResolvedAt == nil {
+					t.Error("resolution has nil ResolvedAt")
+				}
+				if !last.IsResolution() {
+					t.Error("IsResolution() = false")
+				}
+				if last.Severity != SeverityInfo {
+					t.Errorf("severity = %q, want info", last.Severity)
+				}
+			},
+		},
+		{
+			name: "resolving clears active state so a regression alerts again",
+			run: func(e *Engine) {
+				fireConfigError(e, "adapter:github")
+				fireConfigHealthy(e, "adapter:github")
+				fireConfigError(e, "adapter:github")
+			},
+			wantAlerts: 3,
+			wantLast: func(t *testing.T, alerts []*Alert) {
+				if alerts[len(alerts)-1].ResolvedAt != nil {
+					t.Error("re-fired alert should not be a resolution")
+				}
+			},
+		},
+		{
+			name:     "cooldown does not suppress the resolution",
+			cooldown: time.Hour,
+			run: func(e *Engine) {
+				fireConfigError(e, "adapter:github")
+				fireConfigHealthy(e, "adapter:github")
+			},
+			wantAlerts: 2,
+		},
+		{
+			name: "two sources under one rule resolve independently",
+			run: func(e *Engine) {
+				fireConfigError(e, "adapter:github")
+				fireConfigError(e, "adapter:linear")
+				fireConfigHealthy(e, "adapter:github")
+			},
+			wantAlerts: 3,
+			wantLast: func(t *testing.T, alerts []*Alert) {
+				last := alerts[len(alerts)-1]
+				if last.Source != "adapter:github" {
+					t.Errorf("resolved source = %q, want adapter:github", last.Source)
+				}
+			},
+		},
+		{
+			name:       "resolution reaches the original channels despite an info-excluding filter",
+			severities: []Severity{SeverityWarning, SeverityCritical},
+			run: func(e *Engine) {
+				fireConfigError(e, "adapter:github")
+				fireConfigHealthy(e, "adapter:github")
+			},
+			wantAlerts: 2,
+			wantLast: func(t *testing.T, alerts []*Alert) {
+				if !alerts[len(alerts)-1].IsResolution() {
+					t.Error("channel did not receive the resolution")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			engine, mockCh := newResolutionTestEngine(t, tt.severities, tt.cooldown)
+			tt.run(engine)
+
+			got := mockCh.getAlerts()
+			if len(got) != tt.wantAlerts {
+				t.Fatalf("dispatched %d alerts, want %d", len(got), tt.wantAlerts)
+			}
+			if tt.wantLast != nil {
+				tt.wantLast(t, got)
+			}
+		})
+	}
+}
+
+func TestAlertResolutionDisabled(t *testing.T) {
+	engine, mockCh := newResolutionTestEngine(t, nil, 0)
+	disabled := false
+	engine.config.Defaults.NotifyOnResolve = &disabled
+
+	fireConfigError(engine, "adapter:github")
+	fireConfigHealthy(engine, "adapter:github")
+
+	if got := len(mockCh.getAlerts()); got != 1 {
+		t.Fatalf("dispatched %d alerts, want 1 (resolution disabled)", got)
+	}
+}

--- a/internal/alerts/types.go
+++ b/internal/alerts/types.go
@@ -230,6 +230,22 @@ type AlertDefaults struct {
 	Cooldown           time.Duration `yaml:"cooldown"`
 	DefaultSeverity    Severity      `yaml:"default_severity"`
 	SuppressDuplicates bool          `yaml:"suppress_duplicates"`
+	NotifyOnResolve    *bool         `yaml:"notify_on_resolve"`
+}
+
+func (d AlertDefaults) ResolveNotificationsEnabled() bool {
+	return d.NotifyOnResolve == nil || *d.NotifyOnResolve
+}
+
+func (a *Alert) IsResolution() bool {
+	return a != nil && a.ResolvedAt != nil
+}
+
+func (a *Alert) Duration() time.Duration {
+	if !a.IsResolution() {
+		return 0
+	}
+	return a.ResolvedAt.Sub(a.CreatedAt)
 }
 
 // ChannelConfig configures an alert channel

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -400,10 +400,23 @@ type DashboardConfig struct {
 // AlertsConfig holds configuration for the alerting system including
 // channels, rules, and default settings.
 type AlertsConfig struct {
-	Enabled  bool                 `yaml:"enabled"`
-	Channels []AlertChannelConfig `yaml:"channels"`
-	Rules    []AlertRuleConfig    `yaml:"rules"`
-	Defaults AlertDefaultsConfig  `yaml:"defaults"`
+	Enabled             bool                 `yaml:"enabled"`
+	Channels            []AlertChannelConfig `yaml:"channels"`
+	Rules               []AlertRuleConfig    `yaml:"rules"`
+	Defaults            AlertDefaultsConfig  `yaml:"defaults"`
+	HealthCheckInterval time.Duration        `yaml:"health_check_interval"`
+}
+
+const defaultAlertHealthCheckInterval = 15 * time.Minute
+
+func (a *AlertsConfig) ResolvedHealthCheckInterval() time.Duration {
+	if a == nil || a.HealthCheckInterval < 0 {
+		return 0
+	}
+	if a.HealthCheckInterval == 0 {
+		return defaultAlertHealthCheckInterval
+	}
+	return a.HealthCheckInterval
 }
 
 // AlertChannelConfig configures a destination channel for alerts.
@@ -452,6 +465,7 @@ type AlertDefaultsConfig struct {
 	Cooldown           time.Duration `yaml:"cooldown"`
 	DefaultSeverity    string        `yaml:"default_severity"`
 	SuppressDuplicates bool          `yaml:"suppress_duplicates"`
+	NotifyOnResolve    *bool         `yaml:"notify_on_resolve"`
 }
 
 // ToAlertConfig converts the YAML-facing AlertsConfig into the alerts
@@ -511,6 +525,7 @@ func (a *AlertsConfig) ToAlertConfig() *alerts.AlertConfig {
 		Cooldown:           a.Defaults.Cooldown,
 		DefaultSeverity:    a.Defaults.DefaultSeverity,
 		SuppressDuplicates: a.Defaults.SuppressDuplicates,
+		NotifyOnResolve:    a.Defaults.NotifyOnResolve,
 	}
 
 	return alerts.FromConfigAlerts(a.Enabled, channels, rules, defaults)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2370,3 +2370,64 @@ executor:
 		}
 	})
 }
+
+func TestResolvedHealthCheckInterval(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *AlertsConfig
+		want time.Duration
+	}{
+		{name: "unset uses the default", cfg: &AlertsConfig{}, want: 15 * time.Minute},
+		{name: "explicit interval is honoured", cfg: &AlertsConfig{HealthCheckInterval: 90 * time.Second}, want: 90 * time.Second},
+		{name: "negative disables", cfg: &AlertsConfig{HealthCheckInterval: -time.Second}, want: 0},
+		{name: "nil config disables", cfg: nil, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.ResolvedHealthCheckInterval(); got != tt.want {
+				t.Errorf("ResolvedHealthCheckInterval() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToAlertConfigCarriesNotifyOnResolve(t *testing.T) {
+	enabled := true
+	disabled := false
+
+	tests := []struct {
+		name            string
+		notifyOnResolve *bool
+		wantEnabled     bool
+	}{
+		{name: "unset means enabled", notifyOnResolve: nil, wantEnabled: true},
+		{name: "explicit true", notifyOnResolve: &enabled, wantEnabled: true},
+		{name: "explicit false is carried through", notifyOnResolve: &disabled, wantEnabled: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := &AlertsConfig{
+				Enabled:  true,
+				Defaults: AlertDefaultsConfig{NotifyOnResolve: tt.notifyOnResolve},
+			}
+
+			got := in.ToAlertConfig()
+			if got == nil {
+				t.Fatal("ToAlertConfig returned nil")
+			}
+			if got.Defaults.ResolveNotificationsEnabled() != tt.wantEnabled {
+				t.Errorf("ResolveNotificationsEnabled() = %v, want %v",
+					got.Defaults.ResolveNotificationsEnabled(), tt.wantEnabled)
+			}
+		})
+	}
+}
+
+func TestToAlertConfigNilReturnsNil(t *testing.T) {
+	var cfg *AlertsConfig
+	if got := cfg.ToAlertConfig(); got != nil {
+		t.Errorf("ToAlertConfig() on nil = %v, want nil", got)
+	}
+}


### PR DESCRIPTION
Alerts fired on degradation and never reported recovery; `Alert.ResolvedAt` existed with no production writer. Engine now tracks active alerts by rule+source, preflight emits `EventTypeConfigHealthy`, recovery dispatches a RESOLVED notification with duration. Gated by `alerts.defaults.notify_on_resolve` (unset = enabled); `alerts.health_check_interval` (default 15m) re-runs verifiers so recovery doesn't wait for a restart.

Two deliberate choices called out for review in the commit message: resolutions bypass cooldown, and route to the channels that received the original alert (not re-filtered on info severity).

Fixes #4886

Follow-up PR stacked on this one persists active state across restarts (#4890).

Single commit; verified: build/vet/test clean, `--new-from-rev=main` 0 issues, running in production on a fork build.