### PR TITLE
GH-4944: fix(executor): externally-closed epic child fails the whole run at PR-create — should supersede and continue

### DIFF
--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -1982,7 +1982,7 @@ func (r *Runner) getSubIssuePRState(ctx context.Context, projectPath string, prN
 // renders its per-state counts in, so the summary text is deterministic despite
 // being built from a map.
 var childTerminalStateOrder = []string{
-	"completed", "no_op", "skipped", "declined", "rate_limited", "stalled", "infra", "failed",
+	"completed", "no_op", "skipped", "superseded", "declined", "rate_limited", "stalled", "infra", "failed",
 }
 
 // summarizeChildTerminalStates classifies a decomposed parent from its
@@ -2904,6 +2904,42 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 			IsCanary: parent.IsCanary,
 		}
 
+		// GH-4944: revalidate the child issue's live GitHub state immediately
+		// before dispatch — this is the gap checkIssueSupersededBeforePR
+		// (runner.go, the PR-creation backstop below) can't cover: closing a
+		// queued epic child is a legitimate operator verb (removing a
+		// mis-decomposed fragment), but until now the loop dispatched the
+		// CLOSED child anyway. The executor ran to completion and only
+		// aborted at PR-creation time — and that single abort failed the
+		// WHOLE epic run, triggering a parent retry and full nondeterministic
+		// re-decomposition (live specimen: #4929 run 1 / child #4932,
+		// 2026-08-18; pitfall memory
+		// pilot-issue-missing-no-decompose-fragments-single-fix). Mirrors
+		// dispatcher.go's pickup-time guard, which this in-process sub-issue
+		// loop never passes through. Fails open on any lookup error —
+		// pipeline availability outranks the guard, same contract as every
+		// other fetchIssueState call site.
+		if state, ghErr := fetchIssueState(ctx, r, subTask, subTaskRepoPath); ghErr != nil {
+			r.log.Warn("Failed to revalidate child issue state before dispatch; proceeding (fail-open)",
+				"parent_id", parent.ID,
+				"sub_issue", issueRef,
+				"error", ghErr,
+			)
+		} else if state.Closed {
+			detail := fmt.Sprintf("issue closed before dispatch (superseded_label=%t, labels=%v)", state.HasLabel(labelPilotSuperseded), state.Labels)
+			r.log.Info("Child issue closed before dispatch; superseding without execution",
+				"parent_id", parent.ID,
+				"sub_issue", issueRef,
+				"labels", state.Labels,
+			)
+			skipMsg := fmt.Sprintf("⏭️ Skipped %d/%d: closed externally: %s (%s)",
+				i+1, total, issue.Subtask.Title, issueRef)
+			_ = r.UpdateIssueProgress(ctx, projectPath, parentRef, skipMsg)
+			r.recordExecutionEvent(parent.LogExecutionID(), memory.StageSuperseded, detail)
+			childStates = append(childStates, "superseded")
+			continue
+		}
+
 		// GH-4141: give this in-process sub-issue run its own executions ledger
 		// row before invoking the backend. Without one, Task.LogExecutionID()
 		// falls back to subTask.ID ("GH-N"), which has no matching executions
@@ -3046,6 +3082,27 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 					"error", result.Error,
 				)
 				r.finalizeSubIssueExecution(subExecID, "no_op", result, subExecStart)
