### PR TITLE
feat(executor,memory): Contract Evidence gate executor-side implementation (GH-5012)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -208,6 +208,7 @@
 | Lint gates | ✅ | quality | - | `quality.gates[].type=lint` | Run lint commands |
 | Build gates | ✅ | quality | - | `quality.gates[].type=build` | Compile check |
 | Retry on failure | ✅ | quality | - | `quality.max_retries` | Auto-retry with feedback |
+| Contract Evidence gate (executor leg) | 🚧 | executor | - | (project `contract_dependencies`, GH-5010) | TASK-460 doc-vs-wire leg (GH-5009): hard-blocks a task whose diff touches a project's configured `contract_dependencies` file unless every changed wire field carries a fetch-verified producer-source citation. `internal/executor/contract_evidence.go` (executor-local `ContractDependency` mirror — no `internal/config` import, avoids an import cycle): `detectTouchedContractFields` recall-first scans glob-matched diff hunks for Go `json:"..."` tags and TS interface fields on added lines; `verifyContractEvidence` rejects on four rules — field not in diff, citation's repo not a configured dependency, cited line's ±3-line window doesn't contain the field/`ProducingExpr`, or a required field has no citation at all; a fetch error (or no `ContractContentFetcher` configured) is a hard failure, never a silent pass. Spliced into `runner.go`'s `Execute` between self-review/intent-judge and the `DirectCommit`/`CreatePR` branch — same failure shape as the `QualityChecker` gate (`result.Success=false`, `AlertEventTypeTaskFailed`, `webhooks.EventTaskFailed`, `recorder.Finish("failed")`). No-op (zero new GitHub API calls) when no `SetContractDependencyLookup` is configured or the project declares no dependencies. `buildSelfReviewPrompt` gained an advisory-only section pointing executors at producer source before this gate runs; it does not trust that pass and independently re-derives evidence via `getContractEvidence`. 🚧 because the config-driven lookup wiring (`cmd/pilot`, GH-5013) and the real `ContractContentFetcher` (`internal/adapters/github`, GH-5011) are separate, not-yet-landed subtasks — this leg is inert in production until both are wired in (GH-5012) |
 | Knowledge-graph drift local prevention | ✅ | scripts | `python3 scripts/check-graph.py --fix` | - | Pre-commit (blocks commits staging `.agent/knowledge/` paths) and pre-push gate (`[5/6] Knowledge Graph`) now run `check-graph.py` locally, so drift is caught before push instead of first surfacing on CI's Knowledge Graph Drift Gate. `--fix` auto-repairs class-2 findings only (unindexed memory files — stub node generated from the file's frontmatter `name`/`type`/`description`); broken links and dangling edges still fail and need human judgment. No-`--fix` behavior (used by CI) is unchanged (GH-4574, follow-up to the 88fad61c red-main incident) |
 
 ## Memory & Learning
@@ -505,7 +506,7 @@
 | Input Adapters | 35 | 0 | 0 | 0 |
 | Output/Notifications | 18 | 0 | 0 | 0 |
 | Alerts & Monitoring | 13 | 0 | 0 | 0 |
-| Quality Gates | 5 | 0 | 0 | 0 |
+| Quality Gates | 5 | 0 | 1 | 0 |
 | Memory & Learning | 23 | 0 | 0 | 0 |
 | Dashboard | 24 | 0 | 0 | 0 |
 | Replay & Debug | 6 | 0 | 0 | 0 |

