### PR TITLE
GH-5011: feat(github): add Contents API GetFileContent client method

### DIFF
--- a/internal/adapters/github/contents.go
+++ b/internal/adapters/github/contents.go
@@ -1,0 +1,61 @@
+package github
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// contentsResponse is the subset of the GitHub Contents API response
+// (GET /repos/{owner}/{repo}/contents/{path}) needed to decode a file's
+// content. GitHub returns Content base64-encoded, wrapped at 60 characters
+// with embedded newlines, so decoding must strip whitespace first.
+type contentsResponse struct {
+	Content  string `json:"content"`
+	Encoding string `json:"encoding"`
+}
+
+// GetFileContent fetches a single file's contents from a repo at the given
+// ref (branch, tag, or SHA; empty string uses the repo's default branch) via
+// the GitHub Contents API and returns it decoded as a string.
+//
+// This goes through doRequest, so it shares Client's normal auth, retry, and
+// error handling — and, since httpClient.Transport is left unset (nil),
+// requests fall back to http.DefaultTransport, which is exactly the hook
+// internal/ghbudget installs its rate-limit-tracking RoundTripper over at
+// daemon startup. GetFileContent therefore inherits ghbudget protection
+// automatically; no wiring is needed here.
+func (c *Client) GetFileContent(ctx context.Context, owner, repo, path, ref string) (string, error) {
+	apiPath := fmt.Sprintf("/repos/%s/%s/contents/%s", owner, repo, path)
+	if ref != "" {
+		apiPath += "?ref=" + url.QueryEscape(ref)
+	}
+
+	var resp contentsResponse
+	if err := c.doRequest(ctx, http.MethodGet, apiPath, nil, &resp); err != nil {
+		return "", err
+	}
+
+	if resp.Encoding != "" && resp.Encoding != "base64" {
+		return "", fmt.Errorf("unsupported content encoding %q for %s/%s:%s", resp.Encoding, owner, repo, path)
+	}
+
+	// GitHub wraps the base64 payload at 60 characters with embedded
+	// newlines; strip all whitespace before decoding.
+	cleaned := strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\r' || r == ' ' || r == '\t' {
+			return -1
+		}
+		return r
+	}, resp.Content)
+
+	decoded, err := base64.StdEncoding.DecodeString(cleaned)
+	if err != nil {
+		return "", fmt.Errorf("decode base64 content for %s/%s:%s: %w", owner, repo, path, err)
+	}
+
+	return string(decoded), nil
+}

--- a/internal/adapters/github/contents_test.go
+++ b/internal/adapters/github/contents_test.go
@@ -1,0 +1,117 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+func TestGetFileContent_Success(t *testing.T) {
+	want := "package main\n\nfunc main() {}\n"
+	encoded := "cGFja2FnZSBtYWlu\nCgpmdW5jIG1haW4oKSB7fQo=\n" // base64, wrapped like GitHub does
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/owner/repo/contents/main.go" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if got := r.URL.Query().Get("ref"); got != "main" {
+			t.Errorf("ref query param = %q, want %q", got, "main")
+		}
+		if r.Header.Get("Authorization") != "Bearer "+testutil.FakeGitHubToken {
+			t.Errorf("unexpected auth header: %s", r.Header.Get("Authorization"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"content":  encoded,
+			"encoding": "base64",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	got, err := client.GetFileContent(context.Background(), "owner", "repo", "main.go", "main")
+	if err != nil {
+		t.Fatalf("GetFileContent() error = %v", err)
+	}
+	if got != want {
+		t.Errorf("GetFileContent() = %q, want %q", got, want)
+	}
+}
+
+func TestGetFileContent_EmptyRef(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RawQuery != "" {
+			t.Errorf("expected no query string when ref is empty, got %q", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"content":  "aGVsbG8=",
+			"encoding": "base64",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	got, err := client.GetFileContent(context.Background(), "owner", "repo", "hello.txt", "")
+	if err != nil {
+		t.Fatalf("GetFileContent() error = %v", err)
+	}
+	if got != "hello" {
+		t.Errorf("GetFileContent() = %q, want %q", got, "hello")
+	}
+}
+
+func TestGetFileContent_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "Not Found"})
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	_, err := client.GetFileContent(context.Background(), "owner", "repo", "missing.go", "main")
+	if err == nil {
+		t.Fatal("GetFileContent() error = nil, want error for 404 response")
+	}
+}
+
+func TestGetFileContent_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "Internal Server Error"})
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	_, err := client.GetFileContent(context.Background(), "owner", "repo", "main.go", "main")
+	if err == nil {
+		t.Fatal("GetFileContent() error = nil, want error for 500 response")
+	}
+}
+
+func TestGetFileContent_MalformedBase64(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"content":  "not-valid-base64!!!",
+			"encoding": "base64",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	_, err := client.GetFileContent(context.Background(), "owner", "repo", "main.go", "main")
+	if err == nil {
+		t.Fatal("GetFileContent() error = nil, want error for malformed base64 payload")
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5011.

Closes #5011

## Changes

Create internal/adapters/github/contents.go implementing Client.GetFileContent(ctx, owner, repo, path, ref string) (string, error) against the GitHub Contents API with base64 decoding. Inherit internal/ghbudget protection automatically (Transport unset). Add contents_test.go covering: success (base64 decode round-trip), 404 (missing file → error), non-200 HTTP error, and malformed base64 payload. Independent of config and executor work; only touches the internal/adapters/github package.