### PR TITLE
GH-4953: fix(autopilot): releaser baseline ignores tags not created by the releaser — sdk train cut v0.34.2 below existing v0.35.0

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -5321,12 +5321,23 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 		return nil
 	}
 
-	// Get current version from the target repo
-	currentVersion, err := c.releaser.GetCurrentVersionForRepo(ctx, owner, repo)
+	// Get current version from the target repo. GH-4953: the baseline is the
+	// max semver across the latest GitHub Release AND all git tags, so a tag
+	// pushed without a matching Release object (e.g. a base-guard tag) can't
+	// silently outrank what the releaser computes next. Logged on every
+	// release decision so a baseline/tag mismatch is visible before it ships
+	// a version that ranks below one already on the repo.
+	currentVersion, baselineSource, err := c.releaser.GetCurrentVersionForRepoWithSource(ctx, owner, repo)
 	if err != nil {
 		c.log.Warn("failed to get current version, defaulting to 0.0.0", "error", err)
 		currentVersion = SemVer{}
+		baselineSource = "error (defaulted to 0.0.0)"
 	}
+	c.log.Info("release baseline resolved",
+		"pr", prState.PRNumber,
+		"baseline", currentVersion.String(rel.TagPrefix),
+		"baseline_source", baselineSource,
+	)
 
 	// Get commits for bump detection: a "train:" scope carrier is defined as
 	// "everything since the last tag" (CompareCommits, not a member-PR union

--- a/internal/autopilot/releaser.go
+++ b/internal/autopilot/releaser.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -52,6 +51,30 @@ func (v SemVer) Bump(bumpType BumpType) SemVer {
 		return SemVer{Major: v.Major, Minor: v.Minor, Patch: v.Patch + 1}
 	default:
 		return v
+	}
+}
+
+// Compare returns -1, 0, or 1 as v is less than, equal to, or greater than
+// other, ordering by Major then Minor then Patch.
+func (v SemVer) Compare(other SemVer) int {
+	switch {
+	case v.Major != other.Major:
+		if v.Major < other.Major {
+			return -1
+		}
+		return 1
+	case v.Minor != other.Minor:
+		if v.Minor < other.Minor {
+			return -1
+		}
+		return 1
+	case v.Patch != other.Patch:
+		if v.Patch < other.Patch {
+			return -1
+		}
+		return 1
+	default:
+		return 0
 	}
 }
 
@@ -161,48 +184,91 @@ func bumpPriority(b BumpType) int {
 	}
 }
 
