### PR TITLE
GH-4930: feat(jira): add ADFText type with custom UnmarshalJSON

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -117,6 +117,7 @@
 | Linear webhooks | ✅ | adapters/linear | - | `adapters.linear` | Wired in pilot.go, gateway route + handler registered |
 | Linear sub-issue creation | ✅ | adapters/linear | - | `adapters.linear` | CreateIssue GraphQL mutation for epic decomposition (v1.27.0) |
 | Jira webhooks | ✅ | adapters/jira | - | `adapters.jira` | Wired in pilot.go, gateway route + handler + orchestrator |
+| Jira ADF description unmarshal | ✅ | adapters/jira | - | - | `Fields.Description` typed `ADFText`; `UnmarshalJSON` accepts plain string (Server) or ADF doc object (Cloud) via shared ADF walker — fixes `GetIssue`/`SearchIssues` erroring on Cloud issues whose description is an ADF object (GH-4930) |
 | Slack Socket Mode | ✅ | adapters/slack | `pilot start --slack` | `adapters.slack.app_token` | Listen() with auto-reconnect, wired in main.go (v0.29.0) |
 | Parallel GitHub polling | ✅ | adapters/github | - | `orchestrator.max_concurrent` | Goroutines + semaphore for concurrent issue processing (v0.26.1) |
 | Multi-repo polling | ✅ | adapters/github | - | `projects[].github` | Poll issues from all projects with GitHub config (v0.54.0) |

--- a/.agent/tasks/gh-4930.md
+++ b/.agent/tasks/gh-4930.md
@@ -1,0 +1,10 @@
+# GH-4930
+
+**Created:** 2026-08-18
+
+## Problem
+
+In internal/adapters/jira/types.go, add an ADFText string type whose UnmarshalJSON first tries a plain string, then falls back to unmarshaling into map[string]interface{} and extracting text via the ADF walker. Retype Fields.Description (types.go:111) to ADFText.
+
+## Acceptance Criteria
+

--- a/internal/adapters/jira/converter.go
+++ b/internal/adapters/jira/converter.go
@@ -34,7 +34,7 @@ func ConvertIssueToTask(issue *Issue, baseURL string) *TaskInfo {
 	}
 
 	title, titleStripped := text.SanitizeUntrusted(issue.Fields.Summary)
