### PR TITLE
GH-4988: fix(executor): intent judge evaluates diffs against a stale base — 5 false scope-creep vetoes in 2 days (#4922 class, now recurring)

### DIFF
--- a/internal/executor/git.go
+++ b/internal/executor/git.go
@@ -1168,6 +1168,63 @@ func (g *GitOperations) GetDiff(ctx context.Context, baseBranch string) (string,
 	return string(output), nil
 }
 
+// GetDiffAgainstOrigin is GetDiff compared against a freshly fetched
+// origin/<baseBranch> instead of the possibly-stale local <baseBranch> ref.
+// GH-4988: the intent judge calls GetDiff with a local branch name (task's
+// BaseBranch, or GetDefaultBranch's local resolution), which — exactly like
+// the GH-4566 CountNewCommits class this mirrors — can be behind
+// origin/<baseBranch> in a long-lived worktree or shared clone. Other
+// issues merging into origin/main mid-task then show up inside the judge's
+// diff as if this branch produced them, and the judge correctly (but
+// wrongly, from the operator's perspective) vetoes them as scope creep.
+//
+// Fetches origin/<baseBranch> (best-effort — falls back to whatever
+// tracking ref already resolves locally on failure, same as
+// CountNewCommitsAgainstOrigin), resolves the merge-base of that ref and
+// HEAD, and diffs from there. Diffing from the merge-base — rather than
+// origin/<baseBranch>'s tip — guarantees the result never contains commits
+// reachable from current origin/<baseBranch> even when HEAD is also behind
+// tip for unrelated reasons.
+//
+// Returns the diff and the base SHA it was computed against, so callers can
+// log which commit the judge actually evaluated from.
+func (g *GitOperations) GetDiffAgainstOrigin(ctx context.Context, baseBranch string) (diff string, baseSHA string, err error) {
+	fetchCmd := exec.CommandContext(ctx, "git", "fetch", "origin", baseBranch)
+	fetchCmd.Dir = g.projectPath
+	withGitCredentials(ctx, fetchCmd)
+	_ = fetchCmd.Run() // best-effort; fall back to whatever origin/<baseBranch> already resolves to locally
+
+	baseSHA, err = g.resolveMergeBaseSHA(ctx, baseBranch)
+	if err != nil {
+		return "", "", err
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "diff", baseSHA+"...HEAD")
+	cmd.Dir = g.projectPath
+	output, err := cmd.Output()
+	if err != nil {
+		return "", baseSHA, fmt.Errorf("git diff failed: %w", err)
+	}
+	return string(output), baseSHA, nil
+}
+
+// resolveMergeBaseSHA resolves the merge-base commit SHA between HEAD and
+// origin/<baseBranch>, falling back to the local <baseBranch> ref when
+// origin/<baseBranch> doesn't resolve at all (no "origin" remote — bare
+// local repos, some unit tests). Mirrors the fallback order
+// CountNewCommitsAgainstOrigin uses.
+func (g *GitOperations) resolveMergeBaseSHA(ctx context.Context, baseBranch string) (string, error) {
+	for _, ref := range []string{"origin/" + baseBranch, baseBranch} {
+		cmd := exec.CommandContext(ctx, "git", "merge-base", ref, "HEAD")
+		cmd.Dir = g.projectPath
+		output, err := cmd.Output()
+		if err == nil {
+			return strings.TrimSpace(string(output)), nil
+		}
+	}
+	return "", fmt.Errorf("could not resolve merge-base for %q against origin/%s or local %s", baseBranch, baseBranch, baseBranch)
+}
+
 // Pull fetches and merges changes from remote for the specified branch
 func (g *GitOperations) Pull(ctx context.Context, branch string) error {
 	cmd := exec.CommandContext(ctx, "git", "pull", "origin", branch)

--- a/internal/executor/git_gh4988_test.go
+++ b/internal/executor/git_gh4988_test.go
@@ -1,0 +1,156 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestGetDiffAgainstOrigin_StaleLocalBaseExcludesMergedSiblingWork reproduces
+// the GH-4988 intent-judge false veto: a sibling issue's PR (e.g. GH-4930)
+// merges into origin/main, this task's worktree branch is then cut FROM that
+// fresh origin/main (so the sibling's commit is a legitimate ancestor of
+// HEAD), but the shared clone/worktree's local `main` ref was never
+// fast-forwarded past the point before the sibling merged. The old
+// GetDiff(ctx, "main") diffs against that stale local ref, so the resulting
+// diff "bundles" the sibling's already-merged work alongside this task's own
+// commit — exactly the false "scope creep" signal the intent judge reported
+// 5 times in 2 days. GetDiffAgainstOrigin must not reproduce this: it fetches
+// origin fresh and diffs from the merge-base with origin/<base>, so only this
+// branch's own commits appear.
+func TestGetDiffAgainstOrigin_StaleLocalBaseExcludesMergedSiblingWork(t *testing.T) {
+	local, origin := setupSyncTestRepos(t, "main")
+
+	// Sibling issue's PR merges into origin/main via a second clone. Local
+	// `main` in this clone never learns about it (nothing fast-forwards it
+	// mid-task — the same precondition as the GH-4566 CountNewCommits bug).
+	pushExtraCommitFromSecondClone(t, origin, "main", "sibling PR merged (GH-4930-style)")
+
+	// Cut this task's branch from a FRESH origin/main, exactly as
+	// worktree.go does — so the sibling's commit IS a real ancestor of HEAD.
+	runGit(t, local, "fetch", "origin", "main")
+	runGit(t, local, "checkout", "-B", "pilot/GH-4988-task", "origin/main")
+
+	// This task's own commit.
+	if err := os.WriteFile(filepath.Join(local, "task.txt"), []byte("task work"), 0644); err != nil {
+		t.Fatalf("write task.txt: %v", err)
+	}
+	runGit(t, local, "add", "task.txt")
+	runGit(t, local, "commit", "-m", "feat: task's own change")
+
+	git := NewGitOperations(local)
+	ctx := context.Background()
+
+	// Old behavior: diffing against the stale local `main` ref bundles the
+	// sibling's already-merged commit into the judge's diff.
+	staleDiff, err := git.GetDiff(ctx, "main")
+	if err != nil {
+		t.Fatalf("GetDiff: %v", err)
+	}
+	if !strings.Contains(staleDiff, "remote.txt") {
+		t.Fatalf("test setup invalid: expected stale-base diff to bundle the sibling's remote.txt (repro precondition), got:\n%s", staleDiff)
+	}
+
+	// Fixed behavior: GetDiffAgainstOrigin must contain only this branch's
+	// own commit, never the sibling's already-merged work.
+	freshDiff, baseSHA, err := git.GetDiffAgainstOrigin(ctx, "main")
+	if err != nil {
+		t.Fatalf("GetDiffAgainstOrigin: %v", err)
+	}
+	if strings.Contains(freshDiff, "remote.txt") {
+		t.Errorf("REGRESSION: GetDiffAgainstOrigin diff bundles sibling's merged work (remote.txt):\n%s", freshDiff)
+	}
+	if !strings.Contains(freshDiff, "task.txt") {
+		t.Errorf("GetDiffAgainstOrigin diff missing this branch's own commit (task.txt):\n%s", freshDiff)
+	}
+
+	// The base SHA must be origin/main's tip at judge time (the merge-base
+	// of origin/main and HEAD, since HEAD is a direct descendant).
+	originMainSHA := strings.TrimSpace(gitOutput(t, local, "rev-parse", "origin/main"))
+	if baseSHA != originMainSHA {
+		t.Errorf("baseSHA = %s, want origin/main tip %s", baseSHA, originMainSHA)
+	}
+}
+
+// TestGetDiffAgainstOrigin_UpstreamAdvanceAfterWorktreeCut is the acceptance
+// criteria's exact scenario: the worktree is cut from a stale main, then
+// upstream (origin/main) advances further while the task is executing. At
+// judge time, GetDiffAgainstOrigin must fetch that further advance and still
+// produce a diff containing only the task's own commits.
+func TestGetDiffAgainstOrigin_UpstreamAdvanceAfterWorktreeCut(t *testing.T) {
+	local, origin := setupSyncTestRepos(t, "main")
+
+	// Worktree cut from origin/main at its current (soon-to-be-stale) tip.
+	runGit(t, local, "fetch", "origin", "main")
+	runGit(t, local, "checkout", "-B", "pilot/GH-4988-task2", "origin/main")
+
+	// Task's own commit, made before any further upstream advance.
+	if err := os.WriteFile(filepath.Join(local, "task.txt"), []byte("task work"), 0644); err != nil {
+		t.Fatalf("write task.txt: %v", err)
+	}
+	runGit(t, local, "add", "task.txt")
+	runGit(t, local, "commit", "-m", "feat: task's own change")
+
+	// Upstream advances further while the task executes (another sibling
+	// issue merges into origin/main), independent of this branch.
+	pushExtraCommitFromSecondClone(t, origin, "main", "another sibling PR merged mid-task")
+
+	git := NewGitOperations(local)
+	ctx := context.Background()
+
+	diff, baseSHA, err := git.GetDiffAgainstOrigin(ctx, "main")
+	if err != nil {
+		t.Fatalf("GetDiffAgainstOrigin: %v", err)
+	}
+	if strings.Contains(diff, "remote.txt") {
+		t.Errorf("REGRESSION: judge diff contains commits reachable from current origin/main:\n%s", diff)
+	}
+	if !strings.Contains(diff, "task.txt") {
+		t.Errorf("judge diff missing the task's own commit:\n%s", diff)
+	}
+
+	// The base SHA must never be reachable-from-origin/main-only content —
+	// it should equal the merge-base of (freshly fetched) origin/main and
+	// HEAD, which here is origin/main's pre-advance tip (this branch's
+	// parent commit).
+	branchParentSHA := strings.TrimSpace(gitOutput(t, local, "rev-parse", "HEAD~1"))
+	if baseSHA != branchParentSHA {
+		t.Errorf("baseSHA = %s, want %s (this branch's parent commit / origin/main's tip at branch-cut time)", baseSHA, branchParentSHA)
+	}
+}
+
+// TestGetDiffAgainstOrigin_NoOriginRemoteFallsBackToLocalBranch covers repos
+// with no "origin" remote configured (bare local repos, some unit tests) so
+// GetDiffAgainstOrigin doesn't regress GetDiff's original behavior there.
+func TestGetDiffAgainstOrigin_NoOriginRemoteFallsBackToLocalBranch(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	runGit(t, dir, "config", "user.email", "test@test.com")
+	runGit(t, dir, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("init\n"), 0644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "-m", "initial")
+	runGit(t, dir, "checkout", "-b", "pilot/GH-4988-local")
+
+	if err := os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0644); err != nil {
+		t.Fatalf("write feature.txt: %v", err)
+	}
+	runGit(t, dir, "add", "feature.txt")
+	runGit(t, dir, "commit", "-m", "feat: local-only work")
+
+	git := NewGitOperations(dir)
+	diff, baseSHA, err := git.GetDiffAgainstOrigin(context.Background(), "main")
+	if err != nil {
+		t.Fatalf("GetDiffAgainstOrigin: %v", err)
+	}
+	if !strings.Contains(diff, "feature.txt") {
+		t.Errorf("diff missing local-only commit when falling back to local main ref:\n%s", diff)
+	}
+	if baseSHA == "" {
+		t.Error("baseSHA must not be empty on the local-branch fallback path")
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -4690,7 +4690,8 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 					intentBaseBranch = "main"
 				}
 			}
-			intentDiff, intentErr = git.GetDiff(ctx, intentBaseBranch)
+			var intentBaseSHA string
+			intentDiff, intentBaseSHA, intentErr = git.GetDiffAgainstOrigin(ctx, intentBaseBranch)
 			if intentErr != nil {
 				log.Warn("Intent judge skipped: failed to get diff",
 					slog.String("task_id", task.ID),
@@ -4699,6 +4700,16 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 				runIntentJudge = false
 			} else if intentDiff == "" {
 				runIntentJudge = false
+			} else {
+				// GH-4988: record the base SHA the judge diff was computed
+				// against so a false "scope creep" veto can be checked
+				// against what was actually on origin/<baseBranch> at judge
+				// time, instead of guessing whether the base was stale.
+				log.Info("Intent judge diff base resolved",
+					slog.String("task_id", task.ID),
+					slog.String("base_branch", intentBaseBranch),
+					slog.String("base_sha", intentBaseSHA),
+				)
 			}
 		}
 
@@ -4798,9 +4809,18 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 						result.TokensOutput = state.tokensOutput
 						result.TokensTotal = state.tokensInput + state.tokensOutput
 
-						// Re-judge the new diff
-						newDiff, _ := git.GetDiff(ctx, intentBaseBranch)
+						// Re-judge the new diff. GH-4988: re-fetch origin and
+						// re-resolve the merge-base rather than reusing the
+						// first pass's intentBaseSHA — the retry generation
+						// took real wall-clock time, during which
+						// origin/<baseBranch> can have advanced again.
+						newDiff, newBaseSHA, _ := git.GetDiffAgainstOrigin(ctx, intentBaseBranch)
 						if newDiff != "" {
+							log.Info("Intent judge retry diff base resolved",
+								slog.String("task_id", task.ID),
+								slog.String("base_branch", intentBaseBranch),
+								slog.String("base_sha", newBaseSHA),
+							)
 							v2, _ := r.intentJudge.Judge(ctx, task.Title, task.Description, newDiff)
 							if v2 != nil && !v2.Passed {
 								result.IntentWarning = v2.Reason


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4988.

Closes #4988

## Changes

GitHub Issue GH-4988: fix(executor): intent judge evaluates diffs against a stale base — 5 false scope-creep vetoes in 2 days (#4922 class, now recurring)

## Problem

The intent judge repeatedly vetoes correct first-generation diffs because the diff it evaluates contains **other issues' already-merged work** — the diff base is stale. First seen in the #4922 incident (08-17, recorded as a one-off); it has now recurred at least 5 times in 2 days, each costing a full generation + retry:

| When (UTC) | Task | Veto evidence (from daemon.log) |
|---|---|---|
| 08-17 | GH-4922 gen 1 | incident record: "false intent-judge veto off a stale diff base" |
| 08-18 09:56 | GH-4938 | diff "bundles" Jira ADF changes = GH-4930's separately-merged work |
| 08-18 13:51 | sdk GH-119 | diff "bundles" ExecutionSaverV2/TokenFunc = sdk #112/#118 already-merged work |
| 08-18 14:53 | GH-4952 | diff includes version bumps + memory files from prior merges |
| 08-18 ~evening | GH-4965, GH-4966 gen 1 | vetoed for "scope creep" that was other issues' merged work; retries landed clean |

Pattern: the executor computes the judge's diff against a base that predates recently-merged main (worktree created from a stale local main, or diff endpoint pinned to an old SHA). The judge then correctly reports "unrelated changes" — for changes the task never made. Retries succeed because by then the base has caught up. This is a throughput and cost multiplier (~2× generations on affected tasks) and produces misleading "scope creep" telemetry.

## Fix (research may adjust)

At judge time, compute the diff strictly as `git diff <merge-base(origin/main, HEAD)>...HEAD` after a fresh `git fetch origin main` in the execution worktree — never against the local `main` ref or the worktree's creation-time base. If the diff-for-judge is assembled from recorded SHAs instead, refresh the base SHA the same way.

## Acceptance criteria

- [ ] Judge diff for a branch never contains commits reachable from current `origin/main`
- [ ] Regression test: worktree created from stale main + upstream advance → judge diff contains only the task's commits
- [ ] Log line records the base SHA the judge diff was computed against

## Refs

#4922 (first occurrence, incident-killed) · marker `2026-08-18_s3-exit-three-tenant-pass.md` §Open-4 (recurrence watch item, now tripped)