### PR TITLE
GH-4953: fix(autopilot): releaser baseline ignores tags not created by the releaser — sdk train cut v0.34.2 below existing v0.35.0

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -5321,12 +5321,22 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 		return nil
 	}
 
-	// Get current version from the target repo
-	currentVersion, err := c.releaser.GetCurrentVersionForRepo(ctx, owner, repo)
+	// Get current version baseline from the target repo. GH-4953: the
+	// baseline is the max semver across the latest GitHub Release AND every
+	// git tag (regardless of who created it or whether it has a backing
+	// Release object) — a tag-only ref invisible to the old release-first
+	// lookup let a train cut ship below an existing tag.
+	baseline, err := c.releaser.CurrentVersionBaselineForRepo(ctx, owner, repo)
 	if err != nil {
 		c.log.Warn("failed to get current version, defaulting to 0.0.0", "error", err)
-		currentVersion = SemVer{}
+		baseline = VersionBaseline{Version: SemVer{}, Source: "error-fallback"}
 	}
+	currentVersion := baseline.Version
+	c.log.Info("resolved release baseline",
+		"pr", prState.PRNumber,
+		"baseline_version", currentVersion.String(rel.TagPrefix),
+		"baseline_source", baseline.Source,
+	)
 
 	// Get commits for bump detection: a "train:" scope carrier is defined as
 	// "everything since the last tag" (CompareCommits, not a member-PR union

--- a/internal/autopilot/releaser.go
+++ b/internal/autopilot/releaser.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -53,6 +52,30 @@ func (v SemVer) Bump(bumpType BumpType) SemVer {
 	default:
 		return v
 	}
+}
+
+// Compare returns -1, 0, or 1 depending on whether v is less than, equal to,
+// or greater than other.
+func (v SemVer) Compare(other SemVer) int {
+	if v.Major != other.Major {
+		if v.Major > other.Major {
+			return 1
+		}
+		return -1
+	}
+	if v.Minor != other.Minor {
+		if v.Minor > other.Minor {
+			return 1
+		}
+		return -1
+	}
+	if v.Patch != other.Patch {
+		if v.Patch > other.Patch {
+			return 1
+		}
+		return -1
+	}
+	return 0
 }
 
 // ParseSemVer parses a version string like "v1.2.3" or "1.2.3".
@@ -161,48 +184,84 @@ func bumpPriority(b BumpType) int {
 	}
 }
 
