### PR TITLE
GH-4915: fix(autopilot): ProcessPR tail persist resurrects rows removed mid-handle — sideways-merge dead-end not durable across restart (PR#4912 review)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2486,6 +2486,24 @@ func (c *Controller) ProcessPR(ctx context.Context, prNumber int, ghPR *github.P
 		c.resetPRFailures(prNumber)
 	}
 
+	// GH-4915: a handler above (e.g. handleMerging's sideways-merge dead-end at
+	// StageMerged, or handleMerged's SkipPostMergeCI paths) may have called
+	// removePR mid-handle, which already deleted this row from both activePRs
+	// and the state store (persistRemovePR). persistPRState below is an
+	// unconditional UPSERT — without this membership check it would
+	// re-insert the exact row removePR just deleted, and a later restart's
+	// RestoreState would rehydrate it (still at the just-assigned Stage,
+	// e.g. StageMerged) and re-drive deploy/release off content that never
+	// landed on the default branch, silently defeating the dead-end across
+	// restarts. One check under c.mu covers every in-handler removePR site.
+	c.mu.RLock()
+	_, stillActive := c.activePRs[prNumber]
+	c.mu.RUnlock()
+	if !stillActive {
+		c.log.Debug("ProcessPR: skipping tail persist — PR removed mid-handle", "pr", prNumber)
+		return err
+	}
+
 	// Persist state after every processing cycle (covers transitions and updated fields)
 	c.persistPRState(prState)
 
@@ -4318,6 +4336,24 @@ func (c *Controller) handleMerged(ctx context.Context, prState *PRState) error {
 		"env", c.config.EnvironmentName(),
 		"should_release", c.shouldTriggerRelease(),
 	)
+
+	// GH-4915 (belt-and-braces): refuse deploy/release for a PR whose target
+	// isn't the default branch. handleMerging's sideways-merge dead-end
+	// (~line 4168) already calls removePR before Stage ever advances to
+	// StageMerged for a base mismatch, so this should be unreachable in the
+	// normal flow — but it's a cheap second fence, behind the same
+	// resolveMainBranchName predicate family as that guard, in case any
+	// future path ever lands a non-default TargetBranch here some other way.
+	// Empty TargetBranch (pre-GH-2065 restored rows) fails open rather than
+	// blocking every legitimate merged PR on an unpopulated field.
+	if prState.TargetBranch != "" {
+		if defaultBranch := c.resolveMainBranchName(); prState.TargetBranch != defaultBranch {
+			c.log.Warn("handleMerged: refusing deploy/release — TargetBranch is not the default branch",
+				"pr", prState.PRNumber, "target_branch", prState.TargetBranch, "default_branch", defaultBranch)
+			c.removePR(prState.PRNumber)
+			return nil
+		}
+	}
 
 	// Run deployer if configured (webhook, branch-push).
 	// Tag action is a no-op here — handled by the releaser stage.