-	description, bodyStripped := text.SanitizeUntrusted(extractDescription(issue.Fields.Description))
+	description, bodyStripped := text.SanitizeUntrusted(extractDescription(string(issue.Fields.Description)))
 
 	if titleStripped+bodyStripped > 0 {
 		logging.WithComponent("jira").Warn(

--- a/internal/adapters/jira/converter_test.go
+++ b/internal/adapters/jira/converter_test.go
@@ -326,7 +326,7 @@ func TestASCIISmuggling_JiraConvertStripsInvisible(t *testing.T) {
 		Key: "PROJ-1337",
 		Fields: Fields{
 			Summary:     "Fix typo" + hidden,
-			Description: "Line 2 needs fix." + hidden,
+			Description: ADFText("Line 2 needs fix." + hidden),
 			Project:     Project{Key: "PROJ"},
 		},
 	}

--- a/internal/adapters/jira/types.go
+++ b/internal/adapters/jira/types.go
@@ -1,6 +1,10 @@
 package jira
 
-import "time"
+import (
+	"encoding/json"
+	"strings"
+	"time"
+)
 
 // Config holds Jira adapter configuration
 type Config struct {
@@ -105,10 +109,64 @@ type Issue struct {
 	Fields Fields `json:"fields"`
 }
 
+// ADFText holds Jira text content that may arrive as either a plain JSON
+// string (Jira Server) or an Atlassian Document Format (ADF) document
+// (Jira Cloud rich-text fields, e.g. the issue description). It always
+// unmarshals down to plain text.
+type ADFText string
+
+// UnmarshalJSON implements json.Unmarshaler for ADFText. It first tries to
+// decode the value as a plain JSON string. If that fails (because the field
+// is an ADF document object), it falls back to unmarshaling into
+// map[string]interface{} and extracting the plain text via the ADF walker.
+func (t *ADFText) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		*t = ADFText(s)
+		return nil
+	}
+
+	var adf map[string]interface{}
+	if err := json.Unmarshal(data, &adf); err != nil {
+		return err
+	}
+
+	*t = ADFText(extractADFText(adf))
+	return nil
+}
+
+// extractADFText extracts plain text from an Atlassian Document Format node.
+func extractADFText(adf map[string]interface{}) string {
+	var sb strings.Builder
+	extractADFTextRecursive(adf, &sb)
+	return strings.TrimSpace(sb.String())
+}
+
+// extractADFTextRecursive recursively extracts text from ADF nodes.
+func extractADFTextRecursive(node map[string]interface{}, sb *strings.Builder) {
+	if text, ok := node["text"].(string); ok {
+		sb.WriteString(text)
+	}
+
+	if content, ok := node["content"].([]interface{}); ok {
+		for _, item := range content {
+			if itemMap, ok := item.(map[string]interface{}); ok {
+				extractADFTextRecursive(itemMap, sb)
+			}
+		}
+		// Add newline for block elements
+		if nodeType, ok := node["type"].(string); ok {
+			if nodeType == "paragraph" || nodeType == "heading" || nodeType == "listItem" {
+				sb.WriteString("\n")
+			}
+		}
+	}
+}
+
 // Fields represents Jira issue fields
 type Fields struct {
 	Summary     string        `json:"summary"`
-	Description string        `json:"description"`
+	Description ADFText       `json:"description"`
 	IssueType   IssueType     `json:"issuetype"`
 	Status      Status        `json:"status"`
 	Priority    *JiraPriority `json:"priority,omitempty"`

--- a/internal/adapters/jira/types_test.go
+++ b/internal/adapters/jira/types_test.go
@@ -1,0 +1,89 @@
+package jira
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestADFText_UnmarshalJSON_PlainString(t *testing.T) {
+	var got ADFText
+	if err := json.Unmarshal([]byte(`"plain description"`), &got); err != nil {
+		t.Fatalf("UnmarshalJSON() error = %v", err)
+	}
+	if got != "plain description" {
+		t.Errorf("UnmarshalJSON() = %q, want %q", got, "plain description")
+	}
+}
+
+func TestADFText_UnmarshalJSON_ADFDocument(t *testing.T) {
+	adf := `{
+		"type": "doc",
+		"version": 1,
+		"content": [
+			{
+				"type": "paragraph",
+				"content": [
+					{"type": "text", "text": "Hello world"}
+				]
+			}
+		]
+	}`
+
+	var got ADFText
+	if err := json.Unmarshal([]byte(adf), &got); err != nil {
+		t.Fatalf("UnmarshalJSON() error = %v", err)
+	}
+	if got != "Hello world" {
+		t.Errorf("UnmarshalJSON() = %q, want %q", got, "Hello world")
+	}
+}
+
+func TestADFText_UnmarshalJSON_InvalidJSON(t *testing.T) {
+	var got ADFText
+	if err := json.Unmarshal([]byte(`not-json`), &got); err == nil {
+		t.Errorf("UnmarshalJSON() expected error for invalid JSON, got nil")
+	}
+}
+
+func TestFields_Description_UnmarshalsBothShapes(t *testing.T) {
+	t.Run("plain string field", func(t *testing.T) {
+		var f Fields
+		if err := json.Unmarshal([]byte(`{"description":"a simple description"}`), &f); err != nil {
+			t.Fatalf("Unmarshal() error = %v", err)
+		}
+		if f.Description != "a simple description" {
+			t.Errorf("Description = %q, want %q", f.Description, "a simple description")
+		}
+	})
+
+	t.Run("ADF document field", func(t *testing.T) {
+		payload := `{
+			"description": {
+				"type": "doc",
+				"version": 1,
+				"content": [
+					{
+						"type": "paragraph",
+						"content": [
+							{"type": "text", "text": "First paragraph"}
+						]
+					},
+					{
+						"type": "paragraph",
+						"content": [
+							{"type": "text", "text": "Second paragraph"}
+						]
+					}
+				]
+			}
+		}`
+		var f Fields
+		if err := json.Unmarshal([]byte(payload), &f); err != nil {
+			t.Fatalf("Unmarshal() error = %v", err)
+		}
+		want := "First paragraph\nSecond paragraph"
+		if f.Description != ADFText(want) {
+			t.Errorf("Description = %q, want %q", f.Description, want)
+		}
+	})
+}

--- a/internal/adapters/jira/webhook.go
+++ b/internal/adapters/jira/webhook.go
@@ -189,11 +189,15 @@ func (h *WebhookHandler) extractIssue(payload map[string]interface{}) (*Issue, e
 			issue.Fields.Summary, summaryStripped = text.SanitizeUntrusted(summary)
 		}
 		if desc, ok := fieldsData["description"].(string); ok {
-			issue.Fields.Description, descStripped = text.SanitizeUntrusted(desc)
+			var cleaned string
+			cleaned, descStripped = text.SanitizeUntrusted(desc)
+			issue.Fields.Description = ADFText(cleaned)
 		}
 		// Also check for ADF description (Jira Cloud)
 		if desc, ok := fieldsData["description"].(map[string]interface{}); ok {
-			issue.Fields.Description, descStripped = text.SanitizeUntrusted(h.extractADFText(desc))
+			var cleaned string
+			cleaned, descStripped = text.SanitizeUntrusted(h.extractADFText(desc))
+			issue.Fields.Description = ADFText(cleaned)
 		}
 		if summaryStripped+descStripped > 0 {
 			logging.WithComponent("jira").Warn(
@@ -250,32 +254,10 @@ func (h *WebhookHandler) extractIssue(payload map[string]interface{}) (*Issue, e
 	return issue, nil
 }
 
-// extractADFText extracts plain text from Atlassian Document Format
+// extractADFText extracts plain text from Atlassian Document Format.
+// Delegates to the shared ADF walker (types.go) used by ADFText.UnmarshalJSON.
 func (h *WebhookHandler) extractADFText(adf map[string]interface{}) string {
-	var sb strings.Builder
-	h.extractADFTextRecursive(adf, &sb)
-	return strings.TrimSpace(sb.String())
-}
-
-// extractADFTextRecursive recursively extracts text from ADF nodes
-func (h *WebhookHandler) extractADFTextRecursive(node map[string]interface{}, sb *strings.Builder) {
-	if text, ok := node["text"].(string); ok {
-		sb.WriteString(text)
-	}
-
-	if content, ok := node["content"].([]interface{}); ok {
-		for _, item := range content {
-			if itemMap, ok := item.(map[string]interface{}); ok {
-				h.extractADFTextRecursive(itemMap, sb)
-			}
-		}
-		// Add newline for block elements
-		if nodeType, ok := node["type"].(string); ok {
-			if nodeType == "paragraph" || nodeType == "heading" || nodeType == "listItem" {
-				sb.WriteString("\n")
-			}
-		}
-	}
+	return extractADFText(adf)
 }
 
 // hasPilotLabel checks if the issue has the pilot label


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4930.

Closes #4930

## Changes

In internal/adapters/jira/types.go, add an ADFText string type whose UnmarshalJSON first tries a plain string, then falls back to unmarshaling into map[string]interface{} and extracting text via the ADF walker. Retype Fields.Description (types.go:111) to ADFText.