### PR TITLE
GH-5020: fix(config): correct ContractFiles docblock and misleading test fixture

### DIFF
--- a/internal/config/contract_dependencies.go
+++ b/internal/config/contract_dependencies.go
@@ -4,21 +4,23 @@ import "fmt"
 
 // ContractDependency declares that this project's implementation depends on
 // a contract (interface/schema/API shape) defined in another repository
-// (GH-5010). Executor and wiring layers consume this to know which external
-// files to check for drift before trusting a contract as stable — e.g. a
-// console project depending on pilot's gateway API contract files.
+// (GH-5010). Executor and wiring layers consume this to know which local
+// changes should trigger a contract-drift check against Owner/Repo — e.g. a
+// console project gating on changes to the files that consume pilot's
+// gateway API contract.
 type ContractDependency struct {
 	// Owner is the GitHub org/user that owns the dependency repo (required).
 	Owner string `yaml:"owner"`
 	// Repo is the dependency repo name (required).
 	Repo string `yaml:"repo"`
-	// ContractFiles lists the paths (within Repo) that define the contract
-	// this project depends on — e.g. OpenAPI specs, generated types, schema
-	// files. Must contain at least one entry.
+	// ContractFiles is a glob allowlist of paths in the consuming project
+	// (this repo, not Owner/Repo) whose changes trigger the contract-drift
+	// gate — e.g. generated clients, type bindings, or other files that
+	// consume the dependency's contract. Must contain at least one entry.
 	ContractFiles []string `yaml:"contract_files"`
-	// Ref is the git ref (branch, tag, or SHA) to read ContractFiles from.
-	// Optional — an empty Ref lets the caller fall back to the dependency
-	// repo's default branch.
+	// Ref is the git ref (branch, tag, or SHA) in the dependency repo to
+	// check for drift when the gate fires. Optional — an empty Ref lets the
+	// caller fall back to the dependency repo's default branch.
 	Ref string `yaml:"ref,omitempty"`
 }
 

--- a/internal/config/contract_dependencies_test.go
+++ b/internal/config/contract_dependencies_test.go
@@ -92,14 +92,14 @@ func TestConfig_Validate_ContractDependencies(t *testing.T) {
 		{
 			name: "valid deps",
 			deps: []ContractDependency{
-				{Owner: "qf-studio", Repo: "pilot", ContractFiles: []string{"internal/gateway/api.go"}},
+				{Owner: "qf-studio", Repo: "pilot", ContractFiles: []string{"src/lib/pilotClient.ts"}},
 			},
 			wantErr: false,
 		},
 		{
 			name: "invalid entry surfaces indexed error",
 			deps: []ContractDependency{
-				{Owner: "qf-studio", Repo: "pilot", ContractFiles: []string{"internal/gateway/api.go"}},
+				{Owner: "qf-studio", Repo: "pilot", ContractFiles: []string{"src/lib/pilotClient.ts"}},
 				{Owner: "", Repo: "console", ContractFiles: []string{"api/types.ts"}},
 			},
 			wantErr:   true,


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5020.

Closes #5020

## Changes

Reword the `ContractFiles` docblock in `internal/config/contract_dependencies.go:15-18` from producer-repo-path language to "glob allowlist of paths in the consuming project whose changes trigger the gate". Update the misleading test fixture at `contract_dependencies_test.go:98` (currently uses producer-shaped `internal/gateway/api.go`) to a consumer-shaped path that matches the corrected semantics. Verify no remaining prose anywhere in that file describes the field as producer-repo paths. Scope is fully contained in `internal/config/` (one source file + its test), independent of the executor and wiring changes.