### PR TITLE
fix(ghguard): honor an explicit -X GET as a read even with data flags

### DIFF
--- a/internal/executor/ghguard/policy.go
+++ b/internal/executor/ghguard/policy.go
@@ -392,10 +392,14 @@ func Classify(id Identity, args []string) Decision {
 // presence as non-GET is stricter than the letter of "gh api non-GET" but
 // closes that implicit-mutation gap deliberately.
 func checkAPIRead(p parsedArgs) Decision {
-	if p.hasDataFlag {
-		return deny("gh api with -f/-F/--field/--raw-field/--input carries a request body and is treated as a mutation", allowedSummary())
-	}
 	method := strings.ToUpper(strings.TrimSpace(p.method))
+	if p.hasDataFlag {
+		// gh auto-switches to POST only when -X is absent; explicit GET + data flags is a query-parameter read.
+		if method == "GET" {
+			return Decision{Verdict: VerdictAllow, Reason: "gh api explicit -X GET with query fields"}
+		}
+		return deny("gh api with -f/-F/--field/--raw-field/--input carries a request body and is treated as a mutation; for a read-only query add an explicit -X GET, or URL-encode it (gh api 'search/issues?q=...')", allowedSummary())
+	}
 	if method != "" && method != "GET" {
 		return deny(fmt.Sprintf("gh api -X %s is not a read", p.method), allowedSummary())
 	}

--- a/internal/executor/ghguard/policy_test.go
+++ b/internal/executor/ghguard/policy_test.go
@@ -43,6 +43,8 @@ func TestClassify(t *testing.T) {
 		{"api GET implicit", []string{"api", "repos/qf-studio/pilot/issues/1"}, VerdictAllow},
 		{"api GET explicit -X", []string{"api", "repos/qf-studio/pilot/issues/1", "-X", "GET"}, VerdictAllow},
 		{"api GET explicit --method lowercase", []string{"api", "repos/qf-studio/pilot/issues/1", "--method", "get"}, VerdictAllow},
+		{"api search with -f query and explicit GET", []string{"api", "search/issues", "-X", "GET", "-f", "q=6220 in:body type:pr"}, VerdictAllow},
+		{"api search with -f query lowercase get", []string{"api", "search/issues", "--method", "get", "-f", "q=repo:o/r is:open"}, VerdictAllow},
 
 		// --- own-artifact allows ---
 		{"pr create no head (current branch)", []string{"pr", "create", "--title", "t", "--body", "b"}, VerdictAllow},


### PR DESCRIPTION
The data-flag heuristic denies any `gh api` call carrying `-f/-F/--field/--raw-field/--input` to close the implicit-mutation gap (gh auto-switches to POST when data flags are present). But gh only auto-switches **when `-X` is absent** — data flags plus an explicit `-X GET` are unambiguously a query-parameter read. The blanket deny blocked the CLI's documented search form (`gh api search/issues -f q=...`), cutting executors off from read-only research (observed live, #4877).

Change: data flags + explicit GET now pass; the deny message for the remaining ambiguous case teaches both escapes (add `-X GET`, or URL-encode as `gh api 'search/issues?q=...'`) so the model can self-correct. Implicit-mutation behavior without `-X` is unchanged — the deliberate strictness the `checkAPIRead` comment documents still holds where it is actually ambiguous.

Fixes #4877

Verified: ghguard + executor suites green, `golangci-lint --new-from-rev=main` 0 issues. Test rows added for both explicit-GET spellings.