### PR TITLE
fix(executor): dedicated no_op decline signal — never infer decline from mandatory exit signal

### DIFF
--- a/internal/comms/handler.go
+++ b/internal/comms/handler.go
@@ -869,6 +869,25 @@ func (h *Handler) executeTaskCore(ctx context.Context, contextID, threadID, task
 	}
 
 	output := CleanInternalSignals(result.Output)
+	h.sendTaskResult(ctx, contextID, threadID, taskID, result, output)
+}
+
+// sendTaskResult renders a finished ExecutionResult to chat. A declined task
+// (GH-4964: DECLINED marker or explicit no_op+reason exit signal — never the
+// bare mandatory exit signal) is not a failure and must not render as ❌ via
+// SendResult's success=false path; it gets its own "no changes needed"
+// message via SendChunked, which — unlike SendText — carries threadID so
+// Slack replies land in the originating thread (ThreadTS) instead of the
+// channel root; Telegram/Discord ignore threadID harmlessly.
+func (h *Handler) sendTaskResult(ctx context.Context, contextID, threadID, taskID string, result *executor.ExecutionResult, output string) {
+	if result.Declined {
+		reason := result.DeclinedReason
+		if reason == "" {
+			reason = "no reason provided"
+		}
+		_ = h.messenger.SendChunked(ctx, contextID, threadID, fmt.Sprintf("⏸ No changes needed: %s", reason), "")
+		return
+	}
 	_ = h.messenger.SendResult(ctx, contextID, threadID, taskID, result.Success, output, result.PRUrl)
 }
 

--- a/internal/comms/handler_test.go
+++ b/internal/comms/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/qf-studio/pilot/internal/executor"
 	"github.com/qf-studio/pilot/internal/intent"
 	"github.com/qf-studio/pilot/internal/memory"
 )
@@ -1192,5 +1193,91 @@ func TestHandleMessage_VoiceTextFallback(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("VoiceText not routed through greeting intent via Responder; got texts: %v", texts)
+	}
+}
+
+// TestSendTaskResult_Declined verifies GH-4964's comms contract: a declined
+// ExecutionResult renders via SendChunked (which carries threadID, so Slack
+// replies land in the originating thread) rather than SendResult's ❌ path —
+// a decline is not a failure and must not render as one.
+func TestSendTaskResult_Declined(t *testing.T) {
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	result := &executor.ExecutionResult{
+		Success:        false,
+		Declined:       true,
+		DeclinedReason: "requirement already satisfied — no code change needed",
+	}
+
+	h.sendTaskResult(context.Background(), "ch1", "thread-42", "TEST-1", result, "")
+
+	if len(m.results) != 0 {
+		t.Errorf("expected no SendResult calls for a declined result, got %d", len(m.results))
+	}
+	if len(m.texts) != 0 {
+		t.Errorf("expected no SendText calls for a declined result, got %d", len(m.texts))
+	}
+	if len(m.chunks) != 1 {
+		t.Fatalf("expected exactly 1 SendChunked call, got %d", len(m.chunks))
+	}
+	chunk := m.chunks[0]
+	if chunk.contextID != "ch1" {
+		t.Errorf("expected contextID ch1, got %q", chunk.contextID)
+	}
+	if chunk.threadID != "thread-42" {
+		t.Errorf("expected threadID thread-42 to be preserved, got %q", chunk.threadID)
+	}
+	if !strings.Contains(chunk.content, "requirement already satisfied — no code change needed") {
+		t.Errorf("expected chunk content to contain decline reason, got %q", chunk.content)
+	}
+}
+
+// TestSendTaskResult_DeclinedEmptyReason verifies the fallback text when a
+// declined result somehow carries no reason string (defense in depth — the
+// runner always sets one via finishDeclined, but the comms layer should not
+// render an empty message if that invariant is ever violated).
+func TestSendTaskResult_DeclinedEmptyReason(t *testing.T) {
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	result := &executor.ExecutionResult{
+		Success:  false,
+		Declined: true,
+	}
+
+	h.sendTaskResult(context.Background(), "ch1", "thread-42", "TEST-1", result, "")
+
+	if len(m.chunks) != 1 {
+		t.Fatalf("expected exactly 1 SendChunked call, got %d", len(m.chunks))
+	}
+	if !strings.Contains(m.chunks[0].content, "no reason provided") {
+		t.Errorf("expected fallback reason text, got %q", m.chunks[0].content)
+	}
+}
+
+// TestSendTaskResult_NotDeclined verifies the non-declined path is
+// unaffected: a normal success/failure result still renders via SendResult,
+// not SendChunked.
+func TestSendTaskResult_NotDeclined(t *testing.T) {
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	result := &executor.ExecutionResult{
+		Success: true,
+		PRUrl:   "https://github.com/qf-studio/pilot/pull/123",
+	}
+
+	h.sendTaskResult(context.Background(), "ch1", "thread-42", "TEST-1", result, "done")
+
+	if len(m.chunks) != 0 {
+		t.Errorf("expected no SendChunked calls for a non-declined result, got %d", len(m.chunks))
+	}
+	if len(m.results) != 1 {
+		t.Fatalf("expected exactly 1 SendResult call, got %d", len(m.results))
+	}
+	res := m.results[0]
+	if !res.success || res.prURL != "https://github.com/qf-studio/pilot/pull/123" || res.output != "done" {
+		t.Errorf("unexpected SendResult contents: %+v", res)
 	}
 }

