### PR TITLE
GH-4913: chore(deps): bump studio-sdk pin to v0.35.0 — poller default-branch guard (sdk#117) + ExecutionSaverV2 (sdk#111)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/qf-studio/grom v0.2.0
-	github.com/qf-studio/studio-sdk v0.33.0
+	github.com/qf-studio/studio-sdk v0.35.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2
 	github.com/wailsapp/wails/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/qf-studio/grom v0.2.0 h1:EefLLr794KGk8ihdpKBgJnmSyUc//b/n8zZ77VbeuXY=
 github.com/qf-studio/grom v0.2.0/go.mod h1:YVihqE0treA2091TLNhGWvGi5+vMYv/ZBlAlX7Mr/JI=
-github.com/qf-studio/studio-sdk v0.33.0 h1:3KqfNQMGl81BUqG8nmWdAJBa1I4xL/NBNm3/RS66Qbo=
-github.com/qf-studio/studio-sdk v0.33.0/go.mod h1:M/uFBeXsPAtsrO7wiIgE/GgWzfw80ftW6BrQUIOwxUM=
+github.com/qf-studio/studio-sdk v0.35.0 h1:lrObETuoboyur+fT2R/cpDM0z5gvTIIarsuLMhWt9Zw=
+github.com/qf-studio/studio-sdk v0.35.0/go.mod h1:M/uFBeXsPAtsrO7wiIgE/GgWzfw80ftW6BrQUIOwxUM=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4913.

Closes #4913

## Changes

GitHub Issue GH-4913: chore(deps): bump studio-sdk pin to v0.35.0 — poller default-branch guard (sdk#117) + ExecutionSaverV2 (sdk#111)

## Task

Bump the studio-sdk dependency pin to **v0.35.0** (tagged 2026-08-17 at sdk merge commit `4cf5f96`).

What v0.35.0 delivers to pilot (both already reviewed APPROVE on their sdk PRs):
- sdk#117 → PR#118: GitHub poller `hasMergedWork` default-branch check — stacked/sideways merges no longer self-seal issues as delivered (pilot#4872 SDK leg; completes the guard work from PR#4908/#4910). Additive API: `SearchMergedPRsForIssueOnBase`, `FindMergedPRByBranchOnBase`, `Repository.DefaultBranch`.
- sdk#111 → PR#112 (was in v0.34.0, also unconsumed): decline-path repo identity — `ExecutionSaverV2` + `DeclinedExecutionRecord` (unblocks the TASK-471 leg-2 re-anchor, separate issue).

## Scope

- `go.mod`/`go.sum`: `github.com/qf-studio/studio-sdk` → v0.35.0; `go mod tidy`.
- No pilot code changes required — the poller picks up the base-check internally; legacy SDK signatures unchanged (verified in the PR#118 review: pilot has no direct call sites of the changed functions).

## Acceptance

- `make build && make test && make lint` green.
- `go list -m github.com/qf-studio/studio-sdk` reports v0.35.0.
- Sanity: vendorless build resolves the new symbols (compile reference not required — additive).