-// GetCurrentVersion returns the current version from latest release or tags.
-func (r *Releaser) GetCurrentVersion(ctx context.Context) (SemVer, error) {
-	// Try latest release first
-	release, err := r.ghClient.GetLatestRelease(ctx, r.owner, r.repo)
+// VersionBaseline is the resolved release baseline for a repo: the highest
+// semver found across the latest published GitHub Release (if any) and
+// every git tag, plus a human-readable Source describing which ref produced
+// it (e.g. "tag:v0.35.0" or "release:v1.2.3"). GH-4953: a tag pushed without
+// ever going through the Releases API (e.g. a manual base-guard tag) has no
+// backing Release object, so a baseline sourced from GetLatestRelease alone
+// is blind to it — the sdk train cut v0.34.2 as the "next" version while
+// v0.35.0 already existed as a tag-only ref, shipping a version Go module
+// resolution ranks BELOW the newer commit.
+type VersionBaseline struct {
+	Version SemVer
+	Source  string
+}
+
+// currentVersionBaseline computes the release baseline for owner/repo as the
+// max semver across the latest GitHub Release (if any) and ALL git tags —
+// regardless of who created a tag or whether it has a backing Release
+// object (mem-093 / GH-4953). Every release also has a backing tag, so this
+// is normally a superset check; the release lookup is kept alongside the
+// tag scan only as a defensive fallback in case ListTags is ever
+// unreachable while the Releases API is not.
+func (r *Releaser) currentVersionBaseline(ctx context.Context, owner, repo string) (VersionBaseline, error) {
+	var candidates []VersionBaseline
+
+	release, err := r.ghClient.GetLatestRelease(ctx, owner, repo)
 	if err != nil {
-		return SemVer{}, fmt.Errorf("failed to get latest release: %w", err)
+		return VersionBaseline{}, fmt.Errorf("failed to get latest release: %w", err)
 	}
 	if release != nil {
-		return ParseSemVer(release.TagName)
+		if v, perr := ParseSemVer(release.TagName); perr == nil {
+			candidates = append(candidates, VersionBaseline{Version: v, Source: "release:" + release.TagName})
+		}
 	}
 
-	// Fall back to tags
-	tags, err := r.ghClient.ListTags(ctx, r.owner, r.repo, 10)
+	// ListTags paginates exhaustively regardless of the perPage page-size
+	// argument (see studio-sdk client.go), so this covers every tag in the
+	// repo's history, not just the most recent page.
+	tags, err := r.ghClient.ListTags(ctx, owner, repo, 100)
 	if err != nil {
-		return SemVer{}, fmt.Errorf("failed to list tags: %w", err)
+		return VersionBaseline{}, fmt.Errorf("failed to list tags: %w", err)
 	}
-
-	// Find highest semver tag
-	var versions []SemVer
 	for _, tag := range tags {
-		if v, err := ParseSemVer(tag.Name); err == nil {
-			versions = append(versions, v)
+		v, perr := ParseSemVer(tag.Name)
+		if perr != nil {
+			continue
 		}
+		candidates = append(candidates, VersionBaseline{Version: v, Source: "tag:" + tag.Name})
 	}
 
-	if len(versions) == 0 {
-		// No versions found, start at 0.0.0
-		return SemVer{}, nil
+	if len(candidates) == 0 {
+		return VersionBaseline{Version: SemVer{}, Source: "none"}, nil
 	}
 
-	// Sort descending
-	sort.Slice(versions, func(i, j int) bool {
-		if versions[i].Major != versions[j].Major {
-			return versions[i].Major > versions[j].Major
+	best := candidates[0]
+	for _, c := range candidates[1:] {
+		if c.Version.Compare(best.Version) > 0 {
+			best = c
 		}
-		if versions[i].Minor != versions[j].Minor {
-			return versions[i].Minor > versions[j].Minor
-		}
-		return versions[i].Patch > versions[j].Patch
-	})
+	}
+	return best, nil
+}
 
-	return versions[0], nil
+// CurrentVersionBaselineForRepo exposes the full VersionBaseline (version +
+// source) for the specified repo, for callers that need to log how the
+// baseline was determined (GH-4953 acceptance: "Release decision log line
+// includes baseline version + how it was found").
+func (r *Releaser) CurrentVersionBaselineForRepo(ctx context.Context, owner, repo string) (VersionBaseline, error) {
+	return r.currentVersionBaseline(ctx, owner, repo)
+}
+
+// GetCurrentVersion returns the current version baseline (see
+// currentVersionBaseline) for the releaser's configured repo.
+func (r *Releaser) GetCurrentVersion(ctx context.Context) (SemVer, error) {
+	baseline, err := r.currentVersionBaseline(ctx, r.owner, r.repo)
+	if err != nil {
+		return SemVer{}, err
+	}
+	return baseline.Version, nil
 }
 
 // GenerateChangelog generates a changelog from commits.
@@ -313,43 +372,14 @@ func isDuplicateReleaseError(err error) bool {
 	return strings.Contains(strings.ToLower(err.Error()), "already_exists")
 }
 
-// GetCurrentVersionForRepo gets the current version from the specified repository.
+// GetCurrentVersionForRepo returns the current version baseline (see
+// currentVersionBaseline) for the specified repository.
 func (r *Releaser) GetCurrentVersionForRepo(ctx context.Context, owner, repo string) (SemVer, error) {
-	release, err := r.ghClient.GetLatestRelease(ctx, owner, repo)
+	baseline, err := r.currentVersionBaseline(ctx, owner, repo)
 	if err != nil {
-		return SemVer{}, fmt.Errorf("failed to get latest release: %w", err)
+		return SemVer{}, err
 	}
-	if release != nil {
-		return ParseSemVer(release.TagName)
-	}
-
-	tags, err := r.ghClient.ListTags(ctx, owner, repo, 10)
-	if err != nil {
-		return SemVer{}, fmt.Errorf("failed to list tags: %w", err)
-	}
-
-	var versions []SemVer
-	for _, tag := range tags {
-		if v, err := ParseSemVer(tag.Name); err == nil {
-			versions = append(versions, v)
-		}
-	}
-
-	if len(versions) == 0 {
-		return SemVer{}, nil
-	}
-
-	sort.Slice(versions, func(i, j int) bool {
-		if versions[i].Major != versions[j].Major {
-			return versions[i].Major > versions[j].Major
-		}
-		if versions[i].Minor != versions[j].Minor {
-			return versions[i].Minor > versions[j].Minor
-		}
-		return versions[i].Patch > versions[j].Patch
-	})
-
-	return versions[0], nil
+	return baseline.Version, nil
 }
 
 // ShouldRelease determines if a release should be created based on config and bump type.

--- a/internal/autopilot/releaser_test.go
+++ b/internal/autopilot/releaser_test.go
@@ -398,12 +398,21 @@ func TestReleaser_GetCurrentVersion(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			// GH-4953: real GitHub always serves /tags with 200 (empty array
+			// when there are none, never 404), so a release-backed tag also
+			// shows up in ListTags. This mirrors that — both sources agree.
 			name: "from latest release",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path == "/repos/owner/repo/releases/latest" {
 					_ = json.NewEncoder(w).Encode(map[string]interface{}{
 						"id":       1,
 						"tag_name": "v1.2.3",
+					})
+					return
+				}
+				if r.URL.Path == "/repos/owner/repo/tags" {
+					_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+						{"name": "v1.2.3"},
 					})
 					return
 				}
@@ -464,6 +473,113 @@ func TestReleaser_GetCurrentVersion(t *testing.T) {
 			}
 			if !tt.wantErr && got != tt.want {
 				t.Errorf("GetCurrentVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestReleaser_CurrentVersionBaselineForRepo_TagBeyondRelease reproduces the
+// live GH-4953 incident: the sdk train's latest published Release was
+// v0.34.1, but v0.35.0 had already been pushed as a tag-only ref (a manual
+// base-guard tag, never published as a GitHub Release). The old
+// release-first lookup returned v0.34.1 as the baseline, so a "fix:" commit
+// bumped to v0.34.2 — a version Go module resolution ranks BELOW the
+// existing v0.35.0 tag. The baseline must be the max across ALL tags
+// (release-backed or not), so the same patch bump must land on v0.35.1.
+func TestReleaser_CurrentVersionBaselineForRepo_TagBeyondRelease(t *testing.T) {
+	tests := []struct {
+		name             string
+		latestReleaseTag string // "" means no Release object exists (404)
+		tags             []string
+		bumpType         BumpType
+		wantBaseline     SemVer
+		wantSource       string
+		wantNext         SemVer
+	}{
+		{
+			// Acceptance: existing tags {v0.34.1, v0.35.0} + patch release
+			// -> next is v0.35.1 (NOT v0.34.2).
+			name:             "tag-only ref beyond the latest Release wins the baseline",
+			latestReleaseTag: "v0.34.1",
+			tags:             []string{"v0.34.1", "v0.35.0"},
+			bumpType:         BumpPatch,
+			wantBaseline:     SemVer{Major: 0, Minor: 35, Patch: 0},
+			wantSource:       "tag:v0.35.0",
+			wantNext:         SemVer{Major: 0, Minor: 35, Patch: 1},
+		},
+		{
+			// Acceptance: tag-without-Release counts toward the baseline
+			// even when NO Release object exists at all (404 on /releases/latest).
+			name:             "tag-without-release counts toward baseline with no Release object",
+			latestReleaseTag: "",
+			tags:             []string{"v1.0.0", "v1.4.0"},
+			bumpType:         BumpMinor,
+			wantBaseline:     SemVer{Major: 1, Minor: 4, Patch: 0},
+			wantSource:       "tag:v1.4.0",
+			wantNext:         SemVer{Major: 1, Minor: 5, Patch: 0},
+		},
+		{
+			// Acceptance: existing flows unchanged when ledger (Release) and
+			// tags agree — the Release IS the max tag, so the source may
+			// legitimately be either the release or its matching tag, but
+			// the resolved version must be unchanged from pre-fix behavior.
+			name:             "ledger and tags agree, resolved version unchanged",
+			latestReleaseTag: "v2.5.0",
+			tags:             []string{"v2.4.0", "v2.5.0"},
+			bumpType:         BumpPatch,
+			wantBaseline:     SemVer{Major: 2, Minor: 5, Patch: 0},
+			wantNext:         SemVer{Major: 2, Minor: 5, Patch: 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/repos/owner/repo/releases/latest":
+					if tt.latestReleaseTag == "" {
+						w.WriteHeader(http.StatusNotFound)
+						_, _ = w.Write([]byte(`{"message": "Not Found"}`))
+						return
+					}
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"id":       1,
+						"tag_name": tt.latestReleaseTag,
+					})
+				case "/repos/owner/repo/tags":
+					tags := make([]map[string]interface{}, 0, len(tt.tags))
+					for _, name := range tt.tags {
+						tags = append(tags, map[string]interface{}{"name": name})
+					}
+					_ = json.NewEncoder(w).Encode(tags)
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}
+
+			server := httptest.NewServer(http.HandlerFunc(handler))
+			defer server.Close()
+
+			client := github.NewClientWithBaseURL("test-token", server.URL)
+			r := NewReleaser(client, "owner", "repo", DefaultReleaseConfig())
+
+			baseline, err := r.CurrentVersionBaselineForRepo(context.Background(), "owner", "repo")
+			if err != nil {
+				t.Fatalf("CurrentVersionBaselineForRepo() error = %v", err)
+			}
+			if baseline.Version != tt.wantBaseline {
+				t.Errorf("baseline version = %v, want %v", baseline.Version, tt.wantBaseline)
+			}
+			if tt.wantSource != "" && baseline.Source != tt.wantSource {
+				t.Errorf("baseline source = %q, want %q", baseline.Source, tt.wantSource)
+			}
+			if baseline.Source == "" || baseline.Source == "none" {
+				t.Errorf("baseline source must identify how the baseline was found, got %q", baseline.Source)
+			}
+
+			next := baseline.Version.Bump(tt.bumpType)
+			if next != tt.wantNext {
+				t.Errorf("next version = %v, want %v (must never be lower than an existing tag)", next, tt.wantNext)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4953.

Closes #4953

## Changes

GitHub Issue GH-4953: fix(autopilot): releaser baseline ignores tags not created by the releaser — sdk train cut v0.34.2 below existing v0.35.0

Do not decompose — this is a standalone task, one coherent change as a single PR.

## Problem (live specimen, 2026-08-18 14:01Z)

The sdk release train released PR#120 as **v0.34.2** while tag **v0.35.0 already existed** on the repo. Result: the newest commit shipped under a version that Go module resolution ranks BELOW an older commit's version — consumers pinning/upgrading normally can never reach the fix. Operator had to cut a corrective out-of-band tag v0.35.1.

Cause: v0.35.0 was pushed as a tag only (2026-08-17 base-guard tag; no GitHub Release object), and the releaser computed its next-version baseline from a source that misses it (its ledger / the Releases list) instead of from git tags. mem-093 established tags-as-baseline for exactly this reason; the sdk path (or the Release-API publish path, `tag created — published GitHub Release via API`) does not honor it.

## Fix

Baseline = **max semver across ALL git tags** on the repo (annotated or lightweight, regardless of who created them or whether a Release object exists). If the computed next version is not strictly greater than every existing tag, bump from the true max instead. Log the discovered baseline and its source on every release decision.

## Acceptance criteria

- [ ] Table-driven test: existing tags {v0.34.1, v0.35.0} + patch release → next is v0.35.1 (NOT v0.34.2)
- [ ] Tag-without-Release counts toward baseline
- [ ] Release decision log line includes baseline version + how it was found
- [ ] Existing release flows unchanged when ledger and tags agree

## Refs

sdk PR#120 → wrong tag v0.34.2 (13:56Z) · corrective v0.35.1 at `cbef46fd` · mem-093 · box log `component=autopilot pr=120 version=v0.34.2`