-// GetCurrentVersion returns the current version from latest release or tags.
-func (r *Releaser) GetCurrentVersion(ctx context.Context) (SemVer, error) {
-	// Try latest release first
-	release, err := r.ghClient.GetLatestRelease(ctx, r.owner, r.repo)
+// versionBaselineTagWindow bounds how many of the most recent tags
+// resolveVersionBaseline inspects when computing the release baseline. 100 is
+// GitHub's per-page max and ListTags's only supported page (see
+// maxReleaseBackfillTags in release_backfill.go) — wide enough that a tag
+// pushed without a GitHub Release (GH-4953) is still seen even if several
+// releases have landed since.
+const versionBaselineTagWindow = 100
+
+// Baseline sources returned by resolveVersionBaseline, used in release
+// decision logging so an operator can see how the baseline was found.
+const (
+	baselineSourceNone           = "none"
+	baselineSourceRelease        = "release"
+	baselineSourceTags           = "tags"
+	baselineSourceReleaseAndTags = "release+tags (agree)"
+	baselineSourceTagsSupersede  = "tags (supersede release)"
+)
+
+// resolveVersionBaseline computes the release baseline for owner/repo as the
+// max semver across ALL git tags — annotated or lightweight, regardless of
+// whether a GitHub Release object exists for them — reconciled against the
+// GitHub "latest release" API.
+//
+// GH-4953: the releaser previously trusted GetLatestRelease exclusively
+// whenever a release existed, and only fell back to tags when there was no
+// release at all. That let a tag pushed without a matching GitHub Release
+// (e.g. a base-guard tag, or any tag created outside the release-API publish
+// path) silently outrank the "latest release" the API reports. The sdk repo
+// hit this live: tag v0.35.0 existed with no Release object, GetLatestRelease
+// kept returning the older v0.34.1 release, and the next patch train cut
+// v0.34.2 — a version Go module resolution ranks BELOW the already-shipped
+// v0.35.0. mem-093 established tags-as-baseline for exactly this reason; this
+// closes the gap by always computing both and taking the max.
+func (r *Releaser) resolveVersionBaseline(ctx context.Context, owner, repo string) (SemVer, string, error) {
+	var releaseVersion SemVer
+	haveRelease := false
+	release, err := r.ghClient.GetLatestRelease(ctx, owner, repo)
 	if err != nil {
-		return SemVer{}, fmt.Errorf("failed to get latest release: %w", err)
+		return SemVer{}, "", fmt.Errorf("failed to get latest release: %w", err)
 	}
 	if release != nil {
-		return ParseSemVer(release.TagName)
+		if v, perr := ParseSemVer(release.TagName); perr == nil {
+			releaseVersion = v
+			haveRelease = true
+		}
 	}
 
-	// Fall back to tags
-	tags, err := r.ghClient.ListTags(ctx, r.owner, r.repo, 10)
+	tags, err := r.ghClient.ListTags(ctx, owner, repo, versionBaselineTagWindow)
 	if err != nil {
-		return SemVer{}, fmt.Errorf("failed to list tags: %w", err)
+		return SemVer{}, "", fmt.Errorf("failed to list tags: %w", err)
 	}
 
-	// Find highest semver tag
-	var versions []SemVer
+	var maxTagVersion SemVer
+	haveTag := false
 	for _, tag := range tags {
-		if v, err := ParseSemVer(tag.Name); err == nil {
-			versions = append(versions, v)
+		v, perr := ParseSemVer(tag.Name)
+		if perr != nil {
+			continue
+		}
+		if !haveTag || v.Compare(maxTagVersion) > 0 {
+			maxTagVersion = v
+			haveTag = true
 		}
 	}
 
-	if len(versions) == 0 {
-		// No versions found, start at 0.0.0
-		return SemVer{}, nil
+	switch {
+	case haveRelease && haveTag:
+		if maxTagVersion.Compare(releaseVersion) > 0 {
+			return maxTagVersion, baselineSourceTagsSupersede, nil
+		}
+		return releaseVersion, baselineSourceReleaseAndTags, nil
+	case haveRelease:
+		return releaseVersion, baselineSourceRelease, nil
+	case haveTag:
+		return maxTagVersion, baselineSourceTags, nil
+	default:
+		return SemVer{}, baselineSourceNone, nil
 	}
+}
 
-	// Sort descending
-	sort.Slice(versions, func(i, j int) bool {
-		if versions[i].Major != versions[j].Major {
-			return versions[i].Major > versions[j].Major
-		}
-		if versions[i].Minor != versions[j].Minor {
-			return versions[i].Minor > versions[j].Minor
-		}
-		return versions[i].Patch > versions[j].Patch
-	})
-
-	return versions[0], nil
+// GetCurrentVersion returns the current version, using the max semver across
+// the latest GitHub Release and all git tags (GH-4953).
+func (r *Releaser) GetCurrentVersion(ctx context.Context) (SemVer, error) {
+	v, _, err := r.resolveVersionBaseline(ctx, r.owner, r.repo)
+	return v, err
 }
 
 // GenerateChangelog generates a changelog from commits.
@@ -313,43 +379,21 @@ func isDuplicateReleaseError(err error) bool {
 	return strings.Contains(strings.ToLower(err.Error()), "already_exists")
 }
 
-// GetCurrentVersionForRepo gets the current version from the specified repository.
+// GetCurrentVersionForRepo gets the current version from the specified
+// repository, using the max semver across the latest GitHub Release and all
+// git tags (GH-4953). Source-preserving callers that need to log how the
+// baseline was found should use GetCurrentVersionForRepoWithSource instead.
 func (r *Releaser) GetCurrentVersionForRepo(ctx context.Context, owner, repo string) (SemVer, error) {
-	release, err := r.ghClient.GetLatestRelease(ctx, owner, repo)
-	if err != nil {
-		return SemVer{}, fmt.Errorf("failed to get latest release: %w", err)
-	}
-	if release != nil {
-		return ParseSemVer(release.TagName)
-	}
+	v, _, err := r.resolveVersionBaseline(ctx, owner, repo)
+	return v, err
+}
 
-	tags, err := r.ghClient.ListTags(ctx, owner, repo, 10)
-	if err != nil {
-		return SemVer{}, fmt.Errorf("failed to list tags: %w", err)
-	}
-
-	var versions []SemVer
-	for _, tag := range tags {
-		if v, err := ParseSemVer(tag.Name); err == nil {
-			versions = append(versions, v)
-		}
-	}
-
-	if len(versions) == 0 {
-		return SemVer{}, nil
-	}
-
-	sort.Slice(versions, func(i, j int) bool {
-		if versions[i].Major != versions[j].Major {
-			return versions[i].Major > versions[j].Major
-		}
-		if versions[i].Minor != versions[j].Minor {
-			return versions[i].Minor > versions[j].Minor
-		}
-		return versions[i].Patch > versions[j].Patch
-	})
-
-	return versions[0], nil
+// GetCurrentVersionForRepoWithSource is GetCurrentVersionForRepo plus the
+// baseline source ("release", "tags", "release+tags (agree)", or
+// "tags (supersede release)") so callers can log how the baseline was
+// discovered on every release decision (GH-4953 acceptance criteria).
+func (r *Releaser) GetCurrentVersionForRepoWithSource(ctx context.Context, owner, repo string) (SemVer, string, error) {
+	return r.resolveVersionBaseline(ctx, owner, repo)
 }
 
 // ShouldRelease determines if a release should be created based on config and bump type.

--- a/internal/autopilot/releaser_test.go
+++ b/internal/autopilot/releaser_test.go
@@ -392,13 +392,17 @@ func TestReleaser_ShouldRelease(t *testing.T) {
 
 func TestReleaser_GetCurrentVersion(t *testing.T) {
 	tests := []struct {
-		name    string
-		handler http.HandlerFunc
-		want    SemVer
-		wantErr bool
+		name       string
+		handler    http.HandlerFunc
+		want       SemVer
+		wantSource string
+		wantErr    bool
 	}{
 		{
-			name: "from latest release",
+			// GH-4953 acceptance: "existing release flows unchanged when
+			// ledger and tags agree" — the release and the tag list agree on
+			// v1.2.3, so the baseline is the release with no tag override.
+			name: "from latest release, tags agree",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path == "/repos/owner/repo/releases/latest" {
 					_ = json.NewEncoder(w).Encode(map[string]interface{}{
@@ -407,12 +411,20 @@ func TestReleaser_GetCurrentVersion(t *testing.T) {
 					})
 					return
 				}
+				if r.URL.Path == "/repos/owner/repo/tags" {
+					_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+						{"name": "v1.2.3"},
+						{"name": "v1.2.2"},
+					})
+					return
+				}
 				w.WriteHeader(http.StatusNotFound)
 			},
-			want: SemVer{Major: 1, Minor: 2, Patch: 3},
+			want:       SemVer{Major: 1, Minor: 2, Patch: 3},
+			wantSource: baselineSourceReleaseAndTags,
 		},
 		{
-			name: "fallback to tags",
+			name: "fallback to tags, no release",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path == "/repos/owner/repo/releases/latest" {
 					w.WriteHeader(http.StatusNotFound)
@@ -429,7 +441,8 @@ func TestReleaser_GetCurrentVersion(t *testing.T) {
 				}
 				w.WriteHeader(http.StatusNotFound)
 			},
-			want: SemVer{Major: 2, Minor: 0, Patch: 0},
+			want:       SemVer{Major: 2, Minor: 0, Patch: 0},
+			wantSource: baselineSourceTags,
 		},
 		{
 			name: "no releases or tags - zero version",
@@ -445,7 +458,33 @@ func TestReleaser_GetCurrentVersion(t *testing.T) {
 				}
 				w.WriteHeader(http.StatusNotFound)
 			},
-			want: SemVer{Major: 0, Minor: 0, Patch: 0},
+			want:       SemVer{Major: 0, Minor: 0, Patch: 0},
+			wantSource: baselineSourceNone,
+		},
+		{
+			// GH-4953 live specimen: a tag (v0.35.0) was pushed without a
+			// GitHub Release object, so GetLatestRelease still reports the
+			// older v0.34.1 release. The tag must win.
+			name: "tag without Release object supersedes stale latest release",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/repos/owner/repo/releases/latest" {
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"id":       1,
+						"tag_name": "v0.34.1",
+					})
+					return
+				}
+				if r.URL.Path == "/repos/owner/repo/tags" {
+					_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+						{"name": "v0.35.0"},
+						{"name": "v0.34.1"},
+					})
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			},
+			want:       SemVer{Major: 0, Minor: 35, Patch: 0},
+			wantSource: baselineSourceTagsSupersede,
 		},
 	}
 
