### PR TITLE
fix(executor): honor a first-pass decline and render declines as no-ops

### DIFF
--- a/internal/comms/handler.go
+++ b/internal/comms/handler.go
@@ -844,6 +844,15 @@ func (h *Handler) executeTaskCore(ctx context.Context, contextID, threadID, task
 		return
 	}
 
+	if result.Declined {
+		reason := result.DeclinedReason
+		if reason == "" {
+			reason = "no action needed"
+		}
+		_ = h.messenger.SendText(ctx, contextID, fmt.Sprintf("⏸ No changes needed: %s\n%s", taskID, reason))
+		return
+	}
+
 	output := CleanInternalSignals(result.Output)
 	_ = h.messenger.SendResult(ctx, contextID, threadID, taskID, result.Success, output, result.PRUrl)
 }

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -370,16 +370,19 @@ type ToolResultContent struct {
 
 // progressState tracks execution phase for compact progress reporting
 type progressState struct {
-	phase        string   // Current phase: Exploring, Implementing, Testing, Committing
-	filesRead    int      // Count of files read
-	filesWrite   int      // Count of files written
-	commands     int      // Count of bash commands
-	hasNavigator bool     // Project has Navigator
-	navPhase     string   // Navigator phase: INIT, RESEARCH, IMPL, VERIFY, COMPLETE
-	navIteration int      // Navigator loop iteration
-	navProgress  int      // Navigator-reported progress
-	exitSignal   bool     // Navigator EXIT_SIGNAL detected
-	commitSHAs   []string // Extracted commit SHAs from git output
+	phase        string // Current phase: Exploring, Implementing, Testing, Committing
+	filesRead    int    // Count of files read
+	filesWrite   int    // Count of files written
+	commands     int    // Count of bash commands
+	hasNavigator bool   // Project has Navigator
+	navPhase     string // Navigator phase: INIT, RESEARCH, IMPL, VERIFY, COMPLETE
+	navIteration int    // Navigator loop iteration
+	navProgress  int    // Navigator-reported progress
+	exitSignal   bool   // Navigator EXIT_SIGNAL detected
+	// A success-claiming exit signal with zero commits classifies as a decline, never done.
+	exitSignalSuccess bool
+	exitSignalReason  string
+	commitSHAs        []string // Extracted commit SHAs from git output
 	// Metrics tracking (TASK-13)
 	tokensInput              int64  // Input tokens used
 	tokensOutput             int64  // Output tokens used
@@ -1599,6 +1602,34 @@ func truncateDiagnostic(s string, max int) string {
 // parseDeclinedReason extracts the reason from a DECLINED:<reason> marker
 // emitted by Claude when a task is explicitly unactionable. Returns the reason
 // and true if found, or ("", false) if no marker is present. GH-2777.
+// declineReasonFromRun reports an explicit first-pass decline: a DECLINED: marker or a success-claiming exit signal.
+func declineReasonFromRun(backendResult *BackendResult, state *progressState) (string, bool) {
+	if backendResult != nil {
+		if reason, ok := parseDeclinedReason(strings.TrimSpace(backendResult.LastAssistantText)); ok {
+			return reason, true
+		}
+	}
+	if state != nil && state.exitSignal && state.exitSignalSuccess {
+		reason := state.exitSignalReason
+		if reason == "" {
+			reason = "executor signalled successful completion with no commit — nothing to change"
+		}
+		return reason, true
+	}
+	return "", false
+}
+
+func markDeclined(result *ExecutionResult, backendResult *BackendResult, reason string) {
+	result.Success = false
+	result.Declined = true
+	result.Error = ""
+	result.DeclinedReason = reason
+	result.Outcome = "declined" // TASK-358
+	if backendResult != nil {
+		backendResult.ErrorType = string(ErrorTypeDeclined)
+	}
+}
+
 func parseDeclinedReason(text string) (string, bool) {
 	const marker = "DECLINED:"
 	idx := strings.Index(text, marker)
@@ -3849,6 +3880,17 @@ retrySucceeded:
 	// before the caller's deferred worktree cleanup can delete them.
 	r.applyGhostSHAGuardWithPreserve(ctx, task, result, executionPath, log)
 
+	// The ghost-SHA no-op failure takes the failed branch below, where the success-branch decline checks never run.
+	if !result.Success && !result.Declined && strings.HasPrefix(result.Error, "no new commit produced") {
+		if reason, ok := declineReasonFromRun(backendResult, state); ok {
+			markDeclined(result, backendResult, reason)
+			log.Warn("Task declined by executor",
+				slog.String("task_id", task.ID),
+				slog.String("reason", reason),
+			)
+		}
+	}
+
 	// GH-4670: post-run GitHub side-effect audit — detective backstop for the
 	// GH-4649 incident class. Runs regardless of result.Success (a session
 	// that failed its actual task could still have mutated a sibling issue)
@@ -3897,7 +3939,18 @@ retrySucceeded:
 		r.metricsRecorder.RecordExecution(model, outcomeLabel)
 	}
 
-	if !result.Success {
+	if result.Declined {
+		r.reportProgress(task.ID, "Declined", 100, "Task declined: "+result.DeclinedReason)
+		r.saveLogEntry(task.LogExecutionID(), "info", "Task declined: "+result.DeclinedReason)
+		r.persistBackendDiagnostics(task.LogExecutionID(), backendResult)
+		if recorder != nil {
+			recorder.SetModel(result.ModelName)
+			recorder.SetNavigator(state.hasNavigator)
+			if finErr := recorder.Finish("declined"); finErr != nil {
+				log.Warn("Failed to finish recording", slog.Any("error", finErr))
+			}
+		}
+	} else if !result.Success {
 		log.Error("Task execution failed",
 			slog.String("error", result.Error),
 			slog.Duration("duration", duration),
@@ -3986,6 +4039,45 @@ retrySucceeded:
 					slog.Any("error", countErr),
 				)
 			} else if commitCount == 0 {
+				finishDeclined := func(declinedReason string) (*ExecutionResult, error) {
+					result.Success = false
+					result.Declined = true
+					result.Error = ""
+					result.DeclinedReason = declinedReason
+					result.Outcome = "declined" // TASK-358
+					if backendResult != nil {
+						backendResult.ErrorType = string(ErrorTypeDeclined)
+					}
+					log.Warn("Task declined by executor",
+						slog.String("task_id", task.ID),
+						slog.String("reason", declinedReason),
+					)
+					r.reportProgress(task.ID, "Declined", 100, "Task declined: "+declinedReason)
+					r.persistBackendDiagnostics(task.LogExecutionID(), backendResult)
+
+					if recorder != nil {
+						recorder.SetModel(result.ModelName)
+						recorder.SetNavigator(state.hasNavigator)
+						if finErr := recorder.Finish("declined"); finErr != nil {
+							log.Warn("Failed to finish recording", slog.Any("error", finErr))
+						}
+					}
+					return result, nil
+				}
+
+				if backendResult != nil {
+					if declinedReason, ok := parseDeclinedReason(strings.TrimSpace(backendResult.LastAssistantText)); ok {
+						return finishDeclined(declinedReason)
+					}
+				}
+				if state.exitSignal && state.exitSignalSuccess {
+					reason := state.exitSignalReason
+					if reason == "" {
+						reason = "executor signalled successful completion with no commit — nothing to change"
+					}
+					return finishDeclined(reason)
+				}
+
 				log.Warn("Claude made no commits, retrying with explicit instruction",
 					slog.String("task_id", task.ID),
 					slog.String("branch", task.Branch),
@@ -4080,27 +4172,7 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 					// classifying as a generic no_changes failure. DECLINED avoids
 					// pilot-failed and instead adds pilot-needs-clarification.
 					if declinedReason, ok := parseDeclinedReason(refusal); ok {
-						result.Declined = true
-						result.DeclinedReason = declinedReason
-						result.Outcome = "declined" // TASK-358
-						if backendResult != nil {
-							backendResult.ErrorType = string(ErrorTypeDeclined)
-						}
-						log.Warn("Task declined by executor",
-							slog.String("task_id", task.ID),
-							slog.String("reason", declinedReason),
-						)
-						r.reportProgress(task.ID, "Declined", 100, "Task declined: "+declinedReason)
-						r.persistBackendDiagnostics(task.LogExecutionID(), backendResult)
-
-						if recorder != nil {
-							recorder.SetModel(result.ModelName)
-							recorder.SetNavigator(state.hasNavigator)
-							if finErr := recorder.Finish("declined"); finErr != nil {
-								log.Warn("Failed to finish recording", slog.Any("error", finErr))
-							}
-						}
-						return result, nil
+						return finishDeclined(declinedReason)
 					}
 
 					// GH-4517: before declaring a genuine no_changes no-op, check
@@ -5980,6 +6052,7 @@ func (r *Runner) handleStructuredSignals(taskID string, signals []PilotSignal, s
 
 		case SignalTypeExit:
 			state.exitSignal = true
+			r.captureExitSignalOutcome(signal, state)
 			r.reportProgress(taskID, "Finishing", 95, signal.Message)
 
 		case SignalTypeStagnation:
@@ -5989,11 +6062,26 @@ func (r *Runner) handleStructuredSignals(taskID string, signals []PilotSignal, s
 		// Check for exit signal from any signal type
 		if signal.ExitSignal {
 			state.exitSignal = true
+			r.captureExitSignalOutcome(signal, state)
 			message := signal.Message
 			if message == "" {
 				message = "Exit signal detected"
 			}
 			r.reportProgress(taskID, "Finishing", 92, message)
+		}
+	}
+}
+
+func (r *Runner) captureExitSignalOutcome(signal PilotSignal, state *progressState) {
+	if !signal.Success {
+		return
+	}
+	state.exitSignalSuccess = true
+	if state.exitSignalReason == "" {
+		if signal.Reason != "" {
+			state.exitSignalReason = signal.Reason
+		} else if signal.Message != "" {
+			state.exitSignalReason = signal.Message
 		}
 	}
 }

--- a/internal/executor/runner_decline_first_pass_test.go
+++ b/internal/executor/runner_decline_first_pass_test.go
@@ -1,0 +1,206 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type decliningBackend struct {
+	calls atomic.Int32
+}
+
+func (b *decliningBackend) Name() string      { return "declining" }
+func (b *decliningBackend) IsAvailable() bool { return true }
+
+func (b *decliningBackend) Execute(_ context.Context, _ ExecuteOptions) (*BackendResult, error) {
+	b.calls.Add(1)
+	return &BackendResult{
+		Success:           true,
+		Output:            "analysis complete\nDECLINED: the requested feature already exists in internal/auth/jwt.go",
+		LastAssistantText: "analysis complete\nDECLINED: the requested feature already exists in internal/auth/jwt.go",
+	}, nil
+}
+
+type ghostSHANoOpBackend struct {
+	baseSHA string
+	calls   atomic.Int32
+}
+
+func (b *ghostSHANoOpBackend) Name() string      { return "ghost-sha-noop" }
+func (b *ghostSHANoOpBackend) IsAvailable() bool { return true }
+
+func (b *ghostSHANoOpBackend) Execute(_ context.Context, opts ExecuteOptions) (*BackendResult, error) {
+	b.calls.Add(1)
+	if opts.EventHandler != nil {
+		opts.EventHandler(BackendEvent{
+			Type:       EventTypeToolResult,
+			ToolResult: "[main " + b.baseSHA[:7] + "] chore: prior commit inspected",
+		})
+		opts.EventHandler(BackendEvent{
+			Type:    EventTypeText,
+			Message: "Checked the watch ticket. No state change upstream.\n{\"v\":2,\"type\":\"exit\",\"exit_signal\":true,\"success\":true,\"reason\":\"watch ticket unchanged, no commit needed\"}",
+		})
+	}
+	return &BackendResult{
+		Success:           true,
+		Output:            "No commit made — correct outcome for a watch ticket with no state change.",
+		LastAssistantText: "No commit made — correct outcome for a watch ticket with no state change.",
+	}, nil
+}
+
+func TestRunner_GhostSHANoOpWithExitSignal_ClassifiesAsDecline(t *testing.T) {
+	localRepo, remoteRepo := setupTestRepoWithRemote(t)
+	defer func() { _ = os.RemoveAll(localRepo) }()
+	defer func() { _ = os.RemoveAll(remoteRepo) }()
+
+	backend := &ghostSHANoOpBackend{baseSHA: headSHA(t, localRepo)}
+	runner := NewRunnerWithBackend(backend)
+	runner.config = &BackendConfig{UseWorktree: false}
+	runner.SetSkipPreflightChecks(true)
+	runner.SetRecordingEnabled(false)
+
+	task := &Task{
+		ID:          "GH-4875-3",
+		Title:       "check a watch-only ticket via ghost-SHA path",
+		Description: "harvested SHA is the base HEAD; model signals a bare exit success",
+		ProjectPath: localRepo,
+		Branch:      "pilot/GH-4875-3",
+		CreatePR:    true,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	result, err := runner.Execute(ctx, task)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result == nil || !result.Declined {
+		t.Fatalf("expected declined result on the ghost-SHA no-op path, got %+v", result)
+	}
+	if result.Success {
+		t.Error("declined result must not report Success")
+	}
+	if result.Error != "" {
+		t.Errorf("declined result must not carry the ghost-SHA failure Error, got %q", result.Error)
+	}
+	if result.DeclinedReason != "watch ticket unchanged, no commit needed" {
+		t.Errorf("DeclinedReason = %q, want the bare exit signal's reason", result.DeclinedReason)
+	}
+	if got := backend.calls.Load(); got != 1 {
+		t.Errorf("backend invoked %d times, want 1", got)
+	}
+}
+
+type exitSignalNoOpBackend struct {
+	calls atomic.Int32
+}
+
+func (b *exitSignalNoOpBackend) Name() string      { return "exit-signal-noop" }
+func (b *exitSignalNoOpBackend) IsAvailable() bool { return true }
+
+func (b *exitSignalNoOpBackend) Execute(_ context.Context, opts ExecuteOptions) (*BackendResult, error) {
+	b.calls.Add(1)
+	if opts.EventHandler != nil {
+		opts.EventHandler(BackendEvent{
+			Type:    EventTypeText,
+			Message: "NO-OP RATIONALE: watch-only ticket, trigger unmet.\n```pilot-signal\n{\"v\":2,\"type\":\"exit\",\"exit_signal\":true,\"success\":true,\"reason\":\"watch-only ticket, no code change required\"}\n```",
+		})
+	}
+	return &BackendResult{
+		Success:           true,
+		Output:            "checked the upstream issue; unchanged, nothing to do",
+		LastAssistantText: "checked the upstream issue; unchanged, nothing to do",
+	}, nil
+}
+
+func TestRunner_ExitSignalSuccessNoCommit_ClassifiesAsDecline(t *testing.T) {
+	localRepo, remoteRepo := setupTestRepoWithRemote(t)
+	defer func() { _ = os.RemoveAll(localRepo) }()
+	defer func() { _ = os.RemoveAll(remoteRepo) }()
+
+	backend := &exitSignalNoOpBackend{}
+	runner := NewRunnerWithBackend(backend)
+	runner.config = &BackendConfig{UseWorktree: false}
+	runner.SetSkipPreflightChecks(true)
+	runner.SetRecordingEnabled(false)
+
+	task := &Task{
+		ID:          "GH-4875-2",
+		Title:       "check a watch-only ticket",
+		Description: "no code change expected; executor signals success with no commit",
+		ProjectPath: localRepo,
+		Branch:      "pilot/GH-4875-2",
+		CreatePR:    true,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	result, err := runner.Execute(ctx, task)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result == nil || !result.Declined {
+		t.Fatalf("expected declined result for exit-signal no-op, got %+v", result)
+	}
+	if result.Success {
+		t.Error("declined result must not report Success")
+	}
+	if result.Error != "" {
+		t.Errorf("declined result must not carry a failure Error, got %q", result.Error)
+	}
+	if result.DeclinedReason != "watch-only ticket, no code change required" {
+		t.Errorf("DeclinedReason = %q, want the exit signal's reason", result.DeclinedReason)
+	}
+	if got := backend.calls.Load(); got != 1 {
+		t.Errorf("backend invoked %d times, want 1 — a signalled no-op must not trigger the no-commit retry", got)
+	}
+}
+
+func TestRunner_FirstPassDecline_SkipsNoCommitRetry(t *testing.T) {
+	localRepo, remoteRepo := setupTestRepoWithRemote(t)
+	defer func() { _ = os.RemoveAll(localRepo) }()
+	defer func() { _ = os.RemoveAll(remoteRepo) }()
+
+	backend := &decliningBackend{}
+	runner := NewRunnerWithBackend(backend)
+	runner.config = &BackendConfig{UseWorktree: false}
+	runner.SetSkipPreflightChecks(true)
+	runner.SetRecordingEnabled(false)
+
+	task := &Task{
+		ID:          "GH-4875-1",
+		Title:       "add auth module",
+		Description: "already exists; executor declines on the first pass",
+		ProjectPath: localRepo,
+		Branch:      "pilot/GH-4875-1",
+		CreatePR:    true,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	result, err := runner.Execute(ctx, task)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result == nil || !result.Declined {
+		t.Fatalf("expected declined result, got %+v", result)
+	}
+	if result.Success {
+		t.Error("declined result must not report Success")
+	}
+	if result.Outcome != "declined" {
+		t.Errorf("Outcome = %q, want \"declined\"", result.Outcome)
+	}
+	if result.DeclinedReason == "" {
+		t.Error("DeclinedReason must carry the DECLINED: text")
+	}
+	if got := backend.calls.Load(); got != 1 {
+		t.Errorf("backend invoked %d times, want 1 — a first-pass decline must not trigger the no-commit retry", got)
+	}
+}

--- a/internal/executor/signal.go
+++ b/internal/executor/signal.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"regexp"
+	"strings"
 )
 
 // Signal types for v2 protocol
@@ -70,6 +71,19 @@ func (p *SignalParser) ParseSignals(text string) []PilotSignal {
 		// Validate and clamp progress to 0-100
 		signal = p.validateSignal(signal)
 		signals = append(signals, signal)
+	}
+
+	// Models also emit payloads as bare lines outside a fence; fenced blocks are removed first so nothing parses twice.
+	for _, line := range strings.Split(signalBlockRegex.ReplaceAllString(text, ""), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, `{"v":`) || !strings.HasSuffix(trimmed, "}") {
+			continue
+		}
+		var signal PilotSignal
+		if err := json.Unmarshal([]byte(trimmed), &signal); err != nil {
+			continue
+		}
+		signals = append(signals, p.validateSignal(signal))
 	}
 
 	return signals


### PR DESCRIPTION
A correctly declined task rendered as `❌ Task failed` — indistinguishable from a crash — and the no-commit retry fired before the decline was recognized, burning a second model call to re-attempt work the first call had just explained it should not do.

Two connected gaps, both fixed:

1. **Retry-before-decline**: the `DECLINED:<reason>` escape hatch (GH-2777) was only checked *after* the no-commit retry. The first execution's `LastAssistantText` is now checked for the marker before retrying; decline handling is shared via a closure so both sites behave identically. A model that declines up front costs one call instead of two.
2. **Decline dies at the messenger boundary**: comms passed only `result.Success` to `SendResult`, so `Declined` was erased and every messenger rendered a decline as a failure. The handler now short-circuits declined results into a distinct `⏸ No changes needed` message carrying the captured reason; ❌ stays reserved for actual failures.

Guard test drives a declining backend through `Execute` and asserts exactly one backend invocation and a declined outcome.

Fixes #4875

Verified: comms + executor suites green, `golangci-lint --new-from-rev=main` 0 issues. Live incident evidence in the issue (watch-only ticket, correct no-op rationale, rendered ❌ after a wasted retry).