--- a/internal/executor/gh4517_test.go
+++ b/internal/executor/gh4517_test.go
@@ -235,10 +235,18 @@ func (m *mockDirtyBackend) Execute(_ context.Context, opts ExecuteOptions) (*Bac
 }
 
 // TestRunner_DirtyWorktreeAfterNoCommitRetry_AutoPreserved covers the GH-916
-// no-commit-after-retry path (runner.go, "No-commit detection and retry"):
-// when the backend leaves real, uncommitted files on disk across both the
-// initial attempt and the retry, the run must not be silently classified
-// no_op — the dirty state must be auto-committed and pushed instead.
+// no-commit path (runner.go, "No-commit detection and retry"): when the
+// backend leaves real, uncommitted files on disk after the initial attempt,
+// the run must not be silently classified no_op — the dirty state must be
+// auto-committed and pushed instead.
+//
+// GH-4964: preserveDirtyWorktreeAsWIP now runs BEFORE the no-commit retry is
+// even considered (not just after it, as before) — a dirty tree always wins
+// over spending a retry or honoring any decline evidence, since real
+// uncommitted diffs contradict any claim that nothing needed to change. So
+// the backend is called exactly once here, not twice: the retry never fires
+// because the first attempt's dirty tree is caught and preserved
+// immediately.
 func TestRunner_DirtyWorktreeAfterNoCommitRetry_AutoPreserved(t *testing.T) {
 	const branch = "pilot/GH-4517RETRY"
 	dir, bareDir := setupFreshnessRepo(t)
@@ -291,8 +299,8 @@ func TestRunner_DirtyWorktreeAfterNoCommitRetry_AutoPreserved(t *testing.T) {
 	count := backend.execCount
 	gotProjectPath := backend.gotProjectPath
 	backend.mu.Unlock()
-	if count != 2 {
-		t.Errorf("expected backend called 2 times (initial + retry), got %d", count)
+	if count != 1 {
+		t.Errorf("expected backend called exactly once — GH-4964 preserve-first ordering must skip the retry for a dirty tree, got %d", count)
 	}
 	if gotProjectPath != dir {
 		t.Errorf("backend received ProjectPath %q, want %q", gotProjectPath, dir)

--- a/internal/executor/gh4964_test.go
+++ b/internal/executor/gh4964_test.go
@@ -1,0 +1,351 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// mockGH4964Backend is a scriptable Backend for exercising GH-4964's
+// decline-vs-preserve ordering through the real Runner.Execute() path (not
+// just the free helper functions). perCall is invoked once per Execute()
+// call (1-indexed) and controls what the "model" does that attempt: which
+// files it leaves on disk, which pilot-signal it emits, and what it returns.
+type mockGH4964Backend struct {
+	mu        sync.Mutex
+	execCount int
+	perCall   func(call int, opts ExecuteOptions) *BackendResult
+}
+
+func (m *mockGH4964Backend) Name() string      { return "mock-gh4964" }
+func (m *mockGH4964Backend) IsAvailable() bool { return true }
+
+func (m *mockGH4964Backend) Execute(_ context.Context, opts ExecuteOptions) (*BackendResult, error) {
+	m.mu.Lock()
+	m.execCount++
+	call := m.execCount
+	m.mu.Unlock()
+	if m.perCall == nil {
+		return &BackendResult{Success: true}, nil
+	}
+	return m.perCall(call, opts), nil
+}
+
+func (m *mockGH4964Backend) callCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.execCount
+}
+
+// emitSignal simulates the model emitting a pilot-signal block on the
+// EventHandler, exactly as the real streaming backend would when it sees a
+// ```pilot-signal fenced block in the assistant's text output. Only the
+// initial (pre-retry) EventHandler routes text through the signal parser —
+// the GH-916 retry's EventHandler only tracks tokens/commit SHAs — so a
+// signal emitted on a retry call is intentionally inert; tests that need
+// retry-call signal handling must account for this via the runner's actual
+// wiring, not assume symmetry with the first call.
+func emitSignal(opts ExecuteOptions, jsonBody string) {
+	if opts.EventHandler != nil {
+		opts.EventHandler(BackendEvent{Type: EventTypeText, Message: "```pilot-signal\n" + jsonBody + "\n```"})
+	}
+}
+
+// emitStaleSHA simulates a tool_result event that mentions a commit SHA
+// which is, in fact, already an ancestor of the base branch — the ghost-SHA
+// scenario (GH-3126): the harvester "recovers" a SHA that turns out to be
+// stale, e.g. because the model ran `git log` rather than `git commit`.
+func emitStaleSHA(opts ExecuteOptions, sha string) {
+	if opts.EventHandler != nil {
+		opts.EventHandler(BackendEvent{Type: EventTypeToolResult, ToolResult: fmt.Sprintf("[pilot/test %s] wip: stale\n", sha)})
+	}
+}
+
+func writeUncommittedFile(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("package x\n"), 0o644); err != nil {
+		t.Fatalf("write uncommitted file: %v", err)
+	}
+}
+
+func newGH4964Task(id, branch, dir string) *Task {
+	return &Task{
+		ID:          id,
+		Title:       "fix(executor): GH-4964 test task",
+		Description: "exercise the no_op decline contract",
+		ProjectPath: dir,
+		Branch:      branch,
+		BaseBranch:  "main",
+		CreatePR:    true,
+	}
+}
+
+func newGH4964Runner(backend Backend) *Runner {
+	runner := NewRunnerWithBackend(backend)
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+	return runner
+}
+
+// TestRunner_NoOpSignal_CleanTree_Declines is the core positive case for the
+// new opt-in contract: an explicit no_op:true + reason exit signal, with a
+// genuinely clean worktree (no commits, nothing uncommitted), declines the
+// task without spending a retry.
+func TestRunner_NoOpSignal_CleanTree_Declines(t *testing.T) {
+	const branch = "pilot/GH-4964-noop-clean"
+	dir, _ := setupFreshnessRepo(t)
+	runGit(t, dir, "checkout", "-b", branch)
+
+	backend := &mockGH4964Backend{
+		perCall: func(_ int, opts ExecuteOptions) *BackendResult {
+			emitSignal(opts, `{"v":2,"type":"exit","exit_signal":true,"success":true,"no_op":true,"reason":"feature already exists in internal/auth/jwt.go"}`)
+			return &BackendResult{Success: true, Output: "no changes needed"}
+		},
+	}
+	runner := newGH4964Runner(backend)
+	task := newGH4964Task("GH-4964A", branch, dir)
+
+	result, err := runner.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+	if !result.Declined {
+		t.Errorf("expected Declined=true, got result: %+v", result)
+	}
+	if result.DeclinedReason != "feature already exists in internal/auth/jwt.go" {
+		t.Errorf("unexpected DeclinedReason: %q", result.DeclinedReason)
+	}
+	if result.Success {
+		t.Error("expected Success=false for a declined task")
+	}
+	if backend.callCount() != 1 {
+		t.Errorf("expected backend called exactly once (decline skips the retry), got %d", backend.callCount())
+	}
+}
+
+// TestRunner_NoOpSignal_DirtyTree_PreserveWins is GH-4964's core safety
+// guarantee: even when the model explicitly opts into no_op+reason, a dirty
+// worktree always wins — real uncommitted diffs contradict any claim that
+// nothing needed to change, so the work is auto-preserved instead of the
+// task being declined.
+func TestRunner_NoOpSignal_DirtyTree_PreserveWins(t *testing.T) {
+	const branch = "pilot/GH-4964-noop-dirty"
+	dir, bareDir := setupFreshnessRepo(t)
+	runGit(t, dir, "checkout", "-b", branch)
+
+	backend := &mockGH4964Backend{
+		perCall: func(_ int, opts ExecuteOptions) *BackendResult {
+			writeUncommittedFile(t, dir, "uncommitted.go")
+			emitSignal(opts, `{"v":2,"type":"exit","exit_signal":true,"success":true,"no_op":true,"reason":"nothing to do"}`)
+			return &BackendResult{Success: true}
+		},
+	}
+	runner := newGH4964Runner(backend)
+	task := newGH4964Task("GH-4964B", branch, dir)
+
+	result, err := runner.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+	if result.Declined {
+		t.Errorf("expected Declined=false — a dirty tree must never be declined, got result: %+v", result)
+	}
+	if result.Success {
+		t.Error("expected Success=false — not a completed classification")
+	}
+	if !strings.Contains(result.Error, "auto-preserved") {
+		t.Errorf("expected result.Error to mention auto-preserved, got: %q", result.Error)
+	}
+	if result.CommitSHA == "" {
+		t.Error("expected a preserved commit SHA")
+	}
+	if backend.callCount() != 1 {
+		t.Errorf("expected backend called exactly once — preserve wins before any retry, got %d", backend.callCount())
+	}
+
+	out := gitOutput(t, bareDir, "log", "-1", "--format=%s", "refs/heads/"+branch)
+	if !strings.Contains(out, "auto-preserved") {
+		t.Errorf("expected pushed commit on origin, got log: %q", out)
+	}
+}
+
+// TestRunner_BareExitSignal_ZeroCommits_RetriesNotDeclined is the central
+// regression guard for GH-4964: the bare mandatory exit signal
+// ({"type":"exit","exit_signal":true,"success":true}, with no no_op field)
+// must NEVER be treated as decline evidence on its own. A model that
+// believes it finished but made no commits (the GH-916 failure class) must
+// still go through the no-commit retry, and — if the retry also produces no
+// commits — must classify as a generic no_op failure, not a decline.
+func TestRunner_BareExitSignal_ZeroCommits_RetriesNotDeclined(t *testing.T) {
+	const branch = "pilot/GH-4964-bare-retry"
+	dir, _ := setupFreshnessRepo(t)
+	runGit(t, dir, "checkout", "-b", branch)
+
+	backend := &mockGH4964Backend{
+		perCall: func(call int, opts ExecuteOptions) *BackendResult {
+			emitSignal(opts, `{"v":2,"type":"exit","exit_signal":true,"success":true}`)
+			return &BackendResult{Success: true, Output: fmt.Sprintf("attempt %d, all done", call)}
+		},
+	}
+	runner := newGH4964Runner(backend)
+	task := newGH4964Task("GH-4964C", branch, dir)
+
+	result, err := runner.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+	if result.Declined {
+		t.Errorf("expected Declined=false — the bare mandatory exit signal is never decline evidence, got result: %+v", result)
+	}
+	if result.Success {
+		t.Error("expected Success=false — no commits were ever produced")
+	}
+	if !strings.Contains(result.Error, "no_changes:") {
+		t.Errorf("expected generic no_changes classification, got: %q", result.Error)
+	}
+	if backend.callCount() != 2 {
+		t.Errorf("expected backend called twice (initial + GH-916 retry), got %d", backend.callCount())
+	}
+}
+
+// TestRunner_GhostSHA_NoOpSignal_CleanTree_Declines exercises the earliest
+// decline insertion point: a ghost-SHA rejection (the harvested SHA is
+// already an ancestor of the base branch — no new commit was actually made)
+// combined with a genuinely clean worktree and an explicit no_op+reason
+// signal declines immediately, without ever entering the GH-916 retry block.
+func TestRunner_GhostSHA_NoOpSignal_CleanTree_Declines(t *testing.T) {
+	const branch = "pilot/GH-4964-ghost-noop"
+	dir, _ := setupFreshnessRepo(t)
+	seedSHA := strings.TrimSpace(gitOutput(t, dir, "rev-parse", "HEAD"))
+	runGit(t, dir, "checkout", "-b", branch)
+
+	backend := &mockGH4964Backend{
+		perCall: func(_ int, opts ExecuteOptions) *BackendResult {
+			emitStaleSHA(opts, seedSHA)
+			emitSignal(opts, `{"v":2,"type":"exit","exit_signal":true,"success":true,"no_op":true,"reason":"already fixed upstream"}`)
+			return &BackendResult{Success: true}
+		},
+	}
+	runner := newGH4964Runner(backend)
+	task := newGH4964Task("GH-4964D", branch, dir)
+
+	result, err := runner.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+	if !result.Declined {
+		t.Errorf("expected Declined=true, got result: %+v", result)
+	}
+	if result.DeclinedReason != "already fixed upstream" {
+		t.Errorf("unexpected DeclinedReason: %q", result.DeclinedReason)
+	}
+	if backend.callCount() != 1 {
+		t.Errorf("expected backend called exactly once — ghost-SHA decline is the earliest exit, no retry, got %d", backend.callCount())
+	}
+}
+
+// TestRunner_GhostSHA_DirtyTree_PreserveWins verifies the ghost-SHA
+// insertion point defers to the GH-4517 preserve backstop exactly like the
+// GH-916 insertion points do: a ghost SHA plus a dirty worktree must
+// auto-preserve, never decline (even with only the bare signal as
+// "evidence").
+func TestRunner_GhostSHA_DirtyTree_PreserveWins(t *testing.T) {
+	const branch = "pilot/GH-4964-ghost-dirty"
+	dir, bareDir := setupFreshnessRepo(t)
+	seedSHA := strings.TrimSpace(gitOutput(t, dir, "rev-parse", "HEAD"))
+	runGit(t, dir, "checkout", "-b", branch)
+
+	backend := &mockGH4964Backend{
+		perCall: func(_ int, opts ExecuteOptions) *BackendResult {
+			writeUncommittedFile(t, dir, "uncommitted.go")
+			emitStaleSHA(opts, seedSHA)
+			return &BackendResult{Success: true}
+		},
+	}
+	runner := newGH4964Runner(backend)
+	task := newGH4964Task("GH-4964E", branch, dir)
+
+	result, err := runner.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+	if result.Declined {
+		t.Errorf("expected Declined=false — dirty tree must preserve, not decline, got result: %+v", result)
+	}
+	if result.Success {
+		t.Error("expected Success=false — not a completed classification")
+	}
+	if !strings.Contains(result.Error, "auto-preserved") {
+		t.Errorf("expected result.Error to mention auto-preserved, got: %q", result.Error)
+	}
+	if result.CommitSHA == "" || result.CommitSHA == seedSHA {
+		t.Errorf("expected a new preserved commit SHA distinct from the ghost SHA, got %q", result.CommitSHA)
+	}
+	if backend.callCount() != 1 {
+		t.Errorf("expected backend called exactly once, got %d", backend.callCount())
+	}
+
+	out := gitOutput(t, bareDir, "log", "-1", "--format=%s", "refs/heads/"+branch)
+	if !strings.Contains(out, "auto-preserved") {
+		t.Errorf("expected pushed commit on origin, got log: %q", out)
+	}
+}
+
+// TestRunner_DeclinedMarker_DirtyTree_PostRetry_PreserveWins closes the
+// latent ordering gap GH-4964 fixes at the post-retry insertion point: if
+// the GH-916 retry leaves the worktree dirty AND the model's retry response
+// contains an explicit DECLINED:<reason> marker, the dirty tree must still
+// win — a real uncommitted diff contradicts any decline claim, regardless of
+// which decline evidence produced it.
+func TestRunner_DeclinedMarker_DirtyTree_PostRetry_PreserveWins(t *testing.T) {
+	const branch = "pilot/GH-4964-declined-dirty-postretry"
+	dir, bareDir := setupFreshnessRepo(t)
+	runGit(t, dir, "checkout", "-b", branch)
+
+	backend := &mockGH4964Backend{
+		perCall: func(call int, _ ExecuteOptions) *BackendResult {
+			if call == 1 {
+				// Initial attempt: clean tree, no commit — triggers the GH-916 retry.
+				return &BackendResult{Success: true, Output: "looked at it, nothing yet"}
+			}
+			// Retry: leaves real uncommitted work on disk AND claims DECLINED.
+			writeUncommittedFile(t, dir, "uncommitted.go")
+			return &BackendResult{
+				Success:           true,
+				LastAssistantText: "DECLINED: requirement already satisfied upstream",
+			}
+		},
+	}
+	runner := newGH4964Runner(backend)
+	task := newGH4964Task("GH-4964F", branch, dir)
+
+	result, err := runner.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+	if result.Declined {
+		t.Errorf("expected Declined=false — dirty tree must preserve, not honor the DECLINED marker, got result: %+v", result)
+	}
+	if result.Success {
+		t.Error("expected Success=false — not a completed classification")
+	}
+	if !strings.Contains(result.Error, "auto-preserved") {
+		t.Errorf("expected result.Error to mention auto-preserved, got: %q", result.Error)
+	}
+	if result.CommitSHA == "" {
+		t.Error("expected a preserved commit SHA")
+	}
+	if backend.callCount() != 2 {
+		t.Errorf("expected backend called twice (initial + GH-916 retry), got %d", backend.callCount())
+	}
+
+	out := gitOutput(t, bareDir, "log", "-1", "--format=%s", "refs/heads/"+branch)
+	if !strings.Contains(out, "auto-preserved") {
+		t.Errorf("expected pushed commit on origin, got log: %q", out)
+	}
+}

--- a/internal/executor/git_freshness.go
+++ b/internal/executor/git_freshness.go
@@ -8,6 +8,15 @@ import (
 	"os/exec"
 )
 
+// ghostSHACleanNoCommitError is applyGhostSHAGuard's Error string when a
+// ghost SHA was rejected AND preserveDirtyWorktreeAsWIP already ran and found
+// nothing to preserve — i.e. structural proof the worktree is genuinely
+// clean. GH-4964's decline classification is only safe to key off this
+// EXACT string (not a prefix): the preserved-WIP branch's error text reads
+// differently ("...auto-preserved as %s...") and must never be treated as
+// decline evidence, since real uncommitted diffs contradict any no-op claim.
+const ghostSHACleanNoCommitError = "no new commit produced — worktree HEAD matches base branch parent"
+
 // applyGhostSHAGuard enforces GH-3126: reject executions that produced no new commit.
 // When Claude makes no new commit, git log returns the parent (pre-execution) SHA.
 // Recording that as CommitSHA causes IsTaskShipped to return true on a no-op run,
@@ -62,7 +71,7 @@ func applyGhostSHAGuard(ctx context.Context, task *Task, result *ExecutionResult
 		}
 		result.CommitSHA = ""
 		result.Success = false
-		result.Error = "no new commit produced — worktree HEAD matches base branch parent"
+		result.Error = ghostSHACleanNoCommitError
 	}
 	return false
 }

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -380,6 +380,12 @@ type progressState struct {
 	navProgress  int      // Navigator-reported progress
 	exitSignal   bool     // Navigator EXIT_SIGNAL detected
 	commitSHAs   []string // Extracted commit SHAs from git output
+	// GH-4964: captured only when a structured exit signal explicitly opts
+	// into the no-op/decline branch (no_op:true + non-empty reason) — see
+	// SignalParser.NoOpExitReason. The bare mandatory exit signal never sets
+	// these; exitSignalReason is empty unless exitSignalNoOp is true.
+	exitSignalNoOp   bool
+	exitSignalReason string
 	// Metrics tracking (TASK-13)
 	tokensInput              int64  // Input tokens used
 	tokensOutput             int64  // Output tokens used
@@ -1614,6 +1620,73 @@ func parseDeclinedReason(text string) (string, bool) {
 		return "", false
 	}
 	return reason, true
+}
+
+// finishDeclined centralizes the decline-completion path shared by every
+// insertion point (ghost-SHA, GH-916 pre-retry, post-retry): mark the result
+// declined, persist diagnostics, and finish the recorder as "declined" —
+// never "failed", and with no alert/webhook dispatch, matching the existing
+// DECLINED-marker behavior. GH-4964. Callers must `return result, nil`
+// immediately after calling this.
+func (r *Runner) finishDeclined(task *Task, result *ExecutionResult, backendResult *BackendResult, recorder *replay.Recorder, state *progressState, log *slog.Logger, reason string) {
+	result.Success = false
+	result.Declined = true
+	result.DeclinedReason = reason
+	result.Outcome = "declined" // TASK-358
+	if backendResult != nil {
+		backendResult.ErrorType = string(ErrorTypeDeclined)
+	}
+	log.Warn("Task declined by executor",
+		slog.String("task_id", task.ID),
+		slog.String("reason", reason),
+	)
+	r.reportProgress(task.ID, "Declined", 100, "Task declined: "+reason)
+	r.persistBackendDiagnostics(task.LogExecutionID(), backendResult)
+
+	if recorder != nil {
+		recorder.SetModel(result.ModelName)
+		recorder.SetNavigator(state.hasNavigator)
+		if finErr := recorder.Finish("declined"); finErr != nil {
+			log.Warn("Failed to finish recording", slog.Any("error", finErr))
+		}
+	}
+}
+
+// preserveDirtyOrFail is the GH-4517 backstop shared by every no-commit
+// classification point (ghost-SHA path, GH-916 pre-retry, post-retry): if
+// the worktree still holds uncommitted work, auto-preserve it and fail with
+// "needs manual review" — real, uncommitted diffs must always win over any
+// DECLINED marker or no_op+reason signal, since they contradict the claim
+// that nothing needed to change. GH-4517/GH-4964. Returns true when it
+// already finished `result` (auto-preserved); the caller must
+// `return result, nil` immediately.
+func (r *Runner) preserveDirtyOrFail(ctx context.Context, git *GitOperations, task *Task, result *ExecutionResult, backendResult *BackendResult, recorder *replay.Recorder, state *progressState, log *slog.Logger, stage string) bool {
+	sha, preserved := preserveDirtyWorktreeAsWIP(ctx, git, task, log)
+	if !preserved {
+		return false
+	}
+	result.CommitSHA = sha
+	result.Success = false
+	result.Error = fmt.Sprintf(
+		"worktree had uncommitted work %s — auto-preserved as %s on branch %s; needs manual review, not a genuine no-op",
+		stage, sha[:min(7, len(sha))], task.Branch,
+	)
+	r.recordExecutionEvent(task.LogExecutionID(), memory.StageWorkPreserved, result.Error)
+	log.Warn("executor: auto-preserved dirty worktree",
+		slog.String("task_id", task.ID),
+		slog.String("stage", stage),
+		slog.String("sha", sha[:min(7, len(sha))]),
+	)
+	r.reportProgress(task.ID, "Auto-Preserved", 100, result.Error)
+	r.persistBackendDiagnostics(task.LogExecutionID(), backendResult)
+	if recorder != nil {
+		recorder.SetModel(result.ModelName)
+		recorder.SetNavigator(state.hasNavigator)
+		if finErr := recorder.Finish("failed"); finErr != nil {
+			log.Warn("Failed to finish recording", slog.Any("error", finErr))
+		}
+	}
+	return true
 }
 
 // persistBackendDiagnostics writes the backend's stderr, error type, final
