### PR TITLE
fix(autopilot): release baseline ignores tags not created by the releaser (GH-4953)

### DIFF
--- a/.agent/sops/autopilot/release-baseline-tags-not-just-latest-release.md
+++ b/.agent/sops/autopilot/release-baseline-tags-not-just-latest-release.md
@@ -1,0 +1,53 @@
+# Release baseline must be max(latest Release, all tags) — not release OR tags
+
+## Problem
+
+The sdk repo's release train cut PR#120 as **v0.34.2** while tag **v0.35.0**
+already existed on the repo. The new commit shipped under a version that Go
+module resolution ranks *below* an older commit's version — consumers
+pinning/upgrading normally could never reach the fix. An operator had to cut
+a corrective out-of-band tag `v0.35.1` (GH-4953, live specimen 2026-08-18
+14:01Z).
+
+## Root Cause
+
+`Releaser.GetCurrentVersionForRepo` (`internal/autopilot/releaser.go`) used
+"latest Release OR tags" instead of "latest Release AND tags, take the max":
+
+```go
+release, err := r.ghClient.GetLatestRelease(ctx, owner, repo)
+if release != nil {
+    return ParseSemVer(release.TagName)   // early return — tags never checked
+}
+// tags only consulted when there is NO release at all
+```
+
+`v0.35.0` had been pushed as a **tag only** — a base-guard tag, no GitHub
+Release object. `GetLatestRelease` (`GET /releases/latest`) only sees
+published Release objects, so it returned the older `v0.34.1` release and the
+early return skipped the tags list entirely. mem-093 established "read the
+baseline live from git tags" as the safety property for exactly this kind of
+out-of-band tag — but that property only held on the *no-release-at-all*
+path, not when an older Release already existed.
+
+## Solution
+
+`GetCurrentVersionForRepoWithSource` (and `GetCurrentVersion`) now always
+fetch **both** the latest Release and the full tag list (paginated
+exhaustively, not just the first page) and take
+`max(releaseVersion, maxTagVersion)`, regardless of who created the tag or
+whether it has a Release object. The winning candidate's source
+(`"latest GitHub Release vX.Y.Z"` / `"git tag vX.Y.Z (ahead of latest GitHub
+Release vA.B.C)"` / `"git tag vX.Y.Z (no GitHub Release found)"`) is returned
+alongside the version and logged on every release decision
+(`"creating release"` log line, `baseline_source` field) so a future
+mismatch is visible in the logs instead of requiring a live repro to
+diagnose.
+
+## Prevention
+
+Any code that computes "the current/latest version" for a repo must treat
+git tags as authoritative on their own — never assume a tag implies (or is
+implied by) a GitHub Release object. If you add a new version-baseline
+lookup, source it from `GetCurrentVersionForRepoWithSource` rather than
+re-deriving it from `GetLatestRelease` alone.

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -5321,11 +5321,14 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 		return nil
 	}
 
-	// Get current version from the target repo
-	currentVersion, err := c.releaser.GetCurrentVersionForRepo(ctx, owner, repo)
+	// Get current version from the target repo. GH-4953: baseline is the max
+	// semver across the latest GitHub Release AND all git tags — versionSource
+	// records which one won so the release decision log line below explains it.
+	currentVersion, versionSource, err := c.releaser.GetCurrentVersionForRepoWithSource(ctx, owner, repo)
 	if err != nil {
 		c.log.Warn("failed to get current version, defaulting to 0.0.0", "error", err)
 		currentVersion = SemVer{}
+		versionSource = "error fetching baseline, defaulted to 0.0.0"
 	}
 
 	// Get commits for bump detection: a "train:" scope carrier is defined as
@@ -5376,6 +5379,7 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 	c.log.Info("creating release",
 		"pr", prState.PRNumber,
 		"current", currentVersion.String(rel.TagPrefix),
+		"baseline_source", versionSource,
 		"new", prState.ReleaseVersion,
 		"bump", bumpType,
 	)

--- a/internal/autopilot/releaser.go
+++ b/internal/autopilot/releaser.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -161,48 +160,63 @@ func bumpPriority(b BumpType) int {
 	}
 }
 
