### PR TITLE
fix(autopilot): train-recovery WARN fires only after gates pass, skips log at Info

### DIFF
--- a/.agent/tasks/gh-4989.md
+++ b/.agent/tasks/gh-4989.md
@@ -1,0 +1,38 @@
+# GH-4989
+
+**Created:** 2026-08-19
+
+## Problem
+
+GitHub Issue GH-4989: fix(autopilot): train-recovery logging announces before deciding and skips silently — the exact gap behind the #4982 misdiagnosis
+
+## Problem
+
+Post-merge review of PR #4984 (GH-4982) + box-log verification exposed a diagnosability gap that directly caused the #4982 misdiagnosis ("defect #2" — the 14:00Z tick was never actually missed; the row-exists skip was correct but invisible):
+
+1. `recovering missed train` (WARN) logs **before any gate is evaluated** — it fired at every daemon boot on 08-17/08-18 (16:49, 18:22, 18:55, 12:02, 12:07, 12:53, 13:41…) including boots where recovery then did nothing. The log announces an action that mostly doesn't happen.
+2. The row-exists return (`internal/autopilot/scope_schedule.go:246-250`) logs **nothing** — the one skip that mattered on 08-18 15:11Z was silent, which is why the incident was misread as "recovery never ran".
+3. Skip verdicts log at Debug (`:233` lookback, `:267` last-release gate) — invisible at the daemon's Info level.
+
+## Fix
+
+- Move the `recovering missed train` WARN to AFTER all gates pass (i.e., log it only when a recovery release will actually be attempted).
+- Add an Info-level log to the row-exists return: repo, scope key, row state, row tag.
+- Promote the lookback and last-release skip verdicts from Debug to Info, each with scheduled_at + the gate that decided.
+
+One Info line per boot per repo describing the recovery decision (fire, or skip + which gate) satisfies the #4982 acceptance row "diagnosable from one log line".
+
+## Acceptance criteria
+
+- [ ] No `recovering missed train` WARN unless a recovery release is actually attempted
+- [ ] Every skip path (lookback, row-exists, last-release, error) emits one Info line with the reason
+- [ ] Existing #4984 tests still green; new test asserts log side of each verdict
+
+## Refs
+
+https://github.com/qf-studio/pilot/pull/4984#issuecomment-5339816401 (review finding 2) and the box-verification comment on the same PR.
+
+Do not decompose — this is a standalone task, one small change as a single PR.
+
+## Acceptance Criteria
+

