### PR TITLE
GH-4998: fix(jira): legacy adapter Comment.Body is string-typed — Cloud ADF comment responses fail to parse in the live webhook path (twin of sdk#121)

### DIFF
--- a/internal/adapters/jira/client_test.go
+++ b/internal/adapters/jira/client_test.go
@@ -123,6 +123,41 @@ func TestAddComment_Cloud(t *testing.T) {
 	}
 }
 
+// TestAddComment_Cloud_ADFResponseBody verifies AddComment parses a real
+// Jira Cloud v3 response, where the comment body comes back as an ADF
+// object rather than the plain string the request was posted with. Before
+// Comment.Body was ADFText, this response shape failed to unmarshal (see
+// studio-sdk#121): the comment was created successfully server-side, but
+// the client reported an error, so NotifyTaskStarted always WARNed on
+// Cloud sites (GH-4998, twin of sdk PR#122).
+func TestAddComment_Cloud_ADFResponseBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "10047",
+			"body": {
+				"type": "doc",
+				"version": 1,
+				"content": [
+					{"type": "paragraph", "content": [{"type": "text", "text": "Test comment"}]}
+				]
+			},
+			"created": "2026-08-18T15:12:46.244Z",
+			"updated": "2026-08-18T15:12:46.244Z"
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "user@example.com", "api-token", PlatformCloud)
+	comment, err := client.AddComment(context.Background(), "PROJ-42", "Test comment")
+	if err != nil {
+		t.Fatalf("AddComment failed to parse Cloud ADF response: %v", err)
+	}
+	if comment.Body != "Test comment" {
+		t.Errorf("comment.Body = %q, want %q", comment.Body, "Test comment")
+	}
+}
+
 func TestAddComment_Server(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/internal/adapters/jira/notifier_test.go
+++ b/internal/adapters/jira/notifier_test.go
@@ -58,6 +58,42 @@ func TestNotifyTaskStarted_WithTransitionID(t *testing.T) {
 	}
 }
 
