### PR TITLE
fix(jira): hint at platform: cloud config on legacy search 410 (GH-4933)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -118,6 +118,7 @@
 | Linear sub-issue creation | ✅ | adapters/linear | - | `adapters.linear` | CreateIssue GraphQL mutation for epic decomposition (v1.27.0) |
 | Jira webhooks | ✅ | adapters/jira | - | `adapters.jira` | Wired in pilot.go, gateway route + handler + orchestrator |
 | Jira ADF description unmarshal | ✅ | adapters/jira | - | - | `Fields.Description` typed `ADFText`; `UnmarshalJSON` accepts plain string (Server) or ADF doc object (Cloud) via shared ADF walker — fixes `GetIssue`/`SearchIssues` erroring on Cloud issues whose description is an ADF object (GH-4930) |
+| Jira legacy search 410 hint | ✅ | adapters/jira | - | - | `SearchIssues` detects HTTP 410 Gone from legacy `/rest/api/2/search` (retired on Cloud) and wraps the error with a hint to set `platform: cloud` (GH-4933) |
 | Slack Socket Mode | ✅ | adapters/slack | `pilot start --slack` | `adapters.slack.app_token` | Listen() with auto-reconnect, wired in main.go (v0.29.0) |
 | Parallel GitHub polling | ✅ | adapters/github | - | `orchestrator.max_concurrent` | Goroutines + semaphore for concurrent issue processing (v0.26.1) |
 | Multi-repo polling | ✅ | adapters/github | - | `projects[].github` | Poll issues from all projects with GitHub config (v0.54.0) |

--- a/.agent/tasks/gh-4933.md
+++ b/.agent/tasks/gh-4933.md
@@ -1,0 +1,29 @@
+# GH-4933
+
+**Created:** 2026-08-18
+
+## Problem
+
+GitHub Issue GH-4933: fix(jira): handle HTTP 410 on legacy search endpoint in client.go
+
+<!--autopilot-meta
+parent: GH-4929
+inherited-spec: true
+-->
+
+Parent: GH-4929
+
+In client.go, around the legacy /rest/api/2/search call path, detect HTTP 410 responses and wrap the returned error with a hint recommending platform: cloud configuration.
+
+## Scope fence
+
+Implement ONLY the slice described above. The parent issue GH-4929 is decomposed
+into sibling sub-issues that cover the rest of its spec — consult the parent
+for context, but do NOT implement parts of it that fall outside this subtask.
+
+## Test (folded from closed sibling #4936 — include in the SAME PR)
+
+- Legacy `/rest/api/2/search` returning HTTP 410 yields an error whose message contains the `platform: cloud` hint
+
+## Acceptance Criteria
+

--- a/internal/adapters/jira/client.go
+++ b/internal/adapters/jira/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -45,6 +46,18 @@ func (c *Client) apiPath() string {
 	return "/rest/api/2"
 }
 
+// APIError represents a non-2xx response from the Jira API, preserving the
+// HTTP status code so callers can branch on specific failure modes (e.g. 410
+// Gone on the retired legacy search endpoint).
+type APIError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("API error (status %d): %s", e.StatusCode, e.Body)
+}
+
 // doRequest performs an HTTP request to the Jira API
 func (c *Client) doRequest(ctx context.Context, method, path string, body interface{}, result interface{}) error {
 	var bodyReader io.Reader
@@ -82,7 +95,7 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body interf
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
+		return &APIError{StatusCode: resp.StatusCode, Body: string(respBody)}
 	}
 
 	if result != nil && len(respBody) > 0 {
@@ -248,6 +261,10 @@ func (c *Client) SearchIssues(ctx context.Context, jql string, maxResults int) (
 	path := fmt.Sprintf("/search?jql=%s&maxResults=%d", strings.ReplaceAll(jql, " ", "+"), maxResults)
 	var resp SearchResponse
 	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		var apiErr *APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusGone {
+			return nil, fmt.Errorf("legacy /rest/api/2/search endpoint returned 410 Gone — this Jira instance appears to be Cloud, which requires platform: cloud in config: %w", err)
+		}
 		return nil, err
 	}
 	return resp.Issues, nil

--- a/internal/adapters/jira/client_test.go
+++ b/internal/adapters/jira/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -408,6 +409,26 @@ func TestSearchIssues_Server(t *testing.T) {
 	}
 	if len(issues) != 1 {
 		t.Fatalf("expected 1 issue, got %d", len(issues))
+	}
+}
+
+func TestSearchIssues_LegacyEndpointGone(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/api/2/search" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusGone)
+		_, _ = w.Write([]byte(`{"errorMessages":["The requested resource is not available anymore"]}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "admin", "token", PlatformServer)
+	_, err := client.SearchIssues(context.Background(), "labels = pilot", 50)
+	if err == nil {
+		t.Fatal("expected error for HTTP 410 response, got nil")
+	}
+	if !strings.Contains(err.Error(), "platform: cloud") {
+		t.Errorf("expected error to hint at platform: cloud config, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `SearchIssues` now detects HTTP 410 Gone from the legacy `/rest/api/2/search` endpoint (retired on Jira Cloud) and wraps the error with a hint to set `platform: cloud` in config, instead of surfacing a bare API error.
- Introduces an `APIError` type on the client so callers can branch on the HTTP status code of a failed request.

## Test plan
- [x] `TestSearchIssues_LegacyEndpointGone` — legacy endpoint returning 410 yields an error containing the `platform: cloud` hint
- [x] `go test ./internal/adapters/jira/...` passes
- [x] `go build ./...` passes

Closes GH-4933 (subtask of parent GH-4929).