--- a/internal/autopilot/gh4989_test.go
+++ b/internal/autopilot/gh4989_test.go
@@ -1,0 +1,147 @@
+package autopilot
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+// TestRecoverMissedTrainTick_LogsOneLinePerVerdict is the log-hygiene
+// companion to TestRecoverMissedTrainTick (GH-4982) and
+// TestRecoverMissedTrainTick_LastReleaseGate: post-merge review of PR #4984
+// plus box-log verification (2026-08-19) found that recoverMissedTrainTick's
+// skip paths were either silent (row-exists) or logged at Debug (lookback,
+// last-release) — invisible at the daemon's Info level — while the
+// "recovering missed train" WARN was mistakenly believed to fire before any
+// gate ran. That combination is exactly what produced the #4982
+// misdiagnosis: a genuinely-correct row-exists skip on 08-18 15:11Z read as
+// "recovery never ran" because nothing logged the reason.
+//
+// GH-4989 requires: (1) the WARN never appears unless a recovery release is
+// actually attempted, and (2) every skip path (lookback, row-exists,
+// last-release) emits one Info-or-louder line naming the gate and its
+// reason. This test drives all four verdicts end to end and asserts the log
+// side of each.
+func TestRecoverMissedTrainTick_LogsOneLinePerVerdict(t *testing.T) {
+	loc := time.UTC
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	schedule, err := parser.Parse("0 21 * * FRI")
+	if err != nil {
+		t.Fatalf("parse schedule: %v", err)
+	}
+
+	t.Run("lookback gate skip logs at Info with the gate name, never the WARN", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		defer server.Close()
+
+		c, logs := newScheduleControllerWithLogCapture(t, server.URL, "0 21 * * FRI")
+		rel := c.resolvedRelease()
+		rel.ScopeLookback = 1 * time.Millisecond // any past scheduled slot is older than this
+
+		c.recoverMissedTrainTick(context.Background(), rel, schedule, loc)
+
+		got := logs.String()
+		if !strings.Contains(got, "level=INFO") || !strings.Contains(got, "gate=lookback") {
+			t.Errorf("expected an Info-level log naming the lookback gate, got:\n%s", got)
+		}
+		if strings.Contains(got, "recovering missed train") {
+			t.Errorf("WARN \"recovering missed train\" must not fire on a lookback skip, got:\n%s", got)
+		}
+	})
+
+	t.Run("row-exists gate skip logs at Info with row state and tag, never the WARN", func(t *testing.T) {
+		var compareHits int
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.Contains(r.URL.Path, "/compare/") {
+				compareHits++
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		defer server.Close()
+
+		c, logs := newScheduleControllerWithLogCapture(t, server.URL, "0 21 * * FRI")
+		rel := c.resolvedRelease()
+		rel.ScopeLookback = 7 * 24 * time.Hour
+
+		prevScheduled := previousScheduledTime(schedule, time.Now().In(loc))
+		if err := c.stateStore.EnqueueScopeRelease("owner/repo", trainScopeKey(prevScheduled), "Release train existing", []int{1}); err != nil {
+			t.Fatalf("EnqueueScopeRelease: %v", err)
+		}
+
+		c.recoverMissedTrainTick(context.Background(), rel, schedule, loc)
+
+		got := logs.String()
+		if !strings.Contains(got, "level=INFO") || !strings.Contains(got, "gate=row-exists") {
+			t.Errorf("expected an Info-level log naming the row-exists gate, got:\n%s", got)
+		}
+		if !strings.Contains(got, "row_state=pending") {
+			t.Errorf("expected the row-exists skip to log the row's state, got:\n%s", got)
+		}
+		if strings.Contains(got, "recovering missed train") {
+			t.Errorf("WARN \"recovering missed train\" must not fire on a row-exists skip, got:\n%s", got)
+		}
+		if compareHits != 0 {
+			t.Errorf("expected no downstream compare-commits call, got %d", compareHits)
+		}
+	})
+
+	t.Run("last-release gate skip logs at Info with the gate name, never the WARN", func(t *testing.T) {
+		prevScheduled := previousScheduledTime(schedule, time.Now().In(loc))
+
+		var downstreamHits int64
+		server := trainRecoveryServer(t, "v1.0.0", prevScheduled.Add(1*time.Hour), true, &downstreamHits)
+		defer server.Close()
+
+		c, logs := newScheduleControllerWithLogCapture(t, server.URL, "0 21 * * FRI")
+		rel := c.resolvedRelease()
+		rel.ScopeLookback = 7 * 24 * time.Hour
+
+		c.recoverMissedTrainTick(context.Background(), rel, schedule, loc)
+
+		got := logs.String()
+		if !strings.Contains(got, "level=INFO") || !strings.Contains(got, "gate=last-release") {
+			t.Errorf("expected an Info-level log naming the last-release gate, got:\n%s", got)
+		}
+		if strings.Contains(got, "recovering missed train") {
+			t.Errorf("WARN \"recovering missed train\" must not fire on a last-release skip, got:\n%s", got)
+		}
+	})
+
+	t.Run("recovery actually fires: the WARN appears exactly once", func(t *testing.T) {
+		server := scheduleTickServer(t, "v1.0.0", nil, nil)
+		defer server.Close()
+
+		c, logs := newScheduleControllerWithLogCapture(t, server.URL, "0 21 * * FRI")
+		rel := c.resolvedRelease()
+		rel.ScopeLookback = 7 * 24 * time.Hour
+
+		c.recoverMissedTrainTick(context.Background(), rel, schedule, loc)
+
+		got := logs.String()
+		if strings.Count(got, "recovering missed train") != 1 {
+			t.Errorf("expected exactly one \"recovering missed train\" WARN when recovery actually fires, got:\n%s", got)
+		}
+	})
+}
+
+// newScheduleControllerWithLogCapture is newScheduleController plus a
+// buffered slog.Logger so tests can assert on recoverMissedTrainTick's
+// per-verdict log lines (GH-4989).
+func newScheduleControllerWithLogCapture(t *testing.T, serverURL, schedule string) (*Controller, *bytes.Buffer) {
+	t.Helper()
+	c, _ := newScheduleController(t, serverURL, schedule)
+	var buf bytes.Buffer
+	c.log = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	return c, &buf
+}

