### PR TITLE
fix(comms): give chat-originated tasks an executions row via ExecutionLifecycle

### DIFF
--- a/internal/comms/handler.go
+++ b/internal/comms/handler.go
@@ -3,6 +3,7 @@ package comms
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -828,15 +829,38 @@ func (h *Handler) executeTaskCore(ctx context.Context, contextID, threadID, task
 		})
 	}
 
+	// Chat tasks bypass the dispatcher; without Begin, execution_events writes have no parent row.
+	lifecycle := executor.NewExecutionLifecycle(h.store)
+	execID, lifeErr := lifecycle.Begin(task, executor.ExecStatusRunning)
+	if lifeErr != nil {
+		if errors.Is(lifeErr, executor.ErrClaimLost) {
+			_ = h.messenger.SendText(ctx, contextID, fmt.Sprintf("⚠️ %s is already being executed by another Pilot process.", taskID))
+			if h.runner != nil {
+				h.runner.RemoveProgressCallback(callbackName)
+			}
+			return
+		}
+		h.log.Warn("Failed to record execution start; running without an audit trail",
+			slog.String("task_id", taskID), slog.Any("error", lifeErr))
+	}
+
 	// Execute
 	h.log.Info("Executing task",
 		slog.String("task_id", taskID),
 		slog.String("context_id", contextID))
+	startedAt := time.Now()
 	result, err := h.runner.Execute(taskCtx, task)
 
 	// Remove named progress callback
 	if h.runner != nil {
 		h.runner.RemoveProgressCallback(callbackName)
+	}
+
+	if execID != "" && lifeErr == nil {
+		if _, finErr := lifecycle.Finish(execID, result, err, time.Since(startedAt)); finErr != nil {
+			h.log.Warn("Failed to record execution finish",
+				slog.String("task_id", taskID), slog.Any("error", finErr))
+		}
 	}
 
 	if err != nil {

--- a/internal/comms/handler_lifecycle_test.go
+++ b/internal/comms/handler_lifecycle_test.go
@@ -1,0 +1,58 @@
+package comms
+
+import (
+	"context"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/executor"
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+type noopChatBackend struct{}
+
+func (b *noopChatBackend) Name() string      { return "noop-chat" }
+func (b *noopChatBackend) IsAvailable() bool { return true }
+
+func (b *noopChatBackend) Execute(_ context.Context, _ executor.ExecuteOptions) (*executor.BackendResult, error) {
+	return &executor.BackendResult{Success: true, Output: "done"}, nil
+}
+
+func TestExecuteTask_CreatesAndFinalizesExecutionRow(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	runner := executor.NewRunnerWithBackend(&noopChatBackend{})
+	runner.SetSkipPreflightChecks(true)
+	runner.SetRecordingEnabled(false)
+	runner.SetLogStore(store)
+
+	projectPath := t.TempDir()
+	h := NewHandler(&HandlerConfig{
+		Messenger:    &handlerMock{},
+		Runner:       runner,
+		Store:        store,
+		ProjectPath:  projectPath,
+		TaskIDPrefix: "TG",
+	})
+
+	h.executeTask(context.Background(), "chat1", "", "TG-1786832353", "check the upstream issue")
+
+	execs, err := store.ListExecutionsForTask("TG-1786832353", projectPath)
+	if err != nil {
+		t.Fatalf("ListExecutionsForTask: %v", err)
+	}
+	if len(execs) != 1 {
+		t.Fatalf("executions rows = %d, want 1 — chat tasks must get a ledger row", len(execs))
+	}
+	exec := execs[0]
+	if exec.Status == string(executor.ExecStatusRunning) || exec.Status == "queued" {
+		t.Errorf("execution left non-terminal (%q); Finish must run after Execute", exec.Status)
+	}
+
+	if err := store.RecordExecutionEvent(exec.ID, memory.StageCommit, "event writes must work now"); err != nil {
+		t.Errorf("RecordExecutionEvent against the chat task's row failed: %v", err)
+	}
+}


### PR DESCRIPTION
Chat tasks (`executeTaskCore`) call `runner.Execute` directly and never touch the dispatcher or the `ExecutionLifecycle` chokepoint, so no `executions` row exists under the id runner-side writes key on. Every `execution_events` write for a TG-*/SLACK-* task — `spec_validated`, `claude_started`, `implementation_started`, and security-relevant `executor.gh_guard_denied` — was dropped by the validate-first guard (GH-4244) with `execution not found`. A gh-guard denial therefore left **no audit trail at all** (observed live, see #4878).

`executeTaskCore` now mirrors the CLI path (GH-4243's `recordCLITaskStart`/`recordCLITaskFinish`): `Begin` stamps `task.ExecutionID` and creates the claimed row before `Execute`; `Finish` records terminal status and metrics after. A lost claim aborts before backend invocation with a visible message; any other lifecycle error degrades to today's behavior (execute without audit trail) rather than blocking the task.

Question/research/chat-conversation paths stay row-less — ephemeral by design, no lifecycle stages emitted; scoped to the task path where the drops were observed.

Fixes #4878

Verified: comms + executor suites green, `golangci-lint --new-from-rev=main` 0 issues. Guard test drives `executeTask` with a real store and asserts one finalized row and successful event writes against it.