### PR TITLE
GH-4967: fix(comms): consolidate signal stripping onto comms.CleanInternalSignals — slack/discord leak signal blocks today

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -172,6 +172,7 @@
 | Bot grounded Q&A retrieval | ✅ | comms | - | `bot.retrieval` | `Responder.Answer()` + bounded file retrieval; falls back to executor for too-broad questions (v2.194.2, GH-3671) |
 | Bot conversational issue intake | ✅ | comms | - | `bot.enabled`, GitHub adapter | `Responder.DraftIssue()` + `handleIssueIntake`; creates GitHub issue with `pilot` label (v2.194.2, GH-3691) |
 | Bot persona + voice scaffold | ✅ | comms, config | - | `bot.persona`, `bot.voice.enabled` | Persona in Chat/Answer/DraftIssue; VoiceText seam in HandleMessage; fully commented example config (v2.194.2, GH-3673) |
+| Slack/Discord signal stripping wired in | ✅ | adapters/slack, adapters/discord, comms | - | - | Consolidated four independent "strip internal signal markers" copies onto `comms.CleanInternalSignals`; deleted unreachable `slack.CleanInternalSignals` and vestigial `discord.CleanInternalSignals`, deleted telegram's duplicated unexported copy in favor of the comms one. **New production behavior**, not a pure refactor: slack/discord `FormatTaskResult` previously never called any signal-stripping function at all, so `EXIT_SIGNAL`/`NAVIGATOR_STATUS`/fenced `pilot-signal` blocks leaked to Slack/Discord users unconditionally — now stripped before truncation (GH-4967) |
 
 ## Alerts & Monitoring
 

--- a/.agent/tasks/gh-4967.md
+++ b/.agent/tasks/gh-4967.md
@@ -1,0 +1,55 @@
+# GH-4967
+
+**Created:** 2026-08-18
+
+## Problem
+
+GitHub Issue GH-4967: fix(comms): consolidate signal stripping onto comms.CleanInternalSignals — slack/discord leak signal blocks today
+
+## Context
+
+Leg C of `.agent/tasks/TASK-481-review-followup-defects.md`. Gate cleared: #4903 is MERGED — consolidate onto its `comms.CleanInternalSignals`. NOTE: wiring the call into slack/discord `FormatTaskResult` is NEW production behavior, not a refactor — say so in the PR description.
+
+## Problem — signal blocks leak to Slack and Discord users today (four copies, three behaviors)
+
+**Defect — larger than PR #4903's own note.** There are four independent copies of "strip internal signal markers," and slack/discord's are not merely stale: **their `FormatTaskResult` never calls them at all**. `CleanInternalSignals` is unreachable dead code in both adapters, so every `EXIT_SIGNAL` / `NAVIGATOR_STATUS` / fenced `pilot-signal` block in task output reaches Slack and Discord users unconditionally, today.
+
+| Copy | Location | Handles | Fenced blocks | Bare `{"v":…}` | Called from `FormatTaskResult`? |
+|---|---|---|---|---|---|
+| comms (canonical) | `internal/comms/util.go:9-70` | full list + `NAVIGATOR_STATUS` block-skip | after #4903 ✓ | after #4903 ✓ | n/a (library) |
+| telegram (dupe) | `adapters/telegram/formatter.go:330+`, called :133,:197,:243 | same list, independently duplicated constants :11-18 | after #4903 ✓ | after #4903 ✓ | yes |
+| slack | `adapters/slack/formatter.go:302-318` | only 4 literal `[…]` markers via `ReplaceAll` | no | no | **no** — dead code, zero call sites |
+| discord | `adapters/discord/formatter.go:135-143` | a *different* scheme: `<!-- INTERNAL: … -->`, no producer anywhere in the repo (vestigial) | no | no | **no** — only `handler_test.go:781` |
+
+**Fix — consolidate, don't patch four copies.**
+
+1. `internal/comms/util.go` is the home. All three adapters already import `internal/comms` for `Handler`/`IncomingMessage`/`Messenger` — zero new import edges, no cycle risk.
+2. Delete `slack/formatter.go:302-318` and `discord/formatter.go:135-143` outright (unreachable ⇒ deletion is safe and removes the drift surface).
+3. Delete telegram's unexported copy (constants :11-18, function :330+); its three call sites become `comms.CleanInternalSignals(...)`.
+4. **Wire the call in** at `slack/formatter.go:53` (`FormatTaskResult`) and `discord/formatter.go:30`, before truncation/write. This is **new production behavior**, not a refactor — flag it explicitly in the PR description.
+
+**Files**: `adapters/telegram/formatter.go` (+ its `formatter_test.go`) · `adapters/slack/formatter.go` (+import) · `adapters/discord/formatter.go` (+import) · `adapters/discord/handler_test.go:779-` (repoint or remove `TestCleanInternalSignals`).
+
+**Test rows**:
+
+| Adapter | Input to `FormatTaskResult` | Expected |
+|---|---|---|
+| slack | `"done\n[EXIT_SIGNAL]\nreal output"` | contains `real output`, not `[EXIT_SIGNAL]` |
+| slack | fenced ```` ```pilot-signal\n{"v":2,…}\n``` ```` | neither `pilot-signal` nor the JSON payload |
+| discord | `"done\nNAVIGATOR_STATUS\n━━━\nreal output"` | no `NAVIGATOR_STATUS` |
+| discord | `"checked issue\n{\"v\":2,\"type\":\"status\"}\nnothing to do"` | bare JSON line stripped |
+| telegram | existing `formatSuccessResult`/`formatFailureResult` tests | identical output post-redirect |
+| build | old copies removed | `go build ./...` clean |
+
+**Dependency**: **must land after #4903** (or rebased onto it) — #4903 is what makes `comms.CleanInternalSignals` the version worth centralizing on. Landing first would point everyone at the pre-#4903 implementation and require a second pass. Risk note: any existing slack/discord golden-output fixture containing signal-shaped substrings will need updating.
+
+---
+
+
+
+## Acceptance
+
+- All six test rows above pass; slack/discord/telegram local copies deleted; `go build ./...` clean.
+
+## Acceptance Criteria
+