--- a/internal/autopilot/scope_schedule.go
+++ b/internal/autopilot/scope_schedule.go
@@ -230,8 +230,8 @@ func (c *Controller) recoverMissedTrainTick(ctx context.Context, rel *ReleaseCon
 		lookback = 24 * time.Hour
 	}
 	if time.Since(prevScheduled) > lookback {
-		c.log.Debug("recoverMissedTrainTick: previous scheduled tick predates the lookback window, skipping",
-			"scheduled_at", prevScheduled.Format(time.RFC3339), "lookback", lookback)
+		c.log.Info("recoverMissedTrainTick: skipping recovery — previous scheduled tick predates the lookback window",
+			"repo", c.repoKey(), "scheduled_at", prevScheduled.Format(time.RFC3339), "lookback", lookback, "gate", "lookback")
 		return
 	}
 
@@ -240,12 +240,17 @@ func (c *Controller) recoverMissedTrainTick(ctx context.Context, rel *ReleaseCon
 		row, err := c.stateStore.GetScopeRelease(c.repoKey(), scopeKey)
 		if err != nil {
 			c.log.Warn("recoverMissedTrainTick: failed to check for an existing train row, skipping recovery",
-				"scope", scopeKey, "error", err)
+				"repo", c.repoKey(), "scope", scopeKey, "error", err, "gate", "row-lookup-error")
 			return
 		}
 		if row != nil {
 			// Already enqueued — either the tick fired on schedule, or a prior
-			// recovery pass already ran for this slot.
+			// recovery pass already ran for this slot. GH-4989: this was the
+			// one skip that mattered in the #4982 misdiagnosis (08-18 15:11Z)
+			// and it logged nothing, so the incident was misread as "recovery
+			// never ran" — always log the row state that suppressed recovery.
+			c.log.Info("recoverMissedTrainTick: skipping recovery — a row already exists for this scheduled slot",
+				"repo", c.repoKey(), "scope", scopeKey, "row_state", row.State, "row_tag", row.Tag, "gate", "row-exists")
 			return
 		}
 	}
@@ -253,18 +258,19 @@ func (c *Controller) recoverMissedTrainTick(ctx context.Context, rel *ReleaseCon
 	lastReleaseAt, err := c.releaser.GetLastReleaseTime(ctx, c.owner, c.repo)
 	if err != nil {
 		c.log.Warn("recoverMissedTrainTick: failed to determine last release time, skipping recovery",
-			"scheduled_at", prevScheduled.Format(time.RFC3339), "error", err)
+			"repo", c.repoKey(), "scheduled_at", prevScheduled.Format(time.RFC3339), "error", err, "gate", "last-release-lookup-error")
 		return
 	}
 
 	decision := decideTrainRecovery(now, prevScheduled, lastReleaseAt)
 	logArgs := []any{
+		"repo", c.repoKey(),
 		"scheduled_at", prevScheduled.Format(time.RFC3339),
 		"last_release_at", formatOptionalTime(lastReleaseAt),
 		"verdict", decision.Reason,
 	}
 	if !decision.Fire {
-		c.log.Debug("recoverMissedTrainTick: recovery not fired", logArgs...)
+		c.log.Info("recoverMissedTrainTick: skipping recovery — last-release gate", append(logArgs, "gate", "last-release")...)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- The "recovering missed train" WARN in `recoverMissedTrainTick` was already structurally gated behind `decideTrainRecovery`'s Fire verdict, but the surrounding skip paths were not diagnosable: the row-exists skip (the one that mattered in the #4982 misdiagnosis) logged nothing, and the lookback / last-release skip verdicts logged at Debug — invisible at the daemon's Info level.
- Promotes all three skip paths (lookback, row-exists, last-release) to Info, each naming the deciding gate (`gate=lookback|row-exists|last-release`) plus `repo`/`scheduled_at`/reason context. The row-exists skip additionally logs `row_state`/`row_tag`.
- Error paths (`row-lookup-error`, `last-release-lookup-error`) keep their existing Warn level, now also tagged with `gate=` and `repo=` for consistency.

## Why
Closes the diagnosability gap from the #4982 post-merge review (PR #4984 comment) and box-log verification: a correct, silent row-exists skip on 2026-08-18 15:11Z was misread as "recovery never ran" because nothing logged the reason. One Info line per boot per repo now states fire-or-skip-and-why.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/autopilot/...` (full package, includes existing #4984 `TestRecoverMissedTrainTick*` / `TestDecideTrainRecovery` — all green)
- [x] New `TestRecoverMissedTrainTick_LogsOneLinePerVerdict` (gh4989_test.go) asserts the log side of all four verdicts: lookback skip, row-exists skip, last-release skip, and the fire path (WARN appears exactly once, never on a skip)
- [x] `go test ./...` (full repo suite green)