### PR TITLE
fix(executor): recognize bare no-decompose token in issue body

### DIFF
--- a/internal/executor/decompose.go
+++ b/internal/executor/decompose.go
@@ -119,6 +119,11 @@ var noDecomposePhrases = []*regexp.Regexp{
 	regexp.MustCompile(`is a standalone task`),
 	regexp.MustCompile(`as a single pr\b`),
 	regexp.MustCompile(`<!--\s*pilot:no-decompose\s*-->`),
+	// GH-4938: bare "no-decompose" token in body text (mirrors the label name,
+	// the way people naturally write it) — #4929 opened with
+	// "(no-decompose — single subsystem, ...)" and was still decomposed into
+	// 8 sub-issues because only the labeled/prose forms were recognized.
+	regexp.MustCompile(`\bno-decompose\b`),
 }
 
 // HasNoDecomposePhrase returns true when the task title or description contains

--- a/internal/executor/decompose_test.go
+++ b/internal/executor/decompose_test.go
@@ -957,6 +957,17 @@ func TestHasNoDecomposePhrase(t *testing.T) {
 		{name: "mixed case HTML marker", body: "<!-- Pilot:No-Decompose -->", expected: true},
 		// HTML marker with extra whitespace → true
 		{name: "HTML marker with spaces", body: "<!--  pilot:no-decompose  -->", expected: true},
+		// GH-4938: bare "no-decompose" token in body text — the way people
+		// naturally write it, mirroring the label name. #4929 opened with this
+		// exact parenthetical and was still decomposed into 8 sub-issues.
+		{name: "bare token in parenthetical", body: "## Fix (no-decompose — single subsystem, internal/adapters/jira)", expected: true},
+		{name: "bare token alone on a line", body: "no-decompose", expected: true},
+		{name: "bare token mixed case", body: "No-Decompose", expected: true},
+		// GH-4938 negative: word-boundary hyphenated token only — no hyphen or
+		// a space instead of a hyphen must NOT match (unless an existing
+		// phrase separately catches it).
+		{name: "nodecompose without hyphen", body: "Please nodecompose this before merging.", expected: false},
+		{name: "no decompose with space", body: "no decompose please", expected: false},
 		// Phrase as unrelated substring → false
 		{name: "single word only", body: "This is a single change to a file.", expected: false},
 		{name: "split without do not", body: "We should split this into modules.", expected: false},


### PR DESCRIPTION
## Summary

- `noDecomposePhrases` recognized prose forms and the `no-decompose` label, but not the bare hyphenated token `no-decompose` written directly in body text — the way people naturally write it, mirroring the label name.
- Adds `regexp.MustCompile(\`\bno-decompose\b\`)` to the phrase list, matched against lowercased title+description as today.
- `#4929` opened with `## Fix (no-decompose — single subsystem, internal/adapters/jira)` and was still decomposed into 8 sub-issues (#4930-#4937) because only the labeled/prose forms were recognized. Same family as GH-3597.

## Test plan

- [x] `go test ./internal/executor/... -run TestHasNoDecomposePhrase -v` — all cases pass, including new bare-token positives (parenthetical, alone on a line, mixed case) and negatives (`nodecompose` without hyphen, `no decompose` with space)
- [x] `go build ./...` succeeds

Closes GH-4938