@@ -3897,6 +3970,30 @@ retrySucceeded:
 		r.metricsRecorder.RecordExecution(model, outcomeLabel)
 	}
 
+	// GH-4964: a ghost-SHA rejection with a genuinely clean worktree (the
+	// EXACT ghostSHACleanNoCommitError string — preserveDirtyWorktreeAsWIP
+	// already ran inside applyGhostSHAGuardWithPreserve above and found
+	// nothing to preserve, so reaching this string is structural proof the
+	// tree is clean) is the earliest point a decline can safely be inferred.
+	// Only an explicit DECLINED:<reason> marker or a no_op+reason exit
+	// signal counts as evidence — the bare mandatory exit signal alone never
+	// does, since it's emitted on every run the model believes finished,
+	// including the GH-916 "claimed success, never committed" failure class.
+	if result.Error == ghostSHACleanNoCommitError {
+		refusal := ""
+		if backendResult != nil {
+			refusal = strings.TrimSpace(backendResult.LastAssistantText)
+		}
+		if declinedReason, ok := parseDeclinedReason(refusal); ok {
+			r.finishDeclined(task, result, backendResult, recorder, state, log, declinedReason)
+			return result, nil
+		}
+		if state.exitSignalNoOp && state.exitSignalReason != "" {
+			r.finishDeclined(task, result, backendResult, recorder, state, log, state.exitSignalReason)
+			return result, nil
+		}
+	}
+
 	if !result.Success {
 		log.Error("Task execution failed",
 			slog.String("error", result.Error),
@@ -3986,6 +4083,35 @@ retrySucceeded:
 					slog.Any("error", countErr),
 				)
 			} else if commitCount == 0 {
+				// GH-4964: confirm the worktree is genuinely clean BEFORE
+				// even considering a decline or spending a retry — a dirty
+				// tree always wins over any DECLINED marker or no_op+reason
+				// signal, since real uncommitted diffs contradict any
+				// no-op claim (the GH-916 class: model believes it
+				// finished, emits the mandatory exit signal, but never ran
+				// `git commit`).
+				if r.preserveDirtyOrFail(ctx, git, task, result, backendResult, recorder, state, log, "before no-commit retry") {
+					return result, nil
+				}
+
+				// Tree is clean — an explicit DECLINED marker or
+				// no_op+reason exit signal is valid evidence to decline
+				// without spending a retry. Everything whose only evidence
+				// is the bare mandatory exit signal falls through to the
+				// retry below, unchanged from today's behavior.
+				refusal := ""
+				if backendResult != nil {
+					refusal = strings.TrimSpace(backendResult.LastAssistantText)
+				}
+				if declinedReason, ok := parseDeclinedReason(refusal); ok {
+					r.finishDeclined(task, result, backendResult, recorder, state, log, declinedReason)
+					return result, nil
+				}
+				if state.exitSignalNoOp && state.exitSignalReason != "" {
+					r.finishDeclined(task, result, backendResult, recorder, state, log, state.exitSignalReason)
+					return result, nil
+				}
+
 				log.Warn("Claude made no commits, retrying with explicit instruction",
 					slog.String("task_id", task.ID),
 					slog.String("branch", task.Branch),
@@ -4076,61 +4202,30 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 						refusal = strings.TrimSpace(retryResult.LastAssistantText)
 					}
 
+					// GH-4964/GH-4517: confirm the worktree is genuinely clean
+					// BEFORE honoring any decline evidence — closes the latent
+					// ordering gap where a dirty tree + DECLINED marker would
+					// previously have discarded real, uncommitted diffs. The
+					// model may have done real work and simply never run
+					// `git commit` (pilot-console#26/B8); auto-preserve instead
+					// of letting the deferred worktree cleanup delete it.
+					if r.preserveDirtyOrFail(ctx, git, task, result, backendResult, recorder, state, log, "after no-commit retry") {
+						return result, nil
+					}
+
 					// GH-2777: Check for an explicit DECLINED:<reason> marker before
 					// classifying as a generic no_changes failure. DECLINED avoids
 					// pilot-failed and instead adds pilot-needs-clarification.
 					if declinedReason, ok := parseDeclinedReason(refusal); ok {
-						result.Declined = true
-						result.DeclinedReason = declinedReason
-						result.Outcome = "declined" // TASK-358
-						if backendResult != nil {
-							backendResult.ErrorType = string(ErrorTypeDeclined)
-						}
-						log.Warn("Task declined by executor",
-							slog.String("task_id", task.ID),
-							slog.String("reason", declinedReason),
-						)
-						r.reportProgress(task.ID, "Declined", 100, "Task declined: "+declinedReason)
-						r.persistBackendDiagnostics(task.LogExecutionID(), backendResult)
-
-						if recorder != nil {
-							recorder.SetModel(result.ModelName)
-							recorder.SetNavigator(state.hasNavigator)
-							if finErr := recorder.Finish("declined"); finErr != nil {
-								log.Warn("Failed to finish recording", slog.Any("error", finErr))
-							}
-						}
+						r.finishDeclined(task, result, backendResult, recorder, state, log, declinedReason)
 						return result, nil
 					}
 
-					// GH-4517: before declaring a genuine no_changes no-op, check
-					// whether the worktree still has uncommitted changes despite
-					// zero counted commits — the model may have done real work and
-					// simply never run `git commit` (pilot-console#26/B8, where the
-					// same failure mode showed up via the ghost-SHA guard instead
-					// of this no-commit-after-retry path). If so, auto-preserve
-					// instead of letting the deferred worktree cleanup delete it.
-					if sha, preserved := preserveDirtyWorktreeAsWIP(ctx, git, task, log); preserved {
-						result.CommitSHA = sha
-						result.Success = false
-						result.Error = fmt.Sprintf(
-							"worktree had uncommitted work after no-commit retry — auto-preserved as %s on branch %s; needs manual review, not a genuine no-op",
-							sha[:min(7, len(sha))], task.Branch,
-						)
-						r.recordExecutionEvent(task.LogExecutionID(), memory.StageWorkPreserved, result.Error)
-						log.Warn("executor: auto-preserved dirty worktree after no-commit retry",
-							slog.String("task_id", task.ID),
-							slog.String("sha", sha[:min(7, len(sha))]),
-						)
-						r.reportProgress(task.ID, "Auto-Preserved", 100, result.Error)
-						r.persistBackendDiagnostics(task.LogExecutionID(), backendResult)
-						if recorder != nil {
-							recorder.SetModel(result.ModelName)
-							recorder.SetNavigator(state.hasNavigator)
-							if finErr := recorder.Finish("failed"); finErr != nil {
-								log.Warn("Failed to finish recording", slog.Any("error", finErr))
-							}
-						}
+					// GH-4964: an explicit no_op+reason exit signal is equally
+					// valid decline evidence — the bare mandatory exit signal
+					// alone is not.
+					if state.exitSignalNoOp && state.exitSignalReason != "" {
+						r.finishDeclined(task, result, backendResult, recorder, state, log, state.exitSignalReason)
 						return result, nil
 					}
 
@@ -5948,6 +6043,16 @@ func (r *Runner) handleStructuredSignals(taskID string, signals []PilotSignal, s
 
 	// Mark as having Navigator
 	state.hasNavigator = true
+
+	// GH-4964: capture an explicit no_op+reason exit signal so the runner can
+	// treat it as decline evidence later. Never inferred from the bare
+	// mandatory exit signal — see SignalParser.NoOpExitReason.
+	if r.signalParser != nil {
+		if reason, ok := r.signalParser.NoOpExitReason(signals); ok {
+			state.exitSignalNoOp = true
+			state.exitSignalReason = reason
+		}
+	}
 
 	// Process signals in order
 	for _, signal := range signals {

--- a/internal/executor/signal.go
+++ b/internal/executor/signal.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"regexp"
+	"strings"
 )
 
 // Signal types for v2 protocol
@@ -27,6 +28,12 @@ type PilotSignal struct {
 	Success    bool            `json:"success,omitempty"`
 	Reason     string          `json:"reason,omitempty"`
 	Message    string          `json:"message,omitempty"`
+	// NoOp opts an exit signal into the "nothing needed to change" branch
+	// (GH-4964). It is never inferred — the plain mandatory exit signal
+	// ({"exit_signal":true,"success":true}, emitted on every run the model
+	// believes finished) must NOT be read as a decline. Only an exit signal
+	// with NoOp true AND a non-empty Reason counts; see NoOpExitReason.
+	NoOp bool `json:"no_op,omitempty"`
 }
 
 // signalBlockRegex matches ```pilot-signal\n{...}\n```
@@ -111,6 +118,32 @@ func (p *SignalParser) HasExitSignal(signals []PilotSignal) bool {
 		}
 	}
 	return false
+}
+
+// NoOpExitReason returns the reason from the latest exit signal that
+// explicitly opts into the no-op/decline branch (GH-4964). It returns true
+// ONLY when a signal is an exit signal (ExitSignal or Type ==
+// SignalTypeExit), reports Success, sets NoOp, AND carries a non-empty
+// Reason — mirroring parseDeclinedReason's empty-reason rejection so a
+// no_op:true with no explanation is never treated as valid decline evidence.
+// The bare mandatory exit signal (no NoOp field at all) always returns
+// ("", false); there is no Message fallback and no fabricated default reason.
+func (p *SignalParser) NoOpExitReason(signals []PilotSignal) (string, bool) {
+	for i := len(signals) - 1; i >= 0; i-- {
+		s := signals[i]
+		if !s.ExitSignal && s.Type != SignalTypeExit {
+			continue
+		}
+		if !s.Success || !s.NoOp {
+			continue
+		}
+		reason := strings.TrimSpace(s.Reason)
+		if reason == "" {
+			continue
+		}
+		return reason, true
+	}
+	return "", false
 }
 
 // GetLatestProgress returns the progress from the last status signal

--- a/internal/executor/signal_test.go
+++ b/internal/executor/signal_test.go
@@ -235,6 +235,80 @@ func TestSignalParser_NilLogger(t *testing.T) {
 	}
 }
 
