### PR TITLE
GH-4988: fix(executor): intent judge evaluates diffs against a stale base — 5 false scope-creep vetoes in 2 days (#4922 class, now recurring)

### DIFF
--- a/internal/executor/git.go
+++ b/internal/executor/git.go
@@ -1156,16 +1156,77 @@ func (g *GitOperations) ResetHardToCommit(ctx context.Context, sha string) error
 	return nil
 }
 
-// GetDiff returns the diff between the base branch and HEAD.
-// Uses three-dot notation (base...HEAD) to show changes on the current branch.
+// GetDiff returns the diff between HEAD and the merge-base of
+// origin/baseBranch and HEAD. See GetDiffWithBase for the variant that also
+// returns the resolved base SHA.
 func (g *GitOperations) GetDiff(ctx context.Context, baseBranch string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "diff", baseBranch+"...HEAD")
+	diff, _, err := g.GetDiffWithBase(ctx, baseBranch)
+	return diff, err
+}
+
+// GetDiffWithBase returns the diff between HEAD and the merge-base of
+// origin/baseBranch and HEAD, along with the resolved base SHA so callers
+// (the intent judge) can log exactly which commit the diff was computed
+// against.
+//
+// GH-4988: intent judge false-veto RCA. The judge repeatedly flagged correct
+// first-generation diffs as "scope creep" because the diff it evaluated was
+// computed against a stale ref — this function previously ran
+// `git diff <local baseBranch>...HEAD` directly, with no fetch. In a
+// long-lived daemon repo/worktree, the local "main" ref can be arbitrarily
+// behind origin/main by the time the judge runs. Since HEAD (the task
+// branch) descends from an up-to-date origin/main at branch-cut time, the
+// merge-base of the stale local ref and HEAD collapses to the stale ref
+// itself — so the three-dot diff pulled in every commit that had landed on
+// origin/main between that staleness point and judge time (other issues'
+// already-merged work), which the judge then correctly, but misleadingly,
+// flagged as unrelated to this task. Recurred 5x in 2 days (GH-4922,
+// GH-4938, sdk#119, GH-4952, GH-4965/4966) before this fix.
+//
+// Fetching origin/<baseBranch> fresh and diffing against its merge-base with
+// HEAD guarantees the diff never contains commits reachable from current
+// origin/main, regardless of how stale the local ref is. The fetch is
+// best-effort (mirrors CountNewCommitsAgainstOrigin): if it fails, or no
+// "origin" remote is configured at all (bare local repos, some unit tests),
+// this falls back to comparing against the local baseBranch ref, preserving
+// the previous behavior in that environment.
+func (g *GitOperations) GetDiffWithBase(ctx context.Context, baseBranch string) (diff string, baseSHA string, err error) {
+	fetchCmd := exec.CommandContext(ctx, "git", "fetch", "origin", baseBranch)
+	fetchCmd.Dir = g.projectPath
+	withGitCredentials(ctx, fetchCmd)
+	_ = fetchCmd.Run() // best-effort; fall back to the local ref below on failure
+
+	baseRef := "origin/" + baseBranch
+	mergeBaseOut, mbErr := g.mergeBase(ctx, baseRef)
+	if mbErr != nil {
+		// No origin remote, or origin/<baseBranch> doesn't resolve locally -
+		// fall back to the local ref (previous behavior).
+		baseRef = baseBranch
+		mergeBaseOut, mbErr = g.mergeBase(ctx, baseRef)
+		if mbErr != nil {
+			return "", "", fmt.Errorf("git merge-base %s HEAD failed: %w", baseRef, mbErr)
+		}
+	}
+	baseSHA = mergeBaseOut
+
+	cmd := exec.CommandContext(ctx, "git", "diff", baseSHA+"...HEAD")
+	cmd.Dir = g.projectPath
+	output, diffErr := cmd.Output()
+	if diffErr != nil {
+		return "", "", fmt.Errorf("git diff failed: %w", diffErr)
+	}
+	return string(output), baseSHA, nil
+}
+
+// mergeBase resolves the merge-base commit SHA between ref and HEAD.
+func (g *GitOperations) mergeBase(ctx context.Context, ref string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "merge-base", ref, "HEAD")
 	cmd.Dir = g.projectPath
 	output, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("git diff failed: %w", err)
+		return "", err
 	}
-	return string(output), nil
+	return strings.TrimSpace(string(output)), nil
 }
 
 // Pull fetches and merges changes from remote for the specified branch