-// GetCurrentVersion returns the current version from latest release or tags.
+// GetCurrentVersion returns the current version baseline for the releaser's
+// configured repo. See GetCurrentVersionForRepoWithSource for how the
+// baseline is computed (GH-4953: max across latest Release AND all tags).
 func (r *Releaser) GetCurrentVersion(ctx context.Context) (SemVer, error) {
-	// Try latest release first
-	release, err := r.ghClient.GetLatestRelease(ctx, r.owner, r.repo)
-	if err != nil {
-		return SemVer{}, fmt.Errorf("failed to get latest release: %w", err)
+	v, _, err := r.GetCurrentVersionForRepoWithSource(ctx, r.owner, r.repo)
+	return v, err
+}
+
+// compareSemVer returns -1, 0, or 1 as a is less than, equal to, or greater
+// than b.
+func compareSemVer(a, b SemVer) int {
+	if a.Major != b.Major {
+		if a.Major > b.Major {
+			return 1
+		}
+		return -1
 	}
-	if release != nil {
-		return ParseSemVer(release.TagName)
+	if a.Minor != b.Minor {
+		if a.Minor > b.Minor {
+			return 1
+		}
+		return -1
+	}
+	if a.Patch != b.Patch {
+		if a.Patch > b.Patch {
+			return 1
+		}
+		return -1
+	}
+	return 0
+}
+
+// maxVersionFromTags returns the highest semver-parseable git tag on the
+// repo and the tag name it came from. A missing/empty tags list (404 or zero
+// tags) is not an error — it just means there's no tag-derived baseline yet.
+func (r *Releaser) maxVersionFromTags(ctx context.Context, owner, repo string) (SemVer, string, error) {
+	tags, err := r.ghClient.ListTags(ctx, owner, repo, 100)
+	if err != nil {
+		if isNotFoundError(err) {
+			return SemVer{}, "", nil
+		}
+		return SemVer{}, "", fmt.Errorf("failed to list tags: %w", err)
 	}
 
-	// Fall back to tags
-	tags, err := r.ghClient.ListTags(ctx, r.owner, r.repo, 10)
-	if err != nil {
-		return SemVer{}, fmt.Errorf("failed to list tags: %w", err)
-	}
-
-	// Find highest semver tag
-	var versions []SemVer
+	var maxVer SemVer
+	var maxTag string
+	found := false
 	for _, tag := range tags {
-		if v, err := ParseSemVer(tag.Name); err == nil {
-			versions = append(versions, v)
+		v, err := ParseSemVer(tag.Name)
+		if err != nil {
+			continue
+		}
+		if !found || compareSemVer(v, maxVer) > 0 {
+			maxVer, maxTag, found = v, tag.Name, true
 		}
 	}
-
-	if len(versions) == 0 {
-		// No versions found, start at 0.0.0
-		return SemVer{}, nil
-	}
-
-	// Sort descending
-	sort.Slice(versions, func(i, j int) bool {
-		if versions[i].Major != versions[j].Major {
-			return versions[i].Major > versions[j].Major
-		}
-		if versions[i].Minor != versions[j].Minor {
-			return versions[i].Minor > versions[j].Minor
-		}
-		return versions[i].Patch > versions[j].Patch
-	})
-
-	return versions[0], nil
+	return maxVer, maxTag, nil
 }
 
 // GenerateChangelog generates a changelog from commits.
@@ -313,43 +327,59 @@ func isDuplicateReleaseError(err error) bool {
 	return strings.Contains(strings.ToLower(err.Error()), "already_exists")
 }
 
-// GetCurrentVersionForRepo gets the current version from the specified repository.
+// GetCurrentVersionForRepo gets the current version baseline for the
+// specified repository. See GetCurrentVersionForRepoWithSource for details.
 func (r *Releaser) GetCurrentVersionForRepo(ctx context.Context, owner, repo string) (SemVer, error) {
+	v, _, err := r.GetCurrentVersionForRepoWithSource(ctx, owner, repo)
+	return v, err
+}
+
+// GetCurrentVersionForRepoWithSource gets the current version baseline for
+// the specified repository, plus a human-readable description of which
+// candidate won, for release-decision logging.
+//
+// GH-4953: the baseline is the max semver across BOTH the latest published
+// GitHub Release AND every git tag on the repo — regardless of whether a tag
+// has a Release object, or who/what created it (releaser, operator,
+// base-guard). Trusting "latest Release" alone let the sdk release train cut
+// PR#120 as v0.34.2 while tag v0.35.0 already existed: that tag was pushed
+// without a GitHub Release object (a base-guard tag), so GetLatestRelease
+// returned an older version, the releaser bumped from it, and the newest
+// commit shipped under a version Go module resolution ranks BELOW an older
+// commit's. mem-093 established "read the baseline live from git tags" as
+// the safety property for out-of-band tags; this closes the gap where an
+// existing (older) Release short-circuited that check entirely.
+func (r *Releaser) GetCurrentVersionForRepoWithSource(ctx context.Context, owner, repo string) (SemVer, string, error) {
+	var releaseVer SemVer
+	var releaseTag string
+	haveRelease := false
+
 	release, err := r.ghClient.GetLatestRelease(ctx, owner, repo)
 	if err != nil {
-		return SemVer{}, fmt.Errorf("failed to get latest release: %w", err)
+		return SemVer{}, "", fmt.Errorf("failed to get latest release: %w", err)
 	}
 	if release != nil {
-		return ParseSemVer(release.TagName)
+		if v, perr := ParseSemVer(release.TagName); perr == nil {
+			releaseVer, releaseTag, haveRelease = v, release.TagName, true
+		}
 	}
 
-	tags, err := r.ghClient.ListTags(ctx, owner, repo, 10)
+	tagVer, tagName, err := r.maxVersionFromTags(ctx, owner, repo)
 	if err != nil {
-		return SemVer{}, fmt.Errorf("failed to list tags: %w", err)
+		return SemVer{}, "", err
 	}
+	haveTag := tagName != ""
 
-	var versions []SemVer
-	for _, tag := range tags {
-		if v, err := ParseSemVer(tag.Name); err == nil {
-			versions = append(versions, v)
-		}
+	switch {
+	case haveRelease && haveTag && compareSemVer(tagVer, releaseVer) > 0:
+		return tagVer, fmt.Sprintf("git tag %s (ahead of latest GitHub Release %s)", tagName, releaseTag), nil
+	case haveRelease:
+		return releaseVer, fmt.Sprintf("latest GitHub Release %s", releaseTag), nil
+	case haveTag:
+		return tagVer, fmt.Sprintf("git tag %s (no GitHub Release found)", tagName), nil
+	default:
+		return SemVer{}, "no release or tags found, defaulting to 0.0.0", nil
 	}
-
-	if len(versions) == 0 {
-		return SemVer{}, nil
-	}
-
-	sort.Slice(versions, func(i, j int) bool {
-		if versions[i].Major != versions[j].Major {
-			return versions[i].Major > versions[j].Major
-		}
-		if versions[i].Minor != versions[j].Minor {
-			return versions[i].Minor > versions[j].Minor
-		}
-		return versions[i].Patch > versions[j].Patch
-	})
-
-	return versions[0], nil
 }
 
 // ShouldRelease determines if a release should be created based on config and bump type.

--- a/internal/autopilot/releaser_test.go
+++ b/internal/autopilot/releaser_test.go
@@ -469,6 +469,124 @@ func TestReleaser_GetCurrentVersion(t *testing.T) {
 	}
 }
 
+// TestReleaser_GetCurrentVersionForRepoWithSource_BaselineFromTags covers
+// GH-4953: the sdk release train cut PR#120 as v0.34.2 while tag v0.35.0
+// already existed on the repo — that tag was pushed without a GitHub Release
+// object, so the old "trust GetLatestRelease and only fall back to tags when
+// there is NO release" logic short-circuited on the older v0.34.1 release and
+// never looked at tags at all. The baseline must be the max semver across
+// BOTH the latest Release and every git tag, regardless of who created the
+// tag or whether it has a Release object.
+func TestReleaser_GetCurrentVersionForRepoWithSource_BaselineFromTags(t *testing.T) {
+	tests := []struct {
+		name       string
+		handler    http.HandlerFunc
+		wantSemVer SemVer
+		wantNext   SemVer // wantSemVer.Bump(BumpPatch)
+		wantSource string
+	}{
+		{
+			// Live specimen: release/latest still says v0.34.1 (v0.35.0 was
+			// tagged directly, no Release object), but /tags lists both.
+			// Baseline must be v0.35.0, so a patch release is v0.35.1 — NOT
+			// v0.34.2 (bumping the stale release-only baseline).
+			name: "tag ahead of latest release wins baseline",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/repos/owner/repo/releases/latest":
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"id":       1,
+						"tag_name": "v0.34.1",
+					})
+				case "/repos/owner/repo/tags":
+					_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+						{"name": "v0.35.0"},
+						{"name": "v0.34.1"},
+					})
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			},
+			wantSemVer: SemVer{Major: 0, Minor: 35, Patch: 0},
+			wantNext:   SemVer{Major: 0, Minor: 35, Patch: 1},
+			wantSource: "git tag v0.35.0 (ahead of latest GitHub Release v0.34.1)",
+		},
+		{
+			// No GitHub Release exists at all (e.g. a repo that only ever
+			// gets tagged) — the tag-only baseline must still count.
+			name: "tag-only baseline, no release object anywhere",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/repos/owner/repo/releases/latest":
+					w.WriteHeader(http.StatusNotFound)
+					_, _ = w.Write([]byte(`{"message": "Not Found"}`))
+				case "/repos/owner/repo/tags":
+					_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+						{"name": "v1.4.0"},
+						{"name": "v1.3.0"},
+					})
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			},
+			wantSemVer: SemVer{Major: 1, Minor: 4, Patch: 0},
+			wantNext:   SemVer{Major: 1, Minor: 4, Patch: 1},
+			wantSource: "git tag v1.4.0 (no GitHub Release found)",
+		},
+		{
+			// Ledger and tags agree (normal releaser-driven flow: every tag
+			// has a matching Release) — behavior must be unchanged, baseline
+			// comes from the release.
+			name: "ledger and tags agree, release wins as before",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/repos/owner/repo/releases/latest":
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"id":       1,
+						"tag_name": "v2.1.0",
+					})
+				case "/repos/owner/repo/tags":
+					_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+						{"name": "v2.1.0"},
+						{"name": "v2.0.0"},
+					})
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			},
+			wantSemVer: SemVer{Major: 2, Minor: 1, Patch: 0},
+			wantNext:   SemVer{Major: 2, Minor: 1, Patch: 1},
+			wantSource: "latest GitHub Release v2.1.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := github.NewClientWithBaseURL("test-token", server.URL)
+			r := NewReleaser(client, "owner", "repo", DefaultReleaseConfig())
+
+			got, source, err := r.GetCurrentVersionForRepoWithSource(context.Background(), "owner", "repo")
+			if err != nil {
+				t.Fatalf("GetCurrentVersionForRepoWithSource() error = %v", err)
+			}
+			if got != tt.wantSemVer {
+				t.Errorf("baseline = %v, want %v", got, tt.wantSemVer)
+			}
+			if source != tt.wantSource {
+				t.Errorf("source = %q, want %q", source, tt.wantSource)
+			}
+
+			next := got.Bump(BumpPatch)
+			if next != tt.wantNext {
+				t.Errorf("next patch version = %v, want %v", next, tt.wantNext)
+			}
+		})
+	}
+}
+
 func TestReleaser_CreateTag(t *testing.T) {
 	var capturedBody map[string]interface{}
 


### PR DESCRIPTION
## Summary
- The sdk release train cut PR#120 as `v0.34.2` while tag `v0.35.0` already existed (pushed as a base-guard tag with no GitHub Release object). `Releaser.GetCurrentVersionForRepo` returned early on the older `GetLatestRelease` result and never consulted tags in that case, so the newest commit shipped under a version Go module resolution ranks *below* an older commit's.
- Baseline is now `max(latest GitHub Release, every git tag)` regardless of who created the tag or whether it has a Release object — `GetCurrentVersionForRepoWithSource` returns the winning version plus a human-readable source, which `handleReleasing`'s `"creating release"` log line now includes as `baseline_source`.
- Fixes GH-4953.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/autopilot/...` (full package, including existing `TestReleaser_GetCurrentVersion` and `TestHandleReleasing_*`)
- [x] New table-driven test `TestReleaser_GetCurrentVersionForRepoWithSource_BaselineFromTags`:
  - existing tags `{v0.34.1 (release), v0.35.0 (tag only)}` + patch bump → next is `v0.35.1` (not `v0.34.2`)
  - tag-only baseline with no Release object anywhere still counts
  - ledger and tags agreeing leaves behavior unchanged (release wins, as before)