### PR TITLE
GH-4999: fix(autopilot): externally-merged pilot/JIRA-* PRs never trigger the Jira done leg — the KAN-6 case remains unfixed after PR#4992

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -4161,12 +4161,24 @@ func jiraIssueKeyFromBranch(branchName string) string {
 // Linear-originated tasks fall through here untouched. Failure is WARN-only:
 // this must never fail or block the merge path, mirroring every other
 // merge-time notify call in handleMerging (labels, comments, c.notifier).
+//
+// GH-4999: called from two sites — handleMerging (autopilot's own merge) and
+// checkExternalMergeOrClose's merged branch (a human/externally merged
+// pilot/JIRA-* PR, e.g. KAN-6/PR#4955). The latter has no persistPRState call
+// between detecting the merge and its terminal removePR, so JiraDoneNotified
+// is checked-and-set here, with an immediate persist, rather than left to the
+// caller's own end-of-tick persist — a crash between the merge and the
+// notify must not leave a restart free to re-enter the merged branch and
+// double-post the Jira comment.
 func (c *Controller) notifyJiraDone(ctx context.Context, prState *PRState) {
 	if c.jiraDoneNotifier == nil {
 		return
 	}
 	issueKey := jiraIssueKeyFromBranch(prState.BranchName)
 	if issueKey == "" {
+		return
+	}
+	if prState.JiraDoneNotified {
 		return
 	}
 	if err := c.jiraDoneNotifier.NotifyTaskCompleted(ctx, issueKey, prState.PRURL, ""); err != nil {
@@ -4176,6 +4188,11 @@ func (c *Controller) notifyJiraDone(ctx context.Context, prState *PRState) {
 			"error", err,
 		)
 	}
+	// Set unconditionally (mirrors MergeFollowupPosted's attempt-once
+	// semantics): this leg is WARN-only and must never retry indefinitely
+	// against a permanently failing Jira call.
+	prState.JiraDoneNotified = true
+	c.persistPRState(prState)
 }
 
 func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error {
@@ -7958,6 +7975,18 @@ func (c *Controller) checkExternalMergeOrClose(ctx context.Context, prState *PRS
 		}
 
 		c.notifyExternalMerge(ctx, prState)
+
+		// GH-4999: fire the Jira merge-side done leg for a human/externally
+		// merged pilot/JIRA-* PR (the KAN-6/PR#4955 case) — PR#4992 wired
+		// notifyJiraDone into handleMerging only, but a PR merged by anything
+		// other than autopilot's own guarded merge (a human `gh pr merge`, or
+		// GitHub's UI) never reaches handleMerging at all; this is the only
+		// site that ever sees that merge. Independent of the
+		// prState.IssueNumber > 0 block below — Jira-originated PRs carry
+		// IssueNumber == 0 — and gated purely on the branch-derived task ID
+		// (jiraIssueKeyFromBranch returns "" for GH-/Linear-originated
+		// branches), so those are untouched.
+		c.notifyJiraDone(ctx, prState)
 
 		// GH-1486: Close associated issue and add pilot-done label on external merge
 		if prState.IssueNumber > 0 {

--- a/internal/autopilot/gh4999_test.go
+++ b/internal/autopilot/gh4999_test.go
@@ -1,0 +1,195 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestController_CheckExternalMergeOrClose_NotifiesJiraDone covers GH-4999:
+// checkExternalMergeOrClose's merged branch — not just handleMerging — must
+// fire the Jira merge-side done leg. PR#4992 (GH-4987) wired notifyJiraDone
+// into handleMerging only; a human/externally merged pilot/JIRA-* PR (the
+// KAN-6/PR#4955 case) never reaches handleMerging at all, so the done leg
+// silently never fired for it.
+func TestController_CheckExternalMergeOrClose_NotifiesJiraDone(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/pulls/42":
+			resp := github.PullRequest{
+				Number:  42,
+				State:   "closed",
+				Merged:  true,
+				HTMLURL: "https://github.com/owner/repo/pull/42",
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.CIPollInterval = 10 * time.Millisecond
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	notifier := &fakeJiraDoneNotifier{}
+	c.SetJiraDoneNotifier(notifier)
+
+	// Jira-originated PR: IssueNumber == 0 (OnPRCreated's non-GitHub adapters
+	// always pass 0), branch is the pilot/JIRA-<KEY> convention.
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 0, "abc123", "pilot/JIRA-KAN-6", "")
+
+	c.processAllPRs(context.Background())
+
+	wantCalls := []fakeJiraDoneCall{
+		{IssueKey: "KAN-6", PRURL: "https://github.com/owner/repo/pull/42"},
+	}
+	if len(notifier.calls) != len(wantCalls) {
+		t.Fatalf("notifier calls = %+v, want %+v", notifier.calls, wantCalls)
+	}
+	if notifier.calls[0] != wantCalls[0] {
+		t.Errorf("call[0] = %+v, want %+v", notifier.calls[0], wantCalls[0])
+	}
+
+	// The PR should still be drained from tracking exactly as before this fix.
+	if _, ok := c.GetPRState(42); ok {
+		t.Error("PR should be removed after external merge detection")
+	}
+}
+
+// TestController_CheckExternalMergeOrClose_GHTaskUnaffected verifies GH-4999
+// acceptance criteria: no behavior change for GH-/Linear-originated PRs
+// externally merged through the same code path.
+func TestController_CheckExternalMergeOrClose_GHTaskUnaffected(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/pulls/42":
+			resp := github.PullRequest{
+				Number:  42,
+				State:   "closed",
+				Merged:  true,
+				HTMLURL: "https://github.com/owner/repo/pull/42",
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.CIPollInterval = 10 * time.Millisecond
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	notifier := &fakeJiraDoneNotifier{}
+	c.SetJiraDoneNotifier(notifier)
+
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc123", "pilot/GH-10", "")
+
+	c.processAllPRs(context.Background())
+
+	if len(notifier.calls) != 0 {
+		t.Errorf("expected no Jira notify calls for a GH-* task, got %+v", notifier.calls)
+	}
+}
+
+// TestController_CheckExternalMergeOrClose_JiraDoneNotDoubleFiredOnReentry
+// covers GH-4999's idempotency requirement: if checkExternalMergeOrClose's
+// merged branch is re-entered for the same tracked PR (e.g. an earlier tick
+// errored out before reaching removePR), the Jira notify must not fire a
+// second time.
+func TestController_CheckExternalMergeOrClose_JiraDoneNotDoubleFiredOnReentry(t *testing.T) {
+	c := NewController(DefaultConfig(), nil, nil, "owner", "repo")
+	notifier := &fakeJiraDoneNotifier{}
+	c.SetJiraDoneNotifier(notifier)
+
+	prState := &PRState{
+		PRNumber:   42,
+		PRURL:      "https://github.com/owner/repo/pull/42",
+		BranchName: "pilot/JIRA-KAN-6",
+		Stage:      StageWaitingCI,
+		CreatedAt:  time.Now(),
+	}
+
+	c.notifyJiraDone(context.Background(), prState)
+	if len(notifier.calls) != 1 {
+		t.Fatalf("expected 1 notify call after first invocation, got %d", len(notifier.calls))
+	}
+	if !prState.JiraDoneNotified {
+		t.Fatal("expected JiraDoneNotified to be true after first invocation")
+	}
+
+	// Simulate re-entry (e.g. checkExternalMergeOrClose re-running for the
+	// same PR after a crash before its terminal removePR persisted anything).
+	c.notifyJiraDone(context.Background(), prState)
+	if len(notifier.calls) != 1 {
+		t.Errorf("expected still 1 notify call after re-entry, got %d", len(notifier.calls))
+	}
+}
+
+// TestController_NotifyJiraDone_FlagPersistsAcrossRestart verifies GH-4999's
+// "idempotent across restarts" acceptance criterion: JiraDoneNotified is
+// persisted immediately by notifyJiraDone (not left to the caller's own
+// end-of-tick persist), and round-trips through SavePRState/GetPRState /
+// LoadAllPRStates, mirroring MergeFollowupPosted's persistence tests.
+func TestController_NotifyJiraDone_FlagPersistsAcrossRestart(t *testing.T) {
+	store := newTestStateStore(t)
+
+	c := NewController(DefaultConfig(), nil, nil, "owner", "repo")
+	c.SetStateStore(store)
+	notifier := &fakeJiraDoneNotifier{}
+	c.SetJiraDoneNotifier(notifier)
+
+	prState := &PRState{
+		PRNumber:   42,
+		PRURL:      "https://github.com/owner/repo/pull/42",
+		BranchName: "pilot/JIRA-KAN-6",
+		Stage:      StageWaitingCI,
+		CreatedAt:  time.Now().Truncate(time.Second),
+	}
+
+	c.notifyJiraDone(context.Background(), prState)
+	if len(notifier.calls) != 1 {
+		t.Fatalf("expected 1 notify call, got %d", len(notifier.calls))
+	}
+
+	// Simulate a crash right after notifyJiraDone returns, before any other
+	// persist call — reload from the store as a fresh restart would.
+	loaded, err := store.GetPRState("owner/repo", 42)
+	if err != nil {
+		t.Fatalf("GetPRState failed: %v", err)
+	}
+	if loaded == nil || !loaded.JiraDoneNotified {
+		t.Fatalf("JiraDoneNotified did not persist: got %+v", loaded)
+	}
+
+	all, err := store.LoadAllPRStates("owner/repo")
+	if err != nil {
+		t.Fatalf("LoadAllPRStates failed: %v", err)
+	}
+	if len(all) != 1 || !all[0].JiraDoneNotified {
+		t.Fatalf("LoadAllPRStates did not preserve JiraDoneNotified: %+v", all)
+	}
+
+	// Re-drive notifyJiraDone against the *reloaded* state (what a restart's
+	// re-adoption would do) — must not double-notify.
+	c.notifyJiraDone(context.Background(), loaded)
+	if len(notifier.calls) != 1 {
+		t.Errorf("expected still 1 notify call after restart-simulated re-drive, got %d", len(notifier.calls))
+	}
+}

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -215,6 +215,13 @@ func (s *StateStore) migrate() error {
 		// the skip survives a daemon restart; error already carries the
 		// reason via the existing error column.
 		`ALTER TABLE autopilot_pr_state ADD COLUMN release_backfill_abandoned INTEGER NOT NULL DEFAULT 0`,
+		// GH-4999: durable idempotency guard for the Jira merge-side done leg
+		// (notifyJiraDone). checkExternalMergeOrClose's merged branch has no
+		// persistPRState call between detecting the merge and its terminal
+		// removePR, so without a persisted flag a crash in that window would
+		// leave a restart free to re-enter the merged branch and re-fire the
+		// Jira completion comment.
+		`ALTER TABLE autopilot_pr_state ADD COLUMN jira_done_notified INTEGER NOT NULL DEFAULT 0`,
 	}
 
 	for _, m := range migrations {
@@ -481,6 +488,7 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			post_merge_infra_rerun_count INTEGER NOT NULL DEFAULT 0,
 			post_merge_infra_rerun_sha TEXT NOT NULL DEFAULT '',
 			release_backfill_abandoned INTEGER NOT NULL DEFAULT 0,
+			jira_done_notified INTEGER NOT NULL DEFAULT 0,
 			PRIMARY KEY (repo, pr_number)
 		)
 	`); err != nil {
@@ -498,7 +506,7 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			parked, escalation_reason, rebase_hold_active, readopt_count,
 			breaker_hold_active, breaker_readopt_count,
 			post_merge_infra_rerun_count, post_merge_infra_rerun_sha,
-			release_backfill_abandoned
+			release_backfill_abandoned, jira_done_notified
 		)
 		SELECT
 			pr_number, repo, pr_url, issue_number, branch_name, head_sha,
@@ -511,7 +519,7 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			parked, escalation_reason, rebase_hold_active, readopt_count,
 			breaker_hold_active, breaker_readopt_count,
 			post_merge_infra_rerun_count, post_merge_infra_rerun_sha,
-			release_backfill_abandoned
+			release_backfill_abandoned, jira_done_notified
 		FROM autopilot_pr_state
 	`); err != nil {
 		return fmt.Errorf("copy autopilot_pr_state rows: %w", err)
@@ -659,8 +667,8 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 			parked, escalation_reason, rebase_hold_active, readopt_count,
 			breaker_hold_active, breaker_readopt_count,
 			post_merge_infra_rerun_count, post_merge_infra_rerun_sha,
-			release_backfill_abandoned
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			release_backfill_abandoned, jira_done_notified
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(repo, pr_number) DO UPDATE SET
 			pr_url = excluded.pr_url,
 			issue_number = excluded.issue_number,
@@ -695,7 +703,8 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 			breaker_readopt_count = excluded.breaker_readopt_count,
 			post_merge_infra_rerun_count = excluded.post_merge_infra_rerun_count,
 			post_merge_infra_rerun_sha = excluded.post_merge_infra_rerun_sha,
-			release_backfill_abandoned = excluded.release_backfill_abandoned
+			release_backfill_abandoned = excluded.release_backfill_abandoned,
+			jira_done_notified = excluded.jira_done_notified
 	`,
 		pr.PRNumber, repo, pr.PRURL, pr.IssueNumber, pr.BranchName, pr.HeadSHA,
 		string(pr.Stage), string(pr.CIStatus),
@@ -708,7 +717,7 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 		pr.Parked, pr.EscalationReason, pr.RebaseHoldActive, pr.ReadoptCount,
 		pr.BreakerHoldActive, pr.BreakerReadoptCount,
 		pr.PostMergeInfraRerunCount, pr.PostMergeInfraRerunSHA,
-		pr.ReleaseBackfillAbandoned,
+		pr.ReleaseBackfillAbandoned, pr.JiraDoneNotified,
 	)
 	return err
 }
@@ -727,7 +736,7 @@ func (s *StateStore) GetPRState(repo string, prNumber int) (*PRState, error) {
 			parked, escalation_reason, rebase_hold_active, readopt_count,
 			breaker_hold_active, breaker_readopt_count,
 			post_merge_infra_rerun_count, post_merge_infra_rerun_sha,
-			release_backfill_abandoned
+			release_backfill_abandoned, jira_done_notified
 		FROM autopilot_pr_state WHERE repo = ? AND pr_number = ?
 	`, repo, prNumber)
 
@@ -755,7 +764,7 @@ func (s *StateStore) LoadAllPRStates(repo string) ([]*PRState, error) {
 			parked, escalation_reason, rebase_hold_active, readopt_count,
 			breaker_hold_active, breaker_readopt_count,
 			post_merge_infra_rerun_count, post_merge_infra_rerun_sha,
-			release_backfill_abandoned
+			release_backfill_abandoned, jira_done_notified
 		FROM autopilot_pr_state WHERE repo = ?
 	`, repo)
 	if err != nil {
@@ -780,7 +789,7 @@ func (s *StateStore) LoadAllPRStates(repo string) ([]*PRState, error) {
 			&pr.Parked, &pr.EscalationReason, &pr.RebaseHoldActive, &pr.ReadoptCount,
 			&pr.BreakerHoldActive, &pr.BreakerReadoptCount,
 			&pr.PostMergeInfraRerunCount, &pr.PostMergeInfraRerunSHA,
-			&pr.ReleaseBackfillAbandoned,
+			&pr.ReleaseBackfillAbandoned, &pr.JiraDoneNotified,
 		); err != nil {
 			return nil, err
 		}
@@ -1039,7 +1048,7 @@ func scanPRState(row *sql.Row) (*PRState, error) {
 		&pr.Parked, &pr.EscalationReason, &pr.RebaseHoldActive, &pr.ReadoptCount,
 		&pr.BreakerHoldActive, &pr.BreakerReadoptCount,
 		&pr.PostMergeInfraRerunCount, &pr.PostMergeInfraRerunSHA,
-		&pr.ReleaseBackfillAbandoned,
+		&pr.ReleaseBackfillAbandoned, &pr.JiraDoneNotified,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -1231,6 +1231,20 @@ type PRState struct {
 	// Mirrors the MergeNotificationPosted guard above for the same race
 	// (GH-4164).
 	MergeFollowupPosted bool
+	// JiraDoneNotified is true once notifyJiraDone (GH-4987) has attempted the
+	// Jira merge-side done leg (completion comment + done-category transition)
+	// for this PR. GH-4999: notifyJiraDone is now called from two sites —
+	// handleMerging (autopilot's own merge) and checkExternalMergeOrClose's
+	// merged branch (a human/externally merged pilot/JIRA-* PR) — and the
+	// latter has no persistPRState call between detecting the merge and its
+	// terminal removePR, so a crash in that window left nothing durable to
+	// stop a post-restart re-entry from re-firing the Jira comment. Set (and
+	// persisted immediately by notifyJiraDone itself) after the first attempt
+	// regardless of NotifyTaskCompleted's outcome — mirrors MergeFollowupPosted's
+	// unconditional set-after-attempt semantics, since this leg is WARN-only
+	// and must never retry indefinitely against a permanently failing Jira
+	// call. Persisted.
+	JiraDoneNotified bool
 	// InfraRerunCount tracks how many times handleCIFailed has auto-retried
 	// this PR's failed jobs after classifying the failure as a CI
 	// infrastructure outage rather than a code failure (GH-4533). Scoped to
@@ -1360,6 +1374,7 @@ func (ps *PRState) snapshot() *PRState {
 		ScopeTitle:                   ps.ScopeTitle,
 		ConflictRecorded:             ps.ConflictRecorded,
 		MergeFollowupPosted:          ps.MergeFollowupPosted,
+		JiraDoneNotified:             ps.JiraDoneNotified,
 		InfraRerunCount:              ps.InfraRerunCount,
 		InfraRerunSHA:                ps.InfraRerunSHA,
 		RebaseHoldActive:             ps.RebaseHoldActive,


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4999.

Closes #4999

## Changes

GitHub Issue GH-4999: fix(autopilot): externally-merged pilot/JIRA-* PRs never trigger the Jira done leg — the KAN-6 case remains unfixed after PR#4992

## Problem

PR#4992 (GH-4987) added `notifyJiraDone`, but it is called only from `handleMerging` — and the post-merge review traced that **no production path reaches it for the motivating case**: `checkExternalMergeOrClose`'s merged branch (the path that consumed KAN-6's human-merged PR#4955) closes the GH issue, labels, board-syncs, and never calls the Jira done leg. A human- or externally-merged `pilot/JIRA-*` PR still leaves its Jira card in To Do.

## Fix

1. In `checkExternalMergeOrClose`'s merged branch (internal/autopilot/controller.go ~7780-7850), when the PR's branch matches `pilot/JIRA-<KEY>`, call `notifyJiraDone` with the same WARN-only semantics as the handleMerging site (controller.go:4380).
2. Add an idempotency flag on the Jira notify (mirror `MergeFollowupPosted`/`MergeNotificationPosted` in `PRState`) so a crash between merge and notify neither duplicates the comment nor drops the transition when the restart routes the PR through the external-merge detector instead of `handleMerging` (pitfall `handlemerged-shadowed-dead-by-external-merge-detector`).
3. Regression tests: externally-merged `pilot/JIRA-*` → notify called once; restart-replay → not called twice; `pilot/GH-*` external merges unaffected.

## Acceptance criteria

- [ ] Externally/human-merged Jira PRs trigger the done leg (comment + transition attempt)
- [ ] Notify is idempotent across restarts (persisted flag)
- [ ] WARN-only; merge path never blocked
- [ ] No behavior change for GH-/Linear-originated PRs

## Refs

PR#4992 review (findings 2, 5) · #4987 · sibling reachability leg: studio-sdk OnPRCreated bridge issue

Do not decompose — this is a standalone task, one coherent change as a single PR.