### PR TITLE
GH-4997: fix(autopilot): fix-request spawner fires for closed/superseded PRs after the origin issue is delivered (#4995 spawned 45s after #4988 closed)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -3016,6 +3016,61 @@ func (c *Controller) spawnFailureIssue(ctx context.Context, prState *PRState, fa
 	return issueNum, err
 }
 
+// gh4997CIFixSpawnGate re-reads the origin PR (and, for a pre-merge
+// continuation, the origin issue) from GitHub immediately before
+// handleCIFailed mints a fix issue, rather than trusting the possibly-stale
+// failure event that reached this rung. #4995 (08-19) was created 45s after
+// #4988 had already been delivered by a superseding retry: PR#4994 (gen 1)
+// failed CI and was closed without merging, PR#4996 merged and closed #4988
+// — the fix-issue spawn ran anyway and burned a generation "fixing" a PR
+// nothing depended on any more.
+//
+// Two gates, checked in order:
+//
+//   - origin_pr_closed: the failing PR itself was closed without merging —
+//     retry/supersede flows close first-generation PRs as a matter of
+//     course, so a closed-not-merged PR's CI failure is moot by definition.
+//   - origin_issue_closed: the origin ticket issue closed (delivered, or
+//     otherwise) before this continuation could be minted — same PR, but a
+//     sibling/retry PR delivered the ticket first.
+//
+// This gate is wired into handleCIFailed (the pre-merge rung) only, not the
+// post-merge rung's spawnFailureIssue call: a post-merge PR is, by
+// construction, always State=closed+Merged=true (never closed-without-
+// merging, so origin_pr_closed is a no-op there anyway), and its origin
+// issue is *normally* already closed by handleMerging before StagePostMergeCI
+// is even reached (see the comment at that call site) — applying
+// origin_issue_closed there would silently stop every legitimate post-merge
+// fix spawn.
+//
+// Both GitHub reads fail open (log + proceed) on a transient error — an API
+// hiccup must not block a legitimate spawn.
+func (c *Controller) gh4997CIFixSpawnGate(ctx context.Context, prState *PRState) (skip bool, gate string) {
+	pr, err := c.ghClient.GetPullRequest(ctx, c.owner, c.repo, prState.PRNumber)
+	if err != nil {
+		c.log.Warn("CI-fix spawn gate: failed to re-read PR state, proceeding (fail-open)",
+			"pr", prState.PRNumber, "error", err)
+		return false, ""
+	}
+	if pr.State == github.StateClosed && !pr.Merged {
+		return true, "origin_pr_closed"
+	}
+
+	if prState.IssueNumber > 0 {
+		issue, err := c.ghClient.GetIssue(ctx, c.owner, c.repo, prState.IssueNumber)
+		if err != nil {
+			c.log.Warn("CI-fix spawn gate: failed to re-read origin issue state, proceeding (fail-open)",
+				"issue", prState.IssueNumber, "pr", prState.PRNumber, "error", err)
+			return false, ""
+		}
+		if issue.State == github.StateClosed {
+			return true, "origin_issue_closed"
+		}
+	}
+
+	return false, ""
+}
+
 func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error {
 	// GH-4533: classify the failure as code vs. CI infrastructure outage
 	// before doing anything else. An infra-classified failure with retry
@@ -3210,6 +3265,37 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 				return nil
 			}
 		}
+	}
+
+	// GH-4997: race-tolerant gate, checked as late as possible (right before
+	// the fix issue is minted, not from the cached failure event that
+	// triggered this call) — #4995 was created 45s *after* #4988 had already
+	// been delivered by a superseding retry (#4994 failed CI and closed
+	// without merging; #4996 merged and closed #4988). By the time this rung
+	// got here, the failure it was about to spawn a fix for no longer had a
+	// live origin. See gh4997CIFixSpawnGate's doc comment for why this only
+	// applies to the pre-merge rung.
+	if skip, gate := c.gh4997CIFixSpawnGate(ctx, prState); skip {
+		c.log.Info("CI-fix spawn skipped: origin already resolved via another path",
+			"pr", prState.PRNumber, "issue", prState.IssueNumber, "gate", gate)
+		if gate == "origin_issue_closed" {
+			// The origin issue was delivered through another path (e.g. a
+			// superseding retry) while this PR's own CI failure was still in
+			// flight, so this PR is now orphaned — close it so the
+			// sequential poller's merge waiter doesn't block forever on a PR
+			// that will never merge (mirrors the successful-spawn close
+			// below). gate == origin_pr_closed needs no such close: the PR
+			// is already closed by definition.
+			if cerr := c.ghClient.ClosePullRequest(ctx, c.owner, c.repo, prState.PRNumber); cerr != nil {
+				c.log.Warn("CI-fix spawn gate: failed to close orphaned PR", "pr", prState.PRNumber, "error", cerr)
+			}
+		}
+		prState.Stage = StageFailed
+		prState.Error = fmt.Sprintf("CI-fix spawn skipped: %s (GH-4997)", gate)
+		c.metrics.RecordPRFailed()
+		c.metrics.RecordPRFailedClass(failureClass)
+		c.recordCIFailVerdict(failureClass)
+		return nil
 	}
 
 	// GH-1567: Fetch actual CI error logs to include in fix issues.

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -2645,6 +2645,230 @@ func TestHandleCIFailed_RecordsCIRunOnFail(t *testing.T) {
 	}
 }
 