--- a/internal/executor/contract_evidence.go
+++ b/internal/executor/contract_evidence.go
@@ -1,0 +1,441 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Contract Evidence gate (TASK-460 doc-vs-wire leg, GH-5009/GH-5012).
+//
+// A prompt-only fix for the doc-vs-wire failure class (4th TASK-460
+// incident: ui PR#113 trusted a consumer-side types.ts docblock over the
+// producer server handler) was rejected as cosmetic — self-review output is
+// only ever advisory-grepped, never a hard gate. This file implements the
+// genuinely enforced, machine-validated replacement: when a project
+// declares wire-contract dependencies and a diff touches a configured
+// contract file, the executor must cite real producer source for the
+// fields it asserts semantics about, and the daemon independently fetches
+// and verifies those citations before allowing task success.
+//
+// This file is intentionally self-contained within internal/executor:
+//   - No internal/config import (would cycle back into internal/executor
+//     via internal/comms). ContractDependency below is an executor-local
+//     mirror of config.ContractDependency (internal/config/contract_dependencies.go,
+//     GH-5010); cmd/pilot bridges the two (GH-5013, out of this subtask's
+//     scope fence).
+//   - No internal/adapters/github import (same cycle risk). Producer content
+//     is fetched via the injected ContractContentFetcher interface, the same
+//     pattern already used for SubIssueLinker/PRCreator (runner.go) — a
+//     *github.Client satisfies it via GetFileContent (GH-5011, separate
+//     subtask; may be nil until that lands, in which case verification
+//     hard-fails with ContractRejectionFetchError rather than passing open).
+
+// ContractDependency is an executor-local mirror of config.ContractDependency
+// (internal/config/contract_dependencies.go). Duplicated rather than
+// imported to avoid an internal/executor -> internal/config import cycle;
+// cmd/pilot's ContractDependencyLookup implementation is responsible for
+// translating config.ContractDependency values into this shape (GH-5013).
+type ContractDependency struct {
+	// Owner is the GitHub org/user that owns the producer repo.
+	Owner string
+	// Repo is the producer repo name.
+	Repo string
+	// ContractFiles is the glob allowlist of paths (in the project under
+	// execution) that count as touching this contract — e.g. generated
+	// types, OpenAPI specs. Diff files are matched against these globs to
+	// decide whether the gate applies at all (recall-oriented: growing this
+	// list is how new incidents get covered, per the check-mocks.sh model).
+	ContractFiles []string
+	// Ref is the git ref (branch, tag, or SHA) to fetch ContractFiles from
+	// in the producer repo. Empty lets the fetcher fall back to the
+	// producer repo's default branch.
+	Ref string
+}
+
+// ContractDependencyLookup returns the contract dependencies configured for
+// the project at projectPath, or nil/empty when none are configured — in
+// which case the gate is a complete no-op (zero new GitHub API calls, per
+// GH-5009's first acceptance criterion). Set via
+// Runner.SetContractDependencyLookup; cmd/pilot wires the real
+// config-backed implementation (GH-5013).
+type ContractDependencyLookup func(projectPath string) []ContractDependency
+
+// ContractEvidenceSchema is the --json-schema passed to getContractEvidence,
+// mirroring PostExecutionSummarySchema's structured-output style
+// (structured_output.go): evidence is elicited via a schema-constrained
+// call, never parsed out of freeform self-review text.
+const ContractEvidenceSchema = `{"type":"object","properties":{"evidence":{"type":"array","items":{"type":"object","properties":{"field":{"type":"string"},"producer_repo":{"type":"string"},"producer_file":{"type":"string"},"producer_line":{"type":"integer"},"producing_expr":{"type":"string"}},"required":["field","producer_repo","producer_file","producer_line","producing_expr"]}}},"required":["evidence"]}`
+
+// ContractEvidence is one field-level citation of the producer source that
+// defines a wire-contract field's semantics (GH-5009 Requirement 2).
+type ContractEvidence struct {
+	// Field is the wire field name being cited (matched against tokens
+	// detectTouchedContractFields extracted from the diff).
+	Field string `json:"field"`
+	// ProducerRepo identifies the cited repo as "owner/repo"; must match a
+	// configured ContractDependency's Owner+"/"+Repo.
+	ProducerRepo string `json:"producer_repo"`
+	// ProducerFile is the path within ProducerRepo the field's semantics
+	// are cited from.
+	ProducerFile string `json:"producer_file"`
+	// ProducerLine is the 1-indexed line in ProducerFile the citation
+	// points at; verification inspects a small window around it.
+	ProducerLine int `json:"producer_line"`
+	// ProducingExpr is the snippet of code the executor claims establishes
+	// the field's semantics (e.g. "inst.ConfigGeneration"), checked
+	// (whitespace-normalized) against the fetched producer window.
+	ProducingExpr string `json:"producing_expr"`
+}
+
+// contractEvidenceResponse is the --json-schema structured_output payload
+// shape returned by getContractEvidence.
+type contractEvidenceResponse struct {
+	Evidence []ContractEvidence `json:"evidence"`
+}
+
+// ContractContentFetcher fetches file content from a producer repo at a
+// given ref so the gate can independently verify a citation instead of
+// trusting it. *github.Client satisfies this via GetFileContent (GH-5011);
+// injected via interface (rather than imported) to avoid an
+// internal/executor -> internal/adapters/github cycle, the same pattern as
+// SubIssueLinker and PRCreator.
+type ContractContentFetcher interface {
+	GetFileContent(ctx context.Context, owner, repo, path, ref string) (string, error)
+}
+
+// ContractRejectionReason classifies why a contract-evidence citation (or
+// the absence of one for a required field) failed the gate.
+type ContractRejectionReason string
+
+const (
+	// ContractRejectionMissing means a field the diff touched has zero
+	// citations at all (Requirement 5d).
+	ContractRejectionMissing ContractRejectionReason = "missing"
+	// ContractRejectionFieldNotInDiff means the cited Field does not
+	// appear among the fields detectTouchedContractFields extracted from
+	// the diff's added lines within a contract_files-matching hunk — a
+	// real-but-irrelevant citation (Requirement 5a).
+	ContractRejectionFieldNotInDiff ContractRejectionReason = "field_not_in_diff"
+	// ContractRejectionUnconfiguredRepo means ProducerRepo does not match
+	// any configured ContractDependency (Requirement 5b).
+	ContractRejectionUnconfiguredRepo ContractRejectionReason = "unconfigured_repo"
+	// ContractRejectionProducerMismatch means the fetched producer window
+	// around ProducerLine did not contain both the field name and the
+	// cited ProducingExpr (Requirement 5c) — this is the rule that catches
+	// the ui PR#113 shape (citation of a consumer-side comment, not the
+	// producer).
+	ContractRejectionProducerMismatch ContractRejectionReason = "producer_mismatch"
+	// ContractRejectionFetchError means fetching the cited producer
+	// content failed (network/API error, or no fetcher configured at
+	// all). Fetch errors are hard failures, never silent passes
+	// (Requirement 5, closing sentence).
+	ContractRejectionFetchError ContractRejectionReason = "fetch_error"
+)
+
+// ContractFieldRejection records one field-level (or citation-level)
+// failure contributing to a failed ContractEvidenceOutcome.
+type ContractFieldRejection struct {
+	Field  string                  `json:"field"`
+	Reason ContractRejectionReason `json:"reason"`
+	Detail string                  `json:"detail"`
+}
+
+// ContractEvidenceOutcome is the result of verifyContractEvidence: whether
+// the gate applied at all (Required), whether it passed, and — on
+// failure — the specific rejections that explain why.
+type ContractEvidenceOutcome struct {
+	// Required is true when the diff touched at least one file matching a
+	// configured ContractDependency's ContractFiles glob. When false the
+	// gate is a no-op and Passed is trivially true.
+	Required bool `json:"required"`
+	// Passed is true when every required field has at least one verified
+	// citation and no citation was rejected.
+	Passed bool `json:"passed"`
+	// Fields lists the contract fields detected as touched by the diff
+	// (the set requiring citations).
+	Fields []string `json:"fields"`
+	// Verified lists the subset of Fields that had at least one citation
+	// that passed all verification rules.
+	Verified []string `json:"verified,omitempty"`
+	// Rejections lists every failed citation or missing-field reason.
+	// Empty when Passed is true.
+	Rejections []ContractFieldRejection `json:"rejections,omitempty"`
+}
+
+// Summary renders a human-readable description of a failed outcome,
+// suitable for ExecutionResult.Error. Returns "" when the outcome is nil or
+// passed (nothing to report).
+func (o *ContractEvidenceOutcome) Summary() string {
+	if o == nil || o.Passed {
+		return ""
+	}
+	parts := make([]string, 0, len(o.Rejections))
+	for _, rej := range o.Rejections {
+		parts = append(parts, fmt.Sprintf("%s (%s): %s", rej.Field, rej.Reason, rej.Detail))
+	}
+	return fmt.Sprintf(
+		"contract evidence gate failed: %d field citation(s) rejected: %s",
+		len(o.Rejections), strings.Join(parts, "; "),
+	)
+}
+
+// goJSONTagFieldRegex extracts the field name from a Go struct tag like
+// `json:"specVersion,omitempty"` on an added diff line.
+var goJSONTagFieldRegex = regexp.MustCompile(`json:"([a-zA-Z0-9_]+)`)
+
+// tsInterfaceFieldRegex extracts the property name from a TypeScript
+// interface/type member line like `specVersion?: number;` on an added diff
+// line. Anchored to line-start (after diff "+" stripping) with optional
+// leading whitespace, matching the conventional one-property-per-line
+// interface body style.
+var tsInterfaceFieldRegex = regexp.MustCompile(`^\s*([a-zA-Z_$][a-zA-Z0-9_$]*)\??\s*:\s*\S`)
+
+// detectTouchedContractFields scans diff hunks restricted to files matching
+// a configured ContractDependency's ContractFiles glob and extracts changed
+// field tokens (Go json:"..." tags, TS interface property names) from
+// added lines (GH-5009 Requirement 3).
+//
+// This is a recall-oriented heuristic, by design: false negatives here mean
+// a real semantics-changing field silently skips the gate, so the
+// extraction is intentionally permissive (any added line matching either
+// pattern contributes a field, regardless of surrounding context). The
+// verification step (verifyContractEvidence) is where precision is
+// enforced — rejecting bad or irrelevant citations, not the detection step.
+//
+// required reports whether the diff touched at least one contract file at
+// all (independent of whether any field tokens were extracted on added
+// lines); fields is the deduplicated list of extracted field names, in
+// first-seen order.
+func detectTouchedContractFields(diff string, deps []ContractDependency) (required bool, fields []string) {
+	if diff == "" || len(deps) == 0 {
+		return false, nil
+	}
+
+	seen := make(map[string]bool)
+	for _, section := range splitDiffByFile(diff) {
+		if !matchesAnyContractGlob(section.path, deps) {
+			continue
+		}
+		required = true
+
+		for _, line := range strings.Split(section.body, "\n") {
+			if !strings.HasPrefix(line, "+") || strings.HasPrefix(line, "+++") {
+				continue
+			}
+			added := strings.TrimPrefix(line, "+")
+
+			for _, m := range goJSONTagFieldRegex.FindAllStringSubmatch(added, -1) {
+				field := m[1]
+				if !seen[field] {
+					seen[field] = true
+					fields = append(fields, field)
+				}
+			}
+
+			if m := tsInterfaceFieldRegex.FindStringSubmatch(added); m != nil {
+				field := m[1]
+				if !seen[field] {
+					seen[field] = true
+					fields = append(fields, field)
+				}
+			}
+		}
+	}
+
+	return required, fields
+}
+
+// matchesAnyContractGlob reports whether path matches any ContractFiles
+// glob across deps. Tries the full (repo-relative) path first, then falls
+// back to matching the basename alone — this lets a bare pattern like
+// "*.ts" match regardless of directory depth, since path/filepath.Match
+// does not support "**" cross-directory wildcards.
+func matchesAnyContractGlob(path string, deps []ContractDependency) bool {
+	base := filepath.Base(path)
+	for _, dep := range deps {
+		for _, pattern := range dep.ContractFiles {
+			if ok, _ := filepath.Match(pattern, path); ok {
+				return true
+			}
+			if ok, _ := filepath.Match(pattern, base); ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// verifyContractEvidence enforces all four rejection rules from GH-5009
+// Requirement 5:
+//
+//	(a) a citation whose Field doesn't appear among requiredFields (the
+//	    diff-touched, contract_files-matched field set) is rejected as
+//	    field_not_in_diff — blocks real-but-irrelevant citations;
+//	(b) a citation whose ProducerRepo isn't a configured dependency is
+//	    rejected as unconfigured_repo;
+//	(c) a citation is verified by fetching the producer content at the
+//	    cited file+ref and checking that the +/-3-line window around the
+//	    cited line contains both the field name (or its json:"field" form)
+//	    and a whitespace-normalized substring match of ProducingExpr;
+//	    mismatches are rejected as producer_mismatch — this is the rule
+//	    that catches the ui PR#113 shape (a citation of a same-repo
+//	    docblock instead of the actual producer);
+//	(d) any required field with zero citations at all is rejected as
+//	    missing.
+//
+// Fetch errors (including a nil fetcher) are hard failures
+// (fetch_error), never silent passes.
+func verifyContractEvidence(
+	ctx context.Context,
+	fetcher ContractContentFetcher,
+	deps []ContractDependency,
+	requiredFields []string,
+	evidence []ContractEvidence,
+) *ContractEvidenceOutcome {
+	outcome := &ContractEvidenceOutcome{
+		Required: len(requiredFields) > 0,
+		Fields:   requiredFields,
+	}
+	if !outcome.Required {
+		outcome.Passed = true
+		return outcome
+	}
+
+	touched := make(map[string]bool, len(requiredFields))
+	for _, f := range requiredFields {
+		touched[f] = true
+	}
+
+	depByRepo := make(map[string]ContractDependency, len(deps))
+	for _, d := range deps {
+		depByRepo[d.Owner+"/"+d.Repo] = d
+	}
+
+	verified := make(map[string]bool)
+	cited := make(map[string]bool)
+
+	for _, e := range evidence {
+		cited[e.Field] = true
+
+		if !touched[e.Field] {
+			outcome.Rejections = append(outcome.Rejections, ContractFieldRejection{
+				Field:  e.Field,
+				Reason: ContractRejectionFieldNotInDiff,
+				Detail: fmt.Sprintf("field %q not found among fields the diff touched in a contract_files-matching hunk", e.Field),
+			})
+			continue
+		}
+
+		dep, ok := depByRepo[e.ProducerRepo]
+		if !ok {
+			outcome.Rejections = append(outcome.Rejections, ContractFieldRejection{
+				Field:  e.Field,
+				Reason: ContractRejectionUnconfiguredRepo,
+				Detail: fmt.Sprintf("producer repo %q is not a configured contract dependency", e.ProducerRepo),
+			})
+			continue
+		}
+
+		if fetcher == nil {
+			outcome.Rejections = append(outcome.Rejections, ContractFieldRejection{
+				Field:  e.Field,
+				Reason: ContractRejectionFetchError,
+				Detail: "no contract content fetcher is configured",
+			})
+			continue
+		}
+
+		content, err := fetcher.GetFileContent(ctx, dep.Owner, dep.Repo, e.ProducerFile, dep.Ref)
+		if err != nil {
+			outcome.Rejections = append(outcome.Rejections, ContractFieldRejection{
+				Field:  e.Field,
+				Reason: ContractRejectionFetchError,
+				Detail: fmt.Sprintf("fetch %s/%s:%s@%s: %v", dep.Owner, dep.Repo, e.ProducerFile, dep.Ref, err),
+			})
+			continue
+		}
+
+		window := producerLineWindow(content, e.ProducerLine, 3)
+		if !producerWindowContains(window, e.Field, e.ProducingExpr) {
+			outcome.Rejections = append(outcome.Rejections, ContractFieldRejection{
+				Field:  e.Field,
+				Reason: ContractRejectionProducerMismatch,
+				Detail: fmt.Sprintf("producer %s/%s:%s around line %d does not contain field %q and the cited expression", dep.Owner, dep.Repo, e.ProducerFile, e.ProducerLine, e.Field),
+			})
+			continue
+		}
+
+		verified[e.Field] = true
+	}
+
+	for _, f := range requiredFields {
+		if verified[f] {
+			outcome.Verified = append(outcome.Verified, f)
+			continue
+		}
+		if !cited[f] {
+			outcome.Rejections = append(outcome.Rejections, ContractFieldRejection{
+				Field:  f,
+				Reason: ContractRejectionMissing,
+				Detail: fmt.Sprintf("no citation provided for required field %q", f),
+			})
+		}
+		// Fields that were cited but failed (b)/(c) above already have a
+		// specific rejection recorded from the evidence loop; no need to
+		// add a second, less-specific "missing" rejection for them.
+	}
+
+	outcome.Passed = len(outcome.Rejections) == 0
+	return outcome
+}
+
+// producerLineWindow returns the +/-radius lines of content around the
+// 1-indexed line, clamped to content bounds. Returns "" for empty content.
+func producerLineWindow(content string, line int, radius int) string {
+	if content == "" {
+		return ""
+	}
+	lines := strings.Split(content, "\n")
+	if line < 1 {
+		line = 1
+	}
+	start := line - radius - 1 // 0-indexed, inclusive
+	if start < 0 {
+		start = 0
+	}
+	if start >= len(lines) {
+		return ""
+	}
+	end := line + radius // 0-indexed, exclusive
+	if end > len(lines) {
+		end = len(lines)
+	}
+	return strings.Join(lines[start:end], "\n")
+}
+
+// producerWindowContains reports whether window contains both the field
+// name (as a bare token or in json:"field" form) and, when non-empty, a
+// whitespace-normalized substring match of producingExpr.
+func producerWindowContains(window, field, producingExpr string) bool {
+	if window == "" || field == "" {
+		return false
+	}
+	fieldMatch := strings.Contains(window, field) || strings.Contains(window, fmt.Sprintf(`json:"%s`, field))
+	if !fieldMatch {
+		return false
+	}
+	if strings.TrimSpace(producingExpr) == "" {
+		return true
+	}
+	return strings.Contains(normalizeWhitespace(window), normalizeWhitespace(producingExpr))
+}
+
+// normalizeWhitespace collapses all runs of whitespace to single spaces and
+// trims the result, so cited expressions match regardless of incidental
+// formatting differences between the citation and the producer source.
+func normalizeWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/internal/executor/contract_evidence_test.go
+++ b/internal/executor/contract_evidence_test.go
@@ -1,0 +1,337 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fakeContractContentFetcher is a map-backed ContractContentFetcher for
+// tests, keyed "owner/repo/path". Set err to simulate a hard fetch failure
+// regardless of the requested key.
+type fakeContractContentFetcher struct {
+	content map[string]string
+	err     error
+	calls   int
+}
+
+func (f *fakeContractContentFetcher) GetFileContent(ctx context.Context, owner, repo, path, ref string) (string, error) {
+	f.calls++
+	if f.err != nil {
+		return "", f.err
+	}
+	key := owner + "/" + repo + "/" + path
+	content, ok := f.content[key]
+	if !ok {
+		return "", errors.New("fake fetcher: not found: " + key)
+	}
+	return content, nil
+}
+
+func tsInterfaceDiff(path, addedLine string) string {
+	return "diff --git a/" + path + " b/" + path + "\n" +
+		"index 1111111..2222222 100644\n" +
+		"--- a/" + path + "\n" +
+		"+++ b/" + path + "\n" +
+		"@@ -1,3 +1,4 @@\n" +
+		" interface Instance {\n" +
+		"+" + addedLine + "\n" +
+		"-  oldField: string;\n" +
+		" }\n"
+}
+
+func goStructDiff(path, addedLine string) string {
+	return "diff --git a/" + path + " b/" + path + "\n" +
+		"index 1111111..2222222 100644\n" +
+		"--- a/" + path + "\n" +
+		"+++ b/" + path + "\n" +
+		"@@ -1,3 +1,4 @@\n" +
+		" type DTO struct {\n" +
+		"+" + addedLine + "\n" +
+		" }\n"
+}
+
+func TestDetectTouchedContractFields(t *testing.T) {
+	deps := []ContractDependency{
+		{Owner: "qf-studio", Repo: "pilot-console", ContractFiles: []string{"*.ts", "internal/instances/handlers.go"}},
+	}
+
+	t.Run("no dependencies configured is a no-op", func(t *testing.T) {
+		required, fields := detectTouchedContractFields(tsInterfaceDiff("src/lib/api/types.ts", "  specVersion: number;"), nil)
+		if required {
+			t.Fatalf("expected required=false with no deps, got true (fields=%v)", fields)
+		}
+		if len(fields) != 0 {
+			t.Fatalf("expected no fields, got %v", fields)
+		}
+	})
+
+	t.Run("empty diff is a no-op", func(t *testing.T) {
+		required, fields := detectTouchedContractFields("", deps)
+		if required || len(fields) != 0 {
+			t.Fatalf("expected no-op for empty diff, got required=%v fields=%v", required, fields)
+		}
+	})
+
+	t.Run("diff touching an unrelated file does not trigger the gate", func(t *testing.T) {
+		diff := tsInterfaceDiff("src/lib/unrelated.py", "  specVersion: number;")
+		required, fields := detectTouchedContractFields(diff, deps)
+		if required {
+			t.Fatalf("expected required=false for non-matching file, got true (fields=%v)", fields)
+		}
+	})
+
+	t.Run("TS interface property on an added line is detected", func(t *testing.T) {
+		diff := tsInterfaceDiff("src/lib/api/types.ts", "  specVersion: number;")
+		required, fields := detectTouchedContractFields(diff, deps)
+		if !required {
+			t.Fatalf("expected required=true")
+		}
+		if len(fields) != 1 || fields[0] != "specVersion" {
+			t.Fatalf("expected [specVersion], got %v", fields)
+		}
+	})
+
+	t.Run("Go json tag on an added line is detected", func(t *testing.T) {
+		diff := goStructDiff("internal/instances/handlers.go", "\tConfigGeneration int `json:\"specVersion\"`")
+		required, fields := detectTouchedContractFields(diff, deps)
+		if !required {
+			t.Fatalf("expected required=true")
+		}
+		if len(fields) != 1 || fields[0] != "specVersion" {
+			t.Fatalf("expected [specVersion], got %v", fields)
+		}
+	})
+
+	t.Run("removed lines are not scanned", func(t *testing.T) {
+		// tsInterfaceDiff includes a "-  oldField: string;" removed line;
+		// it must never surface in the extracted field set.
+		diff := tsInterfaceDiff("src/lib/api/types.ts", "  specVersion: number;")
+		_, fields := detectTouchedContractFields(diff, deps)
+		for _, f := range fields {
+			if f == "oldField" {
+				t.Fatalf("removed-line field leaked into result: %v", fields)
+			}
+		}
+	})
+
+	t.Run("duplicate field mentions are deduplicated", func(t *testing.T) {
+		diff := "diff --git a/src/lib/api/types.ts b/src/lib/api/types.ts\n" +
+			"--- a/src/lib/api/types.ts\n" +
+			"+++ b/src/lib/api/types.ts\n" +
+			"@@ -1,2 +1,3 @@\n" +
+			"+  specVersion: number;\n" +
+			"+  specVersion: number; // duplicate mention\n"
+		_, fields := detectTouchedContractFields(diff, deps)
+		count := 0
+		for _, f := range fields {
+			if f == "specVersion" {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Fatalf("expected specVersion exactly once, got %d occurrences in %v", count, fields)
+		}
+	})
+}
+
+func TestVerifyContractEvidence_NoRequiredFields(t *testing.T) {
+	outcome := verifyContractEvidence(context.Background(), nil, nil, nil, nil)
+	if !outcome.Passed || outcome.Required {
+		t.Fatalf("expected trivial pass with Required=false, got %+v", outcome)
+	}
+}
+
+func TestVerifyContractEvidence_ZeroEvidenceIsMissing(t *testing.T) {
+	deps := []ContractDependency{{Owner: "qf-studio", Repo: "pilot-console", ContractFiles: []string{"*.ts"}}}
+	outcome := verifyContractEvidence(context.Background(), &fakeContractContentFetcher{}, deps, []string{"specVersion"}, nil)
+
+	if outcome.Passed {
+		t.Fatalf("expected failure for zero evidence, got %+v", outcome)
+	}
+	if len(outcome.Rejections) != 1 || outcome.Rejections[0].Reason != ContractRejectionMissing {
+		t.Fatalf("expected a single missing rejection, got %+v", outcome.Rejections)
+	}
+}
+
+func TestVerifyContractEvidence_FieldNotInDiffRejected(t *testing.T) {
+	deps := []ContractDependency{{Owner: "qf-studio", Repo: "pilot-console", ContractFiles: []string{"*.ts"}}}
+	fetcher := &fakeContractContentFetcher{content: map[string]string{
+		"qf-studio/pilot-console/internal/instances/handlers.go": "package instances\nfunc h() {\n\t// unrelated\n}\n",
+	}}
+
+	evidence := []ContractEvidence{{
+		Field:         "unrelatedField", // real-but-irrelevant: not among requiredFields
+		ProducerRepo:  "qf-studio/pilot-console",
+		ProducerFile:  "internal/instances/handlers.go",
+		ProducerLine:  2,
+		ProducingExpr: "func h()",
+	}}
+
+	outcome := verifyContractEvidence(context.Background(), fetcher, deps, []string{"specVersion"}, evidence)
+
+	if outcome.Passed {
+		t.Fatalf("expected failure, got %+v", outcome)
+	}
+	var gotFieldNotInDiff, gotMissing bool
+	for _, rej := range outcome.Rejections {
+		if rej.Field == "unrelatedField" && rej.Reason == ContractRejectionFieldNotInDiff {
+			gotFieldNotInDiff = true
+		}
+		if rej.Field == "specVersion" && rej.Reason == ContractRejectionMissing {
+			gotMissing = true
+		}
+	}
+	if !gotFieldNotInDiff {
+		t.Errorf("expected a field_not_in_diff rejection for unrelatedField, got %+v", outcome.Rejections)
+	}
+	if !gotMissing {
+		t.Errorf("expected specVersion to still be reported missing (irrelevant citation doesn't satisfy it), got %+v", outcome.Rejections)
+	}
+	// The fetcher must never be called for a citation rejected at rule (a) —
+	// field-membership is checked before any network access.
+	if fetcher.calls != 0 {
+		t.Errorf("expected 0 fetch calls for a field-not-in-diff citation, got %d", fetcher.calls)
+	}
+}
+
+func TestVerifyContractEvidence_UnconfiguredRepoRejected(t *testing.T) {
+	// Mirrors the real ui PR#113 incident shape: the citation points at the
+	// consumer's own repo (a same-repo docblock) instead of the configured
+	// producer — qf-studio/pilot-console-ui was never declared as a
+	// contract dependency, so this is rejected mechanically, without ever
+	// needing to judge the cited text's semantic correctness.
+	deps := []ContractDependency{{Owner: "qf-studio", Repo: "pilot-console", ContractFiles: []string{"*.ts"}}}
+	evidence := []ContractEvidence{{
+		Field:         "specVersion",
+		ProducerRepo:  "qf-studio/pilot-console-ui", // wrong: consumer repo, not the producer
+		ProducerFile:  "src/lib/api/types.ts",
+		ProducerLine:  12,
+		ProducingExpr: "specVersion: number; // the APPLIED generation",
+	}}
+
+	outcome := verifyContractEvidence(context.Background(), &fakeContractContentFetcher{}, deps, []string{"specVersion"}, evidence)
+
+	if outcome.Passed {
+		t.Fatalf("expected failure for unconfigured producer repo, got %+v", outcome)
+	}
+	if len(outcome.Rejections) != 1 || outcome.Rejections[0].Reason != ContractRejectionUnconfiguredRepo {
+		t.Fatalf("expected a single unconfigured_repo rejection, got %+v", outcome.Rejections)
+	}
+}
+
+func TestVerifyContractEvidence_WrongLineRejected(t *testing.T) {
+	deps := []ContractDependency{{Owner: "qf-studio", Repo: "pilot-console", ContractFiles: []string{"internal/instances/handlers.go"}}}
+	producerContent := strings.Join([]string{
+		"package instances",                // 1
+		"",                                 // 2
+		"func Handler() {",                 // 3
+		"\t// nothing relevant here",       // 4
+		"\tlog.Info(\"handling request\")", // 5
+		"}",                                // 6
+		"",                                 // 7
+		"type InstanceDTO struct {",        // 8
+		"\tConfigGeneration int `json:\"specVersion\"`", // 9 - the real producer line
+		"}", // 10
+	}, "\n")
+	fetcher := &fakeContractContentFetcher{content: map[string]string{
+		"qf-studio/pilot-console/internal/instances/handlers.go": producerContent,
+	}}
+
+	evidence := []ContractEvidence{{
+		Field:         "specVersion",
+		ProducerRepo:  "qf-studio/pilot-console",
+		ProducerFile:  "internal/instances/handlers.go",
+		ProducerLine:  3, // wrong line: +/-3 window (lines 1-6) never reaches line 9
+		ProducingExpr: "ConfigGeneration int",
+	}}
+
+	outcome := verifyContractEvidence(context.Background(), fetcher, deps, []string{"specVersion"}, evidence)
+
+	if outcome.Passed {
+		t.Fatalf("expected failure for wrong producer line, got %+v", outcome)
+	}
+	if len(outcome.Rejections) != 1 || outcome.Rejections[0].Reason != ContractRejectionProducerMismatch {
+		t.Fatalf("expected a single producer_mismatch rejection, got %+v", outcome.Rejections)
+	}
+}
+
+func TestVerifyContractEvidence_FetchErrorIsHardFailure(t *testing.T) {
+	deps := []ContractDependency{{Owner: "qf-studio", Repo: "pilot-console", ContractFiles: []string{"*.go"}}}
+	evidence := []ContractEvidence{{
+		Field:         "specVersion",
+		ProducerRepo:  "qf-studio/pilot-console",
+		ProducerFile:  "internal/instances/handlers.go",
+		ProducerLine:  9,
+		ProducingExpr: "ConfigGeneration",
+	}}
+
+	t.Run("fetcher returns an error", func(t *testing.T) {
+		fetcher := &fakeContractContentFetcher{err: errors.New("GitHub API unavailable")}
+		outcome := verifyContractEvidence(context.Background(), fetcher, deps, []string{"specVersion"}, evidence)
+		if outcome.Passed {
+			t.Fatalf("expected failure on fetch error, got %+v", outcome)
+		}
+		if len(outcome.Rejections) != 1 || outcome.Rejections[0].Reason != ContractRejectionFetchError {
+			t.Fatalf("expected a single fetch_error rejection, got %+v", outcome.Rejections)
+		}
+	})
+
+	t.Run("no fetcher configured at all", func(t *testing.T) {
+		outcome := verifyContractEvidence(context.Background(), nil, deps, []string{"specVersion"}, evidence)
+		if outcome.Passed {
+			t.Fatalf("expected failure with nil fetcher, got %+v", outcome)
+		}
+		if len(outcome.Rejections) != 1 || outcome.Rejections[0].Reason != ContractRejectionFetchError {
+			t.Fatalf("expected a single fetch_error rejection, got %+v", outcome.Rejections)
+		}
+	})
+}
+
+func TestVerifyContractEvidence_ValidCitationsSucceed(t *testing.T) {
+	deps := []ContractDependency{{Owner: "qf-studio", Repo: "pilot-console", ContractFiles: []string{"internal/instances/handlers.go"}}}
+	producerContent := strings.Join([]string{
+		"package instances",         // 1
+		"",                          // 2
+		"type InstanceDTO struct {", // 3
+		"\tConfigGeneration int `json:\"specVersion\"`", // 4
+		"}", // 5
+	}, "\n")
+	fetcher := &fakeContractContentFetcher{content: map[string]string{
+		"qf-studio/pilot-console/internal/instances/handlers.go": producerContent,
+	}}
+
+	evidence := []ContractEvidence{{
+		Field:         "specVersion",
+		ProducerRepo:  "qf-studio/pilot-console",
+		ProducerFile:  "internal/instances/handlers.go",
+		ProducerLine:  4,
+		ProducingExpr: "ConfigGeneration int",
+	}}
+
+	outcome := verifyContractEvidence(context.Background(), fetcher, deps, []string{"specVersion"}, evidence)
+
+	if !outcome.Passed {
+		t.Fatalf("expected success, got %+v", outcome)
+	}
+	if len(outcome.Rejections) != 0 {
+		t.Fatalf("expected zero rejections, got %+v", outcome.Rejections)
+	}
+	if len(outcome.Verified) != 1 || outcome.Verified[0] != "specVersion" {
+		t.Fatalf("expected specVersion verified, got %v", outcome.Verified)
+	}
+}
+
+func TestNormalizeWhitespace(t *testing.T) {
+	cases := map[string]string{
+		"  a   b\tc\n": "a b c",
+		"":             "",
+		"single":       "single",
+	}
+	for in, want := range cases {
+		if got := normalizeWhitespace(in); got != want {
+			t.Errorf("normalizeWhitespace(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/executor/prompt_builder.go
+++ b/internal/executor/prompt_builder.go
@@ -690,12 +690,67 @@ func (r *Runner) buildSelfReviewPrompt(task *Task) (prompt string) {
 		}
 	}
 
+	// Advisory only — NOT the enforcement mechanism. The Contract Evidence
+	// gate (contract_evidence.go, TASK-460 doc-vs-wire leg, GH-5009) is a
+	// separate, hard-blocking check that independently fetches and verifies
+	// producer source after this self-review phase completes; this section
+	// exists so the executor front-loads the citations correctly, but the
+	// gate does not read or trust anything written here — it re-derives
+	// evidence via its own dedicated structured-output call
+	// (getContractEvidence) and rejects unverifiable citations regardless
+	// of what this advisory pass concluded.
+	sb.WriteString("### Contract Evidence (advisory)\n")
+	sb.WriteString("If this project declares contract_dependencies and your diff touches a\n")
+	sb.WriteString("configured contract file, a separate hard gate will require you to cite\n")
+	sb.WriteString("real producer source for every changed wire field. When you assert what a\n")
+	sb.WriteString("field means:\n")
+	sb.WriteString("- Cite the code that PRODUCES the value (server handler/serializer/DB\n")
+	sb.WriteString("  write in the dependency repo) — never a same-repo docblock or comment.\n")
+	sb.WriteString("- If issue evidence contradicts a docblock, the evidence wins.\n")
+	sb.WriteString("- This is advisory guidance only; the actual gate independently fetches\n")
+	sb.WriteString("  and verifies your citations and does not trust this self-review pass.\n\n")
+
 	sb.WriteString("### Actions\n")
 	sb.WriteString("- If you find issues: FIX them and commit the fix\n")
 	sb.WriteString("- Output `REVIEW_FIXED: <description>` if you fixed something\n")
 	sb.WriteString("- Output `REVIEW_PASSED` if everything looks good\n\n")
 
 	sb.WriteString("Work autonomously. Fix any issues you find.\n")
+
+	return sb.String()
+}
+
+// buildContractEvidencePrompt constructs the prompt for the Contract
+// Evidence gate's dedicated structured-output call (getContractEvidence,
+// TASK-460 doc-vs-wire leg, GH-5009 Requirement 7). Unlike
+// buildSelfReviewPrompt's advisory section above, this prompt backs the
+// actual enforcement mechanism: its response is schema-constrained
+// (ContractEvidenceSchema) and every citation it returns is independently
+// fetched and verified by verifyContractEvidence — nothing here is trusted
+// at face value.
+func buildContractEvidencePrompt(fields []string) string {
+	var sb strings.Builder
+
+	sb.WriteString("## Contract Evidence\n\n")
+	sb.WriteString("Your diff changed the following wire-contract field(s):\n")
+	for _, field := range fields {
+		sb.WriteString("- `" + field + "`\n")
+	}
+	sb.WriteString("\nFor EACH field above, cite the producer source that defines its\n")
+	sb.WriteString("semantics — the code that PRODUCES the value (a server handler,\n")
+	sb.WriteString("serializer, or DB write in the dependency repository). Do NOT cite a\n")
+	sb.WriteString("same-repo docblock, comment, or consumer-side type definition — those are\n")
+	sb.WriteString("not producer source and will be rejected.\n\n")
+	sb.WriteString("For each field, report:\n")
+	sb.WriteString("- field: the exact field name\n")
+	sb.WriteString("- producer_repo: the producer repository, as \"owner/repo\"\n")
+	sb.WriteString("- producer_file: the path to the producer source file\n")
+	sb.WriteString("- producer_line: the 1-indexed line number where the value is produced\n")
+	sb.WriteString("- producing_expr: the exact code snippet at that line establishing the\n")
+	sb.WriteString("  field's semantics\n\n")
+	sb.WriteString("If you cannot find real producer source for a field, do not fabricate a\n")
+	sb.WriteString("citation — omit it. Every citation you report will be independently\n")
+	sb.WriteString("fetched and verified; unverifiable or irrelevant citations fail the task.\n")
 
 	return sb.String()
 }

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -618,6 +618,11 @@ type ExecutionResult struct {
 	ComplexityLevel string
 	// QualityGates contains the results of quality gate checks (if enabled)
 	QualityGates *QualityGatesResult
+	// ContractEvidence contains the outcome of the Contract Evidence gate
+	// (TASK-460 doc-vs-wire leg, GH-5009/GH-5012), when the gate ran. Nil
+	// when no ContractDependencyLookup is configured or the diff touched no
+	// contract_files-matching path.
+	ContractEvidence *ContractEvidenceOutcome
 	// IsEpic indicates this result is from epic planning (not execution)
 	IsEpic bool
 	// EpicPlan contains the planning result for epic tasks (GH-405)
@@ -856,6 +861,19 @@ type Runner struct {
 	// audit (auditGithubSideEffects becomes a no-op) — set via
 	// SetGithubSideEffectSearcher (sideeffect_audit.go).
 	githubSideEffectSearcher GithubSideEffectSearcher
+	// GH-5009/GH-5012: Contract Evidence gate (TASK-460 doc-vs-wire leg).
+	// contractDependencyLookup returns a project's configured contract
+	// dependencies; nil disables the gate entirely (no-op, zero new GitHub
+	// API calls). Set via SetContractDependencyLookup.
+	contractDependencyLookup ContractDependencyLookup
+	// contractContentFetcher independently fetches producer source to
+	// verify citations; nil makes every citation a hard fetch_error
+	// rejection rather than a silent pass. Set via SetContractContentFetcher.
+	contractContentFetcher ContractContentFetcher
+	// contractEvidenceFetchFn overrides getContractEvidence for testing, so
+	// tests can supply fake evidence without shelling out to the real
+	// `claude` CLI. nil uses the real getContractEvidence implementation.
+	contractEvidenceFetchFn func(ctx context.Context, dir string, fields []string) ([]ContractEvidence, error)
 }
 
 // SetRepoAllowlist injects the allowlist used by the sub-issue creation
@@ -1202,6 +1220,24 @@ func (r *Runner) SetWebhookManager(mgr *webhooks.Manager) {
 // that runs quality gates (build, test, lint) before PR creation.
 func (r *Runner) SetQualityCheckerFactory(factory QualityCheckerFactory) {
 	r.qualityCheckerFactory = factory
+}
+
+// SetContractDependencyLookup sets the lookup used by the Contract
+// Evidence gate (TASK-460 doc-vs-wire leg, GH-5009/GH-5012) to determine a
+// project's configured contract dependencies. A nil lookup (the default)
+// disables the gate entirely: ExecuteTask makes zero new GitHub API calls
+// and never blocks on missing/unverified citations.
+func (r *Runner) SetContractDependencyLookup(lookup ContractDependencyLookup) {
+	r.contractDependencyLookup = lookup
+}
+
+// SetContractContentFetcher sets the fetcher the Contract Evidence gate
+// uses to independently verify a citation's producer source (GH-5009
+// Requirement 5c). A nil fetcher (the default) makes every citation a hard
+// fetch_error rejection rather than a silent pass, so partially wiring the
+// gate (lookup set, fetcher not yet set) fails closed, not open.
+func (r *Runner) SetContractContentFetcher(fetcher ContractContentFetcher) {
+	r.contractContentFetcher = fetcher
 }
 
 // SetModelRouter sets the model router for complexity-based model and timeout selection.
@@ -4848,6 +4884,80 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 				}
 			}
 		}
+
+		// Contract Evidence gate (TASK-460 doc-vs-wire leg, GH-5009/GH-5012):
+		// hard-blocks tasks whose diff touches a configured contract_files
+		// path unless the executor cited real, fetch-verified producer
+		// source for every touched field. Skipped entirely (zero new GitHub
+		// API calls) when no lookup is configured or the diff doesn't touch
+		// a contract file — same failure shape as the QualityChecker gate
+		// above (~:4344-4394), spliced after self-review/intent judge
+		// (wg.Wait() above) and before the DirectCommit/CreatePR branch
+		// below.
+		if r.contractDependencyLookup != nil {
+			contractBaseBranch := task.BaseBranch
+			if contractBaseBranch == "" {
+				contractBaseBranch, _ = git.GetDefaultBranch(ctx)
+				if contractBaseBranch == "" {
+					contractBaseBranch = "main"
+				}
+			}
+			contractDiff, _, diffErr := git.GetDiffAgainstOrigin(ctx, contractBaseBranch)
+			if diffErr != nil {
+				log.Warn("Contract evidence: failed to compute diff, skipping gate",
+					slog.String("task_id", task.ID), slog.Any("error", diffErr))
+			} else {
+				deps := r.contractDependencyLookup(task.ProjectPath)
+				contractRequired, contractFields := detectTouchedContractFields(contractDiff, deps)
+				if contractRequired {
+					r.reportProgress(task.ID, "Contract Evidence", 97, "Verifying wire-contract citations...")
+
+					evidence, evErr := r.getContractEvidence(ctx, executionPath, contractFields)
+					if evErr != nil {
+						log.Warn("Contract evidence: fetch failed, treating as zero evidence",
+							slog.String("task_id", task.ID), slog.Any("error", evErr))
+					}
+
+					contractOutcome := verifyContractEvidence(ctx, r.contractContentFetcher, deps, contractFields, evidence)
+					result.ContractEvidence = contractOutcome
+					r.recordContractEvidenceEvent(task.LogExecutionID(), contractOutcome)
+
+					if !contractOutcome.Passed {
+						result.Success = false
+						result.Error = contractOutcome.Summary()
+						r.reportProgress(task.ID, "Contract Evidence Failed", 100, result.Error)
+
+						r.emitAlertEvent(AlertEvent{
+							Type:      AlertEventTypeTaskFailed,
+							TaskID:    task.ID,
+							TaskTitle: task.Title,
+							Project:   task.ProjectPath,
+							Error:     result.Error,
+							Timestamp: time.Now(),
+						})
+
+						r.dispatchWebhook(ctx, webhooks.EventTaskFailed, webhooks.TaskFailedData{
+							TaskID:   task.ID,
+							Title:    task.Title,
+							Project:  task.ProjectPath,
+							Duration: time.Since(start),
+							Error:    result.Error,
+							Phase:    "Contract Evidence",
+						})
+
+						if recorder != nil {
+							recorder.SetModel(result.ModelName)
+							recorder.SetNavigator(state.hasNavigator)
+							if finErr := recorder.Finish("failed"); finErr != nil {
+								log.Warn("Failed to finish recording", slog.Any("error", finErr))
+							}
+						}
+						return result, nil
+					}
+				}
+			}
+		}
+
 		if task.DirectCommit {
 			r.reportProgress(task.ID, "Pushing", 96, "Pushing to main...")
 
@@ -6672,6 +6782,59 @@ func (r *Runner) recordQualityGateEvents(executionID string, outcome *QualityOut
 	r.recordExecutionEvent(executionID, memory.StageQualityGate, string(summary))
 }
 
+// recordContractEvidenceEvent persists the Contract Evidence gate's outcome
+// (TASK-460 doc-vs-wire leg, GH-5009/GH-5012) as execution_events: one row
+// per evaluated field carrying its citation/verification/rejection status,
+// plus a trailing summary row — same detail-JSON convention as
+// recordQualityGateEvents.
+func (r *Runner) recordContractEvidenceEvent(executionID string, outcome *ContractEvidenceOutcome) {
+	if outcome == nil || !outcome.Required {
+		return
+	}
+
+	verified := make(map[string]bool, len(outcome.Verified))
+	for _, f := range outcome.Verified {
+		verified[f] = true
+	}
+	rejectionByField := make(map[string]ContractFieldRejection, len(outcome.Rejections))
+	for _, rej := range outcome.Rejections {
+		rejectionByField[rej.Field] = rej
+	}
+
+	for _, field := range outcome.Fields {
+		rej, rejected := rejectionByField[field]
+		detail, err := json.Marshal(struct {
+			Field           string `json:"field"`
+			Cited           bool   `json:"cited"`
+			Verified        bool   `json:"verified"`
+			RejectionReason string `json:"rejection_reason,omitempty"`
+		}{
+			Field:           field,
+			Cited:           verified[field] || rejected,
+			Verified:        verified[field],
+			RejectionReason: string(rej.Reason),
+		})
+		if err != nil {
+			continue
+		}
+		r.recordExecutionEvent(executionID, memory.StageContractEvidence, string(detail))
+	}
+
+	summary, err := json.Marshal(struct {
+		Required   bool `json:"required"`
+		Passed     bool `json:"passed"`
+		FieldCount int  `json:"field_count"`
+	}{
+		Required:   outcome.Required,
+		Passed:     outcome.Passed,
+		FieldCount: len(outcome.Fields),
+	})
+	if err != nil {
+		return
+	}
+	r.recordExecutionEvent(executionID, memory.StageContractEvidence, string(summary))
+}
+
 // simpleQualityChecker is a minimal quality checker for auto-enabled build gates (GH-363).
 // Used when quality gates aren't explicitly configured but we still want basic build verification.
 type simpleQualityChecker struct {
@@ -6765,6 +6928,57 @@ func (r *Runner) getPostExecutionSummary(ctx context.Context, dir string) (*Post
 	}
 
 	return &summary, nil
+}
+
+// getContractEvidence runs a structured-output query eliciting per-field
+// producer citations for the Contract Evidence gate (TASK-460 doc-vs-wire
+// leg, GH-5009 Requirement 7). It mirrors getPostExecutionSummary's shape
+// (same --json-schema mechanism, same dir-pinned subprocess) but is only
+// ever invoked when detectTouchedContractFields reports required=true, and
+// asks specifically for producer-source citations rather than git state.
+//
+// contractEvidenceFetchFn overrides this for testing so callers don't need
+// to shell out to the real `claude` CLI.
+func (r *Runner) getContractEvidence(ctx context.Context, dir string, fields []string) ([]ContractEvidence, error) {
+	if r.contractEvidenceFetchFn != nil {
+		return r.contractEvidenceFetchFn(ctx, dir, fields)
+	}
+
+	if r.config == nil || r.config.ClaudeCode == nil {
+		return nil, fmt.Errorf("claude code backend not configured")
+	}
+
+	prompt := buildContractEvidencePrompt(fields)
+
+	claudeCmd := "claude"
+	if r.config.ClaudeCode.Command != "" {
+		claudeCmd = r.config.ClaudeCode.Command
+	}
+	cmd := exec.CommandContext(ctx, claudeCmd,
+		"--print",
+		"-p", prompt,
+		"--model", r.config.ResolveModel("claude-haiku-4-5-20251001"),
+		"--output-format", "json",
+		"--json-schema", ContractEvidenceSchema,
+	)
+	cmd.Dir = dir
+
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("claude command failed: %w", err)
+	}
+
+	structuredOutput, err := extractStructuredOutput(output)
+	if err != nil {
+		return nil, fmt.Errorf("extract structured output: %w", err)
+	}
+
+	var resp contractEvidenceResponse
+	if err := json.Unmarshal(structuredOutput, &resp); err != nil {
+		return nil, fmt.Errorf("parse contract evidence: %w", err)
+	}
+
+	return resp.Evidence, nil
 }
 
 // runWorkflowHook executes a workflow lifecycle hook, logging output and warning on failure.

--- a/internal/executor/runner_contract_evidence_test.go
+++ b/internal/executor/runner_contract_evidence_test.go
@@ -1,0 +1,457 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/webhooks"
+)
+
+// contractFileBackend simulates a Claude Code invocation that writes and
+// commits a single file — used to put a diff-touching-a-contract-file shape
+// in front of the Contract Evidence gate without shelling out to a real
+// backend.
+type contractFileBackend struct {
+	path    string
+	content string
+}
+
+func (b *contractFileBackend) Name() string      { return "contract-file-backend" }
+func (b *contractFileBackend) IsAvailable() bool { return true }
+
+func (b *contractFileBackend) Execute(ctx context.Context, opts ExecuteOptions) (*BackendResult, error) {
+	full := filepath.Join(opts.ProjectPath, b.path)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(full, []byte(b.content), 0o644); err != nil {
+		return nil, err
+	}
+	for _, args := range [][]string{{"add", "."}, {"commit", "-m", "touch contract file"}} {
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = opts.ProjectPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("git %v: %v (%s)", args, err, out)
+		}
+	}
+	return &BackendResult{Success: true, Output: "done"}, nil
+}
+
+// newContractGateTestRunner sets up a Runner against a real local+origin
+// repo pair (so GetDiffAgainstOrigin behaves exactly as in production),
+// wired to skip preflight/recording noise and with CreatePR=false so
+// execution never reaches the real `gh pr create` path — the Contract
+// Evidence gate is spliced before that branch, so CreatePR=false isolates
+// it as the only extra logic under test.
+func newContractGateTestRunner(t *testing.T, backend Backend) (*Runner, *Task) {
+	t.Helper()
+	localRepo, remoteRepo := setupTestRepoWithRemote(t)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(localRepo)
+		_ = os.RemoveAll(remoteRepo)
+	})
+
+	runner := NewRunnerWithBackend(backend)
+	runner.config = &BackendConfig{UseWorktree: false}
+	runner.SetSkipPreflightChecks(true)
+	runner.SetRecordingEnabled(false)
+
+	task := &Task{
+		ID:          "GH-5012-contract-gate",
+		Title:       "contract evidence gate test",
+		Description: "synthetic task exercising the contract evidence gate",
+		ProjectPath: localRepo,
+		Branch:      "pilot/GH-5012-contract-gate",
+		CreatePR:    false,
+	}
+
+	return runner, task
+}
+
+func contractGateExecCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+func specVersionProducerContent() string {
+	return strings.Join([]string{
+		"package instances",         // 1
+		"",                          // 2
+		"type InstanceDTO struct {", // 3
+		"\tConfigGeneration int `json:\"specVersion\"`", // 4
+		"}", // 5
+	}, "\n")
+}
+
+func TestRunner_ContractEvidence_NoLookupConfigured_NoOp(t *testing.T) {
+	backend := &contractFileBackend{
+		path:    "src/lib/api/types.ts",
+		content: "export interface Instance {\n  specVersion: number;\n}\n",
+	}
+	runner, task := newContractGateTestRunner(t, backend)
+
+	fetcher := &fakeContractContentFetcher{content: map[string]string{
+		"qf-studio/pilot-console/internal/instances/handlers.go": specVersionProducerContent(),
+	}}
+	runner.SetContractContentFetcher(fetcher)
+	// Deliberately never call SetContractDependencyLookup: the gate must be
+	// a complete no-op (r.contractDependencyLookup == nil), matching
+	// existing behavior for every project that hasn't opted in.
+
+	result, err := runner.Execute(contractGateExecCtx(t), task)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result == nil || !result.Success {
+		t.Fatalf("expected success with no lookup configured, got %+v", result)
+	}
+	if fetcher.calls != 0 {
+		t.Errorf("expected 0 fetch calls with no lookup configured, got %d", fetcher.calls)
+	}
+	if result.ContractEvidence != nil {
+		t.Errorf("expected nil ContractEvidence outcome when the gate never ran, got %+v", result.ContractEvidence)
+	}
+}
+
+func TestRunner_ContractEvidence_NoDependenciesConfigured_NoOp(t *testing.T) {
+	backend := &contractFileBackend{
+		path:    "src/lib/api/types.ts",
+		content: "export interface Instance {\n  specVersion: number;\n}\n",
+	}
+	runner, task := newContractGateTestRunner(t, backend)
+
+	fetcher := &fakeContractContentFetcher{content: map[string]string{
+		"qf-studio/pilot-console/internal/instances/handlers.go": specVersionProducerContent(),
+	}}
+	runner.SetContractContentFetcher(fetcher)
+	runner.SetContractDependencyLookup(func(projectPath string) []ContractDependency {
+		return nil // configured, but this project declares no dependencies
+	})
+
+	result, err := runner.Execute(contractGateExecCtx(t), task)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result == nil || !result.Success {
+		t.Fatalf("expected success with zero configured dependencies, got %+v", result)
+	}
+	if fetcher.calls != 0 {
+		t.Errorf("expected 0 fetch calls with zero configured dependencies, got %d", fetcher.calls)
+	}
+}
+
+// webhookRecorder is a minimal httptest-backed webhooks.Manager harness:
+// asserting a real Dispatch() round-trip (not an internal mock) proves the
+// failure path actually calls dispatchWebhook with the documented event
+// type, end to end.
+type webhookRecorder struct {
+	mu      sync.Mutex
+	events  []string
+	server  *httptest.Server
+	manager *webhooks.Manager
+}
+
+func newWebhookRecorder() *webhookRecorder {
+	wr := &webhookRecorder{}
+	wr.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wr.mu.Lock()
+		wr.events = append(wr.events, r.Header.Get("X-Pilot-Event"))
+		wr.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	wr.manager = webhooks.NewManager(&webhooks.Config{
+		Enabled: true,
+		Endpoints: []*webhooks.EndpointConfig{
+			{ID: "test", Name: "test", URL: wr.server.URL, Enabled: true},
+		},
+	}, nil)
+	return wr
+}
+
+func (wr *webhookRecorder) close() { wr.server.Close() }
+
+func (wr *webhookRecorder) received(eventType string) bool {
+	wr.mu.Lock()
+	defer wr.mu.Unlock()
+	for _, e := range wr.events {
+		if e == eventType {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRunner_ContractEvidence_ZeroEvidenceFails(t *testing.T) {
+	backend := &contractFileBackend{
+		path:    "src/lib/api/types.ts",
+		content: "export interface Instance {\n  specVersion: number;\n}\n",
+	}
+	runner, task := newContractGateTestRunner(t, backend)
+
+	deps := []ContractDependency{{Owner: "qf-studio", Repo: "pilot-console", ContractFiles: []string{"*.ts"}}}
+	runner.SetContractDependencyLookup(func(projectPath string) []ContractDependency { return deps })
+	runner.contractEvidenceFetchFn = func(ctx context.Context, dir string, fields []string) ([]ContractEvidence, error) {
+		return nil, nil // zero evidence entries
+	}
+
+	alerts := &fakeAlertProcessor{}
+	runner.SetAlertProcessor(alerts)
+	wr := newWebhookRecorder()
+	defer wr.close()
+	runner.SetWebhookManager(wr.manager)
+
+	result, err := runner.Execute(contractGateExecCtx(t), task)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result == nil || result.Success {
+		t.Fatalf("expected failure for zero evidence, got %+v", result)
+	}
+	if result.Error == "" {
+		t.Errorf("expected non-empty result.Error")
+	}
+	if result.ContractEvidence == nil || result.ContractEvidence.Passed {
+		t.Errorf("expected a failed ContractEvidence outcome, got %+v", result.ContractEvidence)
+	}
+
+	var sawTaskFailed bool
+	for _, e := range alerts.events {
+		if e.Type == AlertEventTypeTaskFailed {
+			sawTaskFailed = true
+		}
+	}
+	if !sawTaskFailed {
+		t.Errorf("expected an AlertEventTypeTaskFailed event, got %+v", alerts.events)
+	}
+	if !wr.received(string(webhooks.EventTaskFailed)) {
+		t.Errorf("expected a dispatched %s webhook, got events %v", webhooks.EventTaskFailed, wr.events)
+	}
+}
+
+func TestRunner_ContractEvidence_ZeroEvidenceFails_RecordsFailedFinish(t *testing.T) {
+	backend := &contractFileBackend{
+		path:    "src/lib/api/types.ts",
+		content: "export interface Instance {\n  specVersion: number;\n}\n",
+	}
+	runner, task := newContractGateTestRunner(t, backend)
+
+	recordingsDir := t.TempDir()
+	runner.SetRecordingsPath(recordingsDir)
+	runner.SetRecordingEnabled(true)
+
+	deps := []ContractDependency{{Owner: "qf-studio", Repo: "pilot-console", ContractFiles: []string{"*.ts"}}}
+	runner.SetContractDependencyLookup(func(projectPath string) []ContractDependency { return deps })
+	runner.contractEvidenceFetchFn = func(ctx context.Context, dir string, fields []string) ([]ContractEvidence, error) {
+		return nil, nil
+	}
+
+	result, err := runner.Execute(contractGateExecCtx(t), task)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result == nil || result.Success {
+		t.Fatalf("expected failure, got %+v", result)
+	}
+
+	entries, err := os.ReadDir(recordingsDir)
+	if err != nil {
+		t.Fatalf("ReadDir(recordingsDir): %v", err)
+	}
+	var foundFailedStatus bool
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		data, readErr := os.ReadFile(filepath.Join(recordingsDir, e.Name(), "metadata.json"))
+		if readErr != nil {
+			continue
+		}
+		var meta struct {
+			Status string `json:"status"`
+		}
+		if jsonErr := json.Unmarshal(data, &meta); jsonErr != nil {
+			t.Fatalf("unmarshal metadata.json for %s: %v", e.Name(), jsonErr)
+		}
+		if meta.Status == "failed" {
+			foundFailedStatus = true
+		}
+	}
+	if !foundFailedStatus {
+		t.Errorf("expected a recording with status=failed under %s, entries=%v", recordingsDir, entries)
+	}
+}
+
+func TestRunner_ContractEvidence_IrrelevantCitationFails(t *testing.T) {
+	backend := &contractFileBackend{
+		path:    "src/lib/api/types.ts",
+		content: "export interface Instance {\n  specVersion: number;\n}\n",
+	}
+	runner, task := newContractGateTestRunner(t, backend)
+
+	deps := []ContractDependency{{Owner: "qf-studio", Repo: "pilot-console", ContractFiles: []string{"*.ts"}}}
+	runner.SetContractDependencyLookup(func(projectPath string) []ContractDependency { return deps })
+	fetcher := &fakeContractContentFetcher{content: map[string]string{
+		"qf-studio/pilot-console/internal/instances/handlers.go": specVersionProducerContent(),
+	}}
+	runner.SetContractContentFetcher(fetcher)
+	runner.contractEvidenceFetchFn = func(ctx context.Context, dir string, fields []string) ([]ContractEvidence, error) {
+		return []ContractEvidence{{
+			Field:         "totallyUnrelatedField", // real citation, but for a field the diff never touched
+			ProducerRepo:  "qf-studio/pilot-console",
+			ProducerFile:  "internal/instances/handlers.go",
+			ProducerLine:  4,
+			ProducingExpr: "ConfigGeneration int",
+		}}, nil
+	}
+
+	result, err := runner.Execute(contractGateExecCtx(t), task)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result == nil || result.Success {
+		t.Fatalf("expected failure for an irrelevant citation, got %+v", result)
+	}
+}
+
+func TestRunner_ContractEvidence_WrongProducerLineFails(t *testing.T) {
+	backend := &contractFileBackend{
+		path:    "src/lib/api/types.ts",
+		content: "export interface Instance {\n  specVersion: number;\n}\n",
+	}
+	runner, task := newContractGateTestRunner(t, backend)
+
+	deps := []ContractDependency{{Owner: "qf-studio", Repo: "pilot-console", ContractFiles: []string{"*.ts"}}}
+	runner.SetContractDependencyLookup(func(projectPath string) []ContractDependency { return deps })
+	fetcher := &fakeContractContentFetcher{content: map[string]string{
+		"qf-studio/pilot-console/internal/instances/handlers.go": specVersionProducerContent(),
+	}}
+	runner.SetContractContentFetcher(fetcher)
+	runner.contractEvidenceFetchFn = func(ctx context.Context, dir string, fields []string) ([]ContractEvidence, error) {
+		return []ContractEvidence{{
+			Field:         "specVersion",
+			ProducerRepo:  "qf-studio/pilot-console",
+			ProducerFile:  "internal/instances/handlers.go",
+			ProducerLine:  100, // wrong: the real definition is at line 4; 100 is far outside any +/-3 window and out of file bounds
+			ProducingExpr: "ConfigGeneration int",
+		}}, nil
+	}
+
+	result, err := runner.Execute(contractGateExecCtx(t), task)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result == nil || result.Success {
+		t.Fatalf("expected failure for a wrong producer line, got %+v", result)
+	}
+}
+
+func TestRunner_ContractEvidence_ValidCitationsSucceed(t *testing.T) {
+	backend := &contractFileBackend{
+		path:    "src/lib/api/types.ts",
+		content: "export interface Instance {\n  specVersion: number;\n}\n",
+	}
+	runner, task := newContractGateTestRunner(t, backend)
+
+	deps := []ContractDependency{{Owner: "qf-studio", Repo: "pilot-console", ContractFiles: []string{"*.ts"}}}
+	runner.SetContractDependencyLookup(func(projectPath string) []ContractDependency { return deps })
+	fetcher := &fakeContractContentFetcher{content: map[string]string{
+		"qf-studio/pilot-console/internal/instances/handlers.go": specVersionProducerContent(),
+	}}
+	runner.SetContractContentFetcher(fetcher)
+	runner.contractEvidenceFetchFn = func(ctx context.Context, dir string, fields []string) ([]ContractEvidence, error) {
+		return []ContractEvidence{{
+			Field:         "specVersion",
+			ProducerRepo:  "qf-studio/pilot-console",
+			ProducerFile:  "internal/instances/handlers.go",
+			ProducerLine:  4,
+			ProducingExpr: "ConfigGeneration int",
+		}}, nil
+	}
+
+	result, err := runner.Execute(contractGateExecCtx(t), task)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result == nil || !result.Success {
+		t.Fatalf("expected success for valid, fetch-verified citations, got %+v", result)
+	}
+	if result.ContractEvidence == nil || !result.ContractEvidence.Passed {
+		t.Errorf("expected a passed ContractEvidence outcome, got %+v", result.ContractEvidence)
+	}
+	if fetcher.calls == 0 {
+		t.Errorf("expected the fetcher to be called to verify the citation")
+	}
+}
+
+// TestRunner_ContractEvidence_UIPR113SyntheticFixture replicates the ui
+// PR#113 (ui GH-112) incident shape at the runner level: the diff touches a
+// configured contract file, but the cited "producer" is actually the
+// consumer's own repo — a same-repo docblock, never the real producer
+// (pilot-console/internal/instances/handlers.go). Since
+// qf-studio/pilot-console-ui was never declared as a contract dependency,
+// this is rejected mechanically (unconfigured_repo), the same way it would
+// be caught in production.
+func TestRunner_ContractEvidence_UIPR113SyntheticFixture(t *testing.T) {
+	backend := &contractFileBackend{
+		path: "src/lib/api/types.ts",
+		content: "export interface Instance {\n" +
+			"  // specVersion: the APPLIED config generation.\n" +
+			"  specVersion: number;\n" +
+			"}\n",
+	}
+	runner, task := newContractGateTestRunner(t, backend)
+
+	// Only the real producer is a configured dependency.
+	deps := []ContractDependency{{Owner: "qf-studio", Repo: "pilot-console", ContractFiles: []string{"*.ts"}}}
+	runner.SetContractDependencyLookup(func(projectPath string) []ContractDependency { return deps })
+	fetcher := &fakeContractContentFetcher{content: map[string]string{
+		"qf-studio/pilot-console/internal/instances/handlers.go": specVersionProducerContent(),
+	}}
+	runner.SetContractContentFetcher(fetcher)
+	runner.contractEvidenceFetchFn = func(ctx context.Context, dir string, fields []string) ([]ContractEvidence, error) {
+		return []ContractEvidence{{
+			Field:         "specVersion",
+			ProducerRepo:  "qf-studio/pilot-console-ui", // the executor's own (consumer) repo, not the producer
+			ProducerFile:  "src/lib/api/types.ts",
+			ProducerLine:  2,
+			ProducingExpr: "specVersion: the APPLIED config generation",
+		}}, nil
+	}
+
+	result, err := runner.Execute(contractGateExecCtx(t), task)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result == nil || result.Success {
+		t.Fatalf("expected failure for the ui PR#113 consumer-docblock citation shape, got %+v", result)
+	}
+	if result.ContractEvidence == nil {
+		t.Fatalf("expected a ContractEvidence outcome")
+	}
+	var sawUnconfiguredRepo bool
+	for _, rej := range result.ContractEvidence.Rejections {
+		if rej.Reason == ContractRejectionUnconfiguredRepo {
+			sawUnconfiguredRepo = true
+		}
+	}
+	if !sawUnconfiguredRepo {
+		t.Errorf("expected an unconfigured_repo rejection, got %+v", result.ContractEvidence.Rejections)
+	}
+	// The real producer's content must never even be consulted: rule (b)
+	// rejects the unconfigured-repo citation before any fetch happens.
+	if fetcher.calls != 0 {
+		t.Errorf("expected 0 fetch calls when the citation's repo isn't configured, got %d", fetcher.calls)
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -984,6 +984,15 @@ const (
 	// retry wall-clock share is queryable (GH-4129). Detail is a JSON object:
 	// {"loop","attempt"}.
 	StageRetryAttempt Stage = "retry_attempt"
+	// StageContractEvidence records the Contract Evidence gate's outcome for
+	// tasks touching a configured contract_dependencies file (TASK-460
+	// doc-vs-wire leg, GH-5009/GH-5012): one event per evaluated field
+	// (detail: {"field","cited","verified","rejection_reason"}) plus a
+	// trailing summary event (detail: {"required","passed","field_count"}).
+	// This is the hard-block gate that fetches and verifies producer source
+	// for a diff's wire-contract field citations — distinct from
+	// StageQualityGate (build/test/lint) and purely advisory self-review.
+	StageContractEvidence Stage = "contract_evidence"
 	// StageDecompositionSkipped records that a task classified epic (or at/
 	// above decompose.min_complexity) did NOT enter decomposition — the gate
 	// and concrete threshold/observed values are carried in Detail as a


### PR DESCRIPTION
## Summary

Executor-side leg of the Contract Evidence enforcement gate (TASK-460 doc-vs-wire leg, part of #5009). Implements items (a)-(g) from #5012's scope:

- `internal/executor/contract_evidence.go` — executor-local `ContractDependency` mirror (no `internal/config` import, avoids an import cycle), `--json-schema` constant, `detectTouchedContractFields` (recall-oriented Go `json:"..."` tag / TS interface field scan over glob-matched diff hunks), and `verifyContractEvidence` enforcing all four rejection rules from Requirement 5: field-not-in-diff, citation's repo not a configured dependency, cited producer line's ±3-line window doesn't contain the field/`ProducingExpr`, and missing-for-required. Fetch errors (including no fetcher configured) are hard failures, never a silent pass.
- `internal/executor/runner.go` — `SetContractDependencyLookup`/`SetContractContentFetcher`, `getContractEvidence` (mirrors `getPostExecutionSummary`), and the gate spliced between self-review/intent-judge and the `DirectCommit`/`CreatePR` branch — identical failure shape to the existing `QualityChecker` gate (`result.Success=false`, `AlertEventTypeTaskFailed`, `webhooks.EventTaskFailed`, `recorder.Finish("failed")`). No-op (zero new GitHub API calls) when no lookup is configured or a project declares no contract dependencies.
- `internal/executor/prompt_builder.go` — advisory-only Contract Evidence section in `buildSelfReviewPrompt` (explicitly documented as NOT the enforcement mechanism — the gate independently re-derives and verifies evidence) plus `buildContractEvidencePrompt` for the gate's own structured-output fetch.
- `internal/memory/store.go` — `StageContractEvidence` event stage, following the `StageQualityGate` doc-comment convention.
- `contract_evidence_test.go` / `runner_contract_evidence_test.go` — unit and runner-level integration coverage for every acceptance path: no-config/no-dependency no-ops, zero-evidence failure, irrelevant-citation failure, wrong-producer-line failure, valid-citation success, alert/webhook/recorder-finish assertions via real (not mocked) sinks, and a synthetic fixture reproducing the ui PR#113 consumer-docblock-citation incident shape.

Scope fence (per #5012): does **not** touch `internal/config` (#5010, merged as #5014), `internal/adapters/github/contents.go` (#5011), or `cmd/pilot` wiring (#5013) — those are separate subtasks. This gate is inert in production until the config-driven lookup and the real GitHub content fetcher are wired in.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all packages pass
- [x] `go test ./internal/executor/... -run TestRunner_ContractEvidence -v` — all 8 runner-level tests pass
- [x] `go test ./internal/executor/... -run 'TestDetectTouchedContractFields|TestVerifyContractEvidence|TestNormalizeWhitespace'` — all unit tests pass
- [x] `gofmt -l` clean on all new/modified files