### PR TITLE
GH-4963: fix(ghguard): pflag-faithful per-command parser — close the 11 read/mutation parity gaps

### DIFF
--- a/internal/executor/ghguard/policy.go
+++ b/internal/executor/ghguard/policy.go
@@ -25,6 +25,20 @@
 // Precedent: this mirrors the RepoAllowlist / ValidateTargetRepo shape from
 // executor.repo_guardrail (GH-3027/TASK-286) — a narrow, consumer-side,
 // data-driven allowlist with a loud, logged bypass rather than a silent one.
+//
+// Parser parity (GH-4963): correctness depends entirely on parseArgs
+// deriving the same effective HTTP method/body-presence/repo/head that the
+// real `gh` binary (built on pflag) derives from the same argv. parseArgs
+// mirrors pflag's per-command flag grammar — attached shorthand (-XPOST),
+// `=` forms, boolean bundling, last-occurrence-wins, and `--` termination —
+// via a per-(command,sub) flagSpec table (flagTableFor) rather than one
+// global flag list. Two decisions from the originating research were left
+// open rather than folded in here: denying `api graphql` with field flags
+// regardless of method (belt-and-braces; D2), and consuming known
+// value-flags while scanning for the sub when flags precede the
+// subcommand (a false-deny-only gap; D3). GH_REPO/GH_HOST env var
+// bypasses of the -R/--repo check are tracked separately (D5) since no
+// argv-level fix covers them.
 package ghguard
 
 import (
@@ -172,49 +186,176 @@ var hardDenyIssueSubs = map[string]bool{
 	"develop":  true,
 }
 
-// valueFlags lists `gh` flags that consume the following token as their
-// value (when not given in --flag=value form). This is a conservative,
-// hand-maintained list covering every flag used by the commands in
-// allowRules plus the common mutation flags this guard must recognize
-// (-R/--repo, -X/--method, -f/-F/--input, --add-label/--remove-label,
-// --head). Flags not listed here are treated as boolean (no value
-// consumed) — the effect of a misclassification here is at worst an
-// incorrect positional-argument split, and every code path in this package
-// defaults to deny when it cannot confirm an allow, so an unrecognized flag
-// biases toward safety, not away from it.
-var valueFlags = map[string]bool{
-	"-R": true, "--repo": true,
-	"-X": true, "--method": true,
-	"-f": true, "--raw-field": true,
-	"-F": true, "--field": true,
-	"--input": true,
-	"-H":      true, "--header": true,
-	"--hostname": true,
-	"-q":         true, "--jq": true,
-	"-t": true, "--template": true,
-	"--json": true, "--limit": true,
-	"-s": true, "--state": true,
-	"-a": true, "--assignee": true,
-	"-A": true, "--author": true,
-	"-l": true, "--label": true,
-	"--add-label": true, "--remove-label": true,
-	"-S": true, "--search": true,
-	"--title": true,
-	"-b":      true, "--body": true,
-	"--body-file": true,
-	"-B":          true, "--base": true,
-	"--head": true,
-	"-m":     true, "--milestone": true,
-	"-p": true, "--project": true,
-	"--reviewer": true,
-	"--branch":   true,
-	"--workflow": true,
-	"--status":   true,
+// flagAction is the policy-relevant effect of recognizing a given flag.
+// Most flags (headers, jq filters, titles, ...) are policy-inert — they
+// still need to be in a command's table so their VALUE isn't misparsed as a
+// positional argument or as another flag's value, but Classify never reads
+// them, so they carry actionNone.
+type flagAction int
+
+const (
+	actionNone flagAction = iota
+	actionSetMethod
+	actionSetRepo
+	actionSetHead
+	actionField // -f/-F family: a request body UNLESS method is explicitly GET (see checkAPIRead)
+	actionInput // --input: a request body ALWAYS, regardless of method
+	actionAddLabel
+	actionRemoveLabel
+)
+
+// flagSpec is one entry in a per-command flag table: does this flag consume
+// the following token (or an attached/`=`-joined remainder) as its value,
+// and what does that value mean to the policy.
+type flagSpec struct {
+	takesValue bool
+	action     flagAction
 }
 
-// parsedArgs is the result of a single, conservative pass over `gh` argv.
+// universalFlags is merged into every command's table (including the
+// fallback table for commands with no dedicated entry below). -R/--repo is
+// gh's persistent repo-override flag, present on effectively every
+// subcommand; --add-label/--remove-label are checked globally in Classify
+// regardless of which command carries them. Recognizing -R on a command
+// that doesn't really accept it (e.g. `gh api`, which has no -R of its own)
+// is harmless: it can only ever make the repo-mismatch check in Classify
+// MORE conservative, never less.
+var universalFlags = map[string]flagSpec{
+	"-R": {true, actionSetRepo}, "--repo": {true, actionSetRepo},
+	"--add-label": {true, actionAddLabel}, "--remove-label": {true, actionRemoveLabel},
+}
+
+// apiFlags is `gh api`'s complete flag set (verified against the installed
+// `gh api --help`/live probes against a non-routable host during
+// implementation — see the "pflag-faithful parity" test section for the
+// specifics that a naive reading of gh's docs gets wrong, notably -p).
+var apiFlags = mergeFlags(universalFlags, map[string]flagSpec{
+	"-X": {true, actionSetMethod}, "--method": {true, actionSetMethod},
+	"-f": {true, actionField}, "--raw-field": {true, actionField},
+	"-F": {true, actionField}, "--field": {true, actionField},
+	"--input": {true, actionInput},
+	"-H":      {true, actionNone}, "--header": {true, actionNone},
+	"--hostname": {true, actionNone},
+	"-q":         {true, actionNone}, "--jq": {true, actionNone},
+	"-t": {true, actionNone}, "--template": {true, actionNone},
+	"--cache": {true, actionNone},
+	// -p/--preview takes a value (preview names) — it is NOT a paginate
+	// shorthand. `--paginate` itself has no short form. Confirmed live:
+	// `gh api ... -pXDELETE` sends a plain GET with a (garbage) preview
+	// header, it does NOT set method=DELETE.
+	"-p": {true, actionNone}, "--preview": {true, actionNone},
+	"-i": {false, actionNone}, "--include": {false, actionNone},
+	"--paginate": {false, actionNone},
+	"--silent":   {false, actionNone},
+	"--slurp":    {false, actionNone},
+	"--verbose":  {false, actionNone},
+})
+
+// prCreateFlags is `gh pr create`'s flag set. The load-bearing entry is
+// -f/--fill: it is BOOLEAN (fill title/body from commit info), not a value
+// flag — confirmed via `gh pr create --help`. A parser that treats -f as
+// value-taking (as `gh api`'s -f is) swallows the flag that follows it,
+// which is exactly the G11 gap this table exists to close. -H/--head has
+// both a short and long form; -F here is --body-file, not gh api's --field.
+var prCreateFlags = mergeFlags(universalFlags, map[string]flagSpec{
+	"-H": {true, actionSetHead}, "--head": {true, actionSetHead},
+	"-a": {true, actionNone}, "--assignee": {true, actionNone},
+	"-B": {true, actionNone}, "--base": {true, actionNone},
+	"-b": {true, actionNone}, "--body": {true, actionNone},
+	"-F": {true, actionNone}, "--body-file": {true, actionNone},
+	"-l": {true, actionNone}, "--label": {true, actionNone},
+	"-m": {true, actionNone}, "--milestone": {true, actionNone},
+	"-p": {true, actionNone}, "--project": {true, actionNone},
+	"-r": {true, actionNone}, "--reviewer": {true, actionNone},
+	"--recover": {true, actionNone},
+	"-T":        {true, actionNone}, "--template": {true, actionNone},
+	"-t": {true, actionNone}, "--title": {true, actionNone},
+	"-f": {false, actionNone}, "--fill": {false, actionNone},
+	"--fill-first":   {false, actionNone},
+	"--fill-verbose": {false, actionNone},
+	"-d":             {false, actionNone}, "--draft": {false, actionNone},
+	"--dry-run": {false, actionNone},
+	"-e":        {false, actionNone}, "--editor": {false, actionNone},
+	"--no-maintainer-edit": {false, actionNone},
+	"-w":                   {false, actionNone}, "--web": {false, actionNone},
+})
+
+// commentFlags is `gh issue comment` and `gh pr comment`'s shared flag set
+// (identical per --help for both subcommands).
+var commentFlags = mergeFlags(universalFlags, map[string]flagSpec{
+	"-b": {true, actionNone}, "--body": {true, actionNone},
+	"-F": {true, actionNone}, "--body-file": {true, actionNone},
+	"--create-if-none": {false, actionNone},
+	"--delete-last":    {false, actionNone},
+	"--edit-last":      {false, actionNone},
+	"-e":               {false, actionNone}, "--editor": {false, actionNone},
+	"-w": {false, actionNone}, "--web": {false, actionNone},
+	"--yes": {false, actionNone},
+})
+
+// mergeFlags returns a new table containing every entry from tables, later
+// tables winning on key collision. Used to layer universalFlags underneath
+// each command-specific table without mutating the shared base map.
+func mergeFlags(tables ...map[string]flagSpec) map[string]flagSpec {
+	out := make(map[string]flagSpec)
+	for _, t := range tables {
+		for k, v := range t {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// flagTableFor returns the flag table to parse a command+sub's args
+// against. Commands with no dedicated table (every kindRead command, every
+// hard-denied command, and everything not in the allowlist at all) fall
+// back to universalFlags: read commands only need -R and the two label
+// flags recognized correctly (Classify's checks for those are unconditional
+// — see below), and misparsing anything else on a read command at worst
+// pollutes the positional list, which kindRead never inspects.
+func flagTableFor(command, sub string) map[string]flagSpec {
+	switch {
+	case command == "api" && sub == "":
+		return apiFlags
+	case command == "pr" && sub == "create":
+		return prCreateFlags
+	case command == "issue" && sub == "comment":
+		return commentFlags
+	case command == "pr" && sub == "comment":
+		return commentFlags
+	default:
+		return universalFlags
+	}
+}
+
+// isStrictCommand reports whether unresolved flags (unknown, or missing a
+// required value) should fail Classify closed. This is true for `gh api`
+// and every kindOwnArtifact command: gh itself rejects unknown flags for
+// these, so no legitimate call is ever lost, and a newly added gh flag this
+// table doesn't yet know about stays denied until it's added — a deliberate
+// safety bias (see task D1). kindRead commands stay lenient: they were
+// already unconditionally allowed once the -R check passes, so there is no
+// allow/deny decision left for an unresolved flag to corrupt.
+func isStrictCommand(command, sub string) bool {
+	switch {
+	case command == "api" && sub == "":
+		return true
+	case command == "pr" && sub == "create":
+		return true
+	case command == "issue" && sub == "comment":
+		return true
+	case command == "pr" && sub == "comment":
+		return true
+	}
+	return false
+}
+
+// parsedArgs is the result of a single, pflag-faithful pass over `gh` argv.
 // It is never a full re-implementation of gh's flag grammar — only what
-// Classify needs to decide.
+// Classify needs to decide, but the WALK itself (attached shorthand values,
+// `=` forms, boolean bundling, last-occurrence-wins, `--` termination)
+// mirrors pflag's parseSingleShortArg/parseLongArg exactly, because that is
+// what determines the effective method/body gh derives from the same argv.
 type parsedArgs struct {
 	command        string
 	sub            string
@@ -222,15 +363,50 @@ type parsedArgs struct {
 	repo           string
 	repoGiven      bool
 	method         string
-	hasDataFlag    bool
+	hasFieldFlag   bool // -f/-F (raw-field/field): a body unless method is explicitly GET
+	hasInputFlag   bool // --input: a body ALWAYS, immune to the explicit-GET relaxation
 	hasAddLabel    bool
 	hasRemoveLabel bool
 	head           string
 	headGiven      bool
+	// parseIssue is non-empty when an unrecognized flag or a value flag
+	// missing its value was encountered. Classify enforces it (denies) for
+	// strict commands and ignores it for lenient (kindRead) ones. Only the
+	// first issue in the argv is recorded, since one is enough to deny.
+	parseIssue string
+}
+
+// applyFlag records the policy-relevant effect of one recognized flag
+// occurrence. Scalars (method, repo, head) are last-occurrence-wins by
+// simply overwriting; the flag-presence booleans (field/input/label) only
+// ever go true, never back to false, matching pflag's own semantics (there
+// is no "unset" form of any of these on the real gh commands).
+func applyFlag(p *parsedArgs, action flagAction, val string) {
+	switch action {
+	case actionSetMethod:
+		p.method = val
+	case actionSetRepo:
+		p.repo = val
+		p.repoGiven = true
+	case actionSetHead:
+		p.head = val
+		p.headGiven = true
+	case actionField:
+		p.hasFieldFlag = true
+	case actionInput:
+		p.hasInputFlag = true
+	case actionAddLabel:
+		p.hasAddLabel = true
+	case actionRemoveLabel:
+		p.hasRemoveLabel = true
+	}
 }
 
 // parseArgs scans gh's argv (excluding the "gh" program name itself) into a
-// parsedArgs. It never invokes a shell — this is a plain argv walk.
+// parsedArgs. It never invokes a shell — this is a plain argv walk — and it
+// never guesses at a command's grammar: the flag table for (command, sub)
+// is selected once via flagTableFor, then every flag occurrence is resolved
+// against exactly that table, mirroring gh's own per-command pflag.FlagSet.
 func parseArgs(args []string) parsedArgs {
 	var p parsedArgs
 	if len(args) == 0 {
@@ -242,61 +418,105 @@ func parseArgs(args []string) parsedArgs {
 		p.sub = args[i]
 		i++
 	}
-	for ; i < len(args); i++ {
+
+	table := flagTableFor(p.command, p.sub)
+	strict := isStrictCommand(p.command, p.sub)
+	positionalOnly := false
+
+	for i < len(args) {
 		tok := args[i]
-		if !strings.HasPrefix(tok, "-") {
+
+		if positionalOnly || tok == "-" || !strings.HasPrefix(tok, "-") {
 			p.positional = append(p.positional, tok)
+			i++
 			continue
 		}
-		name := tok
-		val := ""
-		hasVal := false
-		if eq := strings.Index(tok, "="); eq >= 0 {
-			name = tok[:eq]
-			val = tok[eq+1:]
-			hasVal = true
+		if tok == "--" {
+			positionalOnly = true
+			i++
+			continue
 		}
-		switch name {
-		case "-R", "--repo":
-			if !hasVal && i+1 < len(args) {
-				i++
-				val = args[i]
+
+		if strings.HasPrefix(tok, "--") {
+			// Long flag: --name or --name=value.
+			name, val, hasVal := tok, "", false
+			if eq := strings.Index(tok, "="); eq >= 0 {
+				name, val, hasVal = tok[:eq], tok[eq+1:], true
 			}
-			p.repo = val
-			p.repoGiven = true
-		case "-X", "--method":
-			if !hasVal && i+1 < len(args) {
+			spec, ok := table[name]
+			if !ok {
+				if strict && p.parseIssue == "" {
+					p.parseIssue = fmt.Sprintf("unrecognized flag %s", name)
+				}
 				i++
-				val = args[i]
+				continue
 			}
-			p.method = val
-		case "-f", "--raw-field", "-F", "--field", "--input":
-			p.hasDataFlag = true
-			if !hasVal && i+1 < len(args) {
-				i++
+			if spec.takesValue {
+				if !hasVal {
+					if i+1 >= len(args) {
+						if strict && p.parseIssue == "" {
+							p.parseIssue = fmt.Sprintf("flag %s requires a value", name)
+						}
+						i++
+						continue
+					}
+					i++
+					val = args[i]
+				}
 			}
-		case "--add-label":
-			p.hasAddLabel = true
-			if !hasVal && i+1 < len(args) {
-				i++
-			}
-		case "--remove-label":
-			p.hasRemoveLabel = true
-			if !hasVal && i+1 < len(args) {
-				i++
-			}
-		case "--head":
-			if !hasVal && i+1 < len(args) {
-				i++
-				val = args[i]
-			}
-			p.head = val
-			p.headGiven = true
-		default:
-			if valueFlags[name] && !hasVal && i+1 < len(args) {
-				i++
-			}
+			applyFlag(&p, spec.action, val)
+			i++
+			continue
 		}
+
+		// Shorthand cluster: -abc... Walk left to right, mirroring
+		// pflag's parseSingleShortArg. A boolean flag records itself and
+		// the walk continues into the next character; a value-taking
+		// flag consumes the REST of this token as its value (after
+		// stripping a leading '='), or — if nothing is left — the next
+		// argv token, and ends the cluster either way.
+		chars := tok[1:]
+		for j := 0; j < len(chars); j++ {
+			name := "-" + string(chars[j])
+			spec, ok := table[name]
+			if !ok {
+				if strict && p.parseIssue == "" {
+					p.parseIssue = fmt.Sprintf("unrecognized flag %s", name)
+				}
+				break
+			}
+			if !spec.takesValue {
+				applyFlag(&p, spec.action, "")
+				continue
+			}
+			rest := chars[j+1:]
+			var val string
+			missingValue := false
+			switch {
+			case strings.HasPrefix(rest, "="):
+				val = rest[1:]
+			case rest != "":
+				val = rest
+			default:
+				if i+1 >= len(args) {
+					if strict && p.parseIssue == "" {
+						p.parseIssue = fmt.Sprintf("flag %s requires a value", name)
+					}
+					missingValue = true
+				} else {
+					i++
+					val = args[i]
+				}
+			}
+			// missingValue: a switch's break only exits the switch, not
+			// this for loop, so guard applyFlag explicitly rather than
+			// relying on break to skip it.
+			if !missingValue {
+				applyFlag(&p, spec.action, val)
+			}
+			break
+		}
+		i++
 	}
 	return p
 }
@@ -372,6 +592,15 @@ func Classify(id Identity, args []string) Decision {
 		if r.command != p.command || r.sub != p.sub {
 			continue
 		}
+		// Fail closed on an unrecognized/malformed flag for api and every
+		// kindOwnArtifact command (see isStrictCommand) — gh itself would
+		// reject the flag or the call, so no legitimate invocation is lost,
+		// and a gh flag this table doesn't know about yet stays denied
+		// until it's added rather than silently bypassing the checks below
+		// that depend on having parsed every flag correctly.
+		if p.parseIssue != "" && (r.kind == kindAPIRead || r.kind == kindOwnArtifact) {
+			return deny(fmt.Sprintf("gh %s: %s — cannot verify this call is a read/own-artifact op", strings.TrimSpace(p.command+" "+p.sub), p.parseIssue), allowedSummary())
+		}
 		switch r.kind {
 		case kindRead:
 			return Decision{Verdict: VerdictAllow, Reason: "read-only command"}
@@ -385,17 +614,28 @@ func Classify(id Identity, args []string) Decision {
 	return deny(fmt.Sprintf("gh %s is not in the allowed command set for Pilot executor sessions", strings.TrimSpace(p.command+" "+p.sub)), allowedSummary())
 }
 
-// checkAPIRead allows `gh api` only when it is unambiguously a GET: no
-// explicit non-GET -X/--method, and no data-carrying flag. -f/-F/--input
-// imply a mutation even when -X is left at its GET default (gh
-// auto-switches to POST when data flags are present) — treating their mere
-// presence as non-GET is stricter than the letter of "gh api non-GET" but
-// closes that implicit-mutation gap deliberately.
+// checkAPIRead allows `gh api` only when it is unambiguously a GET.
+//
+// --input is a request body ALWAYS — gh will send it even alongside an
+// explicit -X GET (confirmed live: `-X GET --input file.json` still ships
+// the file as the request body) — so it is denied regardless of method,
+// with no relaxation.
+//
+// -f/-F (raw-field/field) are a body UNLESS the method is explicitly GET:
+// gh auto-switches an unset method to POST when either is present, but with
+// an explicit `-X GET`/`--method GET`, their values are appended to the
+// query string instead (confirmed live, including case-insensitively —
+// `--method get` behaves identically to `--method GET`) — this is the
+// relaxation from #4877/#4905, now keyed off the split hasFieldFlag so it
+// can never be satisfied by an --input body.
 func checkAPIRead(p parsedArgs) Decision {
-	if p.hasDataFlag {
-		return deny("gh api with -f/-F/--field/--raw-field/--input carries a request body and is treated as a mutation", allowedSummary())
+	if p.hasInputFlag {
+		return deny("gh api --input always sends a request body and is treated as a mutation", allowedSummary())
 	}
 	method := strings.ToUpper(strings.TrimSpace(p.method))
+	if p.hasFieldFlag && method != "GET" {
+		return deny("gh api with -f/-F/--field/--raw-field carries a request body unless an explicit GET method is set (add -X GET, or use --jq/query params) and is treated as a mutation", allowedSummary())
+	}
 	if method != "" && method != "GET" {
 		return deny(fmt.Sprintf("gh api -X %s is not a read", p.method), allowedSummary())
 	}

--- a/internal/executor/ghguard/policy_test.go
+++ b/internal/executor/ghguard/policy_test.go
@@ -99,6 +99,82 @@ func TestClassify(t *testing.T) {
 		{"gist create", []string{"gist", "create", "file.txt"}, VerdictDeny},
 		{"empty argv", []string{}, VerdictDeny},
 		{"issue comment missing target", []string{"issue", "comment", "--body", "hi"}, VerdictDeny},
+
+		// --- parser parity (pflag shapes) ---
+		// GH-4963: gh uses pflag, which accepts attached shorthand
+		// (-XPOST == -X POST), `=` form, boolean bundling, and
+		// last-occurrence-wins for scalars. Rows below are drawn from the
+		// issue's confirmed parity gaps (G1-G11), each verified live
+		// against the installed `gh` binary (via --hostname pointed at a
+		// non-routable host + --verbose, so no request ever reaches
+		// GitHub) rather than taken on faith from the issue text.
+		{"api attached -XPOST", []string{"api", "repos/o/r/issues", "-XPOST"}, VerdictDeny},       // G1
+		{"api attached -XDELETE", []string{"api", "repos/o/r/issues/1", "-XDELETE"}, VerdictDeny}, // G2
+		{"api attached -XGET is a read", []string{"api", "repos/o/r/issues/1", "-XGET"}, VerdictAllow},
+		{"api eq short -X=POST", []string{"api", "x", "-X=POST"}, VerdictDeny},                           // regression
+		{"api long eq --method=PATCH", []string{"api", "x", "--method=PATCH"}, VerdictDeny},              // regression
+		{"api attached raw-field", []string{"api", "repos/o/r/issues/1", "-fstate=closed"}, VerdictDeny}, // G3
+		{"api attached typed field", []string{"api", "graphql", "-Fquery=mutation"}, VerdictDeny},        // G4
+		{"api eq short field", []string{"api", "graphql", "-F=query=x"}, VerdictDeny},
+
+		// -p/--preview take a VALUE (opt into API previews) — they are not
+		// a paginate shorthand; --paginate itself has no short form. This
+		// was checked live: `gh api ... -pXDELETE` sends a plain GET with
+		// a garbage preview header, never a DELETE. The bundling/attached-
+		// value/doesn't-swallow-the-next-flag mechanics the issue's G5-G7
+		// rows were probing are exercised below with -i/--include instead,
+		// gh's actual boolean short flag on `api`.
+		{"api bundled bool then value (-i include, -X method)", []string{"api", "repos/o/r/x", "-iX", "POST"}, VerdictDeny},
+		{"api bundled attached bool+value", []string{"api", "repos/o/r/x", "-iXPOST"}, VerdictDeny},
+		{"api -i is boolean, does not swallow -X", []string{"api", "repos/o/r/x", "-i", "-X", "POST"}, VerdictDeny},
+		{"api paginate GET stays a read", []string{"api", "repos/o/r/x", "--paginate"}, VerdictAllow},
+		{"api include bool GET stays a read", []string{"api", "repos/o/r/x", "-i"}, VerdictAllow},
+		{"api attached preview value stays a read", []string{"api", "repos/o/r/x", "-pXDELETE"}, VerdictAllow}, // -p swallows "XDELETE" as its own value, not -X/DELETE
+		{"api benign value flags", []string{"api", "x", "--cache", "3600s", "-H", "Accept: a", "-q", ".items", "-t", "{{.}}"}, VerdictAllow},
+		{"api attached header stays a read", []string{"api", "x", "-HAccept: a"}, VerdictAllow},
+
+		// repeated flags — last occurrence wins
+		{"api repeated -X last POST attached", []string{"api", "x", "-X", "GET", "-XPOST"}, VerdictDeny}, // G8
+		{"api repeated -X last GET", []string{"api", "x", "-X", "POST", "-X", "GET"}, VerdictAllow},      // regression
+
+		// attached -R
+		{"issue view attached -R matching", []string{"issue", "view", "1", "-Rqf-studio/pilot"}, VerdictAllow},
+		{"issue view attached -R wrong repo", []string{"issue", "view", "1", "-Rqf-studio/upstream"}, VerdictDeny},                  // G9
+		{"issue comment attached -R cross-repo", []string{"issue", "comment", "4671", "-Rother/repo", "--body", "hi"}, VerdictDeny}, // G10
+
+		// pr create -f is --fill (boolean), not a value flag
+		{"pr create fill does not swallow --head", []string{"pr", "create", "-f", "--head", "other-branch"}, VerdictDeny}, // G11
+		{"pr create fill with own head", []string{"pr", "create", "-f", "--head", "pilot/GH-4671"}, VerdictAllow},
+		{"pr create fill with own head via -H", []string{"pr", "create", "-f", "-H", "pilot/GH-4671"}, VerdictAllow},
+
+		// -- terminates flag parsing
+		{"pr create -- then --head is positional not a flag", []string{"pr", "create", "--head", "pilot/GH-4671", "--", "--head"}, VerdictAllow},
+
+		// fail-closed on unverifiable api/own-artifact flags
+		{"api unknown flag fails closed", []string{"api", "x", "--not-a-real-flag", "v"}, VerdictDeny},
+		{"api dangling -X at end of argv", []string{"api", "x", "-X"}, VerdictDeny},
+		{"pr create unknown flag fails closed", []string{"pr", "create", "--not-a-real-flag", "v"}, VerdictDeny},
+		{"issue comment unknown flag fails closed", []string{"issue", "comment", "4671", "--not-a-real-flag", "v"}, VerdictDeny},
+		// kindRead commands stay lenient on unknown flags — never denied for
+		// this reason alone (repo mismatch / hard-deny checks still apply).
+		{"issue view unknown flag stays lenient", []string{"issue", "view", "1", "--not-a-real-flag", "v"}, VerdictAllow},
+
+		// --- explicit-GET query fields (#4905) ---
+		// All three verified live: gh sends a plain GET with the -f value
+		// appended to the query string, including with a lowercase
+		// "--method get" (gh's method compare is case-insensitive).
+		{"api search -f with explicit -X GET", []string{"api", "search/issues", "-X", "GET", "-f", "q=x in:body"}, VerdictAllow},
+		{"api search -f with --method get", []string{"api", "search/issues", "--method", "get", "-f", "q=x"}, VerdictAllow},
+		{"api search -f with attached -XGET", []string{"api", "search/issues", "-XGET", "-f", "q=x"}, VerdictAllow},
+		{"api field without method still denies", []string{"api", "repos/o/r/issues/1", "-f", "state=closed"}, VerdictDeny}, // regression
+		{"api field with -X GET then -X POST", []string{"api", "x", "-X", "GET", "-f", "a=b", "-X", "POST"}, VerdictDeny},
+
+		// --input is a body ALWAYS — immune to the relaxation. Verified
+		// live: `-X GET --input file.json` still ships the file as the
+		// request body.
+		{"api --input with explicit GET", []string{"api", "x", "-X", "GET", "--input", "p.json"}, VerdictDeny},
+		{"api --input=file", []string{"api", "x", "--input=p.json"}, VerdictDeny}, // regression
+		{"api --input from stdin", []string{"api", "x", "--input", "-"}, VerdictDeny},
 	}
 
 	for _, tt := range tests {
@@ -188,6 +264,74 @@ func TestParseArgs_FlagAliases(t *testing.T) {
 	p = parseArgs([]string{"api", "x", "-X", "DELETE"})
 	if p.method != "DELETE" {
 		t.Errorf("-X short flag not parsed: %+v", p)
+	}
+}
+
+// TestParseArgs_PflagShapes asserts the derived parsedArgs fields
+// (method/hasFieldFlag/hasInputFlag/repo/head) directly for the pflag
+// shapes GH-4963 closes parity gaps on — attached shorthand, `=` forms,
+// boolean bundling, and last-occurrence-wins — independent of the
+// resulting Classify verdict (covered separately in TestClassify).
+func TestParseArgs_PflagShapes(t *testing.T) {
+	p := parseArgs([]string{"api", "x", "-XPOST"})
+	if p.method != "POST" {
+		t.Errorf("attached -XPOST: method = %q, want POST: %+v", p.method, p)
+	}
+
+	p = parseArgs([]string{"api", "x", "-X=POST"})
+	if p.method != "POST" {
+		t.Errorf("-X=POST: method = %q, want POST: %+v", p.method, p)
+	}
+
+	p = parseArgs([]string{"api", "x", "-fstate=closed"})
+	if !p.hasFieldFlag {
+		t.Errorf("attached -fstate=closed: hasFieldFlag = false, want true: %+v", p)
+	}
+
+	p = parseArgs([]string{"api", "x", "--input=payload.json"})
+	if !p.hasInputFlag || p.hasFieldFlag {
+		t.Errorf("--input=payload.json: hasInputFlag=%v hasFieldFlag=%v, want true/false: %+v", p.hasInputFlag, p.hasFieldFlag, p)
+	}
+
+	// Last occurrence wins for the method scalar.
+	p = parseArgs([]string{"api", "x", "-X", "GET", "-XPOST"})
+	if p.method != "POST" {
+		t.Errorf("repeated -X: method = %q, want POST (last wins): %+v", p.method, p)
+	}
+
+	// Boolean bundling: -i (include) doesn't swallow -X's value.
+	p = parseArgs([]string{"api", "x", "-iX", "POST"})
+	if p.method != "POST" {
+		t.Errorf("bundled -iX POST: method = %q, want POST: %+v", p.method, p)
+	}
+
+	// Attached -R on a command outside `api`.
+	p = parseArgs([]string{"issue", "view", "1", "-Rqf-studio/pilot"})
+	if !p.repoGiven || p.repo != "qf-studio/pilot" {
+		t.Errorf("attached -R: repoGiven=%v repo=%q: %+v", p.repoGiven, p.repo, p)
+	}
+
+	// pr create: -f is boolean --fill, does not consume --head's value.
+	p = parseArgs([]string{"pr", "create", "-f", "--head", "other-branch"})
+	if !p.headGiven || p.head != "other-branch" {
+		t.Errorf("pr create -f --head: headGiven=%v head=%q, want true/other-branch: %+v", p.headGiven, p.head, p)
+	}
+
+	// -- terminates flag parsing: a literal "--head" after -- is positional.
+	p = parseArgs([]string{"pr", "create", "--head", "keep-me", "--", "--head"})
+	if p.head != "keep-me" || len(p.positional) != 1 || p.positional[0] != "--head" {
+		t.Errorf("-- termination: head=%q positional=%v, want keep-me/[--head]: %+v", p.head, p.positional, p)
+	}
+
+	// Unknown flag on a strict command sets parseIssue; on a lenient
+	// (kindRead) command it does not.
+	p = parseArgs([]string{"api", "x", "--not-a-real-flag", "v"})
+	if p.parseIssue == "" {
+		t.Errorf("api unknown flag: parseIssue empty, want non-empty: %+v", p)
+	}
+	p = parseArgs([]string{"issue", "view", "1", "--not-a-real-flag", "v"})
+	if p.parseIssue != "" {
+		t.Errorf("issue view unknown flag: parseIssue = %q, want empty (lenient): %+v", p.parseIssue, p)
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4963.

Closes #4963

## Changes

GitHub Issue GH-4963: fix(ghguard): pflag-faithful per-command parser — close the 11 read/mutation parity gaps

no-decompose

Single coherent change in one subsystem (`internal/executor/ghguard/`) — do NOT decompose; one PR.

## Problem

`internal/executor/ghguard/` inspects `gh` command lines our autonomous executor is about to run and classifies each as read (allow) or mutation (deny). Correctness depends entirely on our `parseArgs` deriving the **same effective HTTP method and body-presence** that the real `gh` binary derives from the same argv. Where the two disagree, the guard is simply wrong.

`gh` uses pflag. Our parser models only space-separated flag values, one global flag table, and no bundling. pflag additionally accepts attached shorthand (`-XPOST` ≡ `-X POST`), `=` form (`-X=POST`), boolean bundles (`-piX POST`), last-occurrence-wins for scalars, and `--` termination — and `gh`'s flag grammar is **per-command** (`-f`, `-F`, `-p`, `-t`, `-s` mean different things under `api` vs `pr create` vs `issue comment`).

## Confirmed parity gaps (probed against main)

| # | argv | our parse | gh derives | today | correct |
|---|---|---|---|---|---|
| G1 | `api X -XPOST` | method="" | POST | allow | deny |
| G2 | `api X -XDELETE` | method="" | DELETE | allow | deny |
| G3 | `api X -fstate=closed` | hasData=false | POST+body | allow | deny |
| G4 | `api graphql -Fquery=x` | hasData=false | POST | allow | deny |
| G5 | `api X -pX DELETE` | method="" | DELETE | allow | deny |
| G6 | `api X -pXDELETE` | method="" | DELETE | allow | deny |
| G7 | `api X -p -X POST` | `-p` swallows `-X` | POST | allow | deny |
| G8 | `api X -X GET -XPOST` | GET | POST (last wins) | allow | deny |
| G9 | `issue view 1 -Rother/repo` | repoGiven=false | other repo | allow | deny |
| G10 | `issue comment N -Rother/repo --body x` | repoGiven=false | comments other repo | allow | deny |
| G11 | `pr create -f --head other-branch` | `-f` swallows `--head` | head=other-branch | allow | deny |

G12–G17 are already-correct or benign-false-deny shapes; keep them as regression rows (`-X=POST`, `--method=PATCH`, `--input` variants, `--` terminator, interspersed flags, `--cache`/`--preview`).

Root causes: (a) no attached-shorthand splitting (`policy.go:251-258` + the ignore-unknown-as-boolean default at `295-299`); (b) one global `valueFlags` table (`policy.go:185-213`) where gh's grammar is per-command; (c) no boolean-bundle handling; (d) no `--` handling.

## Current structure (policy.go, 579 lines)

`allowRules` :134-148 · `hardDenyCommands`/`hardDenyIssueSubs` :153-173 · `valueFlags` :185-213 · `parsedArgs` :218-230 · `parseArgs` :234-302 (sub extraction :241-244, `=` split :254-258, method :267-272, data flags :273-277, ignore-unknown :295-299) · `Classify` :348-386 · `checkAPIRead` :394-403 · `checkOwnArtifact` :407-446.

Enforcement path (sole `Classify` call site): shim `gh` → `pilot gh-guard -- <argv>` → `runGhGuard` (`cmd/pilot/ghguard.go:67-118`, Classify at :74). Deny ⇒ journal JSONL + stderr + exit 1, real `gh` never exec'd (fail-closed). Shim wiring `internal/executor/ghguard_spawn.go:39-97`; denial audit `internal/executor/ghguard_audit.go:26-73`.

## Fix

Replace the global `valueFlags` with per-command flag specs:

```go
type flagSpec struct {
    takesValue bool
    isBody     bool // -f/-F fields — body unless method is explicitly GET
    isInput    bool // --input — body ALWAYS
    // semantic sinks: setMethod, setRepo, setHead, ...
}
// apiFlags (complete), prCreateFlags, issueCommentFlags, prCommentFlags, listFlags…
```

Parse loop replacing `policy.go:245-300`, mirroring pflag's `parseSingleShortArg`:

1. Bare `--` ⇒ rest is positional, stop flag parsing.
2. Long `--name[=v]`: split at first `=`; if takesValue and no `=`, consume next token (missing ⇒ `parseErr`). Scalars last-wins; body/input flags OR-accumulate.
3. Shorthand `-abc…`: walk chars left to right. Value-taking ⇒ value is `chars[1:]` minus a leading `=` if present (`-X=POST`, `-XPOST`), else the next argv token (missing ⇒ `parseErr`); stop this token. Boolean ⇒ record and continue the bundle. Unknown ⇒ `unknownFlag`, stop.
4. Method: store raw, last-wins; keep `ToUpper` normalization in `checkAPIRead`.
5. **Split `hasDataFlag` into `hasFieldFlag` (`-f`/`-F`) and `hasInputFlag` (`--input`).** Required for a sound #4905.
6. Fail closed on `unknownFlag`/`parseErr` for `api` and all `kindOwnArtifact` commands (gh itself rejects unknown flags, so no legitimate call is lost; a new gh flag stays denied until table-added — documented safety bias). `kindRead` commands may stay lenient.

New `checkAPIRead`:

```go
if p.hasInputFlag { deny("--input always sends a request body") }        // regardless of method
method := strings.ToUpper(strings.TrimSpace(p.method))
if p.hasFieldFlag && method != "GET" { deny("… add -X GET or URL-encode …") }
if method != "" && method != "GET" { deny(...) }
allow
```

## Relationship to PR #4905

The relaxation's premise is correct: gh auto-switches to POST only when `--method` was **not** passed; with explicit GET, `-f`/`-F` values go to the query string. Keep it — it fixes the #4877 false-deny. Two amendments: it keys off the merged `hasDataFlag`, so `gh api x -X GET --input p.json` would flip deny→allow (`--input` is always a body); and its full value only lands once method derivation is trustworthy. On the broken parser the relaxation fails *safe* (an unseen `-XGET` just means the data-flag deny fires), so merge order is flexible.

## Test rows

`policy_test.go` conventions: anonymous struct `{name string; args []string; wantVerdict Verdict}` in `TestClassify` (:21-25, :104-119); every deny must carry non-empty `Reason` and `Allowed` (already asserted). Add sections `// --- parser parity (pflag shapes) ---` and `// --- explicit-GET query fields (#4905) ---`, plus derived-value assertions in `TestParseArgs_FlagAliases` style for `method`/`hasFieldFlag`/`repo`/`head` on attached forms.

```go
// attached shorthand values
{"api attached -XPOST", []string{"api","repos/o/r/issues","-XPOST"}, VerdictDeny},
{"api attached -XDELETE", []string{"api","repos/o/r/issues/1","-XDELETE"}, VerdictDeny},
{"api attached -XGET is a read", []string{"api","repos/o/r/issues/1","-XGET"}, VerdictAllow},
{"api eq short -X=POST", []string{"api","x","-X=POST"}, VerdictDeny},              // regression
{"api long eq --method=PATCH", []string{"api","x","--method=PATCH"}, VerdictDeny}, // regression
{"api attached raw-field", []string{"api","repos/o/r/issues/1","-fstate=closed"}, VerdictDeny},
{"api attached typed field", []string{"api","graphql","-Fquery=mutation"}, VerdictDeny},
{"api eq short field", []string{"api","graphql","-F=query=x"}, VerdictDeny},

// bundles + context-sensitive shorthands
{"api bundled bool then value", []string{"api","repos/o/r/x","-pX","DELETE"}, VerdictDeny},
{"api bundled attached", []string{"api","repos/o/r/x","-pXDELETE"}, VerdictDeny},
{"api -p is boolean, does not swallow -X", []string{"api","repos/o/r/x","-p","-X","POST"}, VerdictDeny},
{"api paginate GET stays a read", []string{"api","repos/o/r/x","-p"}, VerdictAllow},
{"api benign value flags", []string{"api","x","--cache","3600s","-H","Accept: a","-q",".items","-t","{{.}}"}, VerdictAllow},
{"api attached header stays a read", []string{"api","x","-HAccept: a"}, VerdictAllow},

// repeated flags — last occurrence wins
{"api repeated -X last POST attached", []string{"api","x","-X","GET","-XPOST"}, VerdictDeny},
{"api repeated -X last GET", []string{"api","x","-X","POST","-X","GET"}, VerdictAllow}, // regression

// attached -R
{"issue view attached -R matching", []string{"issue","view","1","-Rqf-studio/pilot"}, VerdictAllow},
{"issue view attached -R wrong repo", []string{"issue","view","1","-Rqf-studio/upstream"}, VerdictDeny},
{"issue comment attached -R cross-repo", []string{"issue","comment","4671","-Rother/repo","--body","hi"}, VerdictDeny},

// pr create -f is --fill (boolean), not a value flag
{"pr create fill does not swallow --head", []string{"pr","create","-f","--head","other-branch"}, VerdictDeny},
{"pr create fill with own head", []string{"pr","create","-f","--head","pilot/GH-4671"}, VerdictAllow},

// fail-closed on unverifiable api flags
{"api unknown flag fails closed", []string{"api","x","--not-a-real-flag","v"}, VerdictDeny},
{"api dangling -X at end of argv", []string{"api","x","-X"}, VerdictDeny},

// explicit-GET query fields (#4905), on top of the faithful parser
{"api search -f with explicit -X GET", []string{"api","search/issues","-X","GET","-f","q=x in:body"}, VerdictAllow},
{"api search -f with --method get", []string{"api","search/issues","--method","get","-f","q=x"}, VerdictAllow},
{"api search -f with attached -XGET", []string{"api","search/issues","-XGET","-f","q=x"}, VerdictAllow},
{"api field without method still denies", []string{"api","repos/o/r/issues/1","-f","state=closed"}, VerdictDeny}, // regression
{"api field with -X GET then -X POST", []string{"api","x","-X","GET","-f","a=b","-X","POST"}, VerdictDeny},

// --input is a body ALWAYS — immune to the relaxation
{"api --input with explicit GET", []string{"api","x","-X","GET","--input","p.json"}, VerdictDeny},
{"api --input=file", []string{"api","x","--input=p.json"}, VerdictDeny},  // regression
{"api --input from stdin", []string{"api","x","--input","-"}, VerdictDeny},
```

## Open decisions

- **D1** Unknown-flag policy for `api`/own-artifact — recommend fail-closed (deny). Cost: new gh flags need a table line.
- **D2** Deny `api graphql` with field flags regardless of method (belt-and-braces; today GitHub doesn't execute GraphQL over GET, but that's their behavior, not our contract). Recommend adding.
- **D3** Flags-before-subcommand (G15) is a false-deny only; fixing needs known-value-flag consumption while scanning for the sub. Low priority.
- **D4** Verify gh's GET comparison is `EqualFold` against vendored source when implementing (our `ToUpper` assumes it).
- **D5** **Separate issue**: the guard never inspects `GH_REPO`/`GH_HOST` env — `GH_REPO=other/repo gh issue comment N --body x` bypasses the repo check exactly like G10, and no argv fix covers it. `runGhGuard` sees the env and could check/scrub it.

## Refs

- External PR: #4905 (amend or follow immediately to exclude `--input`)
- Related issue: #4877 (the false-deny that motivated #4905)
- Prior art: GH-4649 (the mutation class the guard exists to stop)


## Context

Source plan: `.agent/tasks/TASK-479-ghguard-parser-parity.md` (research validated by empirical probe on main, 2026-08-17). Open decision D5 (GH_REPO/GH_HOST env bypass) is filed as its own issue — do not fold it into this PR.