+// TestHandleCIFailed_GH4997_SkipsSpawnWhenOriginPRClosed is the regression
+// test for the #4995 incident (08-19): CI failed on PR#4994 (GH-4988 gen 1)
+// and handleCIFailed was triggered from that (now-stale) failure event, but
+// by the time it re-reads PR state right before spawning, PR#4994 has
+// already been closed without merging — superseded by the retry PR#4996,
+// which merged and delivered #4988 first. No fix issue must be created for
+// a PR whose CI failure is already moot, and the skip must be logged at Info
+// naming the pr/issue/gate.
+func TestHandleCIFailed_GH4997_SkipsSpawnWhenOriginPRClosed(t *testing.T) {
+	issueCreated := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/sha994/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "build", Status: "completed", Conclusion: "failure"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/pulls/4994" && r.Method == http.MethodGet:
+			resp := github.PullRequest{Number: 4994, State: github.StateClosed, Merged: false}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			issueCreated = true
+			resp := github.Issue{Number: 4995}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, resp))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	var logBuf bytes.Buffer
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.log = slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	prState := &PRState{
+		PRNumber:    4994,
+		IssueNumber: 4988,
+		HeadSHA:     "sha994",
+		Stage:       StageCIFailed,
+	}
+
+	if err := c.handleCIFailed(context.Background(), prState); err != nil {
+		t.Fatalf("handleCIFailed returned unexpected error: %v", err)
+	}
+
+	if issueCreated {
+		t.Error("expected no fix issue to be created for a PR already closed without merging")
+	}
+	if prState.Stage != StageFailed {
+		t.Errorf("Stage = %s, want %s", prState.Stage, StageFailed)
+	}
+
+	logs := logBuf.String()
+	if !strings.Contains(logs, "CI-fix spawn skipped") {
+		t.Errorf("expected a skip log line, got logs:\n%s", logs)
+	}
+	if !strings.Contains(logs, "gate=origin_pr_closed") {
+		t.Errorf("expected skip log to name gate=origin_pr_closed, got logs:\n%s", logs)
+	}
+	if !strings.Contains(logs, "pr=4994") {
+		t.Errorf("expected skip log to name pr=4994, got logs:\n%s", logs)
+	}
+	if !strings.Contains(logs, "issue=4988") {
+		t.Errorf("expected skip log to name issue=4988, got logs:\n%s", logs)
+	}
+}
+
+// TestHandleCIFailed_GH4997_SkipsSpawnWhenOriginIssueClosed covers the
+// sibling gate: the failing PR is still open, but the origin issue was
+// already delivered (closed) through another path — e.g. a sibling/retry PR
+// merged first. No fix issue must be created, and the now-orphaned PR must
+// be closed so the sequential poller doesn't block on it forever.
+func TestHandleCIFailed_GH4997_SkipsSpawnWhenOriginIssueClosed(t *testing.T) {
+	issueCreated := false
+	prClosed := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/sha994/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "build", Status: "completed", Conclusion: "failure"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/pulls/4994" && r.Method == http.MethodGet:
+			resp := github.PullRequest{Number: 4994, State: github.StateOpen}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/pulls/4994" && r.Method == http.MethodPatch:
+			prClosed = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		case r.URL.Path == "/repos/owner/repo/issues/4988" && r.Method == http.MethodGet:
+			resp := github.Issue{Number: 4988, State: github.StateClosed}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			issueCreated = true
+			resp := github.Issue{Number: 4995}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, resp))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	var logBuf bytes.Buffer
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.log = slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	prState := &PRState{
+		PRNumber:    4994,
+		IssueNumber: 4988,
+		HeadSHA:     "sha994",
+		Stage:       StageCIFailed,
+	}
+
+	if err := c.handleCIFailed(context.Background(), prState); err != nil {
+		t.Fatalf("handleCIFailed returned unexpected error: %v", err)
+	}
+
+	if issueCreated {
+		t.Error("expected no fix issue to be created when the origin issue is already closed")
+	}
+	if !prClosed {
+		t.Error("expected the now-orphaned open PR to be closed")
+	}
+	if prState.Stage != StageFailed {
+		t.Errorf("Stage = %s, want %s", prState.Stage, StageFailed)
+	}
+
+	logs := logBuf.String()
+	if !strings.Contains(logs, "CI-fix spawn skipped") {
+		t.Errorf("expected a skip log line, got logs:\n%s", logs)
+	}
+	if !strings.Contains(logs, "gate=origin_issue_closed") {
+		t.Errorf("expected skip log to name gate=origin_issue_closed, got logs:\n%s", logs)
+	}
+	if !strings.Contains(logs, "pr=4994") {
+		t.Errorf("expected skip log to name pr=4994, got logs:\n%s", logs)
+	}
+	if !strings.Contains(logs, "issue=4988") {
+		t.Errorf("expected skip log to name issue=4988, got logs:\n%s", logs)
+	}
+}
+
+// TestHandleCIFailed_GH4997_SpawnsWhenOriginPROrIssueOpen is the "unchanged"
+// half of the GH-4997 acceptance criteria: with the PR still open and the
+// origin issue still open, the CI-fix spawn gate must not interfere with the
+// normal fix-issue creation path.
+func TestHandleCIFailed_GH4997_SpawnsWhenOriginPROrIssueOpen(t *testing.T) {
+	issueCreated := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/sha994/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "build", Status: "completed", Conclusion: "failure"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/pulls/4994" && r.Method == http.MethodGet:
+			resp := github.PullRequest{Number: 4994, State: github.StateOpen}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/issues/4988" && r.Method == http.MethodGet:
+			resp := github.Issue{Number: 4988, State: github.StateOpen}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			issueCreated = true
+			resp := github.Issue{Number: 4995}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, resp))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:    4994,
+		IssueNumber: 4988,
+		HeadSHA:     "sha994",
+		Stage:       StageCIFailed,
+	}
+
+	if err := c.handleCIFailed(context.Background(), prState); err != nil {
+		t.Fatalf("handleCIFailed returned unexpected error: %v", err)
+	}
+
+	if !issueCreated {
+		t.Error("expected a fix issue to be created when the origin PR and issue are both still open")
+	}
+	if prState.Stage != StageFailed {
+		t.Errorf("Stage = %s, want %s", prState.Stage, StageFailed)
+	}
+}
+
 // gh4533InfraTestServer builds one httptest.Server answering both the
 // studio-sdk client's endpoints (check-runs list, job log fetch) and the
 // in-tree client's endpoints (jobs API, rerun-failed-jobs), matching the


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4997.

