### PR TITLE
fix(autopilot): backoff, abandon, and breaker-gate the release-backfill sweep

### DIFF
--- a/.agent/tasks/gh-4919.md
+++ b/.agent/tasks/gh-4919.md
@@ -1,0 +1,73 @@
+# GH-4919
+
+**Created:** 2026-08-17
+
+## Problem
+
+GitHub Issue GH-4919: fix(autopilot): release-backfill sweep retries API-failing rows every tick — no backoff, no permanent-failure classification, not breaker-gated
+
+# fix(autopilot): release-backfill sweep retries API-failing rows every tick — no backoff, no permanent-failure classification, not breaker-gated
+
+## Problem
+
+`reconcileReleaseBackfill` (`internal/autopilot/release_backfill.go`) runs on every `epicParentTicker` tick (= `CIPollInterval`, ~30s per repo controller; `controller.go:7371`) and re-attempts every `StageFailed`/`StageReleasing` row unconditionally. Any API error (`GetPullRequest`, `ListTags`, `CompareStatus`) is logged and retried on the very next tick — there is no backoff, no failure counter, and no terminal classification for rows that can never heal.
+
+During the 2026-08-17 GitHub platform incident (compare/tags endpoints returning 404 globally), this loop burned **~2.9k rate hits in one day** against the shared 5000/hr user pool, and continued at the same cadence after the 14:55Z daemon restart:
+
+```
+15:19:21 WARN reconcileReleaseBackfill: tag ancestry lookup failed pr=70  error="... list-repository-tags ... 404"
+15:19:35 WARN reconcileReleaseBackfill: tag ancestry lookup failed pr=118 error="compare 4cf5f96 against tag v0.2.0: ... 404"
+15:19:50 WARN ... pr=70  (repeats every ~15s alternating, indefinitely)
+```
+
+Live burner rows on the box (2026-08-17):
+
+| PR | repo | stage | since | failure mode |
+|---|---|---|---|---|
+| 70 | qf-studio/pilot-console | failed | 07-29 | `ListTags` 404 (incident); pre-incident this row ran GetPR+ListTags+compares every 30s for 3 weeks |
+| 118 | qf-studio/studio-sdk | releasing | 08-17 | `CompareStatus` vs oldest tag 404 (incident) |
+
+Inert-but-unhealable rows in the same class: pr=87/90 reference the **deleted** `qf-studio/pilot-canary-sandbox` repo — they only escape the loop today because no controller exists for that repo anymore. Any row whose repo is deleted 404s permanently and would retry forever.
+
+Aggravating: the TASK-458 `platform_breaker` is enabled in production and was aware of the incident, but the backfill sweep is not routed through it — the daemon kept spending API budget on lookups that could not succeed.
+
+Related but OUT of scope: `scheduleReleaseTick` retries the missed train on the same compare 404 (~2min cadence, bounded) — leave it alone.
+
+## Fix shape
+
+1. **Per-row backoff** on any API error in `healReleaseBackfillRow` / `earliestReleaseTagContaining`: exponential from the poll interval, capped (≥1h). In-memory per controller is fine; reset on success. A row in backoff is skipped by the sweep without any API call.
+2. **Permanent-failure classification**: after N consecutive failures spanning a minimum wall-clock window (so a short incident doesn't terminalize rows), mark the row abandoned — persist the reason (the existing `error` column + a skip flag or a distinct stage; implementer's choice) and skip it in all future sweeps. Log ONCE at WARN on the transition, not per tick. Repo-level 404 (deleted repo) counts toward the same classification.
+3. **Breaker gate**: when the TASK-458 platform breaker is open, skip the entire sweep for that tick.
+4. Healing semantics unchanged — no edits to `recordReleaseBackfillEvent` or the heal/drain path for rows that do resolve.
+
+## Acceptance Criteria
+
+- [x] A row whose lookup errors is not re-attempted on the next tick; backoff schedule is honored across ticks and resets on success.
+- [x] After the failure threshold + minimum window, the row transitions to a persisted skipped/abandoned state exactly once, with the last error recorded; subsequent sweeps make zero API calls for it.
+- [x] Sweep is a no-op while the platform breaker is open.
+- [x] Healthy rows (heal succeeds, or PR genuinely unmerged/untagged) behave exactly as today.
+- [x] Tests: backoff progression · single terminal transition · abandoned row skipped · breaker-open skip · heal path untouched · `-race` clean.
+
+**This task must NOT be decomposed — implement as a single PR.** <!-- pilot:no-decompose -->
+
+## Resolution
+
+Implemented in `internal/autopilot/release_backfill.go`:
+
+- Per-row exponential backoff (`releaseBackfillRowState`, `releaseBackfillDue`/`releaseBackfillObserveFailure`/`releaseBackfillObserveSuccess`), keyed by `owner/repo#pr`, base = `CIPollInterval`, capped at 1h, reset on success. Rows in backoff are skipped with zero API calls.
+- Permanent-failure classification (`releaseBackfillFail`) requires both `releaseBackfillAbandonThreshold` (10) consecutive failures AND `releaseBackfillAbandonMinWindow` (6h) elapsed since the first failure; persists `PRState.ReleaseBackfillAbandoned` + `PRState.Error`, logs once at WARN, and is skipped in all future sweeps.
+- Breaker gate: `reconcileReleaseBackfill` returns immediately when `c.platformBreaker.IsOpen()`.
+- Heal/drain path and `recordReleaseBackfillEvent` untouched.
+
+New schema column `release_backfill_abandoned` added to `state_store.go` (including the GH-3903 `autopilot_pr_state_gh3903` rebuild path, which required its own column-list update).
+
+Verified: `go build ./...`, `go vet ./internal/autopilot/...`, `go test ./internal/autopilot/... -race`, `golangci-lint run --new-from-rev=origin/main ./internal/autopilot/...` — all clean.
+
+## Refs
+
+- `internal/autopilot/release_backfill.go` (GH-4370 origin) · sweep call site `internal/autopilot/controller.go:7405`
+- Breaker: `.agent/tasks/TASK-458-platform-outage-breaker.md`, #4791/#4792
+- Incident: 2026-08-17 GitHub compare-API degradation (githubstatus-confirmed); marker `.agent/.context-markers/2026-08-17_saas-continuation-compact.md`
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -738,6 +738,21 @@ type Controller struct {
 	// — alertPlatformBreakerTransition's nil check makes this byte-identical
 	// to part-1 behavior when unset.
 	admissionPauser AdmissionPauser
+
+	// releaseBackfillMu guards releaseBackfillRows below.
+	releaseBackfillMu sync.Mutex
+	// releaseBackfillRows is reconcileReleaseBackfill's (GH-4919) per-row
+	// backoff and consecutive-failure bookkeeping, keyed by
+	// "owner/repo#pr". Deliberately in-memory only, not persisted: the fix
+	// shape only requires the permanent-failure classification (see
+	// PRState.ReleaseBackfillAbandoned) to survive a restart — losing an
+	// in-progress backoff on restart just means one immediate retry, not a
+	// budget blowout.
+	releaseBackfillRows map[string]*releaseBackfillRowState
+	// releaseBackfillClock overrides time.Now() for reconcileReleaseBackfill
+	// when set — nil in production, used by tests to simulate backoff and
+	// the abandon threshold's wall-clock window without real sleeps.
+	releaseBackfillClock func() time.Time
 }
 
 // AdmissionPauser is the narrow seam Controller uses to pause/resume new-work

