### PR TITLE
GH-4931: refactor(jira): promote ADF walker functions to package-level

### DIFF
--- a/.agent/tasks/gh-4931.md
+++ b/.agent/tasks/gh-4931.md
@@ -1,0 +1,32 @@
+# GH-4931
+
+**Created:** 2026-08-18
+
+## Problem
+
+GitHub Issue GH-4931: refactor(jira): promote ADF walker functions to package-level
+
+<!--autopilot-meta
+parent: GH-4929
+inherited-spec: true
+-->
+
+Parent: GH-4929
+
+Move extractADFText / extractADFTextRecursive out of WebhookHandler (webhook.go:253-279) into package-level functions in internal/adapters/jira so both the poller (via ADFText.UnmarshalJSON) and the webhook path can share them. Update webhook call sites accordingly with no behavior change.
+
+## Scope fence
+
+Implement ONLY the slice described above. The parent issue GH-4929 is decomposed
+into sibling sub-issues that cover the rest of its spec — consult the parent
+for context, but do NOT implement parts of it that fall outside this subtask.
+
+## Tests (folded from closed siblings #4934 / #4935 / #4937 — include in the SAME PR)
+
+- Table-driven `ADFText.UnmarshalJSON` tests: plain string (Server/DC) · nested ADF object (paragraph/heading/listItem) · null/absent → empty string
+- Poller-path test: a v3 `/search/jql` fixture with ADF descriptions parses the full page (no rejection); extracted text reaches `Task.Description` sanitized as today
+- Server/DC regression case: plain-string description behavior unchanged
+- Existing webhook-path tests stay green (walker now package-level)
+
+## Acceptance Criteria
+

--- a/internal/adapters/jira/client_test.go
+++ b/internal/adapters/jira/client_test.go
@@ -432,6 +432,125 @@ func TestSearchIssues_LegacyEndpointGone(t *testing.T) {
 	}
 }
 