Closes #4997

## Changes

GitHub Issue GH-4997: fix(autopilot): fix-request spawner fires for closed/superseded PRs after the origin issue is delivered (#4995 spawned 45s after #4988 closed)

## Problem

The autopilot-fix spawner creates fix-request issues for PRs that are already closed and superseded — after the origin issue has been delivered.

Evidence (2026-08-19): PR#4994 (GH-4988 gen 1) failed pre-merge CI and was closed; the retry **PR#4996 merged at 11:02:26Z**, closing #4988 as delivered. The spawner then created **#4995 at 11:03:11Z** — 45 seconds *after* delivery — labeled `pilot`, and the daemon dispatched it, burning a generation on a task whose premise no longer existed ("fix CI on a closed, superseded PR").

This is the second garbage-spawn channel in two days (08-18: 6 spawns off the lint-cache phantom failures — different root cause, same waste sink: each spawn costs a dispatch, an execution, and operator cleanup).

## Fix

Gate the autopilot-fix spawn: before creating the fix issue, check
1. **Origin PR state** — if the PR is CLOSED (not merged), skip: a closed PR's CI failure is moot by definition (retry/supersede flows close first-generation PRs as a matter of course).
2. **Origin issue state** — if the origin issue is closed (delivered or otherwise), skip.
3. Log the skip at Info with pr, issue, and which gate declined.

Race-tolerance: the check runs at spawn time; a PR closed between failure detection and spawn must be caught (re-read PR state immediately before `gh issue create`, not from the cached failure event).

## Acceptance criteria

- [ ] No fix issue is created when the origin PR is closed or the origin issue is closed at spawn time
- [ ] Skip is logged (Info) with pr/issue/gate
- [ ] Regression test: failure event for a PR that gets closed before spawn → no issue created, skip logged
- [ ] Existing spawn path for open PR + open issue unchanged

## Refs

#4995 (today's moot spawn, closed) · #4994/#4996 (the supersede pair) · 08-18 lint-cache incident spawns #4962/#4970/#4972/#4974/#4957/#4959 (adjacent class — phantom failures; this gate would not have caught those, noting to bound scope)

Do not decompose — this is a standalone task, one small change as a single PR.