--- a/internal/adapters/discord/formatter.go
+++ b/internal/adapters/discord/formatter.go
@@ -3,6 +3,8 @@ package discord
 import (
 	"fmt"
 	"strings"
+
+	"github.com/qf-studio/pilot/internal/comms"
 )
 
 // FormatTaskConfirmation formats a task confirmation message for Discord.
@@ -37,12 +39,16 @@ func FormatTaskResult(output string, success bool, prURL string) string {
 	}
 
 	if output != "" {
-		out := output
+		// Strip internal Navigator/Pilot signal markers before this ever
+		// reaches a Discord user (GH-4967 — previously unwired dead code).
+		out := comms.CleanInternalSignals(output)
 		if len(out) > 1500 {
 			out = out[:1497] + "..."
 		}
-		sb.WriteString(out)
-		sb.WriteString("\n\n")
+		if out != "" {
+			sb.WriteString(out)
+			sb.WriteString("\n\n")
+		}
 	}
 
 	if prURL != "" {
@@ -130,16 +136,6 @@ func ChunkContent(content string, maxLen int) []string {
 	}
 
 	return chunks
-}
-
-// CleanInternalSignals removes internal markers from output.
-func CleanInternalSignals(output string) string {
-	// Remove common internal markers
-	output = strings.ReplaceAll(output, "<!-- INTERNAL: ", "")
-	output = strings.ReplaceAll(output, "<!-- /INTERNAL -->", "")
-	output = strings.ReplaceAll(output, "-->", "")
-	output = strings.TrimSpace(output)
-	return output
 }
 
 // TruncateText truncates text to a maximum length.