+				continue
+			}
+			// GH-4944: the child was closed externally WHILE it executed —
+			// checkIssueSupersededBeforePR (runner.go's PR-creation preflight)
+			// caught it and refused to open the PR, setting Outcome=
+			// "superseded" instead of a bare failure. This is the backstop
+			// for closes that happen mid-execution, i.e. after the
+			// pre-dispatch check above already passed. Treat it the same as
+			// the pre-dispatch case: supersede and continue the sequence
+			// rather than failing the whole epic run.
+			if result.Outcome == "superseded" {
+				childStates = append(childStates, "superseded")
+				supersededMsg := fmt.Sprintf("⏭️ Skipped %d/%d: closed externally: %s — %s",
+					i+1, total, issue.Subtask.Title, result.Error)
+				_ = r.UpdateIssueProgress(ctx, projectPath, parentRef, supersededMsg)
+				r.log.Info("sub-issue superseded (closed during execution); continuing epic",
+					"parent_id", parent.ID,
+					"sub_issue", issueRef,
+					"error", result.Error,
+				)
+				r.finalizeSubIssueExecution(subExecID, "superseded", result, subExecStart)
 				continue
 			}
 			failMsg := fmt.Sprintf("❌ Failed on %d/%d: %s - %s",

--- a/internal/executor/gh4944_epic_supersede_test.go
+++ b/internal/executor/gh4944_epic_supersede_test.go
@@ -1,0 +1,222 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// GH-4944 regression suite: a plain external close of a queued epic child
+// (no `pilot-superseded` label) previously fell through to full execution —
+// the sequential sub-issue loop dispatched the CLOSED child anyway, the
+// executor ran to completion, and only aborted at PR-creation time
+// (checkIssueSupersededBeforePR). That single abort failed the WHOLE epic
+// run, triggering a parent retry and a full nondeterministic
+// re-decomposition (live specimen: #4929 run 1 / child #4932, 2026-08-18;
+// pitfall memory pilot-issue-missing-no-decompose-fragments-single-fix).
+//
+// These tests cover both interception points the fix adds:
+//   - the pre-dispatch check in executeSubIssuesTracked, before Begin()/
+//     executeFunc ever runs for the child (no executor spawn at all)
+//   - the mid-execution PR-create backstop (checkIssueSupersededBeforePR),
+//     surfaced back through result.Outcome == "superseded" and now handled
+//     as a supersede-and-continue instead of a hard failure
+
+// TestExecuteSubIssuesTracked_ChildClosedBeforeDispatch is table-driven over
+// which child (if any) is closed at dispatch time, with and without the
+// `pilot-superseded` label, verifying: no executor spawn for the closed
+// child, its terminal state is "superseded", and the run does not fail.
+func TestExecuteSubIssuesTracked_ChildClosedBeforeDispatch(t *testing.T) {
+	tests := []struct {
+		name          string
+		closedTaskIDs map[string]bool
+		labels        map[string][]string
+		wantStates    []string
+		wantExecuted  []string // task IDs expected to reach executeFunc, in order
+	}{
+		{
+			name:         "no children closed — all execute normally",
+			wantStates:   []string{"completed", "completed", "completed"},
+			wantExecuted: []string{"GH-100", "GH-101", "GH-102"},
+		},
+		{
+			name:          "middle child closed externally, no label — superseded, run continues",
+			closedTaskIDs: map[string]bool{"GH-101": true},
+			wantStates:    []string{"completed", "superseded", "completed"},
+			wantExecuted:  []string{"GH-100", "GH-102"},
+		},
+		{
+			name:          "middle child closed with pilot-superseded label — behavior unchanged",
+			closedTaskIDs: map[string]bool{"GH-101": true},
+			labels:        map[string][]string{"GH-101": {"pilot-superseded", "pilot"}},
+			wantStates:    []string{"completed", "superseded", "completed"},
+			wantExecuted:  []string{"GH-100", "GH-102"},
+		},
+		{
+			name:          "first child closed externally — subsequent children still dispatch",
+			closedTaskIDs: map[string]bool{"GH-100": true},
+			wantStates:    []string{"superseded", "completed", "completed"},
+			wantExecuted:  []string{"GH-101", "GH-102"},
+		},
+		{
+			name:          "last child closed externally — earlier children unaffected",
+			closedTaskIDs: map[string]bool{"GH-102": true},
+			wantStates:    []string{"completed", "completed", "superseded"},
+			wantExecuted:  []string{"GH-100", "GH-101"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issues := makeSubIssues(3, 100)
+
+			stubFetchIssueState(t, func(_ context.Context, _ *Runner, task *Task, _ string) (IssueState, error) {
+				closed := tt.closedTaskIDs[task.ID]
+				return IssueState{Closed: closed, Labels: tt.labels[task.ID]}, nil
+			})
+
+			var executed []string
+			execFn := func(_ context.Context, task *Task) (*ExecutionResult, error) {
+				executed = append(executed, task.ID)
+				return &ExecutionResult{
+					TaskID:    task.ID,
+					Success:   true,
+					PRUrl:     fmt.Sprintf("https://github.com/owner/repo/pull/%s", task.ID),
+					CommitSHA: "sha-" + task.ID,
+				}, nil
+			}
+			runner := newTestRunnerWithExecFunc(execFn)
+
+			parent := &Task{ID: "GH-50", Title: "[epic] GH-4944 pre-dispatch supersede test"}
+			childStates, _, err := runner.executeSubIssuesTracked(context.Background(), parent, issues, parent.ProjectPath, "")
+			if err != nil {
+				t.Fatalf("expected the run to continue past a superseded child, got error: %v", err)
+			}
+
+			if len(childStates) != len(tt.wantStates) {
+				t.Fatalf("childStates = %v, want %v", childStates, tt.wantStates)
+			}
+			for i, want := range tt.wantStates {
+				if childStates[i] != want {
+					t.Errorf("childStates[%d] = %q, want %q (full: %v)", i, childStates[i], want, childStates)
+				}
+			}
+
+			if len(executed) != len(tt.wantExecuted) {
+				t.Fatalf("executed = %v, want %v (no executor should spawn for a closed child)", executed, tt.wantExecuted)
+			}
+			for i, want := range tt.wantExecuted {
+				if executed[i] != want {
+					t.Errorf("executed[%d] = %q, want %q (full: %v)", i, executed[i], want, executed)
+				}
+			}
+		})
+	}
+}
+
+// TestExecuteSubIssuesTracked_ChildClosedMidExecution verifies the
+// PR-creation backstop: a child that passes the pre-dispatch check (issue
+// still open) but is closed externally WHILE it executes surfaces
+// result.Outcome == "superseded" from checkIssueSupersededBeforePR. The
+// epic loop must treat that the same as the pre-dispatch case — supersede
+// and continue to the next child — instead of failing the whole run.
+func TestExecuteSubIssuesTracked_ChildClosedMidExecution(t *testing.T) {
+	issues := makeSubIssues(3, 200)
+
+	// No child is closed at pre-dispatch time — the mid-execution close is
+	// simulated purely through the executeFunc result below.
+	stubFetchIssueState(t, func(_ context.Context, _ *Runner, _ *Task, _ string) (IssueState, error) {
+		return IssueState{Closed: false}, nil
+	})
+
+	var executed []string
+	execFn := func(_ context.Context, task *Task) (*ExecutionResult, error) {
+		executed = append(executed, task.ID)
+		if task.ID == "GH-201" {
+			// Mirrors exactly what checkIssueSupersededBeforePR (runner.go)
+			// produces when the issue closed during this child's run: a
+			// refused PR, Success=false, Outcome="superseded".
+			return &ExecutionResult{
+				TaskID:  task.ID,
+				Success: false,
+				Outcome: "superseded",
+				Error:   "issue closed before PR creation (superseded_label=false, labels=[pilot])",
+			}, nil
+		}
+		return &ExecutionResult{
+			TaskID:    task.ID,
+			Success:   true,
+			PRUrl:     fmt.Sprintf("https://github.com/owner/repo/pull/%s", task.ID),
+			CommitSHA: "sha-" + task.ID,
+		}, nil
+	}
+	runner := newTestRunnerWithExecFunc(execFn)
+
+	parent := &Task{ID: "GH-60", Title: "[epic] GH-4944 mid-execution supersede test"}
+	childStates, _, err := runner.executeSubIssuesTracked(context.Background(), parent, issues, parent.ProjectPath, "")
+	if err != nil {
+		t.Fatalf("expected the run to continue past a mid-execution supersede, got error: %v", err)
+	}
+
+	wantExecuted := []string{"GH-200", "GH-201", "GH-202"}
+	if len(executed) != len(wantExecuted) {
+		t.Fatalf("executed = %v, want %v", executed, wantExecuted)
+	}
+	for i, want := range wantExecuted {
+		if executed[i] != want {
+			t.Errorf("executed[%d] = %q, want %q (full: %v)", i, executed[i], want, executed)
+		}
+	}
+
+	wantStates := []string{"completed", "superseded", "completed"}
+	if len(childStates) != len(wantStates) {
+		t.Fatalf("childStates = %v, want %v", childStates, wantStates)
+	}
+	for i, want := range wantStates {
+		if childStates[i] != want {
+			t.Errorf("childStates[%d] = %q, want %q (full: %v)", i, childStates[i], want, childStates)
+		}
+	}
+}
+
+// TestExecuteSubIssuesTracked_GenuineFailureStillAbortsEpic guards against
+// over-broadening the GH-4944 fix: a child that fails for a real reason
+// (Outcome == "" / anything other than "no_op" or "superseded") must still
+// abort the whole epic run exactly as before.
+func TestExecuteSubIssuesTracked_GenuineFailureStillAbortsEpic(t *testing.T) {
+	issues := makeSubIssues(3, 300)
+
+	stubFetchIssueState(t, func(_ context.Context, _ *Runner, _ *Task, _ string) (IssueState, error) {
+		return IssueState{Closed: false}, nil
+	})
+
+	var executed []string
+	execFn := func(_ context.Context, task *Task) (*ExecutionResult, error) {
+		executed = append(executed, task.ID)
+		if task.ID == "GH-301" {
+			return &ExecutionResult{
+				TaskID:  task.ID,
+				Success: false,
+				Error:   "CI check failed: lint errors",
+			}, nil
+		}
+		return &ExecutionResult{
+			TaskID:    task.ID,
+			Success:   true,
+			PRUrl:     fmt.Sprintf("https://github.com/owner/repo/pull/%s", task.ID),
+			CommitSHA: "sha-" + task.ID,
+		}, nil
+	}
+	runner := newTestRunnerWithExecFunc(execFn)
+
+	parent := &Task{ID: "GH-70", Title: "[epic] GH-4944 genuine failure guard test"}
+	_, _, err := runner.executeSubIssuesTracked(context.Background(), parent, issues, parent.ProjectPath, "")
+	if err == nil {
+		t.Fatal("expected a genuine child failure to still abort the epic run")
+	}
+
+	wantExecuted := []string{"GH-300", "GH-301"}
+	if len(executed) != len(wantExecuted) {
+		t.Fatalf("executed = %v, want %v (third child must not run after the abort)", executed, wantExecuted)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4944.

Closes #4944

## Changes

GitHub Issue GH-4944: fix(executor): externally-closed epic child fails the whole run at PR-create — should supersede and continue

Do not decompose — this is a standalone task, one coherent change as a single PR.
<!-- pilot:no-decompose -->

## Problem (live specimen: #4929 run 1, child #4932, 2026-08-18)

Closing an epic child issue before its dispatch is a legitimate operator verb (removing a mis-decomposed fragment). Today it is maximally punished:

1. The sequential epic dispatched the CLOSED child anyway and the executor ran ~14 minutes on it.
2. Only at PR-creation did it abort: `❌ Failed on 3/8: … issue closed before PR creation (superseded_label=false, labels=[pilot])`.
3. That single aborted child **failed the entire epic run**, triggering a parent retry and full re-decomposition (nondeterministic — the retry planned a different child set).

The `superseded_label=false` in the message shows a skip path exists but is gated on a `superseded` label; a plain close takes the failure path.

## Fix

At child-dispatch time (before spawning the executor), check the child issue's state. If closed:
- record the child outcome as `superseded` (same as the labeled path),
- post the parent progress comment accordingly ("skipped N: closed externally"),
- continue the sequence — do NOT fail the parent run.

Keep the PR-create-time check as the backstop for closes that happen mid-execution; that path should also supersede-and-continue rather than fail the run when the close was external (the #4908 external-close detector already distinguishes own vs external).

## Acceptance criteria

- [ ] Table-driven test: child closed before dispatch → no executor spawn, outcome `superseded`, parent continues to next child, run does not fail
- [ ] Test: child closed mid-execution (PR-create backstop) → superseded, parent continues
- [ ] `superseded`-labeled behavior unchanged
- [ ] Parent progress comments reflect skips distinctly from failures

## Refs

- #4929 run-1 failure comment (09:16:01Z) · #4932 · pitfall memory `pilot-issue-missing-no-decompose-fragments-single-fix` · #4908 (external-close detector) · GH-4655