### PR TITLE
fix(executor): skip quality gates for read-only tasks

### DIFF
--- a/internal/comms/handler.go
+++ b/internal/comms/handler.go
@@ -415,6 +415,7 @@ If the question is too broad, ask for clarification instead of exploring everyth
 		Description: prompt,
 		ProjectPath: questionProjectPath,
 		LocalMode:   true,
+		ReadOnly:    true,
 		CreatePR:    false,
 		Verbose:     false,
 		IsCanary:    h.isCanaryProject(questionProjectPath),
@@ -459,6 +460,7 @@ Provide findings in a structured format with:
 DO NOT make any code changes. This is a read-only research task.`, query),
 		ProjectPath: researchProjectPath,
 		LocalMode:   true,
+		ReadOnly:    true,
 		CreatePR:    false,
 		IsCanary:    h.isCanaryProject(researchProjectPath),
 	}
@@ -601,6 +603,7 @@ Be concise - this is a chat conversation, not a report. Keep response under 500 
 User message: %s`, chatProjectPath, message),
 		ProjectPath: chatProjectPath,
 		LocalMode:   true,
+		ReadOnly:    true,
 		CreatePR:    false,
 		IsCanary:    h.isCanaryProject(chatProjectPath),
 	}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -470,6 +470,8 @@ type Task struct {
 	// When true, BuildPrompt skips Navigator detection and uses a focused
 	// problem-solving prompt suitable for local execution.
 	LocalMode bool
+	// ReadOnly marks tasks whose contract forbids changes (questions, research); quality gates skip them.
+	ReadOnly bool
 	// State is the current issue state in the source adapter (GH-2867).
 	// Examples: "open", "closed", "merged"
 	State string
@@ -4249,7 +4251,7 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 		// Run quality gates if configured.
 		// Previously skipped in LocalMode (v25 OOM concern), re-enabled since
 		// deps are now pre-installed and gate runs pytest only (bounded cost).
-		if r.qualityCheckerFactory != nil {
+		if r.qualityCheckerFactory != nil && !task.ReadOnly {
 			const maxAutoRetries = 2 // Circuit breaker to prevent infinite loops
 
 			// Track quality gate results across retries (GH-209)

--- a/internal/executor/runner_quality_readonly_test.go
+++ b/internal/executor/runner_quality_readonly_test.go
@@ -1,0 +1,58 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type readOnlyAnswerBackend struct{}
+
+func (b *readOnlyAnswerBackend) Name() string      { return "readonly-answer" }
+func (b *readOnlyAnswerBackend) IsAvailable() bool { return true }
+
+func (b *readOnlyAnswerBackend) Execute(_ context.Context, _ ExecuteOptions) (*BackendResult, error) {
+	return &BackendResult{Success: true, Output: "the README says hello"}, nil
+}
+
+func TestRunner_QualityGates_SkippedForReadOnlyTasks(t *testing.T) {
+	localRepo, remoteRepo := setupTestRepoWithRemote(t)
+	defer func() { _ = os.RemoveAll(localRepo) }()
+	defer func() { _ = os.RemoveAll(remoteRepo) }()
+
+	var factoryCalls atomic.Int32
+	runner := NewRunnerWithBackend(&readOnlyAnswerBackend{})
+	runner.config = &BackendConfig{UseWorktree: false}
+	runner.SetSkipPreflightChecks(true)
+	runner.SetRecordingEnabled(false)
+	runner.SetQualityCheckerFactory(func(taskID, projectPath string) QualityChecker {
+		factoryCalls.Add(1)
+		return &failingQualityChecker{}
+	})
+
+	task := &Task{
+		ID:          "Q-1786817067",
+		Title:       "Question: what does the README say",
+		Description: "answer only, no changes",
+		ProjectPath: localRepo,
+		LocalMode:   true,
+		ReadOnly:    true,
+		CreatePR:    false,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	result, err := runner.Execute(ctx, task)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result == nil || !result.Success {
+		t.Fatalf("read-only task must succeed without gate interference, got %+v", result)
+	}
+	if got := factoryCalls.Load(); got != 0 {
+		t.Errorf("quality checker factory invoked %d times for a ReadOnly task, want 0", got)
+	}
+}


### PR DESCRIPTION
Question / research / chat tasks from the comms handler are contract-level read-only (prompts forbid changes, `CreatePR: false`) and run under short caller deadlines (90s / 3m / 60s). Quality gates ran for them anyway — and the observed cascade turned a correctly answered question into a `task_failed` alert: ~40s answer, 1m21s of gates inside the 90s question context, deadline expired mid-gate, gate failure triggered the retry, and the retry's reset + re-invoke inherited the already-dead context and died same-second with `context deadline exceeded`. (The `timeout=72h` in those log lines is the classification label, not the governing deadline — the caller's 90s context wins.)

`Task` gains an explicit `ReadOnly` flag set at the three comms construction sites; the gate block skips such tasks, identical to an unconfigured factory. Guard test asserts the quality factory is never invoked for a `ReadOnly` task.

Fixes #4876

Verified: comms + executor suites green, `golangci-lint --new-from-rev=main` 0 issues. Root-cause narrative and live log evidence in the issue.