### PR TITLE
GH-4968: fix(ghguard): honor GH_REPO/GH_HOST env in classification — env bypasses the repo check today

### DIFF
--- a/cmd/pilot/ghguard.go
+++ b/cmd/pilot/ghguard.go
@@ -53,7 +53,10 @@ func stripLeadingDoubleDash(args []string) []string {
 }
 
 // runGhGuard is the testable core of the gh-guard command: classify args
-// against the identity built from getenv, and either deny (journal +
+// against the identity built from getenv plus gh's own GH_REPO/GH_HOST env
+// overrides (ghguard.EnvOverrideFromEnv — GH-4968/D5, since gh itself
+// honors those vars and a guard that only reads argv can be bypassed by
+// setting them instead of passing -R/--host), and either deny (journal +
 // explain on stderr, no exec) or exec the real `gh` with stdin/stdout/
 // stderr wired straight through. Returns the process exit code the caller
 // should use.
@@ -71,7 +74,8 @@ func runGhGuard(args []string, getenv func(string) string, stdin io.Reader, stdo
 	}
 
 	id := ghguard.IdentityFromEnv(getenv)
-	decision := ghguard.Classify(id, args)
+	env := ghguard.EnvOverrideFromEnv(getenv)
+	decision := ghguard.Classify(id, args, env)
 
 	if decision.Verdict == ghguard.VerdictDeny {
 		journalPath := getenv(ghguard.EnvJournalPath)
@@ -82,6 +86,8 @@ func runGhGuard(args []string, getenv func(string) string, stdin io.Reader, stdo
 			Args:      args,
 			TaskIssue: id.TaskIssue,
 			TaskRepo:  id.TaskRepo,
+			EnvRepo:   decision.EnvRepo,
+			EnvHost:   decision.EnvHost,
 		}
 		// Best-effort: the journal is evidence for the GH-4670 audit to pick
 		// up later, never a reason to change the deny decision itself.

--- a/cmd/pilot/ghguard_test.go
+++ b/cmd/pilot/ghguard_test.go
@@ -116,6 +116,87 @@ func TestRunGhGuard_DeniesMutationAndNeverExecs(t *testing.T) {
 	}
 }
 