--- a/internal/executor/git_test.go
+++ b/internal/executor/git_test.go
@@ -1458,3 +1458,117 @@ func TestCreateRecoveryRef(t *testing.T) {
 func trimNewline(s string) string {
 	return strings.TrimRight(s, "\n")
 }
+
+// runGitIn runs a git command in dir, failing the test on error.
+func runGitIn(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git -C %s %v: %v\n%s", dir, args, err, out)
+	}
+	return string(out)
+}
+
+// TestGetDiffWithBase_StaleLocalMainUpstreamAdvance is the GH-4988
+// regression test. It reproduces the exact false-veto RCA: a worktree's
+// local "main" ref goes stale (never fetched again after the task branch
+// was cut), other issues merge more commits onto origin/main in the
+// meantime, and the intent judge's diff must still contain only the task's
+// own commit — never the commits that landed on origin/main in between.
+func TestGetDiffWithBase_StaleLocalMainUpstreamAdvance(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	ctx := context.Background()
+
+	// Bare "origin" remote.
+	remoteDir := t.TempDir()
+	runGitIn(t, remoteDir, "init", "--bare")
+
+	// workRepo is the long-lived worktree under test.
+	workDir := t.TempDir()
+	runGitIn(t, workDir, "init", "-b", "main")
+	runGitIn(t, workDir, "config", "user.email", "test@test.com")
+	runGitIn(t, workDir, "config", "user.name", "Test User")
+	runGitIn(t, workDir, "remote", "add", "origin", remoteDir)
+	if err := os.WriteFile(filepath.Join(workDir, "shared.txt"), []byte("base"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGitIn(t, workDir, "add", "shared.txt")
+	runGitIn(t, workDir, "commit", "-m", "C0: initial")
+	runGitIn(t, workDir, "push", "-u", "origin", "main")
+
+	// A second clone stands in for other Pilot tasks merging PRs to main
+	// while workDir's task branch is being worked on.
+	otherDir := t.TempDir()
+	runGitIn(t, otherDir, "clone", remoteDir, ".")
+	runGitIn(t, otherDir, "config", "user.email", "other@test.com")
+	runGitIn(t, otherDir, "config", "user.name", "Other User")
+
+	commitAndPush := func(name, content string) {
+		if err := os.WriteFile(filepath.Join(otherDir, name), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+		runGitIn(t, otherDir, "add", name)
+		runGitIn(t, otherDir, "commit", "-m", "merge "+name)
+		runGitIn(t, otherDir, "push", "origin", "main")
+	}
+
+	// C1, C2: two other issues' work land on origin/main.
+	commitAndPush("other1.txt", "other issue 1")
+	commitAndPush("other2.txt", "other issue 2")
+
+	// Simulate worktree/task-branch creation: fetch origin/main (picks up
+	// C1+C2) and branch the task off it - origin/main at branch-cut time.
+	runGitIn(t, workDir, "fetch", "origin", "main")
+	branchCutSHA := trimNewline(runGitIn(t, workDir, "rev-parse", "origin/main"))
+	runGitIn(t, workDir, "checkout", "-b", "task", "origin/main")
+
+	// Task's own commit.
+	if err := os.WriteFile(filepath.Join(workDir, "task.txt"), []byte("task change"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGitIn(t, workDir, "add", "task.txt")
+	runGitIn(t, workDir, "commit", "-m", "C3: task change")
+
+	// C4: yet another issue merges to origin/main *after* the task branch
+	// was cut and *before* the judge runs - this is "current origin/main".
+	commitAndPush("other3.txt", "other issue 3, merged after branch cut")
+
+	// Critically: workDir's local "main" ref is never touched again after
+	// the initial push - it is stale at C0, exactly like a long-lived
+	// daemon repo/worktree whose local main ref isn't kept in sync.
+	staleLocalMainSHA := trimNewline(runGitIn(t, workDir, "rev-parse", "main"))
+
+	git := NewGitOperations(workDir)
+
+	diff, baseSHA, err := git.GetDiffWithBase(ctx, "main")
+	if err != nil {
+		t.Fatalf("GetDiffWithBase failed: %v", err)
+	}
+
+	// The resolved base must be the merge-base with (fetched) origin/main -
+	// i.e. the SHA origin/main pointed to when the task branch was cut -
+	// not the stale local "main" ref, and not current origin/main (C4).
+	if baseSHA != branchCutSHA {
+		t.Errorf("baseSHA = %q, want branch-cut origin/main SHA %q", baseSHA, branchCutSHA)
+	}
+	if baseSHA == staleLocalMainSHA {
+		t.Fatalf("baseSHA resolved to the stale local main ref (%q) - fix regressed", staleLocalMainSHA)
+	}
+
+	// The diff must contain only the task's own change...
+	if !strings.Contains(diff, "task.txt") {
+		t.Errorf("diff missing task's own change (task.txt):\n%s", diff)
+	}
+	// ...and never the other issues' already-merged work, whether it landed
+	// before the branch was cut (other1/other2) or after (other3, which is
+	// reachable from current origin/main but not from HEAD at all).
+	for _, unrelated := range []string{"other1.txt", "other2.txt", "other3.txt"} {
+		if strings.Contains(diff, unrelated) {
+			t.Errorf("diff contains unrelated other-issue file %q - stale/incorrect base leaked into judge diff:\n%s", unrelated, diff)
+		}
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -4666,6 +4666,7 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 		var intentErr error
 		var intentDiff string
 		var intentBaseBranch string
+		var intentBaseSHA string // GH-4988: base commit the judge diff was computed against
 
 		// Determine if intent judge should run
 		runIntentJudge := r.intentJudge != nil && task.CreatePR && !task.DirectCommit && task.Branch != ""
@@ -4690,7 +4691,12 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 					intentBaseBranch = "main"
 				}
 			}
-			intentDiff, intentErr = git.GetDiff(ctx, intentBaseBranch)
+			// GH-4988: GetDiffWithBase fetches origin/<intentBaseBranch>
+			// fresh and diffs against its merge-base with HEAD, so the
+			// judge's diff never contains commits reachable from current
+			// origin/main (e.g. other issues' already-merged work sitting
+			// on a stale local base ref).
+			intentDiff, intentBaseSHA, intentErr = git.GetDiffWithBase(ctx, intentBaseBranch)
 			if intentErr != nil {
 				log.Warn("Intent judge skipped: failed to get diff",
 					slog.String("task_id", task.ID),
@@ -4699,6 +4705,12 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 				runIntentJudge = false
 			} else if intentDiff == "" {
 				runIntentJudge = false
+			} else {
+				log.Info("Intent judge diff base resolved",
+					slog.String("task_id", task.ID),
+					slog.String("base_branch", intentBaseBranch),
+					slog.String("base_sha", intentBaseSHA),
+				)
 			}
 		}
 
@@ -4729,6 +4741,7 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 				log.Info("Intent judge running",
 					slog.String("task_id", task.ID),
 					slog.Int("diff_len", len(intentDiff)),
+					slog.String("base_sha", intentBaseSHA), // GH-4988
 				)
 				r.reportProgress(task.ID, "Intent Check", 96, "Verifying diff matches intent...")
 				intentVerdict, intentErr = r.intentJudge.Judge(ctx, task.Title, task.Description, intentDiff)
@@ -4798,9 +4811,17 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 						result.TokensOutput = state.tokensOutput
 						result.TokensTotal = state.tokensInput + state.tokensOutput
 
-						// Re-judge the new diff
-						newDiff, _ := git.GetDiff(ctx, intentBaseBranch)
+						// Re-judge the new diff. GH-4988: GetDiffWithBase
+						// re-fetches origin/<intentBaseBranch> so the retry's
+						// judge diff is computed against the same
+						// never-stale base as the first pass.
+						newDiff, newBaseSHA, _ := git.GetDiffWithBase(ctx, intentBaseBranch)
 						if newDiff != "" {
+							log.Info("Intent judge retry diff base resolved",
+								slog.String("task_id", task.ID),
+								slog.String("base_branch", intentBaseBranch),
+								slog.String("base_sha", newBaseSHA),
+							)
 							v2, _ := r.intentJudge.Judge(ctx, task.Title, task.Description, newDiff)
 							if v2 != nil && !v2.Passed {
 								result.IntentWarning = v2.Reason


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4988.

Closes #4988

## Changes

GitHub Issue GH-4988: fix(executor): intent judge evaluates diffs against a stale base — 5 false scope-creep vetoes in 2 days (#4922 class, now recurring)

## Problem

The intent judge repeatedly vetoes correct first-generation diffs because the diff it evaluates contains **other issues' already-merged work** — the diff base is stale. First seen in the #4922 incident (08-17, recorded as a one-off); it has now recurred at least 5 times in 2 days, each costing a full generation + retry:

| When (UTC) | Task | Veto evidence (from daemon.log) |
|---|---|---|
| 08-17 | GH-4922 gen 1 | incident record: "false intent-judge veto off a stale diff base" |
| 08-18 09:56 | GH-4938 | diff "bundles" Jira ADF changes = GH-4930's separately-merged work |
| 08-18 13:51 | sdk GH-119 | diff "bundles" ExecutionSaverV2/TokenFunc = sdk #112/#118 already-merged work |
| 08-18 14:53 | GH-4952 | diff includes version bumps + memory files from prior merges |
| 08-18 ~evening | GH-4965, GH-4966 gen 1 | vetoed for "scope creep" that was other issues' merged work; retries landed clean |

Pattern: the executor computes the judge's diff against a base that predates recently-merged main (worktree created from a stale local main, or diff endpoint pinned to an old SHA). The judge then correctly reports "unrelated changes" — for changes the task never made. Retries succeed because by then the base has caught up. This is a throughput and cost multiplier (~2× generations on affected tasks) and produces misleading "scope creep" telemetry.

## Fix (research may adjust)

At judge time, compute the diff strictly as `git diff <merge-base(origin/main, HEAD)>...HEAD` after a fresh `git fetch origin main` in the execution worktree — never against the local `main` ref or the worktree's creation-time base. If the diff-for-judge is assembled from recorded SHAs instead, refresh the base SHA the same way.

## Acceptance criteria

- [ ] Judge diff for a branch never contains commits reachable from current `origin/main`
- [ ] Regression test: worktree created from stale main + upstream advance → judge diff contains only the task's commits
- [ ] Log line records the base SHA the judge diff was computed against

## Refs

#4922 (first occurrence, incident-killed) · marker `2026-08-18_s3-exit-three-tenant-pass.md` §Open-4 (recurrence watch item, now tripped)