+// TestSearchIssues_Server_PlainStringDescription is a regression check: before
+// Fields.Description was retyped to ADFText (GH-4930), Server/DC's plain
+// string description unmarshaled directly into a string field. Confirm that
+// behavior is unchanged now that ADFText.UnmarshalJSON handles the plain
+// string case.
+func TestSearchIssues_Server_PlainStringDescription(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"issues": [
+				{
+					"id": "10001",
+					"key": "PROJ-1",
+					"fields": {
+						"summary": "Server issue",
+						"description": "Plain text description, unchanged."
+					}
+				}
+			],
+			"total": 1
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "admin", "token", PlatformServer)
+	issues, err := client.SearchIssues(context.Background(), "labels = pilot", 50)
+	if err != nil {
+		t.Fatalf("SearchIssues failed: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(issues))
+	}
+	if issues[0].Fields.Description != "Plain text description, unchanged." {
+		t.Errorf("Description = %q, want %q", issues[0].Fields.Description, "Plain text description, unchanged.")
+	}
+
+	task := ConvertIssueToTask(issues[0], "https://jira.example.com")
+	if task.Description != "Plain text description, unchanged." {
+		t.Errorf("task.Description = %q, want %q", task.Description, "Plain text description, unchanged.")
+	}
+}
+
+// TestSearchIssues_Cloud_ADFDescription is the poller-path regression for
+// GH-4931: Cloud's POST /search/jql page can return issues whose description
+// is an ADF document rather than a plain string. Before ADFText existed this
+// broke SearchResponse unmarshaling for the whole page (json.Unmarshal fails
+// atomically), rejecting every issue in the batch, not just the one with a
+// rich-text description. Verify the full page still parses and the walked
+// text reaches Task.Description sanitized, same as the plain-string path.
+func TestSearchIssues_Cloud_ADFDescription(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/api/3/search/jql" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"issues": [
+				{
+					"id": "10001",
+					"key": "PROJ-1",
+					"fields": {
+						"summary": "Cloud issue with ADF description",
+						"description": {
+							"type": "doc",
+							"version": 1,
+							"content": [
+								{
+									"type": "paragraph",
+									"content": [
+										{"type": "text", "text": "First paragraph"}
+									]
+								},
+								{
+									"type": "paragraph",
+									"content": [
+										{"type": "text", "text": "Second paragraph"}
+									]
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": "10002",
+					"key": "PROJ-2",
+					"fields": {
+						"summary": "Cloud issue with plain description",
+						"description": "still a plain string on this issue"
+					}
+				}
+			],
+			"isLast": true
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "user@example.com", "api-token", PlatformCloud)
+	issues, err := client.SearchIssues(context.Background(), "labels = pilot", 50)
+	if err != nil {
+		t.Fatalf("SearchIssues rejected the page: %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("expected the full page (2 issues), got %d", len(issues))
+	}
+
+	wantADF := "First paragraph\nSecond paragraph"
+	if issues[0].Fields.Description != ADFText(wantADF) {
+		t.Errorf("issues[0].Fields.Description = %q, want %q", issues[0].Fields.Description, wantADF)
+	}
+	if issues[1].Fields.Description != "still a plain string on this issue" {
+		t.Errorf("issues[1].Fields.Description = %q, want %q", issues[1].Fields.Description, "still a plain string on this issue")
+	}
+
+	task := ConvertIssueToTask(issues[0], "https://company.atlassian.net")
+	if task.Description != wantADF {
+		t.Errorf("task.Description = %q, want %q", task.Description, wantADF)
+	}
+}
+
 // Integration test helper - verifies client can be created and method signatures are correct
 func TestClientMethodSignatures(t *testing.T) {
 	client := NewClient("https://jira.example.com", "user", "token", PlatformCloud)

--- a/internal/adapters/jira/types_test.go
+++ b/internal/adapters/jira/types_test.go
@@ -5,36 +5,111 @@ import (
 	"testing"
 )
 
-func TestADFText_UnmarshalJSON_PlainString(t *testing.T) {
-	var got ADFText
-	if err := json.Unmarshal([]byte(`"plain description"`), &got); err != nil {
-		t.Fatalf("UnmarshalJSON() error = %v", err)
+func TestADFText_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+		want ADFText
+	}{
+		{
+			name: "plain string (Server/DC)",
+			json: `"plain description"`,
+			want: "plain description",
+		},
+		{
+			name: "nested ADF object: paragraph",
+			json: `{
+				"type": "doc",
+				"version": 1,
+				"content": [
+					{
+						"type": "paragraph",
+						"content": [
+							{"type": "text", "text": "Hello world"}
+						]
+					}
+				]
+			}`,
+			want: "Hello world",
+		},
+		{
+			name: "nested ADF object: heading + listItem",
+			json: `{
+				"type": "doc",
+				"version": 1,
+				"content": [
+					{
+						"type": "heading",
+						"content": [
+							{"type": "text", "text": "Title"}
+						]
+					},
+					{
+						"type": "bulletList",
+						"content": [
+							{
+								"type": "listItem",
+								"content": [
+									{
+										"type": "paragraph",
+										"content": [
+											{"type": "text", "text": "First item"}
+										]
+									}
+								]
+							},
+							{
+								"type": "listItem",
+								"content": [
+									{
+										"type": "paragraph",
+										"content": [
+											{"type": "text", "text": "Second item"}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			}`,
+			// Each block-level node (heading/paragraph/listItem) appends its own
+			// trailing newline, so a listItem wrapping a paragraph yields a
+			// double newline before the next item — this is pre-existing walker
+			// behavior (unchanged by the package-level promotion).
+			want: "Title\nFirst item\n\nSecond item",
+		},
+		{
+			name: "null description",
+			json: `null`,
+			want: "",
+		},
 	}
-	if got != "plain description" {
-		t.Errorf("UnmarshalJSON() = %q, want %q", got, "plain description")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got ADFText
+			if err := json.Unmarshal([]byte(tt.json), &got); err != nil {
+				t.Fatalf("UnmarshalJSON() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("UnmarshalJSON() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
-func TestADFText_UnmarshalJSON_ADFDocument(t *testing.T) {
-	adf := `{
-		"type": "doc",
-		"version": 1,
-		"content": [
-			{
-				"type": "paragraph",
-				"content": [
-					{"type": "text", "text": "Hello world"}
-				]
-			}
-		]
-	}`
-
-	var got ADFText
-	if err := json.Unmarshal([]byte(adf), &got); err != nil {
-		t.Fatalf("UnmarshalJSON() error = %v", err)
+// TestADFText_UnmarshalJSON_Absent covers the case where the description
+// field is entirely absent from the payload (not just null), exercised via
+// the containing Fields struct since a bare ADFText has no zero-value
+// unmarshal call to observe.
+func TestADFText_UnmarshalJSON_Absent(t *testing.T) {
+	var f Fields
+	if err := json.Unmarshal([]byte(`{"summary":"no description field"}`), &f); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
 	}
-	if got != "Hello world" {
-		t.Errorf("UnmarshalJSON() = %q, want %q", got, "Hello world")
+	if f.Description != "" {
+		t.Errorf("Description = %q, want empty string", f.Description)
 	}
 }
 

--- a/internal/adapters/jira/webhook.go
+++ b/internal/adapters/jira/webhook.go
@@ -196,7 +196,7 @@ func (h *WebhookHandler) extractIssue(payload map[string]interface{}) (*Issue, e
 		// Also check for ADF description (Jira Cloud)
 		if desc, ok := fieldsData["description"].(map[string]interface{}); ok {
 			var cleaned string
-			cleaned, descStripped = text.SanitizeUntrusted(h.extractADFText(desc))
+			cleaned, descStripped = text.SanitizeUntrusted(extractADFText(desc))
 			issue.Fields.Description = ADFText(cleaned)
 		}
 		if summaryStripped+descStripped > 0 {
@@ -252,12 +252,6 @@ func (h *WebhookHandler) extractIssue(payload map[string]interface{}) (*Issue, e
 	}
 
 	return issue, nil
-}
-
-// extractADFText extracts plain text from Atlassian Document Format.
-// Delegates to the shared ADF walker (types.go) used by ADFText.UnmarshalJSON.
-func (h *WebhookHandler) extractADFText(adf map[string]interface{}) string {
-	return extractADFText(adf)
 }
 
 // hasPilotLabel checks if the issue has the pilot label

--- a/internal/adapters/jira/webhook_test.go
+++ b/internal/adapters/jira/webhook_test.go
@@ -479,10 +479,11 @@ func TestExtractIssue_MissingIssue(t *testing.T) {
 	}
 }
 
-func TestExtractADFText(t *testing.T) {
-	client := NewClient("https://jira.example.com", "user", "token", PlatformCloud)
-	handler := NewWebhookHandler(client, "", "pilot")
-
+// TestExtractADFText_WebhookPath exercises the package-level extractADFText
+// walker (types.go) via the same fixtures the webhook handler feeds it,
+// confirming the webhook path still gets correct output now that the walker
+// is package-level rather than a WebhookHandler method.
+func TestExtractADFText_WebhookPath(t *testing.T) {
 	tests := []struct {
 		name string
 		adf  map[string]interface{}
@@ -539,7 +540,7 @@ func TestExtractADFText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := handler.extractADFText(tt.adf)
+			got := extractADFText(tt.adf)
 			if got != tt.want {
 				t.Errorf("extractADFText() = %q, want %q", got, tt.want)
 			}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4931.

Closes #4931

## Changes

GitHub Issue GH-4931: refactor(jira): promote ADF walker functions to package-level

<!--autopilot-meta
parent: GH-4929
inherited-spec: true
-->

Parent: GH-4929

Move extractADFText / extractADFTextRecursive out of WebhookHandler (webhook.go:253-279) into package-level functions in internal/adapters/jira so both the poller (via ADFText.UnmarshalJSON) and the webhook path can share them. Update webhook call sites accordingly with no behavior change.

## Scope fence

Implement ONLY the slice described above. The parent issue GH-4929 is decomposed
into sibling sub-issues that cover the rest of its spec — consult the parent
for context, but do NOT implement parts of it that fall outside this subtask.

## Tests (folded from closed siblings #4934 / #4935 / #4937 — include in the SAME PR)

- Table-driven `ADFText.UnmarshalJSON` tests: plain string (Server/DC) · nested ADF object (paragraph/heading/listItem) · null/absent → empty string
- Poller-path test: a v3 `/search/jql` fixture with ADF descriptions parses the full page (no rejection); extracted text reaches `Task.Description` sanitized as today
- Server/DC regression case: plain-string description behavior unchanged
- Existing webhook-path tests stay green (walker now package-level)