### PR TITLE
GH-4966: fix(autopilot): strip compound/non-GH issue prefixes from squash subjects via exported StripIssuePrefix

### DIFF
--- a/internal/autopilot/auto_merger.go
+++ b/internal/autopilot/auto_merger.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/qf-studio/pilot/internal/approval"
+	"github.com/qf-studio/pilot/internal/executor"
 	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 )
 
@@ -77,12 +78,12 @@ func (m *AutoMerger) MergePR(ctx context.Context, prState *PRState) error {
 	commitTitle := fmt.Sprintf("Merge PR #%d", prState.PRNumber)
 	if mergeMethod == github.MergeMethodSquash && prState.PRTitle != "" {
 		commitTitle = prState.PRTitle
-		// Strip "GH-XXXX: " prefix from Pilot-generated PR titles so
+		// Strip adapter issue-id prefixes (e.g. "GH-4909: ", "APP-123: ",
+		// "LIN-ROU-586: ") from Pilot-generated PR titles so
 		// parseBumpFromMessage() sees the conventional commit prefix (e.g. "fix(scope): ...").
-		if prState.IssueNumber > 0 {
-			prefix := fmt.Sprintf("GH-%d: ", prState.IssueNumber)
-			commitTitle = strings.TrimPrefix(commitTitle, prefix)
-		}
+		// Regex only strips on an actual match, so this is safe unconditionally
+		// and also covers adapters where IssueNumber is unset.
+		commitTitle = executor.StripIssuePrefix(commitTitle)
 		// GH-4150: append the "(#N)" suffix GitHub's own squash-merge UI uses,
 		// so scheduleReleaseTick's resolveTrainMemberPRs (trainPRSuffixRe) can
 		// resolve this commit back to its member PR. Skip if the title already

--- a/internal/autopilot/auto_merger_test.go
+++ b/internal/autopilot/auto_merger_test.go
@@ -537,22 +537,46 @@ func TestAutoMerger_MergePR_SquashStripsIssuePrefix(t *testing.T) {
 			wantTitle:   "fix(autopilot): strip issue prefix from squash title (#42)",
 		},
 		{
-			name:        "no strip when issue number mismatches",
+			name:        "strips regardless of issue number mismatch (regex-driven, not IssueNumber-gated)",
 			prTitle:     "GH-9999: feat(scope): something",
 			issueNumber: 2312,
-			wantTitle:   "GH-9999: feat(scope): something (#42)",
+			wantTitle:   "feat(scope): something (#42)",
 		},
 		{
-			name:        "no strip when no issue number",
+			name:        "strips even when no issue number set (GH-4966)",
 			prTitle:     "GH-2312: fix(autopilot): something",
 			issueNumber: 0,
-			wantTitle:   "GH-2312: fix(autopilot): something (#42)",
+			wantTitle:   "fix(autopilot): something (#42)",
 		},
 		{
 			name:        "plain conventional commit unchanged",
 			prTitle:     "feat(api): add endpoint",
 			issueNumber: 2312,
 			wantTitle:   "feat(api): add endpoint (#42)",
+		},
+		{
+			name:        "strips jira-style non-GH prefix (GH-4966)",
+			prTitle:     "APP-123: feat(auth): oauth flow",
+			issueNumber: 123,
+			wantTitle:   "feat(auth): oauth flow (#42)",
+		},
+		{
+			name:        "strips compound linear prefix with no issue number (GH-4966)",
+			prTitle:     "LIN-ROU-586: fix(core): widen window",
+			issueNumber: 0,
+			wantTitle:   "fix(core): widen window (#42)",
+		},
+		{
+			name:        "strips three-segment linear prefix (GH-4966)",
+			prTitle:     "LIN-MY1-TEAM-42: fix(core): resolve",
+			issueNumber: 0,
+			wantTitle:   "fix(core): resolve (#42)",
+		},
+		{
+			name:        "prefix-only title with empty subject does not panic on suffix append (GH-4966)",
+			prTitle:     "GH-123: ",
+			issueNumber: 123,
+			wantTitle:   " (#42)",
 		},
 	}
 

--- a/internal/executor/title.go
+++ b/internal/executor/title.go
@@ -26,6 +26,15 @@ var conventionalCommitRegex = regexp.MustCompile(
 // (see internal/autopilot/auto_merger.go).
 var issuePrefixRegex = regexp.MustCompile(`^[A-Z][A-Z0-9]*(-[A-Z0-9]+)*-\d+:\s+`)
 
+// StripIssuePrefix removes a leading adapter-specific issue prefix (e.g.
+// "GH-2325: ", "APP-123: ", "LIN-ROU-586: ") from title, if present. Exported
+// so the squash-merge path (internal/autopilot/auto_merger.go) can strip the
+// same prefix before parseBumpFromMessage() runs conventional-commit
+// detection on the squash subject.
+func StripIssuePrefix(title string) string {
+	return issuePrefixRegex.ReplaceAllString(title, "")
+}
+
 // ErrNonConventionalTitle is returned when a title does not match the
 // conventional commit format and could not be auto-corrected. Callers use
 // errors.Is to distinguish this from transport failures.

--- a/internal/executor/title_test.go
+++ b/internal/executor/title_test.go
@@ -49,6 +49,30 @@ func TestValidatePRTitle(t *testing.T) {
 	}
 }
 
+func TestStripIssuePrefix(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		want  string
+	}{
+		{"GH prefix", "GH-4909: fix(autopilot): guard merge", "fix(autopilot): guard merge"},
+		{"jira-style prefix", "APP-123: feat(auth): oauth flow", "feat(auth): oauth flow"},
+		{"compound linear prefix", "LIN-ROU-586: fix(core): widen window", "fix(core): widen window"},
+		{"three-segment linear prefix", "LIN-MY1-TEAM-42: fix(core): resolve", "fix(core): resolve"},
+		{"no prefix unchanged", "fix(core): direct commit", "fix(core): direct commit"},
+		{"prefix with empty subject", "GH-123: ", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StripIssuePrefix(tt.title)
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAutoPrefixTitle(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4966.

Closes #4966

## Changes

GitHub Issue GH-4966: fix(autopilot): strip compound/non-GH issue prefixes from squash subjects via exported StripIssuePrefix

## Context

Leg B of `.agent/tasks/TASK-481-review-followup-defects.md`. Gate cleared: #4899 is MERGED — `StripIssuePrefix` inherits its widened regex.

## Problem — auto_merger squash-prefix stripping misses compound/non-GH prefixes

**Defect.** `AutoMerger.MergePR` strips only a literal `fmt.Sprintf("GH-%d: ", prState.IssueNumber)` (`internal/autopilot/auto_merger.go:79-90`). For Linear compound (`LIN-ROU-586: `) or plain Jira-style (`APP-123: `) prefixes the `TrimPrefix` is a no-op, so the identifier leaks into the squash subject and defeats `parseBumpFromMessage()`'s conventional-commit detection — the exact motivation stated in the code's own comment at :80-81.

`internal/executor/title.go:25-26` already *claims* parity: "The downstream squash-merge path strips the same prefix (see internal/autopilot/auto_merger.go)". It doesn't.

**Fix.** Export `StripIssuePrefix(title string) string` from `internal/executor/title.go` (place it right after `issuePrefixRegex` at :27 so regex and accessor stay co-located), then call it from `auto_merger.go:82-85`, dropping the `IssueNumber > 0` guard — the regex only strips on an actual match, so it's safe unconditionally and now also covers adapters where `IssueNumber` is unset. No import cycle: `internal/executor` does not import `internal/autopilot` (verified).

**Files**: `internal/executor/title.go` · `internal/autopilot/auto_merger.go` (+import) · `internal/executor/title_test.go` · `internal/autopilot/auto_merger_test.go`.

**Test rows**:

| PR title | IssueNumber | Expected stripped title |
|---|---|---|
| `GH-4909: fix(autopilot): guard merge` | 4909 | `fix(autopilot): guard merge` |
| `APP-123: feat(auth): oauth flow` | 123 | `feat(auth): oauth flow` |
| `LIN-ROU-586: fix(core): widen window` | 0 | `fix(core): widen window` |
| `LIN-MY1-TEAM-42: fix(core): resolve` | 0 | `fix(core): resolve` |
| `fix(core): direct commit` | 0 | unchanged |
| `GH-123: ` | 123 | `""` — verify the `(#N)` suffix append doesn't panic |

**Dependency**: composes with #4899 (widens the shared regex; `StripIssuePrefix` inherits it for free). Either order — #4899 doesn't touch `auto_merger.go`, this doesn't touch `epic.go`.

---



## Acceptance

- All six test rows above pass; `title.go:25`'s parity claim becomes true; no import cycle introduced.