### PR TITLE
fix(executor): match bare no-decompose token to suppress decomposition

### DIFF
--- a/internal/executor/decompose.go
+++ b/internal/executor/decompose.go
@@ -119,6 +119,10 @@ var noDecomposePhrases = []*regexp.Regexp{
 	regexp.MustCompile(`is a standalone task`),
 	regexp.MustCompile(`as a single pr\b`),
 	regexp.MustCompile(`<!--\s*pilot:no-decompose\s*-->`),
+	// GH-4938: bare "no-decompose" token in body text — mirrors the label
+	// name and is how people naturally write it; #4929 opened with
+	// "(no-decompose — single subsystem)" and was still decomposed.
+	regexp.MustCompile(`\bno-decompose\b`),
 }
 
 // HasNoDecomposePhrase returns true when the task title or description contains

--- a/internal/executor/decompose_test.go
+++ b/internal/executor/decompose_test.go
@@ -946,6 +946,13 @@ func TestHasNoDecomposePhrase(t *testing.T) {
 		{name: "should not be split", body: "This should not be split across PRs.", expected: true},
 		{name: "is a standalone task", body: "This is a standalone task covering one package.", expected: true},
 		{name: "as a single PR", body: "Implement it as a single PR.", expected: true},
+		// GH-4938: bare "no-decompose" token — the way people naturally
+		// write it, mirroring the label name (#4929 mis-split)
+		{name: "bare no-decompose token with context", body: "## Fix (no-decompose — single subsystem, internal/adapters/jira)", expected: true},
+		{name: "bare no-decompose token alone on a line", body: "no-decompose", expected: true},
+		{name: "bare no-decompose token mixed case", body: "No-Decompose", expected: true},
+		{name: "nodecompose without hyphen unmatched", body: "please nodecompose this task", expected: false},
+		{name: "no decompose without hyphen unmatched", body: "no decompose please", expected: false},
 		// Each canonical phrase in title → true
 		{name: "do not decompose in title", title: "do not decompose this", expected: true},
 		{name: "do not split in title", title: "do not split this", expected: true},


### PR DESCRIPTION
## Summary

- `noDecomposePhrases` recognized prose forms and the `no-decompose` label, but not the bare hyphenated token `no-decompose` written directly in body text — the way people naturally write it, mirroring the label name.
- Adds `regexp.MustCompile(\`\bno-decompose\b\`)` to the phrase list, matched against lowercased title+description as today.
- `#4929` opened with `## Fix (no-decompose — single subsystem, internal/adapters/jira)` and was still decomposed into 8 sub-issues (#4930-#4937) because only the labeled/prose forms were recognized. Same family as GH-3597.

## Test plan

- [x] `go test ./internal/executor/... -run TestHasNoDecomposePhrase -v` — all cases pass, including new bare-token positives (parenthetical with context, alone on a line, mixed case) and negatives (`nodecompose` without hyphen, `no decompose` with space)
- [x] `go test ./internal/executor/...` — full package suite passes
- [x] `go build ./...` succeeds

Closes GH-4938