### PR TITLE
GH-4931: refactor(jira): promote ADF walker functions to package-level

### DIFF
--- a/.agent/tasks/gh-4931.md
+++ b/.agent/tasks/gh-4931.md
@@ -1,0 +1,10 @@
+# GH-4931
+
+**Created:** 2026-08-18
+
+## Problem
+
+Move extractADFText / extractADFTextRecursive out of WebhookHandler (webhook.go:253-279) into package-level functions in internal/adapters/jira so both the poller (via ADFText.UnmarshalJSON) and the webhook path can share them. Update webhook call sites accordingly with no behavior change.
+
+## Acceptance Criteria
+

--- a/internal/adapters/jira/types.go
+++ b/internal/adapters/jira/types.go
@@ -1,6 +1,9 @@
 package jira
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // Config holds Jira adapter configuration
 type Config struct {
@@ -103,6 +106,37 @@ type Issue struct {
 	Key    string `json:"key"`
 	Self   string `json:"self"`
 	Fields Fields `json:"fields"`
+}
+
+// extractADFText extracts plain text from Atlassian Document Format.
+//
+// GH-4931: promoted from a WebhookHandler method to a package-level function
+// so it can be shared by both the webhook path and the poller path.
+func extractADFText(adf map[string]interface{}) string {
+	var sb strings.Builder
+	extractADFTextRecursive(adf, &sb)
+	return strings.TrimSpace(sb.String())
+}
+
+// extractADFTextRecursive recursively extracts text from ADF nodes.
+func extractADFTextRecursive(node map[string]interface{}, sb *strings.Builder) {
+	if text, ok := node["text"].(string); ok {
+		sb.WriteString(text)
+	}
+
+	if content, ok := node["content"].([]interface{}); ok {
+		for _, item := range content {
+			if itemMap, ok := item.(map[string]interface{}); ok {
+				extractADFTextRecursive(itemMap, sb)
+			}
+		}
+		// Add newline for block elements
+		if nodeType, ok := node["type"].(string); ok {
+			if nodeType == "paragraph" || nodeType == "heading" || nodeType == "listItem" {
+				sb.WriteString("\n")
+			}
+		}
+	}
 }
 
 // Fields represents Jira issue fields

--- a/internal/adapters/jira/webhook.go
+++ b/internal/adapters/jira/webhook.go
@@ -193,7 +193,7 @@ func (h *WebhookHandler) extractIssue(payload map[string]interface{}) (*Issue, e
 		}
 		// Also check for ADF description (Jira Cloud)
 		if desc, ok := fieldsData["description"].(map[string]interface{}); ok {
-			issue.Fields.Description, descStripped = text.SanitizeUntrusted(h.extractADFText(desc))
+			issue.Fields.Description, descStripped = text.SanitizeUntrusted(extractADFText(desc))
 		}
 		if summaryStripped+descStripped > 0 {
 			logging.WithComponent("jira").Warn(
@@ -248,34 +248,6 @@ func (h *WebhookHandler) extractIssue(payload map[string]interface{}) (*Issue, e
 	}
 
 	return issue, nil
-}
-
-// extractADFText extracts plain text from Atlassian Document Format
-func (h *WebhookHandler) extractADFText(adf map[string]interface{}) string {
-	var sb strings.Builder
-	h.extractADFTextRecursive(adf, &sb)
-	return strings.TrimSpace(sb.String())
-}
-
-// extractADFTextRecursive recursively extracts text from ADF nodes
-func (h *WebhookHandler) extractADFTextRecursive(node map[string]interface{}, sb *strings.Builder) {
-	if text, ok := node["text"].(string); ok {
-		sb.WriteString(text)
-	}
-
-	if content, ok := node["content"].([]interface{}); ok {
-		for _, item := range content {
-			if itemMap, ok := item.(map[string]interface{}); ok {
-				h.extractADFTextRecursive(itemMap, sb)
-			}
-		}
-		// Add newline for block elements
-		if nodeType, ok := node["type"].(string); ok {
-			if nodeType == "paragraph" || nodeType == "heading" || nodeType == "listItem" {
-				sb.WriteString("\n")
-			}
-		}
-	}
 }
 
 // hasPilotLabel checks if the issue has the pilot label

--- a/internal/adapters/jira/webhook_test.go
+++ b/internal/adapters/jira/webhook_test.go
@@ -480,9 +480,6 @@ func TestExtractIssue_MissingIssue(t *testing.T) {
 }
 
 func TestExtractADFText(t *testing.T) {
-	client := NewClient("https://jira.example.com", "user", "token", PlatformCloud)
-	handler := NewWebhookHandler(client, "", "pilot")
-
 	tests := []struct {
 		name string
 		adf  map[string]interface{}
@@ -539,7 +536,7 @@ func TestExtractADFText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := handler.extractADFText(tt.adf)
+			got := extractADFText(tt.adf)
 			if got != tt.want {
 				t.Errorf("extractADFText() = %q, want %q", got, tt.want)
 			}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4931.

Closes #4931

## Changes

Move extractADFText / extractADFTextRecursive out of WebhookHandler (webhook.go:253-279) into package-level functions in internal/adapters/jira so both the poller (via ADFText.UnmarshalJSON) and the webhook path can share them. Update webhook call sites accordingly with no behavior change.