--- a/internal/autopilot/gh4915_test.go
+++ b/internal/autopilot/gh4915_test.go
@@ -1,0 +1,317 @@
+package autopilot
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestController_ProcessPR_SidewaysMergeDeadEnd_NotResurrectedAcrossRestart is
+// the GH-4915 regression for the PR#4912 post-merge review finding: the
+// sideways-merge dead-end (GH-4911) removed the PR from activePRs and the
+// state store via removePR, but ProcessPR's tail persistPRState call ran
+// unconditionally afterward and re-inserted (UPSERTed) the very row that was
+// just deleted, at Stage=StageMerged. RestoreState rehydrates any non-failed
+// row on boot, so a daemon restart resurrected the dead-ended PR and
+// handleMerged went on to deploy/release off content that never landed on
+// the default branch — silently defeating the GH-4911 fix across restarts.
+//
+// Uses a real, file-backed SQLite state store (not a mock) shared across two
+// Controller instances to simulate an actual daemon restart, mirroring
+// restart_approval_integration_test.go's pattern.
+func TestController_ProcessPR_SidewaysMergeDeadEnd_NotResurrectedAcrossRestart(t *testing.T) {
+	var (
+		mergeCalled  atomic.Int32
+		deployCalled atomic.Int32
+	)
+
+	tmpDir, err := os.MkdirTemp("", "gh4915-restart-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	memStore, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = memStore.Close() }()
+
+	stateStore, err := NewStateStore(memStore.DB())
+	if err != nil {
+		t.Fatalf("NewStateStore: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/92/merge" && r.Method == http.MethodPut:
+			mergeCalled.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"sha":"mergedSHA","merged":true,"message":"merged"}`))
+
+		case r.URL.Path == "/repos/owner/repo/pulls/92" && r.Method == http.MethodGet:
+			// Post-merge re-verification: GitHub reports the PR actually
+			// landed on a stacked branch, not the cached "main".
+			resp := github.PullRequest{
+				Number: 92,
+				Head:   github.PRRef{SHA: "sha92"},
+				Base:   github.PRRef{Ref: "pilot/GH-70"},
+				Merged: true,
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = writeJSON(w, resp)
+
+		case r.URL.Path == "/repos/owner/repo/pulls" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_ = writeJSON(w, []*github.PullRequest{})
+
+		case r.URL.Path == "/deploy" && r.Method == http.MethodPost:
+			deployCalled.Add(1)
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c1 := NewController(cfg, ghClient, nil, "owner", "repo")
+	c1.SetStateStore(stateStore)
+	c1.SetAlertsEngine(&fakeAlertSink{})
+	// Deploy would fire on the very next tick (handleMerged) if the dead-end
+	// were ever undone by a resurrection — wire it so we can assert it never
+	// runs, pre- or post-restart.
+	c1.deployer = NewDeployer(ghClient, "owner", "repo", &PostMergeConfig{
+		Action:     "webhook",
+		WebhookURL: server.URL + "/deploy",
+	})
+
+	c1.mu.Lock()
+	c1.activePRs[92] = &PRState{
+		PRNumber:     92,
+		IssueNumber:  72,
+		HeadSHA:      "sha92",
+		BranchName:   "pilot/GH-92",
+		Stage:        StageMerging,
+		TargetBranch: "main", // passes the pre-merge guard
+		CreatedAt:    time.Now(),
+	}
+	c1.mu.Unlock()
+
+	ctx := context.Background()
+	if err := c1.ProcessPR(ctx, 92, nil); err != nil {
+		t.Fatalf("ProcessPR returned error: %v", err)
+	}
+
+	if mergeCalled.Load() != 1 {
+		t.Fatalf("merge called %d times, want 1", mergeCalled.Load())
+	}
+	if deployCalled.Load() != 0 {
+		t.Errorf("deploy called %d times, want 0 — a sideways merge must never deploy", deployCalled.Load())
+	}
+
+	// The PR must be gone from in-memory tracking (removePR ran inside
+	// handleMerging's mismatch path).
+	if _, ok := c1.GetPRState(92); ok {
+		t.Fatal("PR 92 should have been removed from tracking")
+	}
+
+	// GH-4915 core assertion: no row must land in the state store this tick.
+	// Before the fix, ProcessPR's unconditional tail persistPRState re-wrote
+	// the row persistRemovePR had just deleted, at Stage=StageMerged.
+	row, err := stateStore.GetPRState("owner/repo", 92)
+	if err != nil {
+		t.Fatalf("GetPRState: %v", err)
+	}
+	if row != nil {
+		t.Fatalf("state store still has a row for PR 92 after removePR: %+v — tail persist resurrected it", row)
+	}
+
+	// --- Simulated daemon restart: fresh Controller sharing only the
+	// on-disk state store. ---
+	c2 := NewController(cfg, ghClient, nil, "owner", "repo")
+	c2.SetStateStore(stateStore)
+	c2.SetAlertsEngine(&fakeAlertSink{})
+	c2.deployer = NewDeployer(ghClient, "owner", "repo", &PostMergeConfig{
+		Action:     "webhook",
+		WebhookURL: server.URL + "/deploy",
+	})
+
+	if _, err := c2.RestoreState(); err != nil {
+		t.Fatalf("RestoreState: %v", err)
+	}
+
+	if _, ok := c2.GetPRState(92); ok {
+		t.Fatal("PR 92 must NOT be resurrected into the post-restart controller")
+	}
+
+	// A following tick must find nothing to process for PR 92 — ProcessPR
+	// must reject it as untracked rather than silently re-driving it toward
+	// deploy/release.
+	if err := c2.ProcessPR(ctx, 92, nil); err == nil {
+		t.Error("ProcessPR on the post-restart controller should error — PR 92 is no longer tracked")
+	}
+	if deployCalled.Load() != 0 {
+		t.Errorf("deploy called %d times after restart, want 0", deployCalled.Load())
+	}
+}
+
+// TestController_ProcessPR_NormalMerge_StillPersistsAcrossTick guards against
+// the GH-4915 fix over-correcting: a PR that stays in activePRs after its
+// handler runs (the overwhelmingly common case) must still be persisted on
+// every tick exactly as before.
+func TestController_ProcessPR_NormalMerge_StillPersistsAcrossTick(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "gh4915-normal-persist-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	memStore, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = memStore.Close() }()
+
+	stateStore, err := NewStateStore(memStore.DB())
+	if err != nil {
+		t.Fatalf("NewStateStore: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/95/merge" && r.Method == http.MethodPut:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"sha":"mergedSHA","merged":true,"message":"merged"}`))
+		case r.URL.Path == "/repos/owner/repo/pulls/95" && r.Method == http.MethodGet:
+			resp := github.PullRequest{
+				Number: 95,
+				Head:   github.PRRef{SHA: "sha95"},
+				Base:   github.PRRef{Ref: "main"},
+				Merged: true,
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = writeJSON(w, resp)
+		case r.URL.Path == "/repos/owner/repo/pulls" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_ = writeJSON(w, []*github.PullRequest{})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.SetStateStore(stateStore)
+	c.SetAlertsEngine(&fakeAlertSink{})
+
+	c.mu.Lock()
+	c.activePRs[95] = &PRState{
+		PRNumber:     95,
+		IssueNumber:  75,
+		HeadSHA:      "sha95",
+		BranchName:   "pilot/GH-95",
+		Stage:        StageMerging,
+		TargetBranch: "main",
+		CreatedAt:    time.Now(),
+	}
+	c.mu.Unlock()
+
+	if err := c.ProcessPR(context.Background(), 95, nil); err != nil {
+		t.Fatalf("ProcessPR returned error: %v", err)
+	}
+
+	pr, ok := c.GetPRState(95)
+	if !ok {
+		t.Fatal("PR 95 should still be tracked")
+	}
+	if pr.Stage != StageMerged {
+		t.Fatalf("Stage = %s, want %s", pr.Stage, StageMerged)
+	}
+
+	row, err := stateStore.GetPRState("owner/repo", 95)
+	if err != nil {
+		t.Fatalf("GetPRState: %v", err)
+	}
+	if row == nil {
+		t.Fatal("normal merged PR must still be persisted to the state store")
+	}
+	if row.Stage != StageMerged {
+		t.Fatalf("persisted Stage = %s, want %s", row.Stage, StageMerged)
+	}
+}
+
+// TestController_HandleMerged_RefusesDeployOnNonDefaultTarget covers the
+// GH-4915 belt-and-braces fence in handleMerged itself: even if a row
+// somehow reaches StageMerged with a TargetBranch that isn't the resolved
+// default branch, handleMerged must refuse to deploy/release and instead
+// dead-end the PR via removePR — the same predicate family as handleMerging's
+// pre- and post-merge guards.
+func TestController_HandleMerged_RefusesDeployOnNonDefaultTarget(t *testing.T) {
+	var deployCalled atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/deploy" && r.Method == http.MethodPost:
+			deployCalled.Add(1)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.SetAlertsEngine(&fakeAlertSink{})
+	c.deployer = NewDeployer(ghClient, "owner", "repo", &PostMergeConfig{
+		Action:     "webhook",
+		WebhookURL: server.URL + "/deploy",
+	})
+
+	prState := &PRState{
+		PRNumber:     96,
+		IssueNumber:  76,
+		HeadSHA:      "sha96",
+		BranchName:   "pilot/GH-96",
+		Stage:        StageMerged,
+		TargetBranch: "pilot/GH-70", // should be unreachable via handleMerging, but guard belt-and-braces anyway
+		CreatedAt:    time.Now(),
+	}
+	c.mu.Lock()
+	c.activePRs[96] = prState
+	c.mu.Unlock()
+
+	if err := c.handleMerged(context.Background(), prState); err != nil {
+		t.Fatalf("handleMerged returned error: %v", err)
+	}
+
+	if deployCalled.Load() != 0 {
+		t.Errorf("deploy called %d times, want 0", deployCalled.Load())
+	}
+	if _, ok := c.GetPRState(96); ok {
+		t.Fatal("PR 96 should have been removed from tracking")
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4915.

Closes #4915

## Changes

GitHub Issue GH-4915: fix(autopilot): ProcessPR tail persist resurrects rows removed mid-handle — sideways-merge dead-end not durable across restart (PR#4912 review)

## Problem

From PR#4912 post-merge review (verified medium): the sideways-merge dead-end is not durable across a daemon restart.

Chain: `handleMerging`'s mismatch path calls `removePR` (`internal/autopilot/controller.go:4168`) → `persistRemovePR` deletes the row. But the caller `ProcessPR` then unconditionally runs its tail persist (`:2495` → `persistPRState` → `SavePRState`, an unconditional UPSERT, `state_store.go:640-698`) — **re-inserting the row that was just deleted**, at `Stage=StageMerged`. `RestoreState` (`:2117`) rehydrates any non-failed row on boot, and `handleMerged` (`:4315`) runs `deployer.Deploy`/release routing with **no base guard** — so after any restart, the sideways merge deploys and can release anyway, defeating GH-4911 fix 1.

The sibling external-finalize site is safe only because its caller `continue`s before ProcessPR runs. The same resurrection pattern pre-exists at the other in-handler `removePR` sites (`:4428/:4432` area) — harmless there (resurrected rows are delivered on-main merges → redundant re-deploy), but fix it generally.

## Scope

- In `ProcessPR`: skip the tail `persistPRState` when the PR is no longer in `activePRs` (it was removed mid-handle) — one membership check under the existing lock. This fixes all in-handler `removePR` sites at once.
- Test: requires a stateStore-backed test controller (today's mismatch tests have none — that's why this was invisible). Add a test that drives the sideways-merge finalize with a real (temp-file/sqlite) state store, restarts the controller (`RestoreState`), and asserts the PR is NOT rehydrated and no deploy fires.
- Optional belt-and-braces while there: `handleMerged` could refuse deploy/release when `TargetBranch != resolveMainBranchName()` — cheap second fence behind the same predicate family. Include if small.

## Acceptance

- Sideways-merged PR: after `removePR`, no row lands in the state store this tick (store query in test); post-restart `RestoreState` does not resurrect it; zero deploy/release calls.
- Normal merged PRs persist exactly as today.
- Existing GH-4908/4909/4911 tests untouched and green; `make test` green.