+// TestNotifyTaskStarted_CloudADFCommentResponse verifies NotifyTaskStarted
+// succeeds when the Cloud API echoes the posted comment back as an ADF
+// object (the real-world response shape). Before Comment.Body was ADFText,
+// this response failed to unmarshal and NotifyTaskStarted always returned
+// an error despite the comment having been posted successfully (GH-4998,
+// twin of studio-sdk#121, live-verified on the KAN-6 e2e card).
+func TestNotifyTaskStarted_CloudADFCommentResponse(t *testing.T) {
+	client, server := newTestNotifierServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/rest/api/3/issue/PROJ-42/transitions" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusNoContent)
+		case r.URL.Path == "/rest/api/3/issue/PROJ-42/comment" && r.Method == http.MethodPost:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"id": "10047",
+				"body": {
+					"type": "doc",
+					"version": 1,
+					"content": [
+						{"type": "paragraph", "content": [{"type": "text", "text": "started"}]}
+					]
+				}
+			}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer server.Close()
+
+	notifier := NewNotifier(client, "21", "31")
+	if err := notifier.NotifyTaskStarted(context.Background(), "PROJ-42", "task-123"); err != nil {
+		t.Fatalf("NotifyTaskStarted failed on Cloud ADF comment response: %v", err)
+	}
+}
+
 func TestNotifyTaskStarted_WithoutTransitionID(t *testing.T) {
 	var mu sync.Mutex
 	var calls []string

--- a/internal/adapters/jira/types.go
+++ b/internal/adapters/jira/types.go
@@ -234,13 +234,15 @@ type TransitionsResponse struct {
 	Transitions []Transition `json:"transitions"`
 }
 
-// Comment represents a Jira comment
+// Comment represents a Jira comment. Body is ADFText because Jira Cloud v3
+// returns comment bodies as Atlassian Document Format (ADF) objects, while
+// Server/DC returns plain strings (same split as Fields.Description).
 type Comment struct {
-	ID      string `json:"id"`
-	Body    string `json:"body"`
-	Author  User   `json:"author"`
-	Created string `json:"created"`
-	Updated string `json:"updated"`
+	ID      string  `json:"id"`
+	Body    ADFText `json:"body"`
+	Author  User    `json:"author"`
+	Created string  `json:"created"`
+	Updated string  `json:"updated"`
 }
 
 // RemoteLink represents a Jira remote link (for PR linking)

--- a/internal/adapters/jira/types_test.go
+++ b/internal/adapters/jira/types_test.go
@@ -2,6 +2,7 @@ package jira
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -117,6 +118,96 @@ func TestADFText_UnmarshalJSON_InvalidJSON(t *testing.T) {
 	var got ADFText
 	if err := json.Unmarshal([]byte(`not-json`), &got); err == nil {
 		t.Errorf("UnmarshalJSON() expected error for invalid JSON, got nil")
+	}
+}
+
+// TestComment_UnmarshalJSON_MixedBodyShapes verifies that Comment (which
+// embeds ADFText for Body) correctly parses both plain-string (Server/DC)
+// and ADF-object (Cloud v3 AddComment response) body payloads. Before
+// Comment.Body was ADFText, unmarshaling a Cloud response into a plain
+// string field rejected the entire AddComment response with:
+//
+//	json: cannot unmarshal object into Go struct field Comment.body of type string
+//
+// even though the comment had already been posted successfully (GH-4998,
+// twin of studio-sdk#121 / sdk PR#122, same class as pilot#4929).
+func TestComment_UnmarshalJSON_MixedBodyShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+		want ADFText
+	}{
+		{
+			name: "plain string body (Server/DC)",
+			json: `{"id":"10001","body":"Test comment"}`,
+			want: "Test comment",
+		},
+		{
+			name: "ADF object body (Cloud v3)",
+			json: `{
+				"id": "10047",
+				"body": {
+					"type": "doc",
+					"version": 1,
+					"content": [
+						{"type": "paragraph", "content": [{"type": "text", "text": "Pilot started working on this issue"}]}
+					]
+				}
+			}`,
+			want: "Pilot started working on this issue",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c Comment
+			if err := json.Unmarshal([]byte(tt.json), &c); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if c.Body != tt.want {
+				t.Errorf("Body = %q, want %q", c.Body, tt.want)
+			}
+		})
+	}
+}
+
+// TestComment_UnmarshalJSON_LegacyStringFieldWouldFail documents the exact
+// live failure this fix prevents: unmarshaling a Cloud ADF comment body
+// into a plain string field (the pre-fix Comment.Body type) rejects the
+// entire response even though the comment was posted successfully.
+func TestComment_UnmarshalJSON_LegacyStringFieldWouldFail(t *testing.T) {
+	type legacyComment struct {
+		ID   string `json:"id"`
+		Body string `json:"body"`
+	}
+	adfBody := `{
+		"id": "10047",
+		"body": {
+			"type": "doc",
+			"version": 1,
+			"content": [
+				{"type": "paragraph", "content": [{"type": "text", "text": "Pilot started working on this issue"}]}
+			]
+		}
+	}`
+
+	var legacy legacyComment
+	err := json.Unmarshal([]byte(adfBody), &legacy)
+	if err == nil {
+		t.Fatal("expected error unmarshaling ADF body into string-typed field, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot unmarshal object into Go struct field") ||
+		!strings.Contains(err.Error(), "body") {
+		t.Errorf("error = %q, want it to describe the body field unmarshal failure", err.Error())
+	}
+
+	// The fixed Comment type parses the identical payload without error.
+	var fixed Comment
+	if err := json.Unmarshal([]byte(adfBody), &fixed); err != nil {
+		t.Fatalf("Comment (ADFText Body) failed to parse the same payload: %v", err)
+	}
+	if fixed.Body != "Pilot started working on this issue" {
+		t.Errorf("fixed.Body = %q, want %q", fixed.Body, "Pilot started working on this issue")
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4998.

Closes #4998

## Changes

GitHub Issue GH-4998: fix(jira): legacy adapter Comment.Body is string-typed — Cloud ADF comment responses fail to parse in the live webhook path (twin of sdk#121)

## Problem

The sdk PR#122 review (see studio-sdk#121) flagged a latent twin: pilot's legacy Jira adapter still types comment bodies as plain strings — `internal/adapters/jira/types.go:240` (`Body string`) — while Jira **Cloud** v3 returns ADF objects for comment bodies. Identical failure class to the KAN-6 live evidence (`json: cannot unmarshal object into Go struct field Comment.body of type string`): the comment POST succeeds, response parsing fails, callers misreport failure.

This is NOT dead code: the webhook path wires the legacy client live (`internal/pilot/pilot.go:417-427` — `jira.NewClient` + `jira.NewWebhookHandler` when `adapters.jira` webhook mode is configured; `cmd/pilot/onboard_ticket.go` also constructs it). The box currently runs SDK polling (pitfall `jira-two-parallel-clients-poller-is-sdk`), but any webhook-configured Cloud tenant hits this immediately.

## Fix

Port the ADF-tolerant dual-shape unmarshal to `internal/adapters/jira`: `Comment.Body` (types.go:240) and any other comment-bearing response structs in the package accept both plain string (Server/DC) and ADF object (Cloud) — mirror studio-sdk's `ADFText` (`sdk/integrations/jira/types.go:136-165`, introduced sdk PR#120, extended to comments in PR#122). Table-driven tests over both wire shapes including the exact error fixture above. Verify all consumers of `Comment.Body` still compile/behave with the extracted plain text.

## Acceptance criteria

- [ ] AddComment response parses on Cloud (ADF body) and Server (string body) in `internal/adapters/jira`
- [ ] All comment-bearing response structs in the package covered (sweep, not just the one field)
- [ ] Tests cover both shapes + the live error fixture
- [ ] No change to the SDK-poller path

## Refs

studio-sdk#121 / sdk PR#122 (the SDK-side fix + review) · #4987 (merge-side done leg — SDK path) · pitfall `jira-two-parallel-clients-poller-is-sdk`

Do not decompose — this is a standalone task, one coherent change to one package as a single PR.