--- a/internal/adapters/discord/formatter_test.go
+++ b/internal/adapters/discord/formatter_test.go
@@ -1,0 +1,48 @@
+package discord
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFormatTaskResultStripsInternalSignals verifies that FormatTaskResult
+// strips internal Navigator/Pilot signal markers via comms.CleanInternalSignals
+// before the output reaches a Discord user (GH-4967 — previously FormatTaskResult
+// never called any signal-stripping function, so signals leaked unconditionally).
+func TestFormatTaskResultStripsInternalSignals(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   string
+		contains []string
+		excludes []string
+	}{
+		{
+			name:     "strips NAVIGATOR_STATUS block",
+			output:   "done\nNAVIGATOR_STATUS\n━━━━━━━━━━\nreal output",
+			contains: []string{"done", "real output"},
+			excludes: []string{"NAVIGATOR_STATUS"},
+		},
+		{
+			name:     "strips bare protocol JSON line",
+			output:   "checked issue\n{\"v\":2,\"type\":\"status\"}\nnothing to do",
+			contains: []string{"checked issue", "nothing to do"},
+			excludes: []string{`{"v":2,"type":"status"}`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatTaskResult(tt.output, true, "")
+			for _, want := range tt.contains {
+				if !strings.Contains(got, want) {
+					t.Errorf("FormatTaskResult() = %q, want to contain %q", got, want)
+				}
+			}
+			for _, exclude := range tt.excludes {
+				if strings.Contains(got, exclude) {
+					t.Errorf("FormatTaskResult() = %q, should NOT contain %q", got, exclude)
+				}
+			}
+		})
+	}
+}

--- a/internal/adapters/discord/handler_test.go
+++ b/internal/adapters/discord/handler_test.go
@@ -776,19 +776,6 @@ func TestChunkContent(t *testing.T) {
 	}
 }
 
-func TestCleanInternalSignals(t *testing.T) {
-	input := "<!-- INTERNAL: This is internal -->Some output<!-- /INTERNAL -->"
-	output := CleanInternalSignals(input)
-
-	if contains(output, "INTERNAL") {
-		t.Errorf("internal signals not cleaned: %s", output)
-	}
-
-	if !contains(output, "output") {
-		t.Errorf("regular content lost: %s", output)
-	}
-}
-
 // --- Rate limit (Client-level) ---
 
 func TestRateLimitHandling(t *testing.T) {

--- a/internal/adapters/slack/formatter.go
+++ b/internal/adapters/slack/formatter.go
@@ -3,6 +3,8 @@ package slack
 import (
 	"fmt"
 	"strings"
+
+	"github.com/qf-studio/pilot/internal/comms"
 )
 
 // Block Kit formatting helpers for Slack messages.
@@ -60,13 +62,17 @@ func FormatTaskResult(output string, success bool, prURL string) string {
 	}
 
 	if output != "" {
+		// Strip internal Navigator/Pilot signal markers before this ever
+		// reaches a Slack user (GH-4967 — previously unwired dead code).
+		out := comms.CleanInternalSignals(output)
 		// Truncate if too long for Slack
-		out := output
 		if len(out) > 2500 {
 			out = out[:2497] + "..."
 		}
-		sb.WriteString(out)
-		sb.WriteString("\n\n")
+		if out != "" {
+			sb.WriteString(out)
+			sb.WriteString("\n\n")
+		}
 	}
 
 	if prURL != "" {
@@ -297,22 +303,4 @@ func planEmptyMessage(resultError string, resultSuccess bool) string {
 	default:
 		return "🤷 The task may be too simple for planning. Try executing it directly."
 	}
-}
-
-// CleanInternalSignals removes internal Navigator signals from output.
-func CleanInternalSignals(output string) string {
-	// Remove common internal signals
-	signals := []string{
-		"[EXIT_SIGNAL]",
-		"[NAV_COMPLETE]",
-		"[RESEARCH_DONE]",
-		"[IMPL_DONE]",
-	}
-
-	result := output
-	for _, signal := range signals {
-		result = strings.ReplaceAll(result, signal, "")
-	}
-
-	return strings.TrimSpace(result)
 }

--- a/internal/adapters/slack/formatter_test.go
+++ b/internal/adapters/slack/formatter_test.go
@@ -1,0 +1,48 @@
+package slack
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFormatTaskResultStripsInternalSignals verifies that FormatTaskResult
+// strips internal Navigator/Pilot signal markers via comms.CleanInternalSignals
+// before the output reaches a Slack user (GH-4967 — previously FormatTaskResult
+// never called any signal-stripping function, so signals leaked unconditionally).
+func TestFormatTaskResultStripsInternalSignals(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   string
+		contains []string
+		excludes []string
+	}{
+		{
+			name:     "strips bracketed exit signal",
+			output:   "done\n[EXIT_SIGNAL]\nreal output",
+			contains: []string{"real output"},
+			excludes: []string{"[EXIT_SIGNAL]"},
+		},
+		{
+			name:     "strips fenced pilot-signal block",
+			output:   "done\n```pilot-signal\n{\"v\":2,\"type\":\"exit\",\"exit_signal\":true,\"success\":true}\n```\nreal output",
+			contains: []string{"done", "real output"},
+			excludes: []string{"pilot-signal", "exit_signal"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatTaskResult(tt.output, true, "")
+			for _, want := range tt.contains {
+				if !strings.Contains(got, want) {
+					t.Errorf("FormatTaskResult() = %q, want to contain %q", got, want)
+				}
+			}
+			for _, exclude := range tt.excludes {
+				if strings.Contains(got, exclude) {
+					t.Errorf("FormatTaskResult() = %q, should NOT contain %q", got, exclude)
+				}
+			}
+		})
+	}
+}

