### PR TITLE
GH-4952: chore(deps): bump studio-sdk to v0.35.1 — activates the Jira Cloud ADF poller fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/qf-studio/grom v0.2.0
-	github.com/qf-studio/studio-sdk v0.35.0
+	github.com/qf-studio/studio-sdk v0.35.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2
 	github.com/wailsapp/wails/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/qf-studio/grom v0.2.0 h1:EefLLr794KGk8ihdpKBgJnmSyUc//b/n8zZ77VbeuXY=
 github.com/qf-studio/grom v0.2.0/go.mod h1:YVihqE0treA2091TLNhGWvGi5+vMYv/ZBlAlX7Mr/JI=
-github.com/qf-studio/studio-sdk v0.35.0 h1:lrObETuoboyur+fT2R/cpDM0z5gvTIIarsuLMhWt9Zw=
-github.com/qf-studio/studio-sdk v0.35.0/go.mod h1:M/uFBeXsPAtsrO7wiIgE/GgWzfw80ftW6BrQUIOwxUM=
+github.com/qf-studio/studio-sdk v0.35.1 h1:AQNrtdd0mJ/fGgxh3yRyf4ebeLVgxoK3i/nM0Ekw8xc=
+github.com/qf-studio/studio-sdk v0.35.1/go.mod h1:M/uFBeXsPAtsrO7wiIgE/GgWzfw80ftW6BrQUIOwxUM=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4952.

Closes #4952

## Changes

GitHub Issue GH-4952: chore(deps): bump studio-sdk to v0.35.1 — activates the Jira Cloud ADF poller fix

Do not decompose — this is a standalone task, one small change as a single PR.

## Task

Bump `github.com/qf-studio/studio-sdk` in `go.mod` from v0.35.0 to **v0.35.1** and run `go mod tidy`.

v0.35.1 (= v0.34.2 content, corrective tag at `cbef46fd`) carries sdk#119/PR#120: the Jira Cloud v3 ADF description fix + 410 `platform: cloud` hint for the SDK poller client — the actual polling path. Without this bump the fix from pilot#4917/#4929 is inert for polling users (live-reproduced 2026-08-18 13:42Z on the founder box; see pilot#4917 reopen comment).

## Acceptance criteria

- [ ] `go.mod` requires studio-sdk v0.35.1; `go.sum` updated via `go mod tidy`
- [ ] Build + tests green
- [ ] No other dependency changes

## Refs

studio-sdk#119 · sdk PR#120 · pilot#4917 (reopened) · same idiom as pilot#4913 (v0.35.0 pin bump)