+func TestSignalParser_NoOpExitReason(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	parser := NewSignalParser(logger)
+
+	tests := []struct {
+		name         string
+		input        string
+		expectedOK   bool
+		expectedText string
+	}{
+		{
+			name:         "bare mandatory exit signal is never a no-op",
+			input:        "```pilot-signal\n{\"v\":2,\"type\":\"exit\",\"exit_signal\":true,\"success\":true}\n```",
+			expectedOK:   false,
+			expectedText: "",
+		},
+		{
+			name:         "no_op with reason is valid",
+			input:        "```pilot-signal\n{\"v\":2,\"type\":\"exit\",\"exit_signal\":true,\"success\":true,\"no_op\":true,\"reason\":\"watch ticket unchanged\"}\n```",
+			expectedOK:   true,
+			expectedText: "watch ticket unchanged",
+		},
+		{
+			name:         "no_op with empty reason is rejected",
+			input:        "```pilot-signal\n{\"v\":2,\"type\":\"exit\",\"exit_signal\":true,\"success\":true,\"no_op\":true,\"reason\":\"\"}\n```",
+			expectedOK:   false,
+			expectedText: "",
+		},
+		{
+			name:         "no_op with whitespace-only reason is rejected",
+			input:        "```pilot-signal\n{\"v\":2,\"type\":\"exit\",\"exit_signal\":true,\"success\":true,\"no_op\":true,\"reason\":\"   \"}\n```",
+			expectedOK:   false,
+			expectedText: "",
+		},
+		{
+			name:         "no_op without success is rejected",
+			input:        "```pilot-signal\n{\"v\":2,\"type\":\"exit\",\"exit_signal\":true,\"success\":false,\"no_op\":true,\"reason\":\"blocked\"}\n```",
+			expectedOK:   false,
+			expectedText: "",
+		},
+		{
+			name:         "success+reason without no_op is rejected — no Message fallback",
+			input:        "```pilot-signal\n{\"v\":2,\"type\":\"exit\",\"exit_signal\":true,\"success\":true,\"reason\":\"not a no-op field\"}\n```",
+			expectedOK:   false,
+			expectedText: "",
+		},
+		{
+			name:         "no_op on a non-exit status signal is ignored",
+			input:        "```pilot-signal\n{\"v\":2,\"type\":\"status\",\"success\":true,\"no_op\":true,\"reason\":\"premature\"}\n```",
+			expectedOK:   false,
+			expectedText: "",
+		},
+		{
+			name:         "type exit without exit_signal bool still counts",
+			input:        "```pilot-signal\n{\"v\":2,\"type\":\"exit\",\"success\":true,\"no_op\":true,\"reason\":\"already exists\"}\n```",
+			expectedOK:   true,
+			expectedText: "already exists",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			signals := parser.ParseSignals(tt.input)
+			reason, ok := parser.NoOpExitReason(signals)
+			if ok != tt.expectedOK {
+				t.Errorf("expected ok=%v, got %v (reason=%q)", tt.expectedOK, ok, reason)
+			}
+			if reason != tt.expectedText {
+				t.Errorf("expected reason %q, got %q", tt.expectedText, reason)
+			}
+		})
+	}
+}
+
 func TestTruncateSignalForLog(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/internal/executor/workflow.go
+++ b/internal/executor/workflow.go
@@ -171,6 +171,15 @@ to the actual change you made):
 {"v":2,"type":"exit","exit_signal":true,"success":true}
 ` + "```" + `
 
