### PR TITLE
GH-4982: fix(autopilot): missed-train recovery fires before the scheduled tick on boot, then a later restart never recovers the genuinely-missed tick

### DIFF
--- a/internal/autopilot/gh4982_test.go
+++ b/internal/autopilot/gh4982_test.go
@@ -1,0 +1,171 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+	"github.com/robfig/cron/v3"
+)
+
+// TestDecideTrainRecovery covers decideTrainRecovery's four boot/tick/release
+// orderings (GH-4982 acceptance criteria), anchored to the live incident's
+// own timestamps: a daemon restart at 2026-08-18 13:40:57Z ran boot-time
+// recovery before that day's 14:00Z scheduled tick and cut a release anyway
+// (the "early fire" defect); a later restart at 15:12:16Z found the tick had
+// genuinely passed with nothing released for it but didn't recover (the
+// "missed recovery" defect) because a nearby-but-earlier release apparently
+// satisfied whatever gated it.
+func TestDecideTrainRecovery(t *testing.T) {
+	scheduledAt := time.Date(2026, 8, 18, 14, 0, 0, 0, time.UTC) // 16:00 Europe/Berlin daily tick
+
+	tests := []struct {
+		name          string
+		now           time.Time
+		lastReleaseAt time.Time
+		wantFire      bool
+	}{
+		{
+			name:          "boot before tick: scheduled time still in the future — no recovery",
+			now:           time.Date(2026, 8, 18, 13, 40, 57, 0, time.UTC), // restart #1, 15:40 Berlin
+			lastReleaseAt: time.Time{},
+			wantFire:      false,
+		},
+		{
+			name:          "boot after tick with pre-tick release: last release predates the tick — recovery fires",
+			now:           time.Date(2026, 8, 18, 15, 12, 16, 0, time.UTC), // restart #2, 17:12 Berlin
+			lastReleaseAt: time.Date(2026, 8, 18, 13, 45, 7, 0, time.UTC),  // tag cut 15min before the tick
+			wantFire:      true,
+		},
+		{
+			name:          "boot after tick with post-tick release: last release already covers the tick — no recovery",
+			now:           time.Date(2026, 8, 18, 15, 12, 16, 0, time.UTC),
+			lastReleaseAt: scheduledAt.Add(15 * time.Minute),
+			wantFire:      false,
+		},
+		{
+			name:          "boot after tick, no releases at all: recovery fires",
+			now:           time.Date(2026, 8, 18, 15, 12, 16, 0, time.UTC),
+			lastReleaseAt: time.Time{},
+			wantFire:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := decideTrainRecovery(tt.now, scheduledAt, tt.lastReleaseAt)
+			if got.Fire != tt.wantFire {
+				t.Errorf("decideTrainRecovery() fire = %v (reason %q), want fire = %v", got.Fire, got.Reason, tt.wantFire)
+			}
+			if got.Reason == "" {
+				t.Error("decideTrainRecovery() reason is empty — a recovery decision must log its reasoning (GH-4982)")
+			}
+		})
+	}
+}
+
+// trainRecoveryServer builds a fake GitHub server for exercising
+// recoverMissedTrainTick's last-release-time gate end to end (GH-4982).
+// /releases/latest and /releases/tags/<lastTag> both serve a Release
+// timestamped at releaseAt, or both 404 when hasRelease is false (simulating
+// "no releases at all"). /tags is always empty so the release object — not a
+// bare tag — is the GetCurrentVersionWithSource baseline winner, keeping
+// GetLastReleaseTime's tag-name lookup deterministic. downstreamHits counts
+// any request past the gate itself: CompareCommits (the tagged-repo tick
+// path) or ListPullRequests?state=closed (the no-tag first-release path) —
+// a proxy for "the gate fired and the tick actually ran".
+func trainRecoveryServer(t *testing.T, lastTag string, releaseAt time.Time, hasRelease bool, downstreamHits *int64) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/releases/latest"), strings.HasSuffix(r.URL.Path, "/releases/tags/"+lastTag):
+			if !hasRelease {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Release{TagName: lastTag, CreatedAt: releaseAt, PublishedAt: releaseAt})
+		case strings.HasSuffix(r.URL.Path, "/tags"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		case strings.Contains(r.URL.Path, "/compare/"):
+			atomic.AddInt64(downstreamHits, 1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"commits": []}`))
+		case strings.HasSuffix(r.URL.Path, "/pulls") && r.URL.Query().Get("state") == "closed":
+			atomic.AddInt64(downstreamHits, 1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+}
+
+// TestRecoverMissedTrainTick_LastReleaseGate is the end-to-end companion to
+// TestDecideTrainRecovery: it drives recoverMissedTrainTick itself (real
+// schedule, real state store, fake GitHub server) through the three
+// release-timing orderings that require an actual past tick — "boot before
+// tick" is covered separately since previousScheduledTime never hands
+// recoverMissedTrainTick a future scheduledAt to begin with (GH-4982).
+func TestRecoverMissedTrainTick_LastReleaseGate(t *testing.T) {
+	loc := time.UTC
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	schedule, err := parser.Parse("0 21 * * FRI")
+	if err != nil {
+		t.Fatalf("parse schedule: %v", err)
+	}
+	prevScheduled := previousScheduledTime(schedule, time.Now().In(loc))
+
+	tests := []struct {
+		name       string
+		hasRelease bool
+		releaseAt  time.Time
+		wantFire   bool
+	}{
+		{
+			name:       "boot after tick with pre-tick release: recovery fires",
+			hasRelease: true,
+			releaseAt:  prevScheduled.Add(-1 * time.Hour),
+			wantFire:   true,
+		},
+		{
+			name:       "boot after tick with post-tick release: recovery does not fire",
+			hasRelease: true,
+			releaseAt:  prevScheduled.Add(1 * time.Hour),
+			wantFire:   false,
+		},
+		{
+			name:       "boot after tick, no releases at all: recovery fires",
+			hasRelease: false,
+			wantFire:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var downstreamHits int64
+			server := trainRecoveryServer(t, "v1.0.0", tt.releaseAt, tt.hasRelease, &downstreamHits)
+			defer server.Close()
+
+			c, _ := newScheduleController(t, server.URL, "0 21 * * FRI")
+			rel := c.resolvedRelease()
+			rel.ScopeLookback = 7 * 24 * time.Hour
+
+			c.recoverMissedTrainTick(context.Background(), rel, schedule, loc)
+
+			gotFire := atomic.LoadInt64(&downstreamHits) > 0
+			if gotFire != tt.wantFire {
+				t.Errorf("downstream tick fired = %v, want %v (downstream_hits=%d)", gotFire, tt.wantFire, downstreamHits)
+			}
+		})
+	}
+}

--- a/internal/autopilot/releaser.go
+++ b/internal/autopilot/releaser.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 )
@@ -380,6 +381,49 @@ func isDuplicateReleaseError(err error) bool {
 func (r *Releaser) GetCurrentVersionForRepo(ctx context.Context, owner, repo string) (SemVer, error) {
 	v, _, err := r.GetCurrentVersionWithSource(ctx, owner, repo)
 	return v, err
+}
+
+// GetLastReleaseTime returns when the release-version baseline for
+// owner/repo — as computed by GetCurrentVersionWithSource's
+// tags-authoritative comparison (GH-4953) — was actually cut, or the zero
+// time if the repo has no releases/tags yet, or if the winning tag has no
+// covering GitHub Release to read a timestamp from.
+//
+// GH-4982: boot-time missed-train recovery used to gauge "is there already
+// a recent-enough release" from whatever GetLatestRelease happened to
+// return, without comparing its timestamp against the specific tick being
+// considered — so a release that landed minutes before a scheduled tick
+// satisfied a freshness check even though it predated the tick and never
+// covered it. Anchoring the timestamp lookup to the SAME winning tag
+// GetCurrentVersionWithSource resolves (via GetReleaseByTag) avoids
+// repeating that mistake with a second stale-Release trap: GetLatestRelease
+// alone can return an older Release than the true tags-authoritative
+// baseline (the exact GH-4953 gap — a newer tag with no covering Release).
+//
+// A zero return (no covering Release for the winning tag) is treated by
+// callers as "does not satisfy any tick" — this errs toward firing recovery
+// rather than silently skipping a genuinely missed train.
+func (r *Releaser) GetLastReleaseTime(ctx context.Context, owner, repo string) (time.Time, error) {
+	version, _, err := r.GetCurrentVersionWithSource(ctx, owner, repo)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if version == (SemVer{}) {
+		return time.Time{}, nil
+	}
+
+	tagName := version.String(r.config.TagPrefix)
+	release, err := r.ghClient.GetReleaseByTag(ctx, owner, repo, tagName)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if release == nil {
+		return time.Time{}, nil
+	}
+	if !release.PublishedAt.IsZero() {
+		return release.PublishedAt, nil
+	}
+	return release.CreatedAt, nil
 }
 
 // ShouldRelease determines if a release should be created based on config and bump type.

--- a/internal/autopilot/scope_schedule.go
+++ b/internal/autopilot/scope_schedule.go
@@ -143,6 +143,69 @@ func (c *Controller) startScheduleRelease(ctx context.Context) {
 	c.recoverMissedTrainTick(ctx, rel, schedule, loc)
 }
 
+// trainRecoveryDecision is recoverMissedTrainTick's fire/skip verdict plus
+// the reasoning that produced it (GH-4982 acceptance criterion: one log
+// line must be enough to diagnose this class of bug).
+type trainRecoveryDecision struct {
+	Fire   bool
+	Reason string
+}
+
+// decideTrainRecovery judges whether a boot-time recovery pass should fire
+// the release train tick scheduled for scheduledAt, given lastReleaseAt (the
+// timestamp of the most recent release actually cut for the repo, or the
+// zero time if none). Pure function of its three inputs so the boot/tick/
+// release orderings are unit-testable without a state store or GitHub
+// client (GH-4982).
+//
+// GH-4982: two cooperating live defects motivated this gate. (1) A boot
+// restart ran recovery for a tick whose scheduled time hadn't arrived yet
+// and cut a release 15 minutes before the tick it claimed to recover — a
+// recovery pass must never consider a tick still in the future relative to
+// now. (2) A later restart, after the tick had genuinely passed with
+// nothing released for it, apparently treated a nearby-but-earlier release
+// as satisfying the tick and never fired recovery — a release cut before
+// the scheduled time does not satisfy that tick, however close the two
+// timestamps are.
+//
+// The rule: fire iff the tick is actually in the past (scheduledAt <= now)
+// AND the last release for the repo predates it (lastReleaseAt is zero, or
+// strictly before scheduledAt).
+func decideTrainRecovery(now, scheduledAt, lastReleaseAt time.Time) trainRecoveryDecision {
+	if scheduledAt.After(now) {
+		return trainRecoveryDecision{
+			Fire:   false,
+			Reason: "scheduled tick is in the future relative to now",
+		}
+	}
+	if lastReleaseAt.IsZero() {
+		return trainRecoveryDecision{
+			Fire:   true,
+			Reason: "no prior release found for this repo",
+		}
+	}
+	if !lastReleaseAt.Before(scheduledAt) {
+		return trainRecoveryDecision{
+			Fire:   false,
+			Reason: "last release already covers this tick",
+		}
+	}
+	return trainRecoveryDecision{
+		Fire:   true,
+		Reason: "last release predates the scheduled tick",
+	}
+}
+
+// formatOptionalTime renders t as RFC3339, or "none" for the zero time —
+// used to keep recoverMissedTrainTick's decision log line readable when no
+// prior release exists to compare against.
+func formatOptionalTime(t time.Time) string {
+	if t.IsZero() {
+		return "none"
+	}
+	return t.Format(time.RFC3339)
+}
+
 // recoverMissedTrainTick runs the release-train tick once, immediately, if
 // the daemon was offline across a scheduled fire and the missed slot is
 // still within rel.ScopeLookback. A miss older than the lookback is left for
@@ -150,8 +213,14 @@ func (c *Controller) startScheduleRelease(ctx context.Context) {
 // rather than silently tagging a long-stale train — mirrors the
 // lookback-gated backstop precedent in reconcileLabelScope
 // (internal/autopilot/scope_reconcile.go) (GH-3993).
+//
+// Beyond the lookback and existing-scope-row checks, the fire/skip verdict
+// itself is decided by decideTrainRecovery against the repo's actual last
+// release time (GH-4982) rather than trusting the scope row alone — see
+// decideTrainRecovery's doc comment for the two live defects this closes.
 func (c *Controller) recoverMissedTrainTick(ctx context.Context, rel *ReleaseConfig, schedule cron.Schedule, loc *time.Location) {
-	prevScheduled := previousScheduledTime(schedule, time.Now().In(loc))
+	now := time.Now()
+	prevScheduled := previousScheduledTime(schedule, now.In(loc))
 	if prevScheduled.IsZero() {
 		return
 	}
@@ -181,7 +250,25 @@ func (c *Controller) recoverMissedTrainTick(ctx context.Context, rel *ReleaseCon
 		}
 	}
 
-	c.log.Warn("recovering missed train", "scheduled_at", prevScheduled.Format(time.RFC3339))
+	lastReleaseAt, err := c.releaser.GetLastReleaseTime(ctx, c.owner, c.repo)
+	if err != nil {
+		c.log.Warn("recoverMissedTrainTick: failed to determine last release time, skipping recovery",
+			"scheduled_at", prevScheduled.Format(time.RFC3339), "error", err)
+		return
+	}
+
+	decision := decideTrainRecovery(now, prevScheduled, lastReleaseAt)
+	logArgs := []any{
+		"scheduled_at", prevScheduled.Format(time.RFC3339),
+		"last_release_at", formatOptionalTime(lastReleaseAt),
+		"verdict", decision.Reason,
+	}
+	if !decision.Fire {
+		c.log.Debug("recoverMissedTrainTick: recovery not fired", logArgs...)
+		return
+	}
+
+	c.log.Warn("recovering missed train", logArgs...)
 	c.scheduleReleaseTickWithRetry(ctx, prevScheduled)
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4982.

Closes #4982

## Changes

GitHub Issue GH-4982: fix(autopilot): missed-train recovery fires before the scheduled tick on boot, then a later restart never recovers the genuinely-missed tick

## Context

Live evidence 2026-08-18 (founder box, `~/.pilot/logs/daemon.log`): the pilot repo's daily train (`0 16 * * *` Europe/Berlin = 14:00Z) never ran for the day's post-13:45Z merges. Two cooperating defects:

1. **Early fire.** Daemon restart at 13:40:57Z (15:40 Berlin, i.e. BEFORE the 16:00 Berlin tick) ran boot-time missed-train recovery and cut **v2.261.0 at 13:45Z** — 15 minutes before the tick it was 'recovering'. A recovery pass on boot must only consider ticks whose scheduled time is in the PAST.
2. **No recovery when actually missed.** The next restart at 15:12:16Z (17:12 Berlin, AFTER the missed 16:00 Berlin tick) started the pilot scheduler with `next_run=2026-08-19T16:00` and logged **no** `recovering missed train` line for pilot — while the Mon–Fri (`0 16 * * 1-5`) schedulers for other repos at 15:11:27Z/15:11:40Z DID log recovery. Presumably the 13:45Z tag satisfied whatever freshness check gates recovery, even though 13:45Z predates the 14:00Z scheduled time.

Net effect: 15+ merges (sdk v0.35.1 pin #4954, KAN-6 #4955, #4971/#4973/#4975/#4977–#4981, CI fix 049456d5) sat unreleased with next_run a full day out. Operator cut v2.262.0 manually.

Log lines (UTC):
```
13:40:57 platform-outage breaker enabled            (daemon boot #1)
13:45:07 tag v2.261.0 created                        (git tag creatordate; 15min BEFORE tick)
15:11:27 release train scheduler started schedule="0 16 * * 1-5" next_run=2026-08-19T16:00
15:11:27 recovering missed train scheduled_at=2026-08-18T16:00:00+02:00
15:11:28 scheduleReleaseTick: no resolvable member PRs (direct-commit-only train), skipping — v1 limitation last_tag=v0.1.0 commits=9
15:12:16 release train scheduler started schedule="0 16 * * *" timezone=Europe/Berlin next_run=2026-08-19T16:00:00.000+02:00
         (no recovery line for the pilot scheduler despite the 14:00Z tick being missed)
```

## Acceptance

- Boot-time recovery never fires for a tick whose scheduled time is in the future relative to now.
- Boot-time recovery DOES fire for a tick whose scheduled time passed while the daemon was down/restarting, judged against when the last release for that repo was actually cut: a release cut BEFORE the scheduled time does not satisfy the tick.
- Table-driven tests cover: boot before tick (no recovery) · boot after tick with pre-tick release (recovery fires) · boot after tick with post-tick release (no recovery) · boot after tick, no releases at all (recovery fires).
- A recovery decision (fire or skip) logs its reasoning (scheduled_at, last_release_at, verdict) so this class is diagnosable from one log line.

## Implementation

- The recovery gate lives in the release-train scheduler startup path (`internal/autopilot` — the code emitting "release train scheduler started" / "recovering missed train"). Compare last tag/release creation time for the repo against the most recent past scheduled tick; fire recovery iff last_release < scheduled_at <= now.
- Reuse the tags-authoritative baseline from GH-4953 (PR#4973, `GetCurrentVersionWithSource`) to timestamp the last release rather than trusting the GitHub Release object.

## Refs

- GH-4953 / PR#4973 (tags-authoritative baseline — sibling releaser defect, merged same day)
- mem-093 (release-wedge semantics), release-cycles workflow doc in `.agent/DEVELOPMENT-README.md`