### PR TITLE
fix(dispatch): unwind pilot-in-progress when SDK dispatch drops a pickup

### DIFF
--- a/cmd/pilot/github_sdk_label_unwind_test.go
+++ b/cmd/pilot/github_sdk_label_unwind_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/executor"
+)
+
+// TestShouldUnwindGithubInProgressLabel_Table is the GH-4961 table-driven
+// acceptance test: notifyTaskStartedSDK applies pilot-in-progress BEFORE the
+// dispatcher has actually claimed the task (GH-4687 pre-claim ordering). When
+// the dispatch that follows drops the pickup — repick backoff, claim lost, or
+// any other admission-gate decline surfaced as hr.IsDispatchGated() — and no
+// other execution genuinely owns the task, the label just applied is the
+// only "in progress" evidence left behind and must be removed again, or the
+// issue is wedged forever (every future poll tick skips it). A successful
+// dispatch must never trigger the unwind — the happy-path label/comment
+// behavior established by GH-4687 must not regress, and no extra label
+// round-trip may occur on that path.
+func TestShouldUnwindGithubInProgressLabel_Table(t *testing.T) {
+	tests := []struct {
+		name             string
+		notifyAttempted  bool
+		hr               *HandlerResult
+		dispatcherActive bool
+		want             bool
+	}{
+		{
+			name:             "dispatch dropped by repick backoff, no active execution — unwind",
+			notifyAttempted:  true,
+			hr:               &HandlerResult{Success: false, Error: executor.ErrDispatchGated},
+			dispatcherActive: false,
+			want:             true,
+		},
+		{
+			name:             "dispatch dropped by claim lost, no active execution — unwind",
+			notifyAttempted:  true,
+			hr:               &HandlerResult{Success: false, Error: executor.ErrDispatchGated},
+			dispatcherActive: false,
+			want:             true,
+		},
+		{
+			name:             "dispatch dropped, but a different execution is genuinely active — must not strip",
+			notifyAttempted:  true,
+			hr:               &HandlerResult{Success: false, Error: executor.ErrDispatchGated},
+			dispatcherActive: true,
+			want:             false,
+		},
+		{
+			name:             "dispatch succeeds — label applied exactly as today, no unwind",
+			notifyAttempted:  true,
+			hr:               &HandlerResult{Success: true},
+			dispatcherActive: false,
+			want:             false,
+		},
+		{
+			name:             "dispatch succeeds while another execution also reports active — still no unwind",
+			notifyAttempted:  true,
+			hr:               &HandlerResult{Success: true},
+			dispatcherActive: true,
+			want:             false,
+		},
+		{
+			name:             "label was never applied this call (issue closed) — nothing to unwind",
+			notifyAttempted:  false,
+			hr:               &HandlerResult{Success: false, Error: executor.ErrDispatchGated},
+			dispatcherActive: false,
+			want:             false,
+		},
+		{
+			name:             "genuine execution failure (not gated) — must not unwind the label",
+			notifyAttempted:  true,
+			hr:               &HandlerResult{Success: false, Error: errors.New("execution failed: boom")},
+			dispatcherActive: false,
+			want:             false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldUnwindGithubInProgressLabel(tt.notifyAttempted, tt.hr, tt.dispatcherActive); got != tt.want {
+				t.Errorf("shouldUnwindGithubInProgressLabel(%v, %+v, %v) = %v, want %v",
+					tt.notifyAttempted, tt.hr, tt.dispatcherActive, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestShouldUnwindGithubInProgressLabel_WrappedGatedError confirms the helper
+// consults hr.IsDispatchGated() (errors.Is-based), not a bare equality check,
+// so a wrapped executor.ErrDispatchGated — as handleIssueGeneric's own
+// hrErr construction can produce via fmt.Errorf("...: %w", ...) elsewhere in
+// the codebase — is still recognized as a gated drop.
+func TestShouldUnwindGithubInProgressLabel_WrappedGatedError(t *testing.T) {
+	hr := &HandlerResult{Success: false, Error: errWrap(executor.ErrDispatchGated)}
+	if !hr.IsDispatchGated() {
+		t.Fatal("expected wrapped ErrDispatchGated to satisfy IsDispatchGated()")
+	}
+	if !shouldUnwindGithubInProgressLabel(true, hr, false) {
+		t.Error("expected unwind for a wrapped ErrDispatchGated with no active execution")
+	}
+}
+
+func errWrap(err error) error {
+	return &wrappedErr{msg: "dispatch: " + err.Error(), err: err}
+}
+
+type wrappedErr struct {
+	msg string
+	err error
+}
+
+func (w *wrappedErr) Error() string { return w.msg }
+func (w *wrappedErr) Unwrap() error { return w.err }
+
+// TestGithubHandlerSDK_LabelUnwindWired is a source-level guard (mirrors
+// TestGithubHandlerSDK_NotifyTaskStartedWired's established pattern for this
+// otherwise-unexercisable function): handleGithubIssueEventSDK must call
+// shouldUnwindGithubInProgressLabel AFTER handleIssueGeneric returns (so the
+// dispatch outcome is known), and the unwind call itself must remove the
+// label via the same specClient the apply used — never a fresh client — so
+// it targets the same repo/token context.
+func TestGithubHandlerSDK_LabelUnwindWired(t *testing.T) {
+	body := githubFuncBody(t, "handlers.go", "func handleGithubIssueEventSDK(")
+
+	handleIssueGenericIdx := strings.Index(body, "hr, execErr := handleIssueGeneric(ctx, deps, info, task)")
+	unwindIdx := strings.Index(body, "shouldUnwindGithubInProgressLabel(")
+	if handleIssueGenericIdx < 0 || unwindIdx < 0 {
+		t.Fatal("expected both the handleIssueGeneric call and shouldUnwindGithubInProgressLabel in handleGithubIssueEventSDK")
+	}
+	if unwindIdx < handleIssueGenericIdx {
+		t.Error("shouldUnwindGithubInProgressLabel must be consulted after handleIssueGeneric returns, once the dispatch outcome is known")
+	}
+
+	if !strings.Contains(body, "specClient.RemoveLabel(ctx, repoOwner, repoName, issueNum, pilotLabel)") {
+		t.Error("the unwind path must call specClient.RemoveLabel with the same owner/repo/issue/label the apply used")
+	}
+}

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -816,8 +816,14 @@ func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkco
 	// GH-4050) — treat that as unknown, not closed, so the label still fires
 	// when state can't be determined. Mirrors the surfaceStalledIssue guard
 	// (dispatcher.go).
+	// notifyAttempted and labelTracker are captured here (rather than kept
+	// local to the block below) so the post-dispatch unwind further down —
+	// GH-4961 — can reuse the exact same client/label/tracker that applied
+	// pilot-in-progress, without re-deriving them.
+	var notifyAttempted bool
+	var pilotLabel string
+	var labelTracker *alerts.DeadManTracker
 	if specClient != nil && issueState != githubSDK.StateClosed {
-		pilotLabel := ""
 		if cfg.Adapters != nil && cfg.Adapters.GitHub != nil {
 			pilotLabel = cfg.Adapters.GitHub.PilotLabel
 		}
@@ -831,12 +837,13 @@ func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkco
 		// (zero attempts despite issues flowing) is detectable the same way
 		// zero attempts already are (Stale) instead of hiding behind an
 		// error-only counter.
-		labelTracker := alertsEngine.RegisterDeadManTracker(
+		labelTracker = alertsEngine.RegisterDeadManTracker(
 			labelLifecycleDeadManTrackerName(repoOwner+"/"+repoName),
 			alerts.AlertTypeLabelLifecycleFailureStreak,
 			alerts.DefaultDeadManFailureThreshold,
 			alerts.DefaultDeadManWindow,
 		)
+		notifyAttempted = true
 		labelTracker.RecordAttempt()
 		if err := notifyTaskStartedSDK(ctx, specClient, pilotLabel, repoOwner, repoName, issueNum, taskID); err != nil {
 			labelTracker.RecordFailure(map[string]string{"repo": repoOwner + "/" + repoName})
@@ -905,6 +912,47 @@ func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkco
 
 	hr, execErr := handleIssueGeneric(ctx, deps, info, task)
 
+	// GH-4961: notifyTaskStartedSDK above applies pilot-in-progress BEFORE
+	// the dispatcher has actually claimed the task (preserving the GH-4687
+	// pre-claim ordering for the happy path). When the dispatcher instead
+	// drops this pickup — repick backoff, claim lost, or any other
+	// admission-gate decline surfaced as hr.IsDispatchGated() — and no other
+	// execution genuinely owns the task, the label just applied is the only
+	// evidence of "in progress" left behind with nothing running to clear it
+	// later. Unwind it here so the next poll tick isn't permanently skipped.
+	//
+	// dispatcher.IsActive is the same live-ownership check
+	// handleIssueGeneric's own admission gates consult (GH-4008): if it
+	// reports true, a *different*, genuinely active execution owns this
+	// task (e.g. a legitimate concurrent dispatch) and the label correctly
+	// reflects that — must not strip it. hr.IsDispatchGated() can only be
+	// true when dispatcher != nil (every ErrDispatchGated-setting branch in
+	// handleIssueGeneric requires it), but dispatcherActive is still guarded
+	// explicitly here since it's evaluated as a plain argument before
+	// shouldUnwindGithubInProgressLabel's own short-circuit ever runs — a
+	// bare dispatcher.IsActive(...) call would otherwise risk a nil-pointer
+	// dereference if that invariant is ever violated.
+	dispatcherActive := dispatcher != nil && dispatcher.IsActive(taskID, projectPath)
+	if shouldUnwindGithubInProgressLabel(notifyAttempted, hr, dispatcherActive) {
+		labelTracker.RecordAttempt()
+		if err := specClient.RemoveLabel(ctx, repoOwner, repoName, issueNum, pilotLabel); err != nil {
+			// A failed unwind is a genuine label-lifecycle failure (the
+			// label is now stranded), unlike the unwind itself — which is a
+			// deliberate correction, not evidence the original apply/notify
+			// path is broken.
+			labelTracker.RecordFailure(map[string]string{"repo": repoOwner + "/" + repoName})
+			logging.WithComponent("github").Warn("Failed to unwind pilot-in-progress after dropped dispatch pickup",
+				slog.String("task_id", taskID),
+				slog.Int("issue", issueNum),
+				slog.Any("error", err))
+		} else {
+			labelTracker.RecordSuccess()
+			logging.WithComponent("github").Info("Unwound pilot-in-progress label after dropped dispatch pickup",
+				slog.String("task_id", taskID),
+				slog.Int("issue", issueNum))
+		}
+	}
+
 	issueResult := &sdkcore.IssueResult{
 		Success:    hr.EffectiveSuccess(), // GH-4587/GH-4794: admission-gate declines and superseded/canceled executions are not genuine failures
 		BranchName: hr.BranchName,
@@ -957,6 +1005,37 @@ const labelLifecycleDeadManTrackerPrefix = "label_lifecycle:"
 // registration and the event-time registration racing to create two.
 func labelLifecycleDeadManTrackerName(repoFullName string) string {
 	return labelLifecycleDeadManTrackerPrefix + repoFullName
+}
+
+// shouldUnwindGithubInProgressLabel reports whether a pilot-in-progress label
+// applied earlier in handleGithubIssueEventSDK (before the dispatch attempt,
+// per GH-4687's pre-claim ordering) must be removed again because the
+// dispatch that followed never actually claimed the task (GH-4961).
+//
+// notifyAttempted is true only when notifyTaskStartedSDK was actually called
+// for this event (skipped entirely for a closed issue, or when specClient
+// couldn't be built) — nothing to unwind if the label was never touched.
+//
+// hr.IsDispatchGated() is true for every admission-gate decline
+// handleIssueGeneric can return with no execution having been claimed:
+// already-active/backoff/terminal-completion pre-checks, and the dispatcher's
+// own repick-backoff/claim-lost drops (QueueTask returning "", nil) — see
+// executor.ErrDispatchGated and handler_common.go's gatedDrop paths.
+//
+// dispatcherActive distinguishes the two ways a gated decline can arise:
+//   - false: nothing is running for this task — the label just applied is
+//     now the sole (stale) evidence of "in progress" and must be removed, or
+//     every future poll tick will skip the issue forever (the wedge this
+//     bug fixes).
+//   - true: a *different*, genuinely active execution owns the task (e.g. a
+//     legitimate concurrent dispatch race) — the label correctly describes
+//     reality and must be left alone.
+//
+// A successful (non-gated) dispatch must never reach here with a true
+// result — see the call site — so the happy path never performs the extra
+// label round-trip this function exists to avoid.
+func shouldUnwindGithubInProgressLabel(notifyAttempted bool, hr *HandlerResult, dispatcherActive bool) bool {
+	return notifyAttempted && hr.IsDispatchGated() && !dispatcherActive
 }
 
 // notifyTaskStartedSDK applies the pilot-in-progress label and posts the


### PR DESCRIPTION
## Summary
- Fixes GH-4961: after a declined execution, the SDK poller re-applies `pilot-in-progress` (GH-4687 pre-claim ordering) before the dispatcher gets a chance to claim the task. When the dispatcher drops the pickup (repick backoff, claim lost — `QueueTask` returning `"", nil`), nothing unwound the label, permanently wedging the issue: every later poll tick sees the label and skips it.
- `handleGithubIssueEventSDK` now removes the label it just applied whenever `handleIssueGeneric` returns a dispatch-gated result (`hr.IsDispatchGated()`) **and** `dispatcher.IsActive(...)` confirms no other execution genuinely owns the task. If a different execution really is active, the label is left alone.
- The decision is extracted into `shouldUnwindGithubInProgressLabel` for direct table-driven unit testing, since `handleGithubIssueEventSDK` itself can't be exercised end-to-end (real GitHub token/client resolution).
- Happy-path dispatch is unaffected — still exactly one label apply, no extra round-trip.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] `go test ./...` — all packages pass
- [x] New table-driven test `TestShouldUnwindGithubInProgressLabel_Table` covers: repick-backoff/claim-lost drop with no active execution → unwind; gated drop with a genuinely active execution → no unwind; successful dispatch → no unwind (happy path unchanged); label never applied (closed issue) → no unwind; genuine (non-gated) failure → no unwind
- [x] Existing GH-4687 ordering test (`TestGithubHandlerSDK_NotifyTaskStartedWired`) still passes — pre-claim label-apply ordering preserved