--- a/internal/adapters/telegram/formatter.go
+++ b/internal/adapters/telegram/formatter.go
@@ -6,25 +6,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/qf-studio/pilot/internal/comms"
 	"github.com/qf-studio/pilot/internal/executor"
 )
-
-// Internal signals to strip from output
-var internalSignals = []string{
-	"EXIT_SIGNAL: true",
-	"EXIT_SIGNAL:true",
-	"LOOP COMPLETE",
-	"TASK MODE COMPLETE",
-	"NAVIGATOR_STATUS",
-	"━━━━━━━━━━",
-	"Phase:",
-	"Iteration:",
-	"Progress:",
-	"Completion Indicators:",
-	"Exit Conditions:",
-	"State Hash:",
-	"Next Action:",
-}
 
 // FormatTaskConfirmation formats a task confirmation message
 func FormatTaskConfirmation(taskID, description, projectPath string) string {
@@ -130,7 +114,7 @@ func formatSuccessResult(result *executor.ExecutionResult) string {
 	}
 
 	// Clean and add output summary
-	cleanOutput := cleanInternalSignals(result.Output)
+	cleanOutput := comms.CleanInternalSignals(result.Output)
 	if cleanOutput != "" {
 		// Extract key information from output
 		summary := extractSummary(cleanOutput)
@@ -194,7 +178,7 @@ func formatFailureResult(result *executor.ExecutionResult) string {
 		sb.WriteString(formatQualityGatesSummary(result.QualityGates))
 	}
 
-	cleanError := cleanInternalSignals(result.Error)
+	cleanError := comms.CleanInternalSignals(result.Error)
 	if cleanError == "" {
 		cleanError = "Unknown error"
 	}
@@ -240,7 +224,7 @@ func FormatQuestionAck() string {
 // FormatQuestionAnswer formats an answer to a question
 func FormatQuestionAnswer(answer string) string {
 	// Clean any internal signals from the answer
-	cleanAnswer := cleanInternalSignals(answer)
+	cleanAnswer := comms.CleanInternalSignals(answer)
 
 	// Convert markdown tables to lists (Telegram doesn't support tables)
 	cleanAnswer = convertTablesToLists(cleanAnswer)
@@ -325,73 +309,6 @@ func parseTableRow(row string) []string {
 		}
 	}
 	return cells
-}
-
-// cleanInternalSignals removes internal Navigator signals from output
-func cleanInternalSignals(text string) string {
-	if text == "" {
-		return ""
-	}
-
-	lines := strings.Split(text, "\n")
-	var cleanLines []string
-	skipBlock := false
-	inSignalFence := false
-
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if inSignalFence {
-			if trimmed == "```" {
-				inSignalFence = false
-			}
-			continue
-		}
-		if strings.HasPrefix(trimmed, "```pilot-signal") {
-			inSignalFence = true
-			continue
-		}
-		if strings.HasPrefix(trimmed, `{"v":`) && strings.HasSuffix(trimmed, "}") {
-			continue
-		}
-		// Skip NAVIGATOR_STATUS blocks
-		if strings.Contains(line, "NAVIGATOR_STATUS") {
-			skipBlock = true
-			continue
-		}
-		if skipBlock {
-			// End of block when we see another separator
-			if strings.HasPrefix(strings.TrimSpace(line), "━") && len(cleanLines) > 0 {
-				skipBlock = false
-			}
-			continue
-		}
-
-		// Skip lines with internal signals
-		shouldSkip := false
-		for _, signal := range internalSignals {
-			if strings.Contains(line, signal) {
-				shouldSkip = true
-				break
-			}
-		}
-		if shouldSkip {
-			continue
-		}
-
-		// Skip empty lines at the start
-		if len(cleanLines) == 0 && strings.TrimSpace(line) == "" {
-			continue
-		}
-
-		cleanLines = append(cleanLines, line)
-	}
-
-	// Trim trailing empty lines
-	for len(cleanLines) > 0 && strings.TrimSpace(cleanLines[len(cleanLines)-1]) == "" {
-		cleanLines = cleanLines[:len(cleanLines)-1]
-	}
-
-	return strings.Join(cleanLines, "\n")
 }
 
 // extractSummary extracts key summary points from output

--- a/internal/adapters/telegram/formatter_test.go
+++ b/internal/adapters/telegram/formatter_test.go
@@ -8,64 +8,6 @@ import (
 	"github.com/qf-studio/pilot/internal/executor"
 )
 
-func TestCleanInternalSignals(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "empty string",
-			input:    "",
-			expected: "",
-		},
-		{
-			name:     "clean text stays clean",
-			input:    "Created file.go\nModified main.go",
-			expected: "Created file.go\nModified main.go",
-		},
-		{
-			name:     "removes EXIT_SIGNAL",
-			input:    "Task done\nEXIT_SIGNAL: true\nCompleted",
-			expected: "Task done\nCompleted",
-		},
-		{
-			name:     "removes LOOP COMPLETE",
-			input:    "Done\nLOOP COMPLETE\nEnd",
-			expected: "Done\nEnd",
-		},
-		{
-			name:     "removes NAVIGATOR_STATUS block",
-			input:    "Start\n━━━━━━━━━━\nNAVIGATOR_STATUS\nPhase: IMPL\nIteration: 2\n━━━━━━━━━━\nContinuing",
-			expected: "Start\nContinuing",
-		},
-		{
-			name:     "removes Phase and Progress lines",
-			input:    "Working\nPhase: VERIFY\nProgress: 80%\nDone",
-			expected: "Working\nDone",
-		},
-		{
-			name:     "trims leading empty lines",
-			input:    "\n\n\nActual content",
-			expected: "Actual content",
-		},
-		{
-			name:     "trims trailing empty lines",
-			input:    "Content\n\n\n",
-			expected: "Content",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := cleanInternalSignals(tt.input)
-			if got != tt.expected {
-				t.Errorf("cleanInternalSignals() =\n%q\nwant\n%q", got, tt.expected)
-			}
-		})
-	}
-}
-
 func TestExtractSummary(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -673,59 +615,6 @@ func TestFormatFailureResultTruncation(t *testing.T) {
 	}
 }
 
