### PR TITLE
fix(comms): strip pilot-signal protocol blocks from user-facing replies

### DIFF
--- a/internal/adapters/telegram/formatter.go
+++ b/internal/adapters/telegram/formatter.go
@@ -336,8 +336,23 @@ func cleanInternalSignals(text string) string {
 	lines := strings.Split(text, "\n")
 	var cleanLines []string
 	skipBlock := false
+	inSignalFence := false
 
 	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if inSignalFence {
+			if trimmed == "```" {
+				inSignalFence = false
+			}
+			continue
+		}
+		if strings.HasPrefix(trimmed, "```pilot-signal") {
+			inSignalFence = true
+			continue
+		}
+		if strings.HasPrefix(trimmed, `{"v":`) && strings.HasSuffix(trimmed, "}") {
+			continue
+		}
 		// Skip NAVIGATOR_STATUS blocks
 		if strings.Contains(line, "NAVIGATOR_STATUS") {
 			skipBlock = true

--- a/internal/comms/util.go
+++ b/internal/comms/util.go
@@ -29,8 +29,23 @@ func CleanInternalSignals(text string) string {
 	lines := strings.Split(text, "\n")
 	var clean []string
 	skipBlock := false
+	inSignalFence := false
 
 	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if inSignalFence {
+			if trimmed == "```" {
+				inSignalFence = false
+			}
+			continue
+		}
+		if strings.HasPrefix(trimmed, "```pilot-signal") {
+			inSignalFence = true
+			continue
+		}
+		if isBareSignalLine(trimmed) {
+			continue
+		}
 		if strings.Contains(line, "NAVIGATOR_STATUS") {
 			skipBlock = true
 			continue
@@ -67,6 +82,11 @@ func CleanInternalSignals(text string) string {
 	}
 
 	return strings.Join(clean, "\n")
+}
+
+// isBareSignalLine reports whether a line is an unfenced pilot-signal protocol payload.
+func isBareSignalLine(trimmed string) bool {
+	return strings.HasPrefix(trimmed, `{"v":`) && strings.HasSuffix(trimmed, "}")
 }
 
 // ChunkContent splits text into chunks of at most maxLen characters,

--- a/internal/comms/util_test.go
+++ b/internal/comms/util_test.go
@@ -19,6 +19,11 @@ func TestCleanInternalSignals(t *testing.T) {
 		{"leading blanks stripped", "\n\nhello", "hello"},
 		{"trailing blanks stripped", "hello\n\n", "hello"},
 		{"multiple signals", "[EXIT_SIGNAL]\n[IMPL_DONE]\nreal output", "real output"},
+		{"pilot-signal fence stripped", "answer\n```pilot-signal\n{\"v\":2,\"type\":\"exit\",\"exit_signal\":true,\"success\":true}\n```\nmore", "answer\nmore"},
+		{"bare protocol line stripped", "checked the issue\n{\"v\":2,\"type\":\"status\",\"phase\":\"INIT\",\"progress\":5}\nnothing to do", "checked the issue\nnothing to do"},
+		{"multiline fence stripped", "```pilot-signal\n{\"v\":2,\n\"type\":\"exit\"}\n```\nresult", "result"},
+		{"ordinary code fence kept", "```go\nfmt.Println(\"hi\")\n```", "```go\nfmt.Println(\"hi\")\n```"},
+		{"prose json kept", "the response was {\"ok\": true}", "the response was {\"ok\": true}"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
`CleanInternalSignals` predates the v2 signal protocol (GH-960): it strips legacy string markers but passes fenced ```pilot-signal``` blocks and bare `{"v":...}` JSON lines straight through — chat replies arrived carrying raw protocol payloads inline (observed live on Telegram, see issue).

Comms cleaner + the telegram formatter copy now drop pilot-signal fences and bare protocol lines; ordinary code fences and JSON in prose are untouched (tests cover both keep-cases). Slack/discord formatter copies share the gap — noted in the issue; the four-way cleaner divergence is worth its own consolidation pass.

Fixes #4902

Verified: comms + telegram suites green, `golangci-lint --new-from-rev=main` 0 issues.