### PR TITLE
chore(dashboard): remove unused renderPanelInfo

### DIFF
--- a/internal/dashboard/grom_chrome.go
+++ b/internal/dashboard/grom_chrome.go
@@ -45,12 +45,6 @@ var warnChrome = render.PanelStyle{
 	Title:  gromTheme.WarningStyle().Bold(true),
 }
 
-// renderPanelInfo builds a grom-style card with a legend embedded in the
-// top-right border: ╭─ title ────┤ info ├─╮.
-func renderPanelInfo(title, info, content string, tw int) string {
-	return renderPanelStyled(title, info, content, tw, panelChrome)
-}
-
 // renderPanelStyled renders the card with explicit chrome (warn, focus).
 // Height is derived from the content so panels stay content-sized.
 func renderPanelStyled(title, info, content string, tw int, ps render.PanelStyle) string {


### PR DESCRIPTION
## Summary
- Removes `renderPanelInfo` from `internal/dashboard/grom_chrome.go` — dead code since PR#4923 removed `renderEvalStats`, its last caller.
- `golangci-lint`'s `unused` check was failing locally on this, which blocked the pre-push gate for the v2.260.1 tag (bypassed at the time).

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — all packages pass
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/dashboard/...` — 0 issues

Fixes GH-4924.