### PR TITLE
fix(telegram): surface edited-message and empty-text drops instead of hiding them

### DIFF
--- a/internal/adapters/telegram/client.go
+++ b/internal/adapters/telegram/client.go
@@ -69,6 +69,7 @@ type Result struct {
 type Update struct {
 	UpdateID      int64          `json:"update_id"`
 	Message       *Message       `json:"message,omitempty"`
+	EditedMessage *Message       `json:"edited_message,omitempty"`
 	CallbackQuery *CallbackQuery `json:"callback_query,omitempty"`
 }
 

--- a/internal/adapters/telegram/handler.go
+++ b/internal/adapters/telegram/handler.go
@@ -310,6 +310,20 @@ func (h *Handler) processUpdate(ctx context.Context, update *Update) {
 	}
 
 	if update.Message == nil {
+		// Edits are deliberately not re-processed: a task-triggering edit would double-dispatch.
+		if update.EditedMessage != nil {
+			chatID := int64(0)
+			if update.EditedMessage.Chat != nil {
+				chatID = update.EditedMessage.Chat.ID
+			}
+			logging.WithComponent("telegram").Info("ignoring edited message",
+				slog.Int64("chat_id", chatID),
+				slog.Int64("message_id", update.EditedMessage.MessageID),
+			)
+			return
+		}
+		logging.WithComponent("telegram").Debug("ignoring update with no message payload",
+			slog.Int64("update_id", update.UpdateID))
 		return
 	}
 
@@ -330,6 +344,10 @@ func (h *Handler) processUpdate(ctx context.Context, update *Update) {
 
 	// Skip if no text
 	if msg.Text == "" {
+		logging.WithComponent("telegram").Debug("ignoring message with no text",
+			slog.Int64("chat_id", msg.Chat.ID),
+			slog.Int64("message_id", msg.MessageID),
+		)
 		return
 	}
 

--- a/internal/adapters/telegram/handler_test.go
+++ b/internal/adapters/telegram/handler_test.go
@@ -1688,3 +1688,34 @@ func TestStripBotMention(t *testing.T) {
 		})
 	}
 }
+
+func TestProcessUpdateEditedMessageDoesNotDispatch(t *testing.T) {
+	h := &Handler{}
+
+	h.processUpdate(context.Background(), &Update{
+		UpdateID: 399151960,
+		EditedMessage: &Message{
+			MessageID: 12,
+			Chat:      &Chat{ID: -100123, Type: "supergroup"},
+			From:      &User{ID: 55},
+			Text:      "edited text",
+		},
+	})
+}
+
+func TestUpdateParsesEditedMessage(t *testing.T) {
+	raw := `{"update_id": 399151959, "edited_message": {"message_id": 7, "chat": {"id": -100123, "type": "supergroup"}, "text": "fixed typo"}}`
+	var u Update
+	if err := json.Unmarshal([]byte(raw), &u); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if u.EditedMessage == nil {
+		t.Fatal("edited_message not parsed into Update")
+	}
+	if u.EditedMessage.Text != "fixed typo" {
+		t.Errorf("EditedMessage.Text = %q, want %q", u.EditedMessage.Text, "fixed typo")
+	}
+	if u.Message != nil {
+		t.Error("Message must stay nil for an edited_message update")
+	}
+}


### PR DESCRIPTION
`Update` parsed only `message` and `callback_query`; an `edited_message` hit the `Message == nil` return and evaporated with no log line at any level (found via a daemon-stop + raw `getUpdates` session — see #4906). The empty-`Text` drop was equally silent.

`Update` gains `EditedMessage`. Edits log at Info and are deliberately **not** re-processed — a task-triggering edit would double-dispatch; re-routing edits as fresh messages is a separate product decision the issue leaves open. The no-payload and empty-text drops log at Debug with identifying fields.

Fixes #4906

Verified: telegram suite green, `golangci-lint --new-from-rev=main` 0 issues. Tests cover the parse (`edited_message` → `Update.EditedMessage`, `Message` stays nil) and the no-dispatch path.