--- a/internal/autopilot/release_backfill.go
+++ b/internal/autopilot/release_backfill.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/qf-studio/pilot/internal/memory"
 )
@@ -14,6 +15,144 @@ import (
 // residue (GH-4370), so 100 (GitHub's per-page max, and ListTags's only
 // supported page) comfortably covers the window without unbounded pagination.
 const maxReleaseBackfillTags = 100
+
+// releaseBackfillRowState is reconcileReleaseBackfill's (GH-4919) per-row
+// backoff and consecutive-failure bookkeeping. Held in
+// Controller.releaseBackfillRows, keyed by "owner/repo#pr".
+type releaseBackfillRowState struct {
+	// nextRetryAt is when this row becomes eligible for another sweep
+	// attempt; releaseBackfillDue skips it (with zero API calls) until then.
+	nextRetryAt time.Time
+	// firstFailAt is when the current unbroken failure streak began — reset
+	// whenever the streak is cleared by a success. The abandon threshold
+	// requires the streak to also span releaseBackfillAbandonMinWindow since
+	// this timestamp.
+	firstFailAt time.Time
+	// consecutiveFails counts API errors since the last success.
+	consecutiveFails int
+}
+
+const (
+	// releaseBackfillMaxBackoff caps the exponential per-row backoff below —
+	// a wedged row's API calls can never exceed roughly this cadence,
+	// regardless of how long its failure streak runs.
+	releaseBackfillMaxBackoff = time.Hour
+	// releaseBackfillAbandonThreshold is the consecutive-failure count (see
+	// releaseBackfillRowState.consecutiveFails) required, together with
+	// releaseBackfillAbandonMinWindow, before a row is classified permanently
+	// failed.
+	releaseBackfillAbandonThreshold = 10
+	// releaseBackfillAbandonMinWindow is the minimum wall-clock span a
+	// failure streak must cover before a row is classified permanently
+	// failed — deliberately independent of the failure count so a same-day
+	// platform incident (this fix's own motivating case, the 2026-08-17
+	// GitHub compare-API degradation) cannot itself terminalize a row that
+	// would have healed once the incident cleared.
+	releaseBackfillAbandonMinWindow = 6 * time.Hour
+)
+
+// releaseBackfillRowKey builds the distinct-row identity used for backoff
+// bookkeeping. Includes owner/repo (not just the PR number) since one
+// controller's persisted rows can reference a foreign repo (RepoOwnerAndName)
+// when the row was adopted cross-repo.
+func releaseBackfillRowKey(owner, repo string, pr int) string {
+	return fmt.Sprintf("%s/%s#%d", owner, repo, pr)
+}
+
+// releaseBackfillDue reports whether key is eligible for a sweep attempt
+// right now. A row with no bookkeeping (never failed, or its streak was
+// cleared by a prior success) is always due.
+func (c *Controller) releaseBackfillDue(key string, now time.Time) bool {
+	c.releaseBackfillMu.Lock()
+	defer c.releaseBackfillMu.Unlock()
+	st := c.releaseBackfillRows[key]
+	if st == nil {
+		return true
+	}
+	return !now.Before(st.nextRetryAt)
+}
+
+// releaseBackfillObserveSuccess clears key's failure streak and backoff. Any
+// error-free API round for the row — healed or not (a genuinely unmerged PR
+// is a successful, informative fetch, not a failure) — proves the row is
+// currently reachable, so the streak that feeds both backoff and the abandon
+// threshold resets (GH-4919).
+func (c *Controller) releaseBackfillObserveSuccess(key string) {
+	c.releaseBackfillMu.Lock()
+	defer c.releaseBackfillMu.Unlock()
+	delete(c.releaseBackfillRows, key)
+}
+
+// releaseBackfillObserveFailure records one API-error observation for key:
+// advances its consecutive-failure streak and sets its next eligible retry
+// time via exponential backoff from the poll interval, capped at
+// releaseBackfillMaxBackoff. Reports whether the row has now crossed the
+// permanent-failure threshold (releaseBackfillAbandonThreshold consecutive
+// failures AND releaseBackfillAbandonMinWindow elapsed since the streak's
+// first failure).
+func (c *Controller) releaseBackfillObserveFailure(key string, now time.Time) (abandon bool, streak int) {
+	c.releaseBackfillMu.Lock()
+	defer c.releaseBackfillMu.Unlock()
+	if c.releaseBackfillRows == nil {
+		c.releaseBackfillRows = make(map[string]*releaseBackfillRowState)
+	}
+	st := c.releaseBackfillRows[key]
+	if st == nil {
+		st = &releaseBackfillRowState{firstFailAt: now}
+		c.releaseBackfillRows[key] = st
+	}
+	st.consecutiveFails++
+
+	base := c.config.CIPollInterval
+	if base <= 0 {
+		base = 30 * time.Second
+	}
+	backoff := base
+	for i := 1; i < st.consecutiveFails && backoff < releaseBackfillMaxBackoff; i++ {
+		backoff *= 2
+	}
+	if backoff > releaseBackfillMaxBackoff {
+		backoff = releaseBackfillMaxBackoff
+	}
+	st.nextRetryAt = now.Add(backoff)
+
+	abandon = st.consecutiveFails >= releaseBackfillAbandonThreshold &&
+		now.Sub(st.firstFailAt) >= releaseBackfillAbandonMinWindow
+	if abandon {
+		// The persisted ReleaseBackfillAbandoned flag is now authoritative
+		// for skipping this row — no need to keep the in-memory streak
+		// around too.
+		delete(c.releaseBackfillRows, key)
+	}
+	return abandon, st.consecutiveFails
+}
+
+// releaseBackfillFail is healReleaseBackfillRow's single call site for any
+// API error: records the failure/backoff and, if it just crossed the
+// permanent-failure threshold, persists prState as abandoned so every future
+// sweep skips it with zero API calls — logged once, on the transition only
+// (GH-4919).
+func (c *Controller) releaseBackfillFail(key string, now time.Time, prState *PRState, cause error) {
+	abandon, streak := c.releaseBackfillObserveFailure(key, now)
+	if !abandon {
+		return
+	}
+
+	prState.ReleaseBackfillAbandoned = true
+	prState.Error = fmt.Sprintf(
+		"release-backfill: abandoned after %d consecutive API failures spanning >= %s — last error: %v",
+		streak, releaseBackfillAbandonMinWindow, cause)
+
+	if c.stateStore != nil {
+		if serr := c.stateStore.SavePRState(c.repoKey(), prState); serr != nil {
+			c.log.Warn("reconcileReleaseBackfill: failed to persist abandoned row",
+				"pr", prState.PRNumber, "error", serr)
+			return
+		}
+	}
+	c.log.Warn("reconcileReleaseBackfill: row abandoned — API failures exceeded threshold, will not be retried",
+		"pr", prState.PRNumber, "consecutive_failures", streak, "error", cause)
+}
 
 // reconcileReleaseBackfill is GH-4370's periodic release-ledger reconciliation.
 // A manual tag push (bypassing the automated release train entirely) leaves
@@ -27,8 +166,23 @@ const maxReleaseBackfillTags = 100
 // heals any row whose PR did in fact merge and ship. Ground truth is git
 // ancestry: a PR is released iff its merge commit is an ancestor of an
 // existing release tag; the earliest such tag names the version.
+//
+// GH-4919: every tick unconditionally re-attempted every candidate row, even
+// one whose lookups were erroring — during the 2026-08-17 GitHub platform
+// incident this burned ~2.9k rate-limit hits in a day against the shared
+// 5000/hr pool. Three guards now bound that cost: the platform-outage breaker
+// (TASK-458) skips the whole sweep while a platform incident is suspected
+// open; a per-row exponential backoff skips an individual erroring row
+// without any API call until its next scheduled retry
+// (releaseBackfillObserveFailure/releaseBackfillDue); and a row whose errors
+// outlive the abandon threshold is persisted as permanently failed
+// (PRState.ReleaseBackfillAbandoned) and skipped by every future sweep.
 func (c *Controller) reconcileReleaseBackfill(ctx context.Context) {
 	if c.stateStore == nil || c.ghClient == nil {
+		return
+	}
+	if c.platformBreaker.IsOpen() {
+		c.log.Debug("reconcileReleaseBackfill: skipping sweep — platform-outage breaker open")
 		return
 	}
 	states, err := c.stateStore.LoadAllPRStates(c.repoKey())
@@ -36,11 +190,23 @@ func (c *Controller) reconcileReleaseBackfill(ctx context.Context) {
 		c.log.Warn("reconcileReleaseBackfill: failed to load PR states", "error", err)
 		return
 	}
+	now := time.Now()
+	if c.releaseBackfillClock != nil {
+		now = c.releaseBackfillClock()
+	}
 	for _, prState := range states {
 		if prState.Stage != StageFailed && prState.Stage != StageReleasing {
 			continue
 		}
-		c.healReleaseBackfillRow(ctx, prState)
+		if prState.ReleaseBackfillAbandoned {
+			continue
+		}
+		owner, repo := prState.RepoOwnerAndName(c.owner, c.repo)
+		key := releaseBackfillRowKey(owner, repo, prState.PRNumber)
+		if !c.releaseBackfillDue(key, now) {
+			continue
+		}
+		c.healReleaseBackfillRow(ctx, prState, key, now)
 	}
 }
 
@@ -49,18 +215,22 @@ func (c *Controller) reconcileReleaseBackfill(ctx context.Context) {
 // and drains the residue row — mirroring exactly what a successful
 // handleReleasing does on the normal path, without re-running any of the
 // tag-creation logic (the tag already exists; this is bookkeeping, not a new
-// release).
-func (c *Controller) healReleaseBackfillRow(ctx context.Context, prState *PRState) {
+// release). key/now are reconcileReleaseBackfill's backoff-bookkeeping
+// identity and clock reading for this row (GH-4919).
+func (c *Controller) healReleaseBackfillRow(ctx context.Context, prState *PRState, key string, now time.Time) {
 	owner, repo := prState.RepoOwnerAndName(c.owner, c.repo)
 
 	ghPR, err := c.ghClient.GetPullRequest(ctx, owner, repo, prState.PRNumber)
 	if err != nil {
 		c.log.Debug("reconcileReleaseBackfill: failed to fetch PR, skipping",
 			"pr", prState.PRNumber, "error", err)
+		c.releaseBackfillFail(key, now, prState, err)
 		return
 	}
 	if !ghPR.Merged || ghPR.MergeCommitSHA == "" {
-		// Genuinely unreleased (or never merged) — leave the row exactly as is.
+		// Genuinely unreleased (or never merged) — leave the row exactly as
+		// is. The fetch itself succeeded, so this clears any prior streak.
+		c.releaseBackfillObserveSuccess(key)
 		return
 	}
 
@@ -68,8 +238,10 @@ func (c *Controller) healReleaseBackfillRow(ctx context.Context, prState *PRStat
 	if err != nil {
 		c.log.Warn("reconcileReleaseBackfill: tag ancestry lookup failed",
 			"pr", prState.PRNumber, "sha", ShortSHA(ghPR.MergeCommitSHA), "error", err)
+		c.releaseBackfillFail(key, now, prState, err)
 		return
 	}
+	c.releaseBackfillObserveSuccess(key)
 	if tag == "" {
 		// Merged, but not yet covered by any tag — genuinely unreleased.
 		return

--- a/internal/autopilot/release_backfill_test.go
+++ b/internal/autopilot/release_backfill_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/qf-studio/pilot/internal/memory"
 	"github.com/qf-studio/pilot/internal/testutil"
@@ -245,5 +246,385 @@ func TestReconcileReleaseBackfill_SkipsNonCandidateStages(t *testing.T) {
 
 	if pullFetches != 0 {
 		t.Errorf("pull fetches = %d, want 0 — non-candidate stages must never be touched", pullFetches)
+	}
+}
+
+// alwaysErrorPullServer serves a 500 for every /pulls/ request (any PR
+// number) and counts how many were made — the fixture for GH-4919's
+// backoff/abandon tests, which need every attempt to fail identically.
+func alwaysErrorPullServer(t *testing.T, fetches *int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/pulls/") {
+			*fetches++
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+}
+
+// TestReconcileReleaseBackfill_Backoff covers GH-4919's per-row exponential
+// backoff: a row whose GetPullRequest call errors must not be re-attempted
+// on the very next tick, the backoff schedule must double from the poll
+// interval each consecutive failure, and a due row (clock has reached
+// nextRetryAt) must be retried exactly on schedule.
+func TestReconcileReleaseBackfill_Backoff(t *testing.T) {
+	var pullFetches int
+	server := alwaysErrorPullServer(t, &pullFetches)
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	store, err := NewStateStoreFromPath(":memory:")
+	if err != nil {
+		t.Fatalf("NewStateStoreFromPath: %v", err)
+	}
+	c.SetStateStore(store)
+
+	if err := store.SavePRState("owner/repo", &PRState{
+		PRNumber: 300,
+		PRURL:    "https://github.com/owner/repo/pull/300",
+		Stage:    StageFailed,
+	}); err != nil {
+		t.Fatalf("SavePRState: %v", err)
+	}
+
+	base := cfg.CIPollInterval // 30s default — releaseBackfillObserveFailure's backoff base
+	clock := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	c.releaseBackfillClock = func() time.Time { return clock }
+
+	// Tick 1: first attempt, first failure. backoff = base.
+	c.reconcileReleaseBackfill(context.Background())
+	if pullFetches != 1 {
+		t.Fatalf("after tick 1: pull fetches = %d, want 1", pullFetches)
+	}
+
+	// Tick 2: same instant — row must be skipped without any API call.
+	c.reconcileReleaseBackfill(context.Background())
+	if pullFetches != 1 {
+		t.Fatalf("after tick 2 (still in backoff): pull fetches = %d, want 1", pullFetches)
+	}
+
+	// Just short of the first backoff deadline — still skipped.
+	clock = clock.Add(base - time.Second)
+	c.reconcileReleaseBackfill(context.Background())
+	if pullFetches != 1 {
+		t.Fatalf("after tick 3 (1s short of backoff): pull fetches = %d, want 1", pullFetches)
+	}
+
+	// Backoff elapsed — due again. Second failure doubles backoff to 2*base.
+	clock = clock.Add(time.Second)
+	c.reconcileReleaseBackfill(context.Background())
+	if pullFetches != 2 {
+		t.Fatalf("after tick 4 (backoff elapsed): pull fetches = %d, want 2", pullFetches)
+	}
+
+	// Just short of the doubled deadline — still skipped.
+	clock = clock.Add(2*base - time.Second)
+	c.reconcileReleaseBackfill(context.Background())
+	if pullFetches != 2 {
+		t.Fatalf("after tick 5 (1s short of doubled backoff): pull fetches = %d, want 2", pullFetches)
+	}
+
+	// Doubled backoff elapsed — third failure.
+	clock = clock.Add(time.Second)
+	c.reconcileReleaseBackfill(context.Background())
+	if pullFetches != 3 {
+		t.Fatalf("after tick 6 (doubled backoff elapsed): pull fetches = %d, want 3", pullFetches)
+	}
+
+	row, err := store.GetPRState("owner/repo", 300)
+	if err != nil {
+		t.Fatalf("GetPRState: %v", err)
+	}
+	if row == nil {
+		t.Fatal("row unexpectedly drained")
+	}
+	if row.ReleaseBackfillAbandoned {
+		t.Error("row abandoned prematurely — only 3 of the 10-failure threshold observed")
+	}
+}
+
+// TestReconcileReleaseBackfill_BackoffResetsOnSuccess covers the "resets on
+// success" half of GH-4919's backoff contract: once an API call succeeds
+// (even if the row is genuinely still unreleased), the very next tick must
+// not be held back by a stale backoff from an earlier failure.
+func TestReconcileReleaseBackfill_BackoffResetsOnSuccess(t *testing.T) {
+	var pullFetches int
+	failFirst := true
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/pulls/") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		pullFetches++
+		if failFirst {
+			failFirst = false
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(&github.PullRequest{Number: 301, Merged: false})
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	store, err := NewStateStoreFromPath(":memory:")
+	if err != nil {
+		t.Fatalf("NewStateStoreFromPath: %v", err)
+	}
+	c.SetStateStore(store)
+
+	if err := store.SavePRState("owner/repo", &PRState{
+		PRNumber: 301,
+		PRURL:    "https://github.com/owner/repo/pull/301",
+		Stage:    StageFailed,
+	}); err != nil {
+		t.Fatalf("SavePRState: %v", err)
+	}
+
+	clock := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	c.releaseBackfillClock = func() time.Time { return clock }
+
+	// Tick 1: fails, backoff scheduled.
+	c.reconcileReleaseBackfill(context.Background())
+	if pullFetches != 1 {
+		t.Fatalf("after tick 1: pull fetches = %d, want 1", pullFetches)
+	}
+
+	// Advance past the backoff and succeed — this must clear the streak.
+	clock = clock.Add(cfg.CIPollInterval)
+	c.reconcileReleaseBackfill(context.Background())
+	if pullFetches != 2 {
+		t.Fatalf("after tick 2 (success): pull fetches = %d, want 2", pullFetches)
+	}
+
+	// Immediately due again (no clock advance) — a stale backoff would skip this.
+	c.reconcileReleaseBackfill(context.Background())
+	if pullFetches != 3 {
+		t.Fatalf("after tick 3 (post-success, same instant): pull fetches = %d, want 3 — backoff should have reset on success", pullFetches)
+	}
+}
+
+// TestReconcileReleaseBackfill_AbandonsAfterThreshold covers GH-4919's
+// permanent-failure classification: a row must cross BOTH the consecutive-
+// failure count and the minimum wall-clock window before it is marked
+// abandoned, the transition must persist (ReleaseBackfillAbandoned + Error),
+// and it must happen exactly once — every sweep after the transition makes
+// zero further API calls for the row.
+func TestReconcileReleaseBackfill_AbandonsAfterThreshold(t *testing.T) {
+	var pullFetches int
+	server := alwaysErrorPullServer(t, &pullFetches)
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	store, err := NewStateStoreFromPath(":memory:")
+	if err != nil {
+		t.Fatalf("NewStateStoreFromPath: %v", err)
+	}
+	c.SetStateStore(store)
+
+	if err := store.SavePRState("owner/repo", &PRState{
+		PRNumber: 400,
+		PRURL:    "https://github.com/owner/repo/pull/400",
+		Stage:    StageFailed,
+	}); err != nil {
+		t.Fatalf("SavePRState: %v", err)
+	}
+
+	clock := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	c.releaseBackfillClock = func() time.Time { return clock }
+
+	// Drive releaseBackfillAbandonThreshold consecutive failures, jumping the
+	// clock well past releaseBackfillMaxBackoff between each so every tick is
+	// immediately due — this also comfortably clears
+	// releaseBackfillAbandonMinWindow well before the threshold count is
+	// reached, isolating the count as the binding constraint being exercised.
+	for i := 0; i < releaseBackfillAbandonThreshold; i++ {
+		if i > 0 {
+			clock = clock.Add(releaseBackfillMaxBackoff + time.Minute)
+		}
+		c.reconcileReleaseBackfill(context.Background())
+	}
+
+	if pullFetches != releaseBackfillAbandonThreshold {
+		t.Fatalf("pull fetches = %d, want exactly %d (the threshold) — abandon must fire on the crossing tick, not before or after",
+			pullFetches, releaseBackfillAbandonThreshold)
+	}
+
+	row, err := store.GetPRState("owner/repo", 400)
+	if err != nil {
+		t.Fatalf("GetPRState: %v", err)
+	}
+	if row == nil {
+		t.Fatal("row unexpectedly drained — abandon must persist the row, not remove it")
+	}
+	if !row.ReleaseBackfillAbandoned {
+		t.Fatal("row not marked abandoned after crossing the threshold")
+	}
+	if row.Error == "" {
+		t.Error("abandoned row's Error is empty — reason must be persisted")
+	}
+	if row.Stage != StageFailed {
+		t.Errorf("abandoned row Stage = %q, want unchanged %q", row.Stage, StageFailed)
+	}
+
+	// Further sweeps — even ones due by the clock — must never call the API
+	// for this row again: the persisted flag is now authoritative.
+	for i := 0; i < 3; i++ {
+		clock = clock.Add(releaseBackfillMaxBackoff + time.Minute)
+		c.reconcileReleaseBackfill(context.Background())
+	}
+	if pullFetches != releaseBackfillAbandonThreshold {
+		t.Errorf("pull fetches after abandonment = %d, want unchanged %d — abandoned row must never be retried",
+			pullFetches, releaseBackfillAbandonThreshold)
+	}
+}
+
+// TestReconcileReleaseBackfill_ShortIncidentDoesNotAbandon covers the window
+// half of GH-4919's abandon gate: a failure streak that crosses the
+// consecutive-failure count quickly (a burst of retries within a short span,
+// not a sustained multi-hour incident) must NOT be classified permanent —
+// this is the guard that stops a same-day platform incident from
+// terminalizing a row that would have healed once the incident cleared.
+func TestReconcileReleaseBackfill_ShortIncidentDoesNotAbandon(t *testing.T) {
+	var pullFetches int
+	server := alwaysErrorPullServer(t, &pullFetches)
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	store, err := NewStateStoreFromPath(":memory:")
+	if err != nil {
+		t.Fatalf("NewStateStoreFromPath: %v", err)
+	}
+	c.SetStateStore(store)
+
+	if err := store.SavePRState("owner/repo", &PRState{
+		PRNumber: 401,
+		PRURL:    "https://github.com/owner/repo/pull/401",
+		Stage:    StageFailed,
+	}); err != nil {
+		t.Fatalf("SavePRState: %v", err)
+	}
+
+	clock := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	// Directly seed a failure streak one short of the count threshold, but
+	// with firstFailAt only a minute old — nowhere near
+	// releaseBackfillAbandonMinWindow. Exercises releaseBackfillObserveFailure
+	// without needing releaseBackfillAbandonThreshold real sweeps.
+	c.releaseBackfillRows = map[string]*releaseBackfillRowState{
+		releaseBackfillRowKey("owner", "repo", 401): {
+			consecutiveFails: releaseBackfillAbandonThreshold - 1,
+			firstFailAt:      clock.Add(-time.Minute),
+			nextRetryAt:      clock,
+		},
+	}
+	c.releaseBackfillClock = func() time.Time { return clock }
+
+	// One more failure crosses the count threshold but not the window.
+	c.reconcileReleaseBackfill(context.Background())
+	if pullFetches != 1 {
+		t.Fatalf("pull fetches = %d, want 1", pullFetches)
+	}
+
+	row, err := store.GetPRState("owner/repo", 401)
+	if err != nil {
+		t.Fatalf("GetPRState: %v", err)
+	}
+	if row.ReleaseBackfillAbandoned {
+		t.Error("row abandoned on a short (1-minute) failure streak — the minimum wall-clock window must gate this")
+	}
+}
+
+// TestReconcileReleaseBackfill_AbandonedRowSkipped covers a row that was
+// already marked abandoned by a prior sweep (e.g. before a daemon restart):
+// the very next sweep must make zero API calls for it.
+func TestReconcileReleaseBackfill_AbandonedRowSkipped(t *testing.T) {
+	var pullFetches int
+	server := alwaysErrorPullServer(t, &pullFetches)
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	store, err := NewStateStoreFromPath(":memory:")
+	if err != nil {
+		t.Fatalf("NewStateStoreFromPath: %v", err)
+	}
+	c.SetStateStore(store)
+
+	if err := store.SavePRState("owner/repo", &PRState{
+		PRNumber:                 402,
+		PRURL:                    "https://github.com/owner/repo/pull/402",
+		Stage:                    StageFailed,
+		Error:                    "release-backfill: abandoned after 10 consecutive API failures",
+		ReleaseBackfillAbandoned: true,
+	}); err != nil {
+		t.Fatalf("SavePRState: %v", err)
+	}
+
+	c.reconcileReleaseBackfill(context.Background())
+
+	if pullFetches != 0 {
+		t.Errorf("pull fetches = %d, want 0 — an already-abandoned row must never be retried", pullFetches)
+	}
+}
+
+// TestReconcileReleaseBackfill_BreakerOpenSkipsSweep covers GH-4919's
+// breaker gate: the TASK-458 platform-outage breaker being open must make
+// the ENTIRE sweep a no-op for that tick — no row is fetched, healed, or
+// have its backoff/failure state touched, regardless of stage or prior
+// history.
+func TestReconcileReleaseBackfill_BreakerOpenSkipsSweep(t *testing.T) {
+	var pullFetches int
+	server := alwaysErrorPullServer(t, &pullFetches)
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+	c.platformBreaker = &PlatformBreaker{open: true}
+
+	store, err := NewStateStoreFromPath(":memory:")
+	if err != nil {
+		t.Fatalf("NewStateStoreFromPath: %v", err)
+	}
+	c.SetStateStore(store)
+
+	if err := store.SavePRState("owner/repo", &PRState{
+		PRNumber: 403,
+		PRURL:    "https://github.com/owner/repo/pull/403",
+		Stage:    StageFailed,
+	}); err != nil {
+		t.Fatalf("SavePRState: %v", err)
+	}
+
+	c.reconcileReleaseBackfill(context.Background())
+
+	if pullFetches != 0 {
+		t.Errorf("pull fetches = %d, want 0 — sweep must be a no-op while the platform breaker is open", pullFetches)
+	}
+
+	row, err := store.GetPRState("owner/repo", 403)
+	if err != nil {
+		t.Fatalf("GetPRState: %v", err)
+	}
+	if row.ReleaseBackfillAbandoned {
+		t.Error("row abandoned despite the breaker-gated sweep never running")
+	}
+
+	// Once the breaker closes, the row must behave exactly as if nothing
+	// happened — normal sweep resumes.
+	c.platformBreaker = &PlatformBreaker{open: false}
+	c.reconcileReleaseBackfill(context.Background())
+	if pullFetches != 1 {
+		t.Errorf("pull fetches after breaker closed = %d, want 1", pullFetches)
 	}
 }

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -207,6 +207,14 @@ func (s *StateStore) migrate() error {
 		// grant a fresh 2-retry budget on the same SHA.
 		`ALTER TABLE autopilot_pr_state ADD COLUMN post_merge_infra_rerun_count INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE autopilot_pr_state ADD COLUMN post_merge_infra_rerun_sha TEXT NOT NULL DEFAULT ''`,
+		// GH-4919: permanent-failure classification for reconcileReleaseBackfill.
+		// A row whose API lookups keep erroring (deleted repo, unresolved
+		// platform incident) is marked abandoned once it crosses both a
+		// consecutive-failure and a minimum-wall-clock-window threshold, so
+		// every future sweep can skip it without any API call. Persisted so
+		// the skip survives a daemon restart; error already carries the
+		// reason via the existing error column.
+		`ALTER TABLE autopilot_pr_state ADD COLUMN release_backfill_abandoned INTEGER NOT NULL DEFAULT 0`,
 	}
 
 	for _, m := range migrations {
@@ -472,6 +480,7 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			breaker_readopt_count INTEGER NOT NULL DEFAULT 0,
 			post_merge_infra_rerun_count INTEGER NOT NULL DEFAULT 0,
 			post_merge_infra_rerun_sha TEXT NOT NULL DEFAULT '',
+			release_backfill_abandoned INTEGER NOT NULL DEFAULT 0,
 			PRIMARY KEY (repo, pr_number)
 		)
 	`); err != nil {
@@ -488,7 +497,8 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			pr_title, merge_followup_posted, infra_rerun_count, infra_rerun_sha,
 			parked, escalation_reason, rebase_hold_active, readopt_count,
 			breaker_hold_active, breaker_readopt_count,
-			post_merge_infra_rerun_count, post_merge_infra_rerun_sha
+			post_merge_infra_rerun_count, post_merge_infra_rerun_sha,
+			release_backfill_abandoned
 		)
 		SELECT
 			pr_number, repo, pr_url, issue_number, branch_name, head_sha,
@@ -500,7 +510,8 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			pr_title, merge_followup_posted, infra_rerun_count, infra_rerun_sha,
 			parked, escalation_reason, rebase_hold_active, readopt_count,
 			breaker_hold_active, breaker_readopt_count,
-			post_merge_infra_rerun_count, post_merge_infra_rerun_sha
+			post_merge_infra_rerun_count, post_merge_infra_rerun_sha,
+			release_backfill_abandoned
 		FROM autopilot_pr_state
 	`); err != nil {
 		return fmt.Errorf("copy autopilot_pr_state rows: %w", err)
@@ -647,8 +658,9 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 			pr_title, merge_followup_posted, infra_rerun_count, infra_rerun_sha,
 			parked, escalation_reason, rebase_hold_active, readopt_count,
 			breaker_hold_active, breaker_readopt_count,
-			post_merge_infra_rerun_count, post_merge_infra_rerun_sha
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			post_merge_infra_rerun_count, post_merge_infra_rerun_sha,
+			release_backfill_abandoned
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(repo, pr_number) DO UPDATE SET
 			pr_url = excluded.pr_url,
 			issue_number = excluded.issue_number,
@@ -682,7 +694,8 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 			breaker_hold_active = excluded.breaker_hold_active,
 			breaker_readopt_count = excluded.breaker_readopt_count,
 			post_merge_infra_rerun_count = excluded.post_merge_infra_rerun_count,
-			post_merge_infra_rerun_sha = excluded.post_merge_infra_rerun_sha
+			post_merge_infra_rerun_sha = excluded.post_merge_infra_rerun_sha,
+			release_backfill_abandoned = excluded.release_backfill_abandoned
 	`,
 		pr.PRNumber, repo, pr.PRURL, pr.IssueNumber, pr.BranchName, pr.HeadSHA,
 		string(pr.Stage), string(pr.CIStatus),
@@ -695,6 +708,7 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 		pr.Parked, pr.EscalationReason, pr.RebaseHoldActive, pr.ReadoptCount,
 		pr.BreakerHoldActive, pr.BreakerReadoptCount,
 		pr.PostMergeInfraRerunCount, pr.PostMergeInfraRerunSHA,
+		pr.ReleaseBackfillAbandoned,
 	)
 	return err
 }
@@ -712,7 +726,8 @@ func (s *StateStore) GetPRState(repo string, prNumber int) (*PRState, error) {
 			pr_title, merge_followup_posted, infra_rerun_count, infra_rerun_sha,
 			parked, escalation_reason, rebase_hold_active, readopt_count,
 			breaker_hold_active, breaker_readopt_count,
-			post_merge_infra_rerun_count, post_merge_infra_rerun_sha
+			post_merge_infra_rerun_count, post_merge_infra_rerun_sha,
+			release_backfill_abandoned
 		FROM autopilot_pr_state WHERE repo = ? AND pr_number = ?
 	`, repo, prNumber)
 
@@ -739,7 +754,8 @@ func (s *StateStore) LoadAllPRStates(repo string) ([]*PRState, error) {
 			pr_title, merge_followup_posted, infra_rerun_count, infra_rerun_sha,
 			parked, escalation_reason, rebase_hold_active, readopt_count,
 			breaker_hold_active, breaker_readopt_count,
-			post_merge_infra_rerun_count, post_merge_infra_rerun_sha
+			post_merge_infra_rerun_count, post_merge_infra_rerun_sha,
+			release_backfill_abandoned
 		FROM autopilot_pr_state WHERE repo = ?
 	`, repo)
 	if err != nil {
@@ -764,6 +780,7 @@ func (s *StateStore) LoadAllPRStates(repo string) ([]*PRState, error) {
 			&pr.Parked, &pr.EscalationReason, &pr.RebaseHoldActive, &pr.ReadoptCount,
 			&pr.BreakerHoldActive, &pr.BreakerReadoptCount,
 			&pr.PostMergeInfraRerunCount, &pr.PostMergeInfraRerunSHA,
+			&pr.ReleaseBackfillAbandoned,
 		); err != nil {
 			return nil, err
 		}
@@ -1022,6 +1039,7 @@ func scanPRState(row *sql.Row) (*PRState, error) {
 		&pr.Parked, &pr.EscalationReason, &pr.RebaseHoldActive, &pr.ReadoptCount,
 		&pr.BreakerHoldActive, &pr.BreakerReadoptCount,
 		&pr.PostMergeInfraRerunCount, &pr.PostMergeInfraRerunSHA,
+		&pr.ReleaseBackfillAbandoned,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -1299,6 +1299,18 @@ type PRState struct {
 	// current PostMergeSHA, the effective retry budget is treated as 0.
 	// Persisted.
 	PostMergeInfraRerunSHA string
+	// ReleaseBackfillAbandoned is true once reconcileReleaseBackfill
+	// (GH-4919) has classified this row's API failures as permanent — it
+	// crossed both the consecutive-failure and minimum-wall-clock-window
+	// thresholds in releaseBackfillObserveFailure, so no future sweep will
+	// call the GitHub API for it again. Error carries the last failure
+	// reason at the moment of the transition. Distinct from
+	// RebaseHoldActive/BreakerHoldActive: those hold a PR that is expected
+	// to be re-driven back to normal processing; this marks a row the sweep
+	// has given up on entirely (e.g. its repo was deleted, or the incident
+	// that broke it never resolved). Persisted so the skip survives a
+	// daemon restart.
+	ReleaseBackfillAbandoned bool
 }
 
 // snapshot returns a detached, field-by-field copy of the PRState with a fresh
@@ -1357,6 +1369,7 @@ func (ps *PRState) snapshot() *PRState {
 		BreakerReadoptCount:          ps.BreakerReadoptCount,
 		PostMergeInfraRerunCount:     ps.PostMergeInfraRerunCount,
 		PostMergeInfraRerunSHA:       ps.PostMergeInfraRerunSHA,
+		ReleaseBackfillAbandoned:     ps.ReleaseBackfillAbandoned,
 	}
 	// DiscoveredChecks and ScopeMemberPRs are slices — copy the backing arrays
 	// so consumers can't mutate the live PR's slice through the snapshot.


### PR DESCRIPTION
## Summary

- `reconcileReleaseBackfill` retried every `StageFailed`/`StageReleasing` row on every ~30s tick with no backoff and no terminal classification for rows that can never heal (e.g. deleted repos). During the 2026-08-17 GitHub platform incident this burned ~2.9k rate-limit hits in a day against the shared 5000/hr pool.
- Adds per-row exponential backoff (capped at 1h, resets on success), persisted permanent-failure classification after 10 consecutive failures spanning >= 6h (so a short incident doesn't terminalize a row), and a platform-breaker gate that no-ops the whole sweep while the breaker is open.
- Heal/drain semantics and `recordReleaseBackfillEvent` are unchanged.

Closes GH-4919.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/autopilot/... -race` (full package, including new `TestReconcileReleaseBackfill_Backoff`, `_BackoffResetsOnSuccess`, `_AbandonsAfterThreshold`, `_ShortIncidentDoesNotAbandon`, `_AbandonedRowSkipped`, `_BreakerOpenSkipsSweep`)