### PR TITLE
GH-5006: chore(deps): bump studio-sdk v0.35.1 → v0.35.2 — activates the KAN-6 Jira chain (ADF comments, OnPRCreated bridge, category transitions)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/qf-studio/grom v0.2.0
-	github.com/qf-studio/studio-sdk v0.35.1
+	github.com/qf-studio/studio-sdk v0.35.2
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2
 	github.com/wailsapp/wails/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/qf-studio/grom v0.2.0 h1:EefLLr794KGk8ihdpKBgJnmSyUc//b/n8zZ77VbeuXY=
 github.com/qf-studio/grom v0.2.0/go.mod h1:YVihqE0treA2091TLNhGWvGi5+vMYv/ZBlAlX7Mr/JI=
-github.com/qf-studio/studio-sdk v0.35.1 h1:AQNrtdd0mJ/fGgxh3yRyf4ebeLVgxoK3i/nM0Ekw8xc=
-github.com/qf-studio/studio-sdk v0.35.1/go.mod h1:M/uFBeXsPAtsrO7wiIgE/GgWzfw80ftW6BrQUIOwxUM=
+github.com/qf-studio/studio-sdk v0.35.2 h1:ela9pIg9oV3QQywwBhDD9+x1zE+miBqcDg/8wwV6PXc=
+github.com/qf-studio/studio-sdk v0.35.2/go.mod h1:M/uFBeXsPAtsrO7wiIgE/GgWzfw80ftW6BrQUIOwxUM=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5006.

Closes #5006

## Changes

GitHub Issue GH-5006: chore(deps): bump studio-sdk v0.35.1 → v0.35.2 — activates the KAN-6 Jira chain (ADF comments, OnPRCreated bridge, category transitions)

## Task

Bump the studio-sdk pin: `go.mod` `github.com/qf-studio/studio-sdk v0.35.1` → **v0.35.2** (released 2026-08-19T14:01Z), `go mod tidy`, ensure build + tests green.

## Why

v0.35.2 carries the three sdk legs of the KAN-6 Jira chain, inert in pilot until this pin lands:

- sdk#122 — `Comment.Body` is ADFText: Cloud v3 ADF comment responses parse (GH-121)
- sdk#125 — bridge `OnPRCreated`: pilot's PR tracking was dead for these adapters (GH-123)
- sdk#126 — transition fallback matches status category, not English name; comment decoupled from transition (GH-124)

Pilot-side legs already merged (PR#4992 + PR#5002, both in v2.263.0). After this pin merges and the next release is on the box, the chain goes live end-to-end.

## Acceptance

1. `go.mod`/`go.sum` pin exactly v0.35.2 (the tag, not a pseudo-version).
2. `make build` + `make test` green; no other dependency changes.
3. No code changes beyond what a compile against v0.35.2 strictly requires (expected: none — all three sdk changes were additive/behavioral; if the compiler disagrees, keep the adaptation minimal and note it in the PR body).

## Scope fence

Pin bump only. No Jira adapter changes, no config changes, no unrelated `go mod tidy` churn.

## Refs

sdk v0.35.2 release notes · precedent: #4824 → PR#4827 (v0.33.0 pin bump) · KAN-6 chain: PR#4992, PR#5002, sdk#122/#125/#126