### PR TITLE
GH-4985: fix(linear): GetLabelByTeamID declares $teamId as String! in an ID position — merged #4978 is a functional no-op

### DIFF
--- a/internal/adapters/linear/client.go
+++ b/internal/adapters/linear/client.go
@@ -424,7 +424,7 @@ func (c *Client) GetLabelByName(ctx context.Context, teamID, labelName string) (
 		}
 	`
 	const queryByID = `
-		query GetLabelByTeamID($teamId: String!, $name: String!) {
+		query GetLabelByTeamID($teamId: ID!, $name: String!) {
 			issueLabels(filter: { team: { id: { eq: $teamId } }, name: { eq: $name } }) {
 				nodes { id name }
 			}

--- a/internal/adapters/linear/client_test.go
+++ b/internal/adapters/linear/client_test.go
@@ -1489,6 +1489,67 @@ func TestGetLabelByNameWorkspaceFallback(t *testing.T) {
 	}
 }
 
+// TestGetLabelByNameVariableDeclaration pins the GraphQL variable type
+// declared for $teamId on each branch of GetLabelByName. GH-4985: the
+// ID-branch query filters via `team: { id: { eq: $teamId } }`, and Linear's
+// schema types NullableTeamFilter.id as IDComparator (`eq: ID`) — GraphQL
+// does not coerce a `String!` variable into an `ID` position, so a
+// `$teamId: String!` declaration fails schema validation with HTTP 400
+// GRAPHQL_VALIDATION_FAILED before auth is even checked (empirically
+// reproduced against api.linear.app). The httptest mock below performs no
+// GraphQL schema validation, so only an explicit substring assertion on the
+// declaration text catches a regression here — that's why #4978 shipped
+// green despite being a functional no-op.
+func TestGetLabelByNameVariableDeclaration(t *testing.T) {
+	const teamUUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+	tests := []struct {
+		name       string
+		teamID     string
+		wantDecl   string
+		unwantDecl string
+	}{
+		{
+			name:       "UUID-configured team declares $teamId as ID!",
+			teamID:     teamUUID,
+			wantDecl:   "$teamId: ID!",
+			unwantDecl: "$teamId: String!",
+		},
+		{
+			name:     "key-configured team declaration is unchanged",
+			teamID:   "ROU",
+			wantDecl: "$teamId: String!",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sawQuery string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req struct {
+					Query string `json:"query"`
+				}
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				sawQuery = req.Query
+				_, _ = w.Write([]byte(`{"data":{"issueLabels":{"nodes":[{"id":"team-label","name":"llm-pilot"}]}}}`))
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL("test-linear-key", server.URL)
+			if _, err := client.GetLabelByName(context.Background(), tt.teamID, "llm-pilot"); err != nil {
+				t.Fatalf("GetLabelByName: %v", err)
+			}
+
+			if !strings.Contains(sawQuery, tt.wantDecl) {
+				t.Errorf("request body does not contain %q; got query:\n%s", tt.wantDecl, sawQuery)
+			}
+			if tt.unwantDecl != "" && strings.Contains(sawQuery, tt.unwantDecl) {
+				t.Errorf("request body unexpectedly contains %q; got query:\n%s", tt.unwantDecl, sawQuery)
+			}
+		})
+	}
+}
+
 func TestGetOrCreateLabel(t *testing.T) {
 	const teamUUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4985.

Closes #4985

## Changes

GitHub Issue GH-4985: fix(linear): GetLabelByTeamID declares $teamId as String! in an ID position — merged #4978 is a functional no-op

## Problem

PR #4977's sibling #4978 (GH-4965, TASK-481 Leg A) merged green but is a **functional no-op for its target scenario**. The ID-branch query in `internal/adapters/linear/client.go:427` declares `$teamId: String!` but uses it in `team: { id: { eq: $teamId } }`. Linear's schema types `NullableTeamFilter.id` as `IDComparator` (`eq: ID`), and GraphQL does not coerce `String!` into an `ID` position.

**Empirically reproduced against api.linear.app** (post-merge review, 2026-08-19): the merged `GetLabelByTeamID` document returns HTTP 400 `GRAPHQL_VALIDATION_FAILED: Variable "$teamId" of type "String!" used in position expecting type "ID"` — before auth is checked. The identical document with `$teamId: ID!` passes validation.

Consequence: for a UUID-configured `team_id`, `GetLabelByName` errors on every call → `GetOrCreateLabel` (client.go:589-597) falls through to `CreateLabel` → duplicate-name rejection → the exact #4884 startup symptom #4978 was merged to fix.

## Fix

1. In the `queryByID` GraphQL document (`internal/adapters/linear/client.go:427`), change the variable declaration `$teamId: String!` → `$teamId: ID!`. The Go side needs no change (the variable value stays a string).
2. Add a regression test that pins the variable declaration: the existing httptest mock performs no GraphQL schema validation (which is why #4978 shipped green), so at minimum assert the ID-branch request body contains `$teamId: ID!`.

## Acceptance criteria

- [ ] ID-branch query declares `$teamId: ID!`
- [ ] Test asserts the declaration text in the outgoing request body for the UUID-configured path
- [ ] Key-configured path remains byte-identical (no change)

## Refs

Review evidence: https://github.com/qf-studio/pilot/pull/4978#issuecomment-5339805817

Do not decompose — this is a standalone task, one small change as a single PR.