-// TestCleanInternalSignalsNavigatorBlock tests NAVIGATOR_STATUS block removal
-func TestCleanInternalSignalsNavigatorBlock(t *testing.T) {
-	input := `Start of output
-━━━━━━━━━━
-NAVIGATOR_STATUS
-Phase: IMPL
-Iteration: 2
-Progress: 50%
-━━━━━━━━━━
-End of output`
-
-	got := cleanInternalSignals(input)
-
-	if strings.Contains(got, "NAVIGATOR_STATUS") {
-		t.Error("cleanInternalSignals should remove NAVIGATOR_STATUS")
-	}
-	if strings.Contains(got, "Phase: IMPL") {
-		t.Error("cleanInternalSignals should remove Phase line")
-	}
-	if !strings.Contains(got, "Start of output") {
-		t.Error("cleanInternalSignals should keep Start of output")
-	}
-	if !strings.Contains(got, "End of output") {
-		t.Error("cleanInternalSignals should keep End of output")
-	}
-}
-
-// TestCleanInternalSignalsAllSignals tests all signal types
-func TestCleanInternalSignalsAllSignals(t *testing.T) {
-	signals := []string{
-		"EXIT_SIGNAL: true",
-		"EXIT_SIGNAL:true",
-		"LOOP COMPLETE",
-		"TASK MODE COMPLETE",
-		"Iteration: 5",
-		"Completion Indicators: done",
-		"Exit Conditions: met",
-		"State Hash: abc123",
-		"Next Action: verify",
-	}
-
-	for _, signal := range signals {
-		t.Run(signal, func(t *testing.T) {
-			input := "Before\n" + signal + "\nAfter"
-			got := cleanInternalSignals(input)
-
-			if strings.Contains(got, signal) {
-				t.Errorf("cleanInternalSignals should remove %q, got:\n%s", signal, got)
-			}
-		})
-	}
-}
-
 // TestExtractSummaryPatterns tests all extraction patterns
 func TestExtractSummaryPatterns(t *testing.T) {
 	tests := []struct {
@@ -942,46 +831,6 @@ func TestFormatTaskResultSuccessWithInternalSignals(t *testing.T) {
 	}
 	if strings.Contains(got, "LOOP COMPLETE") {
 		t.Error("FormatTaskResult() should clean LOOP COMPLETE from output")
-	}
-}
-
-// TestInternalSignalsArray tests the internal signals slice
-func TestInternalSignalsArray(t *testing.T) {
-	expectedSignals := []string{
-		"EXIT_SIGNAL: true",
-		"EXIT_SIGNAL:true",
-		"LOOP COMPLETE",
-		"TASK MODE COMPLETE",
-		"NAVIGATOR_STATUS",
-	}
-
-	for _, expected := range expectedSignals {
-		found := false
-		for _, signal := range internalSignals {
-			if signal == expected {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("internalSignals should contain %q", expected)
-		}
-	}
-}
-
-// TestCleanInternalSignalsWithSeparators tests separator handling
-func TestCleanInternalSignalsWithSeparators(t *testing.T) {
-	input := `Before content
-━━━━━━━━━━
-More text
-━━━━━━━━━━
-After content`
-
-	got := cleanInternalSignals(input)
-
-	// Separators should be removed
-	if strings.Contains(got, "━━━━━━━━━━") {
-		t.Errorf("cleanInternalSignals should remove separators, got:\n%s", got)
 	}
 }
 

--- a/internal/adapters/telegram/messenger.go
+++ b/internal/adapters/telegram/messenger.go
@@ -90,7 +90,7 @@ func (m *TelegramMessenger) SendResult(ctx context.Context, contextID, threadID,
 
 	text := fmt.Sprintf("%s Task %s: %s", icon, status, taskID)
 	if output != "" {
-		clean := cleanInternalSignals(output)
+		clean := comms.CleanInternalSignals(output)
 		if len(clean) > 3000 {
 			clean = clean[:3000] + "..."
 		}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4967.

Closes #4967

## Changes

GitHub Issue GH-4967: fix(comms): consolidate signal stripping onto comms.CleanInternalSignals — slack/discord leak signal blocks today

## Context

Leg C of `.agent/tasks/TASK-481-review-followup-defects.md`. Gate cleared: #4903 is MERGED — consolidate onto its `comms.CleanInternalSignals`. NOTE: wiring the call into slack/discord `FormatTaskResult` is NEW production behavior, not a refactor — say so in the PR description.

## Problem — signal blocks leak to Slack and Discord users today (four copies, three behaviors)

**Defect — larger than PR #4903's own note.** There are four independent copies of "strip internal signal markers," and slack/discord's are not merely stale: **their `FormatTaskResult` never calls them at all**. `CleanInternalSignals` is unreachable dead code in both adapters, so every `EXIT_SIGNAL` / `NAVIGATOR_STATUS` / fenced `pilot-signal` block in task output reaches Slack and Discord users unconditionally, today.

| Copy | Location | Handles | Fenced blocks | Bare `{"v":…}` | Called from `FormatTaskResult`? |
|---|---|---|---|---|---|
| comms (canonical) | `internal/comms/util.go:9-70` | full list + `NAVIGATOR_STATUS` block-skip | after #4903 ✓ | after #4903 ✓ | n/a (library) |
| telegram (dupe) | `adapters/telegram/formatter.go:330+`, called :133,:197,:243 | same list, independently duplicated constants :11-18 | after #4903 ✓ | after #4903 ✓ | yes |
| slack | `adapters/slack/formatter.go:302-318` | only 4 literal `[…]` markers via `ReplaceAll` | no | no | **no** — dead code, zero call sites |
| discord | `adapters/discord/formatter.go:135-143` | a *different* scheme: `<!-- INTERNAL: … -->`, no producer anywhere in the repo (vestigial) | no | no | **no** — only `handler_test.go:781` |

**Fix — consolidate, don't patch four copies.**

1. `internal/comms/util.go` is the home. All three adapters already import `internal/comms` for `Handler`/`IncomingMessage`/`Messenger` — zero new import edges, no cycle risk.
2. Delete `slack/formatter.go:302-318` and `discord/formatter.go:135-143` outright (unreachable ⇒ deletion is safe and removes the drift surface).
3. Delete telegram's unexported copy (constants :11-18, function :330+); its three call sites become `comms.CleanInternalSignals(...)`.
4. **Wire the call in** at `slack/formatter.go:53` (`FormatTaskResult`) and `discord/formatter.go:30`, before truncation/write. This is **new production behavior**, not a refactor — flag it explicitly in the PR description.

**Files**: `adapters/telegram/formatter.go` (+ its `formatter_test.go`) · `adapters/slack/formatter.go` (+import) · `adapters/discord/formatter.go` (+import) · `adapters/discord/handler_test.go:779-` (repoint or remove `TestCleanInternalSignals`).

**Test rows**:

| Adapter | Input to `FormatTaskResult` | Expected |
|---|---|---|
| slack | `"done\n[EXIT_SIGNAL]\nreal output"` | contains `real output`, not `[EXIT_SIGNAL]` |
| slack | fenced ```` ```pilot-signal\n{"v":2,…}\n``` ```` | neither `pilot-signal` nor the JSON payload |
| discord | `"done\nNAVIGATOR_STATUS\n━━━\nreal output"` | no `NAVIGATOR_STATUS` |
| discord | `"checked issue\n{\"v\":2,\"type\":\"status\"}\nnothing to do"` | bare JSON line stripped |
| telegram | existing `formatSuccessResult`/`formatFailureResult` tests | identical output post-redirect |
| build | old copies removed | `go build ./...` clean |

**Dependency**: **must land after #4903** (or rebased onto it) — #4903 is what makes `comms.CleanInternalSignals` the version worth centralizing on. Landing first would point everyone at the pre-#4903 implementation and require a second pass. Risk note: any existing slack/discord golden-output fixture containing signal-shaped substrings will need updating.

---



## Acceptance

- All six test rows above pass; slack/discord/telegram local copies deleted; `go build ./...` clean.