### PR TITLE
GH-4953: fix(autopilot): releaser baseline ignores tags not created by the releaser — sdk train cut v0.34.2 below existing v0.35.0

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -5321,11 +5321,17 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 		return nil
 	}
 
-	// Get current version from the target repo
-	currentVersion, err := c.releaser.GetCurrentVersionForRepo(ctx, owner, repo)
+	// Get current version from the target repo. GH-4953: baseline is the max
+	// semver across ALL git tags, compared against the latest GitHub Release —
+	// not the Release alone, which can be stale relative to a tag pushed
+	// without a covering Release (sdk PR#120: v0.34.2 shipped over an existing
+	// v0.35.0 tag). versionSource records which one won, for the release
+	// decision log below.
+	currentVersion, versionSource, err := c.releaser.GetCurrentVersionWithSource(ctx, owner, repo)
 	if err != nil {
 		c.log.Warn("failed to get current version, defaulting to 0.0.0", "error", err)
 		currentVersion = SemVer{}
+		versionSource = "error, defaulted to 0.0.0"
 	}
 
 	// Get commits for bump detection: a "train:" scope carrier is defined as
@@ -5376,6 +5382,7 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 	c.log.Info("creating release",
 		"pr", prState.PRNumber,
 		"current", currentVersion.String(rel.TagPrefix),
+		"baseline_source", versionSource,
 		"new", prState.ReleaseVersion,
 		"bump", bumpType,
 	)

--- a/internal/autopilot/releaser.go
+++ b/internal/autopilot/releaser.go
@@ -161,48 +161,109 @@ func bumpPriority(b BumpType) int {
 	}
 }
 
