### PR TITLE
GH-4911: fix(autopilot): GH-4909 advisories — dead-end sideways merges at handleMerging (no deploy/release) + clear park residue on resume (PR#4910 review)

### DIFF
--- a/.agent/tasks/gh-4911.md
+++ b/.agent/tasks/gh-4911.md
@@ -1,0 +1,24 @@
+# GH-4911
+
+**Created:** 2026-08-17
+
+## Problem
+
+GitHub Issue GH-4911: fix(autopilot): GH-4909 advisories — dead-end sideways merges at handleMerging (no deploy/release) + clear park residue on resume (PR#4910 review)
+
+## Problem
+
+Two advisory gaps from the PR#4910 pre-merge review (GH-4909 base-guard fixes) — both in `internal/autopilot/controller.go`.
+
+**1. Sideways-merged PR can still deploy/release.** The new `handleMerging` finalize predicate correctly withholds the five delivered effects when a merge landed off-default, but leaves the PRState at `StageMerged` — next tick `handleMerged` runs `deployer.Deploy` (Branch = the stack branch) and can route to `StageReleasing`. The sibling external-merge mismatch site (~:7541) calls `removePR` specifically to prevent deploy/release off a sideways merge. Reachable only via the merge-instant retarget race, but the two sites should behave identically: after the withheld finalize, `removePR` (without branch delete — the branch may be another PR's base, see `safeDeleteBranch`) so the sideways merge dead-ends the same way at both sites.
+
+**2. Park residue never cleared on resume.** When a parked PR resumes (base fixed → guard passes → merges), `Parked`/`EscalationReason` and the `parked-awaiting-approval` label persist (state_store, GH-4598). Residual `Parked=true` later silently skips `submitAsyncApprovalRequest`'s one-time misconfig side effects (bare `Parked` check at ~:3614). Clear the flag + reason + label at the point the guard passes for a previously-parked PR (log the un-park), and change the :3614 check to compare the reason, not the bare flag.
+
+## Acceptance
+
+- Finalize-predicate test extended: after the withheld finalize, next tick performs no deploy/release for that PR (effect counts stay zero); PR tracking removed; branch NOT deleted when it bases an open PR.
+- Retarget-resume test extended: after the resumed merge, `Parked=false`, `EscalationReason` empty, park label removed; a later misconfig on the same PR still triggers its one-time side effects.
+- Existing GH-4908/4909 tests unchanged and green; `make test` green.
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1615,6 +1615,14 @@ func (c *Controller) alertApprovalMisconfigOnce(prState *PRState, reason, missin
 // misconfigCommentMarker in auto_merger.go).
 const baseMismatchCommentMarker = "<!-- pilot-base-mismatch -->"
 
+// baseMismatchReasonPrefix identifies an EscalationReason set by
+// parkForBaseMismatch, as opposed to any other cause that shares the same
+// Parked flag (e.g. submitAsyncApprovalRequest's misconfig park, GH-4596).
+// GH-4911: handleMerging's guard-pass un-park check uses this prefix to
+// confirm a residual Parked=true belongs to a now-resolved base mismatch
+// before clearing it, so it never clobbers an unrelated, still-active park.
+const baseMismatchReasonPrefix = "base branch mismatch:"
+
 // basePivotCommentMarker identifies the GH-4872 "merged sideways" comment
 // posted by postBasePivotComment to an issue whose linked PR merged into a
 // non-default base outside autopilot's own guarded merge path (external
@@ -1645,7 +1653,7 @@ const basePivotCommentMarker = "<!-- pilot-base-pivot -->"
 // inheriting the first park.
 func (c *Controller) parkForBaseMismatch(ctx context.Context, prState *PRState, target, defaultBranch string) {
 	reason := fmt.Sprintf(
-		"base branch mismatch: PR targets %q, not the default branch %q — this looks like a stacked or mis-based PR; a human must retarget it or merge the stack in order",
+		baseMismatchReasonPrefix+" PR targets %q, not the default branch %q — this looks like a stacked or mis-based PR; a human must retarget it or merge the stack in order",
 		target, defaultBranch,
 	)
 	alreadyParkedForThisMismatch := prState.Parked && prState.EscalationReason == reason
@@ -3687,8 +3695,19 @@ func (c *Controller) submitAsyncApprovalRequest(ctx context.Context, prState *PR
 		// the gate that fired, and Parked dedupes the one-time log/PR
 		// comment/alert across every subsequent tick while the misconfig
 		// persists.
+		//
+		// GH-4911 (GH-4909 defect-4 pattern applied here too): Parked is a
+		// single flag shared with every other park cause, including
+		// parkForBaseMismatch's — and unlike that call site, this one used to
+		// compare the bare flag only. A PR still carrying Parked=true from an
+		// unrelated, already-resolved park (e.g. state-store residue that
+		// predates handleMerging's GH-4911 un-park fix, or any future park
+		// cause) would silently inherit the old park and skip this cause's own
+		// one-time alert/label/comment. Snapshot the OLD reason before
+		// overwriting EscalationReason below so the comparison is meaningful.
+		alreadyParkedForThisMisconfig := prState.Parked && prState.EscalationReason == reason
 		prState.EscalationReason = reason
-		if prState.Parked {
+		if alreadyParkedForThisMisconfig {
 			// Already logged/commented on a prior tick — stay parked quietly.
 			return nil
 		}
@@ -3700,9 +3719,9 @@ func (c *Controller) submitAsyncApprovalRequest(ctx context.Context, prState *PR
 		// them having to read daemon logs — a label on the linked issue (same
 		// convention as escalateAndHold's labelNeedsHuman), the misconfig PR
 		// comment below (naming the exact unset config key), and a single
-		// deduped operator alert. The `if prState.Parked` early-return above
-		// guards every later tick; alertApprovalMisconfigOnce's {PR, reason}
-		// map additionally dedupes across fresh cycles where Parked resets.
+		// deduped operator alert. The alreadyParkedForThisMisconfig early-return
+		// above guards every later tick for this reason; alertApprovalMisconfigOnce's
+		// {PR, reason} map additionally dedupes across fresh cycles where Parked resets.
 		if prState.IssueNumber > 0 {
 			if err := c.labeler.AddLabels(ctx, c.owner, c.repo, prState.IssueNumber, []string{labelParkedAwaitingApproval}); err != nil {
 				c.log.Warn("failed to apply parked-awaiting-approval label", "issue", prState.IssueNumber, "pr", prState.PRNumber, "error", err)
@@ -4012,6 +4031,29 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 		return nil
 	}
 
+	// GH-4911: the guard above just passed, so any residual park from an
+	// earlier tick's base mismatch (parkForBaseMismatch) is now resolved — a
+	// human retargeted the PR back to the default branch. Parked,
+	// EscalationReason, and the parked-awaiting-approval label all persist
+	// across ticks via the state store (GH-4598); left in place, they wedge
+	// here as dead state once the PR merges below, and a bare `if
+	// prState.Parked` check elsewhere (submitAsyncApprovalRequest) would
+	// wrongly treat this PR as still parked for a later, unrelated cause.
+	// Guarded by the reason prefix so an unrelated, still-active park (e.g.
+	// an approval misconfig) is never clobbered by this base-mismatch-only
+	// cleanup.
+	if prState.Parked && strings.HasPrefix(prState.EscalationReason, baseMismatchReasonPrefix) {
+		c.log.Info("handleMerging: un-parking PR — base mismatch resolved, guard now passes",
+			"pr", prState.PRNumber, "issue", prState.IssueNumber, "prior_reason", prState.EscalationReason)
+		prState.Parked = false
+		prState.EscalationReason = ""
+		if prState.IssueNumber > 0 {
+			if err := c.labeler.RemoveLabel(ctx, c.owner, c.repo, prState.IssueNumber, labelParkedAwaitingApproval); err != nil {
+				c.log.Debug("parked-awaiting-approval label cleanup on un-park", "issue", prState.IssueNumber, "error", err)
+			}
+		}
+	}
+
 	prState.MergeAttempts++
 
 	c.log.Info("handleMerging: attempting merge",
@@ -4085,9 +4127,18 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 	// checkExternalMergeOrClose below. Fail-open on a re-read error (mirrors
 	// the CI re-validation fail-open above) — trust the pre-merge value
 	// rather than holding every successful merge hostage to a flaky
-	// follow-up API call. Skip ONLY the delivered bookkeeping (issue close,
-	// pilot-done label, monitor.Complete, self-heal, board->Done) — branch
-	// cleanup and the merge notifier still run below regardless of base.
+	// follow-up API call.
+	//
+	// GH-4911: a positive result here used to skip only the delivered
+	// bookkeeping (issue close, pilot-done label, monitor.Complete,
+	// self-heal, board->Done) while leaving Stage=StageMerged — the next
+	// tick's handleMerged then ran deployer.Deploy against the stack branch
+	// and could route to StageReleasing off content that never reached the
+	// default branch. The sibling external-merge mismatch site below
+	// (checkExternalMergeOrClose, "PR merged into non-default base") already
+	// calls removePR to prevent exactly that; the block right after this one
+	// now does the same here so both sites dead-end a sideways merge
+	// identically instead of leaving one of them to keep ticking forward.
 	baseMismatchAfterMerge := false
 	if mergedPR, gerr := c.ghClient.GetPullRequest(ctx, c.owner, c.repo, prState.PRNumber); gerr != nil {
 		c.log.Warn("handleMerging: failed to re-verify merged PR's base branch post-merge — trusting pre-merge value",
@@ -4104,9 +4155,23 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 		c.postBasePivotComment(ctx, prState.IssueNumber, prState.PRNumber, target, defaultBranch)
 	}
 
+	// GH-4911: dead-end a sideways merge here instead of leaving Stage=
+	// StageMerged for handleMerged to pick up next tick (deployer.Deploy /
+	// StageReleasing off content that landed on the wrong branch). Mirrors
+	// checkExternalMergeOrClose's "PR merged into non-default base" site,
+	// which calls plain removePR for the identical reason. removePR's own
+	// safeDeleteBranch call still refuses to delete BranchName if it happens
+	// to be the base of another open (stacked) PR — the same protection the
+	// sibling site relies on — so this branch is not force-deleted out from
+	// under a dependent PR merely because this one merged sideways.
+	if baseMismatchAfterMerge {
+		c.removePR(prState.PRNumber)
+		return nil
+	}
+
 	// GH-1015: Add pilot-done label after successful merge (not at PR creation)
 	// This prevents false positives where PRs are closed without merging
-	if !baseMismatchAfterMerge && prState.IssueNumber > 0 && !c.shouldDeferIssueClose(ctx, prState.IssueNumber, prState.PRNumber) {
+	if prState.IssueNumber > 0 && !c.shouldDeferIssueClose(ctx, prState.IssueNumber, prState.PRNumber) {
 		// GH-3271: mark issue processed in all pollers before any label updates so
 		// a poll tick that fires during the merge→pilot-done propagation window
 		// cannot re-dispatch the issue (phantom pilot-blocked).

--- a/internal/autopilot/gh4909_test.go
+++ b/internal/autopilot/gh4909_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -19,8 +20,23 @@ import (
 // `gh pr merge`. Before this fix, ProcessPR only ever wrote TargetBranch
 // once (when it was empty), so the resume check in handleMerging kept
 // re-reading the stale non-default value forever and the PR stayed parked.
+//
+// GH-4911: extended to cover the PR#4910 review's second advisory — the
+// park residue (Parked, EscalationReason, parked-awaiting-approval label)
+// must be cleared once the guard passes and the PR resumes, not just left
+// to rot as dead state. Also verifies that a later, unrelated park cause on
+// the same PR still gets its own one-time side effects afterward — the
+// cleared residue must not fool submitAsyncApprovalRequest's Parked check
+// (now reason-based) into treating the new cause as already handled.
 func TestController_ProcessPR_RetargetToDefault_ResumesWithoutManualIntervention(t *testing.T) {
-	var mergeCalled atomic.Int32
+	var (
+		mergeCalled      atomic.Int32
+		labelRemoveCalls atomic.Int32
+		labelApplyCalls  atomic.Int32
+	)
+
+	const labelPath = "/repos/owner/repo/issues/74/labels"
+	const labelRemovePath = labelPath + "/autopilot/parked-awaiting-approval"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -28,6 +44,13 @@ func TestController_ProcessPR_RetargetToDefault_ResumesWithoutManualIntervention
 			mergeCalled.Add(1)
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"sha":"mergedSHA","merged":true,"message":"merged"}`))
+		case r.URL.Path == labelRemovePath && r.Method == http.MethodDelete:
+			labelRemoveCalls.Add(1)
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == labelPath && r.Method == http.MethodPost:
+			labelApplyCalls.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
 		default:
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("{}"))
@@ -45,6 +68,7 @@ func TestController_ProcessPR_RetargetToDefault_ResumesWithoutManualIntervention
 	c.mu.Lock()
 	c.activePRs[90] = &PRState{
 		PRNumber:     90,
+		IssueNumber:  74,
 		HeadSHA:      "sha90",
 		Stage:        StageMerging,
 		TargetBranch: "pilot/GH-70", // parked on a stacked base from a prior tick
@@ -80,6 +104,39 @@ func TestController_ProcessPR_RetargetToDefault_ResumesWithoutManualIntervention
 	}
 	if pr.Stage != StageMerged {
 		t.Errorf("Stage = %s, want %s", pr.Stage, StageMerged)
+	}
+
+	// GH-4911: the base-mismatch park residue must not survive the resume.
+	if pr.Parked {
+		t.Error("Parked should be false after the base mismatch resolved and the PR merged")
+	}
+	if pr.EscalationReason != "" {
+		t.Errorf("EscalationReason = %q, want empty after un-park", pr.EscalationReason)
+	}
+	if labelRemoveCalls.Load() != 1 {
+		t.Errorf("parked-awaiting-approval label removal calls = %d, want 1", labelRemoveCalls.Load())
+	}
+
+	// A later, unrelated misconfig park on the same PR must still get its
+	// own one-time alert/label/comment. labelApplyCalls already includes the
+	// pilot-done label POST from the merge finalize above, so compare
+	// against a baseline taken right before this second park.
+	labelApplyBaseline := labelApplyCalls.Load()
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+	pr.Stage = StageAwaitApproval
+	pr.EscalationReason = "PR adds 656 net lines (> 500 threshold)"
+	if err := c.submitAsyncApprovalRequest(context.Background(), pr); err != nil {
+		t.Fatalf("submitAsyncApprovalRequest: %v", err)
+	}
+	if !pr.Parked {
+		t.Error("Parked should be true after the new misconfig park")
+	}
+	if got := labelApplyCalls.Load() - labelApplyBaseline; got != 1 {
+		t.Errorf("parked-awaiting-approval label apply calls = %d, want 1 for the new misconfig", got)
+	}
+	if len(sink.events) != 1 {
+		t.Errorf("alerts fired %d times, want 1 for the new misconfig", len(sink.events))
 	}
 }
 
@@ -167,13 +224,30 @@ func TestController_ProcessPR_RetargetToNonDefault_StaleCacheNoLongerMerges(t *t
 // pre-merge guard on a cached "main" TargetBranch, but the post-merge
 // re-verification GetPullRequest call reveals the PR actually landed on a
 // non-default base.
+//
+// GH-4911: extended to cover the follow-up advisory from the PR#4910
+// review — leaving Stage=StageMerged after the withheld finalize let the
+// next tick's handleMerged deploy/release off a sideways merge. Now
+// asserts the PR is fully de-tracked (removePR, mirroring
+// checkExternalMergeOrClose's identical sibling site) instead of merely
+// StageMerged, that its own branch survives because it is the base of
+// another open (stacked) PR, and that a following tick performs no further
+// action for this PR at all.
 func TestController_HandleMerging_PostMergeBaseMismatch_SkipsFinalize(t *testing.T) {
 	var (
-		mergeCalled atomic.Int32
-		issueClosed atomic.Bool
-		doneAdded   atomic.Bool
-		pivotPosted atomic.Int32
+		mergeCalled       atomic.Int32
+		issueClosed       atomic.Bool
+		doneAdded         atomic.Bool
+		pivotPosted       atomic.Int32
+		branchDeleteCalls atomic.Int32
 	)
+
+	// PR#93 is an open, stacked PR whose base is PR#92's own head branch —
+	// deleting pilot/GH-92 out from under it would repeat the 2026-08-15
+	// incident this predicate exists to prevent.
+	openPRs := []*github.PullRequest{
+		{Number: 93, State: "open", Head: github.PRRef{Ref: "ui/GH-73"}, Base: github.PRRef{Ref: "pilot/GH-92"}},
+	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -193,6 +267,14 @@ func TestController_HandleMerging_PostMergeBaseMismatch_SkipsFinalize(t *testing
 			}
 			w.WriteHeader(http.StatusOK)
 			_ = writeJSON(w, resp)
+
+		case r.URL.Path == "/repos/owner/repo/pulls" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_ = writeJSON(w, openPRs)
+
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/git/refs/heads/") && r.Method == http.MethodDelete:
+			branchDeleteCalls.Add(1)
+			w.WriteHeader(http.StatusOK)
 
 		case r.URL.Path == "/repos/owner/repo/issues/72" && r.Method == http.MethodPatch:
 			issueClosed.Store(true)
@@ -236,6 +318,7 @@ func TestController_HandleMerging_PostMergeBaseMismatch_SkipsFinalize(t *testing
 		PRNumber:     92,
 		IssueNumber:  72,
 		HeadSHA:      "sha92",
+		BranchName:   "pilot/GH-92", // this PR's own head branch, bases open PR#93 above
 		Stage:        StageMerging,
 		TargetBranch: "main", // passes the pre-merge guard
 		CreatedAt:    time.Now(),
@@ -258,19 +341,32 @@ func TestController_HandleMerging_PostMergeBaseMismatch_SkipsFinalize(t *testing
 	if pivotPosted.Load() != 1 {
 		t.Errorf("pivot comment posted %d times, want 1", pivotPosted.Load())
 	}
-	if len(sink.events) != 1 {
-		t.Fatalf("alerts fired %d times, want 1", len(sink.events))
+	// Two distinct alerts are expected here: alertBaseMismatchOnce (the
+	// sideways-merge finding itself) and alertBranchDeleteHeldOnce (fired by
+	// safeDeleteBranch inside removePR, below, because pilot/GH-92 is the
+	// base of open PR#93).
+	if len(sink.events) != 2 {
+		t.Fatalf("alerts fired %d times, want 2", len(sink.events))
+	}
+	if branchDeleteCalls.Load() != 0 {
+		t.Errorf("branch delete attempted %d times, want 0 — pilot/GH-92 is the base of open PR#93", branchDeleteCalls.Load())
 	}
 
-	pr, ok := c.GetPRState(92)
-	if !ok {
-		t.Fatal("PR 92 should still be tracked")
+	// GH-4911: the withheld finalize must dead-end tracking entirely instead
+	// of leaving Stage=StageMerged for handleMerged to pick up next tick.
+	if _, ok := c.GetPRState(92); ok {
+		t.Fatal("PR 92 should have been removed from tracking (removePR) — a sideways merge must not stay live for handleMerged to deploy/release")
 	}
-	if pr.Stage != StageMerged {
-		t.Errorf("Stage = %s, want %s (the merge itself still succeeded)", pr.Stage, StageMerged)
+
+	// A following tick must perform no further action at all: the PR is no
+	// longer tracked, so ProcessPR must reject it rather than silently
+	// re-running (or advancing past) any deploy/release step.
+	if err := c.ProcessPR(context.Background(), 92, nil); err == nil {
+		t.Error("ProcessPR on the next tick should error — PR 92 is no longer tracked")
 	}
-	if pr.TargetBranch != "pilot/GH-70" {
-		t.Errorf("TargetBranch = %q, want re-verified value %q", pr.TargetBranch, "pilot/GH-70")
+	if mergeCalled.Load() != 1 || issueClosed.Load() || doneAdded.Load() || pivotPosted.Load() != 1 || len(sink.events) != 2 {
+		t.Errorf("next tick produced further effects: merge=%d issueClosed=%v doneAdded=%v pivot=%d alerts=%d — want all unchanged (no deploy/release)",
+			mergeCalled.Load(), issueClosed.Load(), doneAdded.Load(), pivotPosted.Load(), len(sink.events))
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4911.

Closes #4911

## Changes

GitHub Issue GH-4911: fix(autopilot): GH-4909 advisories — dead-end sideways merges at handleMerging (no deploy/release) + clear park residue on resume (PR#4910 review)

## Problem

Two advisory gaps from the PR#4910 pre-merge review (GH-4909 base-guard fixes) — both in `internal/autopilot/controller.go`.

**1. Sideways-merged PR can still deploy/release.** The new `handleMerging` finalize predicate correctly withholds the five delivered effects when a merge landed off-default, but leaves the PRState at `StageMerged` — next tick `handleMerged` runs `deployer.Deploy` (Branch = the stack branch) and can route to `StageReleasing`. The sibling external-merge mismatch site (~:7541) calls `removePR` specifically to prevent deploy/release off a sideways merge. Reachable only via the merge-instant retarget race, but the two sites should behave identically: after the withheld finalize, `removePR` (without branch delete — the branch may be another PR's base, see `safeDeleteBranch`) so the sideways merge dead-ends the same way at both sites.

**2. Park residue never cleared on resume.** When a parked PR resumes (base fixed → guard passes → merges), `Parked`/`EscalationReason` and the `parked-awaiting-approval` label persist (state_store, GH-4598). Residual `Parked=true` later silently skips `submitAsyncApprovalRequest`'s one-time misconfig side effects (bare `Parked` check at ~:3614). Clear the flag + reason + label at the point the guard passes for a previously-parked PR (log the un-park), and change the :3614 check to compare the reason, not the bare flag.

## Acceptance

- Finalize-predicate test extended: after the withheld finalize, next tick performs no deploy/release for that PR (effect counts stay zero); PR tracking removed; branch NOT deleted when it bases an open PR.
- Retarget-resume test extended: after the resumed merge, `Parked=false`, `EscalationReason` empty, park label removed; a later misconfig on the same PR still triggers its one-time side effects.
- Existing GH-4908/4909 tests unchanged and green; `make test` green.