+// TestRunGhGuard_GhRepoEnvBypassDenied is GH-4968/D5's e2e check: gh itself
+// honors GH_REPO from the environment (not just -R/--repo on argv), so a
+// task session that sets GH_REPO instead of passing -R must be denied and
+// journaled exactly like the argv form is — confirming the env var is
+// actually read from the subprocess environment runGhGuard inherits, not
+// just exercised via ghguard.Classify's own unit tests.
+func TestRunGhGuard_GhRepoEnvBypassDenied(t *testing.T) {
+	tmpDir := t.TempDir()
+	recordPath := filepath.Join(tmpDir, "record.txt")
+	fakeGh := writeFakeGh(t, tmpDir, recordPath)
+	journalPath := filepath.Join(tmpDir, "journal.jsonl")
+
+	env := envLookup(map[string]string{
+		"PILOT_TASK_ISSUE":       "123",
+		"PILOT_TASK_REPO":        "qf-studio/pilot",
+		"PILOT_TASK_BRANCH":      "pilot/GH-123",
+		"PILOT_GH_REAL":          fakeGh,
+		"PILOT_GH_GUARD_JOURNAL": journalPath,
+		"GH_REPO":                "other/repo",
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := runGhGuard([]string{"issue", "comment", "1", "--body", "x"}, env, strings.NewReader(""), &stdout, &stderr)
+
+	if code == 0 {
+		t.Fatal("expected non-zero exit code for a GH_REPO cross-repo bypass attempt")
+	}
+	if _, err := os.Stat(recordPath); err == nil {
+		t.Error("expected fake gh to never be invoked on a deny verdict")
+	}
+
+	journalBytes, err := os.ReadFile(journalPath)
+	if err != nil {
+		t.Fatalf("expected a journal entry to be written on deny: %v", err)
+	}
+	journalStr := string(journalBytes)
+	if !strings.Contains(journalStr, `"env_repo":"other/repo"`) {
+		t.Errorf("expected journal entry to record the env-derived repo, got: %s", journalStr)
+	}
+	if !strings.Contains(stderr.String(), "GH_REPO") {
+		t.Errorf("expected stderr to explain the GH_REPO-driven denial, got: %s", stderr.String())
+	}
+}
+
+// TestRunGhGuard_GhHostEnvOverrideDenied is GH-4968/D5's e2e check for
+// GH_HOST: a non-github.com host is fail-closed regardless of command.
+func TestRunGhGuard_GhHostEnvOverrideDenied(t *testing.T) {
+	tmpDir := t.TempDir()
+	recordPath := filepath.Join(tmpDir, "record.txt")
+	fakeGh := writeFakeGh(t, tmpDir, recordPath)
+	journalPath := filepath.Join(tmpDir, "journal.jsonl")
+
+	env := envLookup(map[string]string{
+		"PILOT_TASK_ISSUE":       "123",
+		"PILOT_TASK_REPO":        "qf-studio/pilot",
+		"PILOT_TASK_BRANCH":      "pilot/GH-123",
+		"PILOT_GH_REAL":          fakeGh,
+		"PILOT_GH_GUARD_JOURNAL": journalPath,
+		"GH_HOST":                "ghe.example.com",
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := runGhGuard([]string{"api", "user"}, env, strings.NewReader(""), &stdout, &stderr)
+
+	if code == 0 {
+		t.Fatal("expected non-zero exit code for a non-github.com GH_HOST")
+	}
+	if _, err := os.Stat(recordPath); err == nil {
+		t.Error("expected fake gh to never be invoked on a deny verdict")
+	}
+
+	journalBytes, err := os.ReadFile(journalPath)
+	if err != nil {
+		t.Fatalf("expected a journal entry to be written on deny: %v", err)
+	}
+	journalStr := string(journalBytes)
+	if !strings.Contains(journalStr, `"env_host":"ghe.example.com"`) {
+		t.Errorf("expected journal entry to record the env-derived host, got: %s", journalStr)
+	}
+}
+
 func TestRunGhGuard_NoArgs(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := runGhGuard(nil, envLookup(nil), strings.NewReader(""), &stdout, &stderr)

--- a/internal/executor/ghguard/policy.go
+++ b/internal/executor/ghguard/policy.go
@@ -36,9 +36,19 @@
 // open rather than folded in here: denying `api graphql` with field flags
 // regardless of method (belt-and-braces; D2), and consuming known
 // value-flags while scanning for the sub when flags precede the
-// subcommand (a false-deny-only gap; D3). GH_REPO/GH_HOST env var
-// bypasses of the -R/--repo check are tracked separately (D5) since no
-// argv-level fix covers them.
+// subcommand (a false-deny-only gap; D3).
+//
+// GH_REPO/GH_HOST env bypass (GH-4968/D5): argv-only classification missed
+// that `gh` itself also honors GH_REPO/GH_HOST from the environment, so
+// `GH_REPO=other/repo gh issue comment N --body x` used to sail through the
+// -R/--repo check (which only ever looked at argv) straight into a
+// cross-repo mutation — the exact class GH-4649 exists to stop. Classify
+// now takes an EnvOverride carrying those two vars: a set GH_REPO is
+// treated exactly like an explicit -R/--repo when argv gave none (argv
+// still wins when both are present, matching gh's own -R > GH_REPO > local
+// git remote precedence — see EnvOverride's doc comment), and a non-
+// github.com GH_HOST is a hard, unconditional deny (fail closed: every
+// repo this guard reasons about lives on github.com).
 package ghguard
 
 import (
@@ -108,6 +118,31 @@ type Identity struct {
 	RealGh     string
 }
 
+// EnvOverride carries the subset of gh's OWN environment variables (not
+// Pilot's — contrast Identity, which is built from PILOT_* vars) that
+// change which repo/host a `gh` call actually targets, independent of
+// argv. gh resolves the target repo as: -R/--repo flag > GH_REPO env var >
+// the repo detected from the current directory's git remote (`gh help
+// environment`); GH_HOST similarly overrides the default "github.com" host
+// gh assumes when no repo/host can otherwise be resolved. Classify honors
+// both so an executor session can't launder a cross-repo (or
+// cross-instance) mutation past the -R/--repo check just by setting an env
+// var instead of passing a flag (GH-4968/D5).
+type EnvOverride struct {
+	Repo string // GH_REPO, empty if unset
+	Host string // GH_HOST, empty if unset
+}
+
+// EnvOverrideFromEnv builds an EnvOverride from gh's own environment
+// variables. The caller (cmd/pilot/ghguard.go) calls this directly against
+// the same getenv it passes to IdentityFromEnv.
+func EnvOverrideFromEnv(getenv func(string) string) EnvOverride {
+	return EnvOverride{
+		Repo: getenv("GH_REPO"),
+		Host: getenv("GH_HOST"),
+	}
+}
+
 // Decision is the result of Classify: whether to allow the call, and (on
 // deny) a one-line reason plus a hint of what IS allowed, so the executor
 // session sees actionable stderr instead of a bare failure.
@@ -115,6 +150,13 @@ type Decision struct {
 	Verdict Verdict
 	Reason  string
 	Allowed string // populated on deny only
+
+	// EnvRepo/EnvHost are populated only when a deny was actually driven by
+	// GH_REPO/GH_HOST (as opposed to argv or an unrelated hard-deny rule),
+	// so the journal entry built from this Decision can distinguish an
+	// env-bypass denial from an argv one (GH-4968).
+	EnvRepo string
+	EnvHost string
 }
 
 // ruleKind distinguishes the three ways an allowlisted command is verified.
@@ -560,12 +602,13 @@ func isAllDigits(s string) bool {
 	return true
 }
 
-// Classify is the pure policy core: given the task's Identity and the `gh`
+// Classify is the pure policy core: given the task's Identity, the `gh`
 // argv (excluding the "gh" program name — e.g. []string{"issue", "view",
-// "42"}), decide whether the call may proceed. Deterministic, no I/O, safe
-// to call from a table test for every rule in allowRules plus every
+// "42"}), and gh's own env-var overrides (GH_REPO/GH_HOST — see
+// EnvOverride), decide whether the call may proceed. Deterministic, no I/O,
+// safe to call from a table test for every rule in allowRules plus every
 // hard-deny case.
-func Classify(id Identity, args []string) Decision {
+func Classify(id Identity, args []string, env EnvOverride) Decision {
 	if len(args) == 0 {
 		return deny("empty gh invocation", allowedSummary())
 	}
@@ -584,8 +627,40 @@ func Classify(id Identity, args []string) Decision {
 	if p.hasAddLabel || p.hasRemoveLabel {
 		return deny("label mutation (--add-label/--remove-label) is never permitted", allowedSummary())
 	}
-	if p.repoGiven && id.TaskRepo != "" && p.repo != id.TaskRepo {
-		return deny(fmt.Sprintf("-R/--repo %s does not match the task's repo %s", p.repo, id.TaskRepo), allowedSummary())
+
+	// GH_HOST fail-closed (GH-4968/D5): every repo this guard's TaskRepo/
+	// allowlist reasoning assumes lives on github.com. A GH_HOST pointing
+	// anywhere else (GHE, a test double, ...) means we can no longer vouch
+	// for what host the call actually reaches, so deny unconditionally
+	// rather than evaluate the rest of the policy against an assumption
+	// that no longer holds.
+	if env.Host != "" && !strings.EqualFold(env.Host, "github.com") {
+		d := deny(fmt.Sprintf("GH_HOST=%s is not github.com; refusing to guess what host this call actually targets", env.Host), allowedSummary())
+		d.EnvHost = env.Host
+		return d
+	}
+
+	// Repo-scoping check, argv OR env: gh resolves the target repo as
+	// -R/--repo flag > GH_REPO env var > local git remote, so an explicit
+	// argv -R/--repo always wins when both are present — effRepoGiven only
+	// falls through to env.Repo when parseArgs saw no -R/--repo at all.
+	// This closes the GH-4968 bypass (GH_REPO alone used to skip this check
+	// entirely) while still matching gh's own precedence rather than adding
+	// a guard-only rule that argv could never override.
+	effRepo, effRepoGiven, envRepoUsed := p.repo, p.repoGiven, false
+	if !effRepoGiven && env.Repo != "" {
+		effRepo, effRepoGiven, envRepoUsed = env.Repo, true, true
+	}
+	if effRepoGiven && id.TaskRepo != "" && effRepo != id.TaskRepo {
+		reason := fmt.Sprintf("-R/--repo %s does not match the task's repo %s", effRepo, id.TaskRepo)
+		if envRepoUsed {
+			reason = fmt.Sprintf("GH_REPO=%s does not match the task's repo %s (no -R/--repo flag given)", effRepo, id.TaskRepo)
+		}
+		d := deny(reason, allowedSummary())
+		if envRepoUsed {
+			d.EnvRepo = env.Repo
+		}
+		return d
 	}
 
 	for _, r := range allowRules {
@@ -711,6 +786,13 @@ type JournalEntry struct {
 	Args      []string  `json:"args"`
 	TaskIssue string    `json:"task_issue,omitempty"`
 	TaskRepo  string    `json:"task_repo,omitempty"`
+
+	// EnvRepo/EnvHost record GH_REPO/GH_HOST when they actually drove this
+	// denial (see Decision.EnvRepo/EnvHost), so a denied env-bypass attempt
+	// is distinguishable in the audit trail from an argv -R/--repo one
+	// (GH-4968).
+	EnvRepo string `json:"env_repo,omitempty"`
+	EnvHost string `json:"env_host,omitempty"`
 }
 
 // AppendJournal appends one entry to the JSONL journal at path, creating it

--- a/internal/executor/ghguard/policy_test.go
+++ b/internal/executor/ghguard/policy_test.go
@@ -3,6 +3,7 @@ package ghguard
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -179,7 +180,7 @@ func TestClassify(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := Classify(id, tt.args)
+			got := Classify(id, tt.args, EnvOverride{})
 			if got.Verdict != tt.wantVerdict {
 				t.Fatalf("Classify(%v) = %s (reason: %q), want %s", tt.args, got.Verdict, got.Reason, tt.wantVerdict)
 			}
@@ -195,6 +196,97 @@ func TestClassify(t *testing.T) {
 	}
 }
 
+// TestClassify_EnvOverride is GH-4968/D5: gh itself honors GH_REPO/GH_HOST
+// from the environment, not just -R/--repo on argv, so Classify must too —
+// otherwise `GH_REPO=other/repo gh issue comment N --body x` sails through
+// the repo-scoping check (which used to look at argv only) into a
+// cross-repo mutation, the exact class GH-4649 exists to stop. Kept as its
+// own table (rather than folded into TestClassify's) since every row here
+// exercises the env parameter, not just args.
+func TestClassify_EnvOverride(t *testing.T) {
+	id := testIdentity()
+
+	tests := []struct {
+		name        string
+		args        []string
+		env         EnvOverride
+		wantVerdict Verdict
+	}{
+		{"GH_REPO cross-repo mutation denied like argv -R would be",
+			[]string{"issue", "comment", "1", "--body", "x"}, EnvOverride{Repo: "other/repo"}, VerdictDeny},
+		{"GH_REPO matching own repo allows a read",
+			[]string{"issue", "view", "1"}, EnvOverride{Repo: "qf-studio/pilot"}, VerdictAllow},
+		{"GH_REPO matching own repo allows own-artifact comment",
+			[]string{"issue", "comment", "4671", "--body", "x"}, EnvOverride{Repo: "qf-studio/pilot"}, VerdictAllow},
+		{"argv -R wins over conflicting GH_REPO (own repo via argv, foreign via env)",
+			[]string{"issue", "view", "1", "-R", "qf-studio/pilot"}, EnvOverride{Repo: "other/repo"}, VerdictAllow},
+		{"argv -R wins over conflicting GH_REPO (foreign via argv, own via env) — still denied",
+			[]string{"issue", "view", "1", "-R", "other/repo"}, EnvOverride{Repo: "qf-studio/pilot"}, VerdictDeny},
+		{"GH_HOST non-github.com denies an otherwise-allowed read",
+			[]string{"api", "user"}, EnvOverride{Host: "ghe.example.com"}, VerdictDeny},
+		{"GH_HOST=github.com is a no-op",
+			[]string{"issue", "view", "1"}, EnvOverride{Host: "github.com"}, VerdictAllow},
+		{"GH_HOST case-insensitive match is a no-op",
+			[]string{"issue", "view", "1"}, EnvOverride{Host: "GitHub.com"}, VerdictAllow},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Classify(id, tt.args, tt.env)
+			if got.Verdict != tt.wantVerdict {
+				t.Fatalf("Classify(%v, env=%+v) = %s (reason: %q), want %s", tt.args, tt.env, got.Verdict, got.Reason, tt.wantVerdict)
+			}
+			if got.Verdict == VerdictDeny {
+				if got.Reason == "" {
+					t.Errorf("deny decision missing Reason")
+				}
+				if got.Allowed == "" {
+					t.Errorf("deny decision missing Allowed hint")
+				}
+			}
+		})
+	}
+}
+
+// TestClassify_EnvBypassJournalDistinguishable verifies the GH-4968
+// requirement that a denial driven by GH_REPO/GH_HOST is distinguishable
+// from an argv -R/--repo denial: the Decision carries the env-derived
+// value (which cmd/pilot/ghguard.go copies into the journal entry) and the
+// Reason text itself names the env var rather than "-R/--repo".
+func TestClassify_EnvBypassJournalDistinguishable(t *testing.T) {
+	id := testIdentity()
+
+	envDeny := Classify(id, []string{"issue", "comment", "1", "--body", "x"}, EnvOverride{Repo: "other/repo"})
+	if envDeny.Verdict != VerdictDeny {
+		t.Fatalf("expected deny, got %s", envDeny.Verdict)
+	}
+	if envDeny.EnvRepo != "other/repo" {
+		t.Errorf("expected Decision.EnvRepo = %q, got %q", "other/repo", envDeny.EnvRepo)
+	}
+	if !strings.Contains(envDeny.Reason, "GH_REPO") {
+		t.Errorf("expected env-derived deny reason to mention GH_REPO, got %q", envDeny.Reason)
+	}
+
+	argvDeny := Classify(id, []string{"issue", "comment", "1", "--body", "x", "-R", "other/repo"}, EnvOverride{})
+	if argvDeny.Verdict != VerdictDeny {
+		t.Fatalf("expected deny, got %s", argvDeny.Verdict)
+	}
+	if argvDeny.EnvRepo != "" {
+		t.Errorf("expected Decision.EnvRepo empty for an argv-driven denial, got %q", argvDeny.EnvRepo)
+	}
+	if strings.Contains(argvDeny.Reason, "GH_REPO") {
+		t.Errorf("argv-driven deny reason should not mention GH_REPO, got %q", argvDeny.Reason)
+	}
+
+	hostDeny := Classify(id, []string{"api", "user"}, EnvOverride{Host: "ghe.example.com"})
+	if hostDeny.Verdict != VerdictDeny {
+		t.Fatalf("expected deny, got %s", hostDeny.Verdict)
+	}
+	if hostDeny.EnvHost != "ghe.example.com" {
+		t.Errorf("expected Decision.EnvHost = %q, got %q", "ghe.example.com", hostDeny.EnvHost)
+	}
+}
+
 // TestClassify_IncompleteIdentity verifies that when TaskRepo/TaskBranch/
 // TaskIssue are empty (identity incomplete), repo-mismatch checks are
 // skipped (unenforceable) but own-artifact checks still deny rather than
@@ -203,20 +295,20 @@ func TestClassify_IncompleteIdentity(t *testing.T) {
 	id := Identity{} // fully empty
 
 	// Reads still work — the allowlist doesn't require identity.
-	if got := Classify(id, []string{"issue", "view", "1"}); got.Verdict != VerdictAllow {
+	if got := Classify(id, []string{"issue", "view", "1"}, EnvOverride{}); got.Verdict != VerdictAllow {
 		t.Errorf("read with empty identity: got %s, want allow", got.Verdict)
 	}
 
 	// Own-artifact still denies — can't confirm ownership without identity.
-	if got := Classify(id, []string{"issue", "comment", "1", "--body", "hi"}); got.Verdict != VerdictDeny {
+	if got := Classify(id, []string{"issue", "comment", "1", "--body", "hi"}, EnvOverride{}); got.Verdict != VerdictDeny {
 		t.Errorf("issue comment with empty identity: got %s, want deny", got.Verdict)
 	}
-	if got := Classify(id, []string{"pr", "create", "--head", "some-branch"}); got.Verdict != VerdictDeny {
+	if got := Classify(id, []string{"pr", "create", "--head", "some-branch"}, EnvOverride{}); got.Verdict != VerdictDeny {
 		t.Errorf("pr create --head with empty identity: got %s, want deny", got.Verdict)
 	}
 
 	// pr create with no --head at all still allows (defaults to current branch).
-	if got := Classify(id, []string{"pr", "create", "--title", "t"}); got.Verdict != VerdictAllow {
+	if got := Classify(id, []string{"pr", "create", "--title", "t"}, EnvOverride{}); got.Verdict != VerdictAllow {
 		t.Errorf("pr create no --head with empty identity: got %s, want allow", got.Verdict)
 	}
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4968.

Closes #4968

## Changes

GitHub Issue GH-4968: fix(ghguard): honor GH_REPO/GH_HOST env in classification — env bypasses the repo check today

## Context

Spun out of TASK-479 research (open decision D5, `.agent/tasks/TASK-479-ghguard-parser-parity.md`): gh-guard classifies argv only. `gh` also reads `GH_REPO`/`GH_HOST` from the environment, so `GH_REPO=other/repo gh issue comment N --body x` comments on a foreign repo while the guard's repo check sees no `-R` flag and allows it — the exact cross-repo mutation class the guard exists to stop (GH-4649), and no argv-parser fix covers it.

## Problem

`runGhGuard` (cmd/pilot/ghguard.go) inherits the executor subprocess environment but never inspects it. The repo-scoping check in `internal/executor/ghguard/policy.go` (`checkOwnArtifact`) derives the target repo from `-R/--repo` argv only, defaulting to "current repo" when absent — while gh itself would honor `GH_REPO`.

## Implementation

- In `runGhGuard`, read `GH_REPO` and `GH_HOST` before classification. Treat a set `GH_REPO` exactly like an explicit `-R <value>` (feed it into the classification as the repo argument when argv has none; argv `-R` wins when both are present, matching gh's own precedence — verify precedence against gh docs/source and note it in a comment). A set `GH_HOST` pointing anywhere other than github.com ⇒ deny (fail closed — our repos live on github.com).
- Alternative considered and rejected: scrubbing the vars before exec'ing real gh would silently change the command's meaning; classify-with-env keeps the guard honest about what gh would actually do.
- Journal the env-derived repo in the denial audit record so a denied env-bypass attempt is distinguishable from an argv one.

## Acceptance

- `GH_REPO=other/repo gh issue comment 1 --body x` → deny (cross-repo mutation), same reason quality as the argv `-R` deny.
- `GH_REPO=<own repo> gh issue view 1` → allow.
- `GH_HOST=ghe.example.com gh api user` → deny.
- Argv `-R` + conflicting `GH_REPO`: argv wins (gh precedence), with a test row proving it.
- Table-driven tests alongside the existing policy tests; denial journal includes the env-derived repo.

## Refs

- TASK-479 D5 · sibling issue: the pflag-parity parser rewrite (lands independently; no ordering constraint)