-// GetCurrentVersion returns the current version from latest release or tags.
+// GetCurrentVersion returns the current version baseline for the releaser's
+// default repo. See GetCurrentVersionWithSource for how the baseline is
+// computed.
 func (r *Releaser) GetCurrentVersion(ctx context.Context) (SemVer, error) {
-	// Try latest release first
-	release, err := r.ghClient.GetLatestRelease(ctx, r.owner, r.repo)
+	v, _, err := r.GetCurrentVersionWithSource(ctx, r.owner, r.repo)
+	return v, err
+}
+
+// GetCurrentVersionWithSource computes the release-version baseline as the
+// MAX semver across every git tag on the repo, compared against the latest
+// GitHub Release's tag (if any), and returns which one won plus a
+// human-readable description of where it came from.
+//
+// GH-4953: the previous implementation returned the latest Release's tag
+// immediately and only consulted the tags list when no Release existed at
+// all. That let a tag-only version (no Release object — e.g. a manual
+// base-guard tag, or the Release-API publish path failing after the tag
+// landed) rank BELOW a stale Release. Live incident: the sdk repo had tag
+// v0.35.0 with no covering Release; the releaser's baseline read the older
+// Release tag v0.34.1 and cut the next patch as v0.34.2 — a version Go
+// module resolution ranks below the v0.35.0 that was already out. mem-093
+// documented "the releaser reads the baseline live from git tags" as the
+// safety net for out-of-band tags; this had silently stopped being true
+// whenever a Release object existed. Tags are now always the source of
+// truth, regardless of whether a Release was ever published for them.
+func (r *Releaser) GetCurrentVersionWithSource(ctx context.Context, owner, repo string) (SemVer, string, error) {
+	// Latest Release is a hint, not authoritative — a repo can have no
+	// Releases at all (tags-only) so this error is non-fatal.
+	var releaseVersion SemVer
+	var haveReleaseVersion bool
+	var releaseTag string
+	release, err := r.ghClient.GetLatestRelease(ctx, owner, repo)
 	if err != nil {
-		return SemVer{}, fmt.Errorf("failed to get latest release: %w", err)
+		return SemVer{}, "", fmt.Errorf("failed to get latest release: %w", err)
 	}
 	if release != nil {
-		return ParseSemVer(release.TagName)
+		if v, perr := ParseSemVer(release.TagName); perr == nil {
+			releaseVersion = v
+			haveReleaseVersion = true
+			releaseTag = release.TagName
+		}
 	}
 
-	// Fall back to tags
-	tags, err := r.ghClient.ListTags(ctx, r.owner, r.repo, 10)
+	// Tags are the authoritative baseline: every tag counts, whether or not
+	// it has a covering GitHub Release. maxReleaseBackfillTags (100, paginated
+	// by ListTags) comfortably covers full tag history for any repo with a
+	// sane release cadence.
+	tags, err := r.ghClient.ListTags(ctx, owner, repo, maxReleaseBackfillTags)
 	if err != nil {
-		return SemVer{}, fmt.Errorf("failed to list tags: %w", err)
+		return SemVer{}, "", fmt.Errorf("failed to list tags: %w", err)
 	}
 
-	// Find highest semver tag
-	var versions []SemVer
+	var tagVersions []SemVer
+	tagNames := map[SemVer]string{}
 	for _, tag := range tags {
 		if v, err := ParseSemVer(tag.Name); err == nil {
-			versions = append(versions, v)
+			tagVersions = append(tagVersions, v)
+			tagNames[v] = tag.Name
 		}
 	}
 
-	if len(versions) == 0 {
-		// No versions found, start at 0.0.0
-		return SemVer{}, nil
-	}
-
-	// Sort descending
-	sort.Slice(versions, func(i, j int) bool {
-		if versions[i].Major != versions[j].Major {
-			return versions[i].Major > versions[j].Major
+	sort.Slice(tagVersions, func(i, j int) bool {
+		if tagVersions[i].Major != tagVersions[j].Major {
+			return tagVersions[i].Major > tagVersions[j].Major
 		}
-		if versions[i].Minor != versions[j].Minor {
-			return versions[i].Minor > versions[j].Minor
+		if tagVersions[i].Minor != tagVersions[j].Minor {
+			return tagVersions[i].Minor > tagVersions[j].Minor
 		}
-		return versions[i].Patch > versions[j].Patch
+		return tagVersions[i].Patch > tagVersions[j].Patch
 	})
 
-	return versions[0], nil
+	var maxTagVersion SemVer
+	var haveTagVersion bool
+	var maxTagName string
+	if len(tagVersions) > 0 {
+		maxTagVersion = tagVersions[0]
+		haveTagVersion = true
+		maxTagName = tagNames[maxTagVersion]
+	}
+
+	switch {
+	case !haveReleaseVersion && !haveTagVersion:
+		return SemVer{}, "no releases or tags found, starting at 0.0.0", nil
+	case !haveTagVersion:
+		return releaseVersion, fmt.Sprintf("latest release %s (no tags found)", releaseTag), nil
+	case !haveReleaseVersion:
+		return maxTagVersion, fmt.Sprintf("max tag %s (no releases found)", maxTagName), nil
+	case tagCompare(maxTagVersion, releaseVersion) > 0:
+		return maxTagVersion, fmt.Sprintf("max tag %s (ahead of latest release %s)", maxTagName, releaseTag), nil
+	default:
+		return releaseVersion, fmt.Sprintf("latest release %s (tags do not exceed it)", releaseTag), nil
+	}
+}
+
+// tagCompare returns >0 if a > b, 0 if equal, <0 if a < b.
+func tagCompare(a, b SemVer) int {
+	if a.Major != b.Major {
+		return a.Major - b.Major
+	}
+	if a.Minor != b.Minor {
+		return a.Minor - b.Minor
+	}
+	return a.Patch - b.Patch
 }
 
 // GenerateChangelog generates a changelog from commits.
@@ -313,43 +374,12 @@ func isDuplicateReleaseError(err error) bool {
 	return strings.Contains(strings.ToLower(err.Error()), "already_exists")
 }
 
-// GetCurrentVersionForRepo gets the current version from the specified repository.
+// GetCurrentVersionForRepo returns the current version baseline for the
+// specified repository. See GetCurrentVersionWithSource for how the
+// baseline is computed.
 func (r *Releaser) GetCurrentVersionForRepo(ctx context.Context, owner, repo string) (SemVer, error) {
-	release, err := r.ghClient.GetLatestRelease(ctx, owner, repo)
-	if err != nil {
-		return SemVer{}, fmt.Errorf("failed to get latest release: %w", err)
-	}
-	if release != nil {
-		return ParseSemVer(release.TagName)
-	}
-
-	tags, err := r.ghClient.ListTags(ctx, owner, repo, 10)
-	if err != nil {
-		return SemVer{}, fmt.Errorf("failed to list tags: %w", err)
-	}
-
-	var versions []SemVer
-	for _, tag := range tags {
-		if v, err := ParseSemVer(tag.Name); err == nil {
-			versions = append(versions, v)
-		}
-	}
-
-	if len(versions) == 0 {
-		return SemVer{}, nil
-	}
-
-	sort.Slice(versions, func(i, j int) bool {
-		if versions[i].Major != versions[j].Major {
-			return versions[i].Major > versions[j].Major
-		}
-		if versions[i].Minor != versions[j].Minor {
-			return versions[i].Minor > versions[j].Minor
-		}
-		return versions[i].Patch > versions[j].Patch
-	})
-
-	return versions[0], nil
+	v, _, err := r.GetCurrentVersionWithSource(ctx, owner, repo)
+	return v, err
 }
 
 // ShouldRelease determines if a release should be created based on config and bump type.

--- a/internal/autopilot/releaser_test.go
+++ b/internal/autopilot/releaser_test.go
@@ -398,16 +398,25 @@ func TestReleaser_GetCurrentVersion(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			// GH-4953: GetCurrentVersion now always consults the tags list
+			// too (not just the latest Release), so this mocks the realistic
+			// GitHub behavior of an empty (not 404) tags array when the
+			// release tag is also the highest tag.
 			name: "from latest release",
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path == "/repos/owner/repo/releases/latest" {
+				switch r.URL.Path {
+				case "/repos/owner/repo/releases/latest":
 					_ = json.NewEncoder(w).Encode(map[string]interface{}{
 						"id":       1,
 						"tag_name": "v1.2.3",
 					})
-					return
+				case "/repos/owner/repo/tags":
+					_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+						{"name": "v1.2.3"},
+					})
+				default:
+					w.WriteHeader(http.StatusNotFound)
 				}
-				w.WriteHeader(http.StatusNotFound)
 			},
 			want: SemVer{Major: 1, Minor: 2, Patch: 3},
 		},
@@ -464,6 +473,96 @@ func TestReleaser_GetCurrentVersion(t *testing.T) {
 			}
 			if !tt.wantErr && got != tt.want {
 				t.Errorf("GetCurrentVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestReleaser_GetCurrentVersionWithSource_TagBeatsStaleRelease is a
+// table-driven regression test for GH-4953: a tag pushed without a covering
+// GitHub Release must still count toward the baseline. Live incident: the
+// sdk repo's latest Release was v0.34.1 but tag v0.35.0 already existed
+// (pushed as a base-guard tag, no Release object); the releaser used to read
+// only the Release and cut the next patch as v0.34.2 — a version Go module
+// resolution ranks BELOW the v0.35.0 already shipped.
+func TestReleaser_GetCurrentVersionWithSource_TagBeatsStaleRelease(t *testing.T) {
+	tests := []struct {
+		name          string
+		latestRelease string // empty = 404 (no release)
+		tags          []string
+		wantVersion   SemVer
+		wantSourceHas string // substring the source description must contain
+		wantNextPatch SemVer // currentVersion.Bump(BumpPatch)
+	}{
+		{
+			name:          "tag without covering release beats stale release (sdk PR#120 incident)",
+			latestRelease: "v0.34.1",
+			tags:          []string{"v0.34.1", "v0.35.0"},
+			wantVersion:   SemVer{Major: 0, Minor: 35, Patch: 0},
+			wantSourceHas: "max tag",
+			wantNextPatch: SemVer{Major: 0, Minor: 35, Patch: 1},
+		},
+		{
+			name:          "ledger and tags agree - release flow unchanged",
+			latestRelease: "v1.2.3",
+			tags:          []string{"v1.2.3", "v1.2.2", "v1.2.1"},
+			wantVersion:   SemVer{Major: 1, Minor: 2, Patch: 3},
+			wantSourceHas: "latest release",
+			wantNextPatch: SemVer{Major: 1, Minor: 2, Patch: 4},
+		},
+		{
+			name:          "tag-only repo, no release object at all",
+			latestRelease: "",
+			tags:          []string{"v2.0.0", "v1.0.0"},
+			wantVersion:   SemVer{Major: 2, Minor: 0, Patch: 0},
+			wantSourceHas: "max tag",
+			wantNextPatch: SemVer{Major: 2, Minor: 0, Patch: 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/repos/owner/repo/releases/latest":
+					if tt.latestRelease == "" {
+						w.WriteHeader(http.StatusNotFound)
+						_, _ = w.Write([]byte(`{"message": "Not Found"}`))
+						return
+					}
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"id":       1,
+						"tag_name": tt.latestRelease,
+					})
+				case "/repos/owner/repo/tags":
+					tags := make([]map[string]interface{}, len(tt.tags))
+					for i, name := range tt.tags {
+						tags[i] = map[string]interface{}{"name": name}
+					}
+					_ = json.NewEncoder(w).Encode(tags)
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			client := github.NewClientWithBaseURL("test-token", server.URL)
+			r := NewReleaser(client, "owner", "repo", DefaultReleaseConfig())
+
+			got, source, err := r.GetCurrentVersionWithSource(context.Background(), "owner", "repo")
+			if err != nil {
+				t.Fatalf("GetCurrentVersionWithSource() error = %v", err)
+			}
+			if got != tt.wantVersion {
+				t.Errorf("GetCurrentVersionWithSource() version = %v, want %v", got, tt.wantVersion)
+			}
+			if !strings.Contains(source, tt.wantSourceHas) {
+				t.Errorf("GetCurrentVersionWithSource() source = %q, want to contain %q", source, tt.wantSourceHas)
+			}
+
+			nextPatch := got.Bump(BumpPatch)
+			if nextPatch != tt.wantNextPatch {
+				t.Errorf("Bump(BumpPatch) from baseline = %v, want %v", nextPatch, tt.wantNextPatch)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4953.

Closes #4953

## Changes

GitHub Issue GH-4953: fix(autopilot): releaser baseline ignores tags not created by the releaser — sdk train cut v0.34.2 below existing v0.35.0

Do not decompose — this is a standalone task, one coherent change as a single PR.

## Problem (live specimen, 2026-08-18 14:01Z)

The sdk release train released PR#120 as **v0.34.2** while tag **v0.35.0 already existed** on the repo. Result: the newest commit shipped under a version that Go module resolution ranks BELOW an older commit's version — consumers pinning/upgrading normally can never reach the fix. Operator had to cut a corrective out-of-band tag v0.35.1.

Cause: v0.35.0 was pushed as a tag only (2026-08-17 base-guard tag; no GitHub Release object), and the releaser computed its next-version baseline from a source that misses it (its ledger / the Releases list) instead of from git tags. mem-093 established tags-as-baseline for exactly this reason; the sdk path (or the Release-API publish path, `tag created — published GitHub Release via API`) does not honor it.

## Fix

Baseline = **max semver across ALL git tags** on the repo (annotated or lightweight, regardless of who created them or whether a Release object exists). If the computed next version is not strictly greater than every existing tag, bump from the true max instead. Log the discovered baseline and its source on every release decision.

## Acceptance criteria

- [ ] Table-driven test: existing tags {v0.34.1, v0.35.0} + patch release → next is v0.35.1 (NOT v0.34.2)
- [ ] Tag-without-Release counts toward baseline
- [ ] Release decision log line includes baseline version + how it was found
- [ ] Existing release flows unchanged when ledger and tags agree

## Refs

sdk PR#120 → wrong tag v0.34.2 (13:56Z) · corrective v0.35.1 at `cbef46fd` · mem-093 · box log `component=autopilot pr=120 version=v0.34.2`