### PR TITLE
GH-4946: test(autopilot): TestNewController_LogsResolvedReleasePolicy is flaky under CI load — killed an unrelated green PR

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -238,6 +238,27 @@ type EvalStore interface {
 // ControllerOption is a functional option for Controller configuration.
 type ControllerOption func(*Controller)
 
+// WithLogger overrides the controller's logger, which otherwise defaults to
+// slog.Default() captured at construction time. GH-4946: tests asserting on
+// NewController's startup log output (e.g. "resolved release policy") used
+// to mutate the process-global slog.SetDefault() around the constructor
+// call — safe in isolation, but other autopilot components (metrics
+// persister/alerter, feedback loop, deployer, ci-monitor) independently
+// capture slog.Default() too and can log through it from background
+// goroutines left running by earlier tests in the same package binary,
+// racing on the test's private bytes.Buffer under CI's heavier scheduling
+// load and producing an intermittent, code-unrelated failure (killed the
+// unrelated PR#4943). Passing a logger via this option lets a test assert
+// against a buffer no other goroutine can write to, without touching global
+// state. Nil is a no-op (falls back to the slog.Default() capture).
+func WithLogger(log *slog.Logger) ControllerOption {
+	return func(c *Controller) {
+		if log != nil {
+			c.log = log.With("component", "autopilot")
+		}
+	}
+}
+
 // WithProjectBoardSync wires a GitHub Projects V2 board sync into the controller.
 // doneStatus: merged PRs; failStatus: CI/exec failures; reviewStatus: PR created (In Progress → Review);
 // inProgressStatus: reserved for future use (wired for symmetry, not yet emitted).

--- a/internal/autopilot/logging_levels_test.go
+++ b/internal/autopilot/logging_levels_test.go
@@ -146,13 +146,17 @@ func TestNewController_LogsResolvedReleasePolicy(t *testing.T) {
 				cfg.activeEnvConfig = &EnvironmentConfig{Release: tt.envRelease}
 			}
 
-			var buf bytes.Buffer
-			h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
-			prev := slog.Default()
-			slog.SetDefault(slog.New(h))
-			defer slog.SetDefault(prev)
+			// GH-4946: assert against a logger private to this subtest rather
+			// than mutating the process-global slog default. Other autopilot
+			// components (metrics persister/alerter, feedback loop, deployer,
+			// ci-monitor) independently capture slog.Default() and can log
+			// through it from background goroutines started by earlier tests
+			// in this package binary; swapping the global default raced with
+			// those writes into this test's buffer under CI load and
+			// intermittently corrupted/blanked the captured output.
+			logger, buf := newCapturingLogger()
 
-			NewController(cfg, ghClient, nil, "owner", "repo")
+			NewController(cfg, ghClient, nil, "owner", "repo", WithLogger(logger))
 
 			out := buf.String()
 			if !strings.Contains(out, "resolved release policy") {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4946.

Closes #4946

## Changes

GitHub Issue GH-4946: test(autopilot): TestNewController_LogsResolvedReleasePolicy is flaky under CI load — killed an unrelated green PR

Do not decompose — this is a standalone task, one small change as a single PR.
<!-- pilot:no-decompose -->

## Problem

`TestNewController_LogsResolvedReleasePolicy` (internal/autopilot) failed in CI on PR#4943 — a diff touching ONLY `internal/adapters/jira` — and autopilot closed the correct PR and spawned garbage fix issue #4945 (closed manually; PR reopened + rerun). The same test passes on identical code locally, both isolated (`-count=2`) and in the full package run (10s local vs 79s under CI parallel load), so the failure is load/interleaving-dependent flake, not code.

Failure output (CI run 32123286557):
```
--- FAIL: TestNewController_LogsResolvedReleasePolicy (0.00s)
```
(subtests assert slog output of NewController's resolved release policy lines)

## Fix

Make the test deterministic: it should assert against a logger/handler instance PRIVATE to the test (own `slog.Handler` capturing into a buffer passed to the controller under test), not any shared/global logging state that concurrently-running package tests can write to or reconfigure. Inspect what the test currently hooks; if the controller only logs via a globally-set default logger, inject the logger (constructor already takes options — extend if needed, minimal surface). No behavior change to non-test code beyond optional logger injection.

## Acceptance criteria

- [ ] Test passes with `-race -count=20` and under `go test ./internal/autopilot/` full-package parallel runs
- [ ] No assertion reads global logger state shared with other tests
- [ ] If logger injection is added, default behavior unchanged

## Refs

- PR#4943 (innocent victim) · #4945 (flake-spawned, closed) · GH-4526/PR#4529→#4530 (same class) · TASK-418/#4531 (infra-flake vs real-failure classification — the systemic half)