@@ -465,7 +504,64 @@ func TestReleaser_GetCurrentVersion(t *testing.T) {
 			if !tt.wantErr && got != tt.want {
 				t.Errorf("GetCurrentVersion() = %v, want %v", got, tt.want)
 			}
+
+			gotSrc, srcErr := r.resolveVersionBaselineSourceForTest(context.Background())
+			if srcErr != nil {
+				t.Fatalf("resolveVersionBaseline() error = %v", srcErr)
+			}
+			if !tt.wantErr && gotSrc != tt.wantSource {
+				t.Errorf("resolveVersionBaseline() source = %v, want %v", gotSrc, tt.wantSource)
+			}
 		})
+	}
+}
+
+// resolveVersionBaselineSourceForTest exposes resolveVersionBaseline's source
+// string to the table-driven test above without adding a second exported
+// method solely for tests.
+func (r *Releaser) resolveVersionBaselineSourceForTest(ctx context.Context) (string, error) {
+	_, source, err := r.resolveVersionBaseline(ctx, r.owner, r.repo)
+	return source, err
+}
+
+// TestReleaser_NextVersion_TagsSupersedeRelease is the GH-4953 acceptance
+// criterion verbatim: existing tags {v0.34.1, v0.35.0} plus a patch-bump
+// release must compute next = v0.35.1, never v0.34.2 (the wrong version the
+// sdk release train actually cut in production because the releaser trusted
+// the stale v0.34.1 GitHub Release over the untagged-by-Release v0.35.0 tag).
+func TestReleaser_NextVersion_TagsSupersedeRelease(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/releases/latest":
+			// The GitHub Release ledger is stale — it never saw v0.35.0
+			// because that tag was pushed without a matching Release object.
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":       1,
+				"tag_name": "v0.34.1",
+			})
+		case "/repos/owner/repo/tags":
+			_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+				{"name": "v0.35.0"},
+				{"name": "v0.34.1"},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := github.NewClientWithBaseURL("test-token", server.URL)
+	r := NewReleaser(client, "owner", "repo", DefaultReleaseConfig())
+
+	baseline, err := r.GetCurrentVersionForRepo(context.Background(), "owner", "repo")
+	if err != nil {
+		t.Fatalf("GetCurrentVersionForRepo() error = %v", err)
+	}
+
+	next := baseline.Bump(BumpPatch)
+	want := SemVer{Major: 0, Minor: 35, Patch: 1}
+	if next != want {
+		t.Errorf("next version = %v, want %v (NOT v0.34.2)", next, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4953.

Closes #4953

## Changes

GitHub Issue GH-4953: fix(autopilot): releaser baseline ignores tags not created by the releaser — sdk train cut v0.34.2 below existing v0.35.0

Do not decompose — this is a standalone task, one coherent change as a single PR.

## Problem (live specimen, 2026-08-18 14:01Z)

The sdk release train released PR#120 as **v0.34.2** while tag **v0.35.0 already existed** on the repo. Result: the newest commit shipped under a version that Go module resolution ranks BELOW an older commit's version — consumers pinning/upgrading normally can never reach the fix. Operator had to cut a corrective out-of-band tag v0.35.1.

Cause: v0.35.0 was pushed as a tag only (2026-08-17 base-guard tag; no GitHub Release object), and the releaser computed its next-version baseline from a source that misses it (its ledger / the Releases list) instead of from git tags. mem-093 established tags-as-baseline for exactly this reason; the sdk path (or the Release-API publish path, `tag created — published GitHub Release via API`) does not honor it.

## Fix

Baseline = **max semver across ALL git tags** on the repo (annotated or lightweight, regardless of who created them or whether a Release object exists). If the computed next version is not strictly greater than every existing tag, bump from the true max instead. Log the discovered baseline and its source on every release decision.

## Acceptance criteria

- [ ] Table-driven test: existing tags {v0.34.1, v0.35.0} + patch release → next is v0.35.1 (NOT v0.34.2)
- [ ] Tag-without-Release counts toward baseline
- [ ] Release decision log line includes baseline version + how it was found
- [ ] Existing release flows unchanged when ledger and tags agree

## Refs

sdk PR#120 → wrong tag v0.34.2 (13:56Z) · corrective v0.35.1 at `cbef46fd` · mem-093 · box log `component=autopilot pr=120 version=v0.34.2`