### PR TITLE
fix(ci): lint full tree on PRs instead of only changed lines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,4 +108,4 @@ jobs:
           # v2.0.2 was built with go1.24 and refuses the go 1.25 target
           # (TASK-390 bumped the toolchain for grot); 2.8.0 matches local.
           version: v2.8.0
-          args: --timeout=5m --new-from-rev=origin/main
+          args: --timeout=5m


### PR DESCRIPTION
## Summary
- Removes `--new-from-rev=origin/main` from the golangci-lint CI step (`.github/workflows/ci.yml`) so PR CI lints the full tree, matching the local pre-push gate.
- `--new-from-rev` filtered findings to changed lines, creating a blind spot: deleting the last caller of a function orphans it as `unused`, but on a line the PR never touched — so the finding was filtered out and CI stayed green. This shipped a real defect in PR#4923 (`renderPanelInfo` orphaned, caught only by the local pre-push gate post-merge, forcing a `--no-verify` tag push and fast-follow #4924/PR#4926).
- `version: v2.8.0` pin and `--timeout=5m` are unchanged; no other args touched.

Closes GH-4927.

## Test plan
- [x] `ci.yml` lint step no longer passes `--new-from-rev`
- [ ] CI lint run on this PR passes (proves full-tree lint is green — main verified lint-clean at `d5904cca`)