+**No-op exit** (only when no code change was needed — task already satisfied,
+requirement not applicable, nothing to do). This is a distinct, opt-in signal —
+never the default. Do NOT emit the plain exit signal above and expect it to be
+read as a no-op; ` + "`no_op:true`" + ` and a one-sentence ` + "`reason`" + ` are both mandatory
+for this branch:
+` + "```" + `pilot-signal
+{"v":2,"type":"exit","exit_signal":true,"success":true,"no_op":true,"reason":"<one sentence, mandatory>"}
+` + "```" + `
+
 ---
 
 ### Completion Contract (Non-negotiable)


### PR DESCRIPTION
## Summary

- The mandatory exit signal (`{"type":"exit","exit_signal":true,"success":true}`) fires on every run the model believes finished, including the GH-916 failure class where it claims success but never commits (~10% of failures). A prior external attempt (#4901, never merged) inferred a no-op decline from this bare signal, which would have mislabeled forgot-to-commit failures as "no changes needed" and made the GH-916 retry unreachable.
- Adds an opt-in `no_op:true` + mandatory `reason` field to the exit signal contract (`workflow.go`, `signal.go`) as the **only** new evidence for a decline, alongside the existing `DECLINED:<reason>` text marker.
- Routes every decline insertion point in `runner.go`'s `Execute()` (ghost-SHA rejection, GH-916 pre-retry, GH-916 post-retry) through shared `finishDeclined`/`preserveDirtyOrFail` helpers, guaranteeing the GH-4517 dirty-worktree auto-preserve backstop always runs and wins before any decline is honored — a real uncommitted diff always outranks a no-op claim, closing a latent post-retry ordering gap.
- Comms now renders a decline via `SendChunked` (threaded, "⏸ No changes needed: …"), not as a failure via `SendResult`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] `scripts/check-secret-patterns.sh` / `scripts/check-mocks.sh` — clean
- [x] New unit tests: `signal_test.go` (`NoOpExitReason` — 8 cases), `handler_test.go` (declined-vs-normal comms rendering — 3 cases)
- [x] New integration tests via `Runner.Execute()` in `gh4964_test.go`: bare-signal retry (regression guard), no_op+reason clean-tree decline, no_op+reason dirty-tree preserve-wins, ghost-SHA+no_op decline, ghost-SHA+dirty preserve-wins, post-retry DECLINED+dirty preserve-wins