### PR TITLE
GH-5010: feat(config): add ContractDependency type and per-project validation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -295,6 +295,10 @@ type ProjectConfig struct {
 	// metrics hydrator, and dashboard history, so re-enabling the canary cron
 	// cannot contaminate production telemetry.
 	Canary bool `yaml:"canary,omitempty"`
+	// ContractDependencies declares other repos' contract files this
+	// project depends on (GH-5010). Gives the executor and wiring layers a
+	// stable type to consume for contract-drift checks before dispatch.
+	ContractDependencies []ContractDependency `yaml:"contract_dependencies,omitempty"`
 }
 
 // ResolveBaseBranch returns the branch that Pilot should branch from and
@@ -1146,6 +1150,18 @@ func (c *Config) Validate() error {
 		source := string(*p.Approval.ApprovalSource)
 		if !approval.ApprovalSourceValues[source] {
 			return fmt.Errorf("projects[%d].approval.approval_source must be \"telegram\", \"slack\", or \"github-review\", got %q", i, source)
+		}
+	}
+
+	// GH-5010: Validate each project's contract_dependencies entries.
+	for i, p := range c.Projects {
+		if p == nil {
+			continue
+		}
+		for j := range p.ContractDependencies {
+			if err := p.ContractDependencies[j].Validate(); err != nil {
+				return fmt.Errorf("projects[%d].contract_dependencies[%d]: %w", i, j, err)
+			}
 		}
 	}
 

--- a/internal/config/contract_dependencies.go
+++ b/internal/config/contract_dependencies.go
@@ -1,0 +1,42 @@
+package config
+
+import "fmt"
+
+// ContractDependency declares that this project's implementation depends on
+// a contract (interface/schema/API shape) defined in another repository
+// (GH-5010). Executor and wiring layers consume this to know which external
+// files to check for drift before trusting a contract as stable — e.g. a
+// console project depending on pilot's gateway API contract files.
+type ContractDependency struct {
+	// Owner is the GitHub org/user that owns the dependency repo (required).
+	Owner string `yaml:"owner"`
+	// Repo is the dependency repo name (required).
+	Repo string `yaml:"repo"`
+	// ContractFiles lists the paths (within Repo) that define the contract
+	// this project depends on — e.g. OpenAPI specs, generated types, schema
+	// files. Must contain at least one entry.
+	ContractFiles []string `yaml:"contract_files"`
+	// Ref is the git ref (branch, tag, or SHA) to read ContractFiles from.
+	// Optional — an empty Ref lets the caller fall back to the dependency
+	// repo's default branch.
+	Ref string `yaml:"ref,omitempty"`
+}
+
+// Validate checks that a ContractDependency has all required fields set.
+// Owner, Repo, and at least one ContractFiles entry are mandatory; Ref is
+// optional.
+func (d *ContractDependency) Validate() error {
+	if d == nil {
+		return nil
+	}
+	if d.Owner == "" {
+		return fmt.Errorf("owner is required")
+	}
+	if d.Repo == "" {
+		return fmt.Errorf("repo is required")
+	}
+	if len(d.ContractFiles) == 0 {
+		return fmt.Errorf("contract_files must contain at least one entry")
+	}
+	return nil
+}

--- a/internal/config/contract_dependencies_test.go
+++ b/internal/config/contract_dependencies_test.go
@@ -1,0 +1,128 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestContractDependency_Validate(t *testing.T) {
+	tests := []struct {
+		name      string
+		dep       ContractDependency
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "valid",
+			dep: ContractDependency{
+				Owner:         "qf-studio",
+				Repo:          "console",
+				ContractFiles: []string{"api/openapi.yaml"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid with ref",
+			dep: ContractDependency{
+				Owner:         "qf-studio",
+				Repo:          "console",
+				ContractFiles: []string{"api/openapi.yaml", "api/types.ts"},
+				Ref:           "main",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing owner",
+			dep: ContractDependency{
+				Repo:          "console",
+				ContractFiles: []string{"api/openapi.yaml"},
+			},
+			wantErr:   true,
+			errSubstr: "owner is required",
+		},
+		{
+			name: "missing repo",
+			dep: ContractDependency{
+				Owner:         "qf-studio",
+				ContractFiles: []string{"api/openapi.yaml"},
+			},
+			wantErr:   true,
+			errSubstr: "repo is required",
+		},
+		{
+			name: "empty contract_files",
+			dep: ContractDependency{
+				Owner: "qf-studio",
+				Repo:  "console",
+			},
+			wantErr:   true,
+			errSubstr: "contract_files must contain at least one entry",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.dep.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.errSubstr)
+				}
+				if !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Fatalf("expected error containing %q, got %q", tt.errSubstr, err.Error())
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestConfig_Validate_ContractDependencies(t *testing.T) {
+	tests := []struct {
+		name      string
+		deps      []ContractDependency
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:    "nil deps is valid",
+			deps:    nil,
+			wantErr: false,
+		},
+		{
+			name: "valid deps",
+			deps: []ContractDependency{
+				{Owner: "qf-studio", Repo: "pilot", ContractFiles: []string{"internal/gateway/api.go"}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid entry surfaces indexed error",
+			deps: []ContractDependency{
+				{Owner: "qf-studio", Repo: "pilot", ContractFiles: []string{"internal/gateway/api.go"}},
+				{Owner: "", Repo: "console", ContractFiles: []string{"api/types.ts"}},
+			},
+			wantErr:   true,
+			errSubstr: "projects[0].contract_dependencies[1]: owner is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := baseValidConfig()
+			cfg.Projects[0].ContractDependencies = tt.deps
+
+			err := cfg.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.errSubstr)
+				}
+				if !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Fatalf("expected error containing %q, got %q", tt.errSubstr, err.Error())
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5010.

Closes #5010

## Changes

Create internal/config/contract_dependencies.go defining ContractDependency (Owner, Repo string; ContractFiles []string required non-empty; optional Ref string) and add ContractDependencies []ContractDependency to ProjectConfig. Implement Validate() rejecting empty Owner/Repo/ContractFiles and wire it into the existing config validation entry point. Add contract_dependencies_test.go with a table-driven test covering at least 4 cases (valid, missing owner, missing repo, empty contract_files). No other packages touched — pure config plumbing so the executor and wiring layers have a stable type to consume.