### PR TITLE
GH-5021: fix(executor): close diff-error fail-open crack and guard empty-fields LLM call

### DIFF
--- a/internal/executor/contract_evidence.go
+++ b/internal/executor/contract_evidence.go
@@ -268,6 +268,42 @@ func matchesAnyContractGlob(path string, deps []ContractDependency) bool {
 	return false
 }
 
+// shortCircuitEmptyContractFields decides, from detectTouchedContractFields'
+// required/fields output, whether the getContractEvidence LLM/structured-
+// output subprocess call is needed at all (GH-5021b).
+//
+// A contract file can be touched (required=true) by a hunk that adds no
+// line matching either field-token regex — e.g. a comment-only or
+// non-field change inside an allow-listed file. There is nothing to cite in
+// that case, so calling out to getContractEvidence would spend a real LLM
+// invocation on an empty field set for no reason. This short-circuits
+// before that call: it builds the outcome directly via
+// verifyContractEvidence's existing empty-fields behavior (nil evidence,
+// empty requiredFields), which reports Required=false/Passed=true —
+// deliberately reusing that path rather than hand-building an equivalent
+// trivial outcome, so the two "nothing to verify" cases (no contract file
+// touched at all vs. touched-but-fieldless) stay consistent.
+//
+// Returns a non-nil outcome (and needsLLM=false) when the caller should
+// skip getContractEvidence and use the outcome as-is; returns a nil outcome
+// with needsLLM=true when the caller must still call getContractEvidence
+// and run its result through verifyContractEvidence itself.
+func shortCircuitEmptyContractFields(
+	ctx context.Context,
+	fetcher ContractContentFetcher,
+	deps []ContractDependency,
+	required bool,
+	fields []string,
+) (outcome *ContractEvidenceOutcome, needsLLM bool) {
+	if !required {
+		return nil, false
+	}
+	if len(fields) == 0 {
+		return verifyContractEvidence(ctx, fetcher, deps, fields, nil), false
+	}
+	return nil, true
+}
+
 // verifyContractEvidence enforces all four rejection rules from GH-5009
 // Requirement 5:
 //

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -4902,57 +4902,94 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 					contractBaseBranch = "main"
 				}
 			}
+
+			// failContractEvidenceGate runs the standard contract-evidence
+			// failure sequence (alert + webhook + recorder, with
+			// result.Success=false) shared by every hard-failure exit from
+			// this gate: a rejected citation below, and (GH-5021) a diff
+			// compute error on a project that actually has contract
+			// dependencies configured — that case used to fail open with a
+			// Warn log instead of blocking the task.
+			failContractEvidenceGate := func(errMsg string) {
+				result.Success = false
+				result.Error = errMsg
+				r.reportProgress(task.ID, "Contract Evidence Failed", 100, result.Error)
+
+				r.emitAlertEvent(AlertEvent{
+					Type:      AlertEventTypeTaskFailed,
+					TaskID:    task.ID,
+					TaskTitle: task.Title,
+					Project:   task.ProjectPath,
+					Error:     result.Error,
+					Timestamp: time.Now(),
+				})
+
+				r.dispatchWebhook(ctx, webhooks.EventTaskFailed, webhooks.TaskFailedData{
+					TaskID:   task.ID,
+					Title:    task.Title,
+					Project:  task.ProjectPath,
+					Duration: time.Since(start),
+					Error:    result.Error,
+					Phase:    "Contract Evidence",
+				})
+
+				if recorder != nil {
+					recorder.SetModel(result.ModelName)
+					recorder.SetNavigator(state.hasNavigator)
+					if finErr := recorder.Finish("failed"); finErr != nil {
+						log.Warn("Failed to finish recording", slog.Any("error", finErr))
+					}
+				}
+			}
+
+			// GH-5021: deps must be resolved before the diffErr branch below
+			// decides whether a diff-compute failure is a silent skip (no
+			// deps configured for this project — the gate would have been a
+			// no-op anyway) or a hard gate failure (deps ARE configured, so
+			// we cannot silently let an unverifiable diff through).
+			deps := r.contractDependencyLookup(task.ProjectPath)
 			contractDiff, _, diffErr := git.GetDiffAgainstOrigin(ctx, contractBaseBranch)
 			if diffErr != nil {
-				log.Warn("Contract evidence: failed to compute diff, skipping gate",
-					slog.String("task_id", task.ID), slog.Any("error", diffErr))
+				if len(deps) == 0 {
+					log.Warn("Contract evidence: failed to compute diff, skipping gate",
+						slog.String("task_id", task.ID), slog.Any("error", diffErr))
+				} else {
+					failContractEvidenceGate(fmt.Sprintf(
+						"contract evidence: failed to compute diff against %s: %v", contractBaseBranch, diffErr))
+					return result, nil
+				}
 			} else {
-				deps := r.contractDependencyLookup(task.ProjectPath)
 				contractRequired, contractFields := detectTouchedContractFields(contractDiff, deps)
 				if contractRequired {
-					r.reportProgress(task.ID, "Contract Evidence", 97, "Verifying wire-contract citations...")
+					if len(contractFields) == 0 {
+						// GH-5021: a contract file was touched but no field
+						// tokens were extracted (e.g. a non-field hunk
+						// inside an allow-listed file) — there is nothing to
+						// cite, so skip the LLM/structured-output
+						// subprocess call entirely. verifyContractEvidence
+						// already reports Required=false/Passed=true for an
+						// empty field set, so reuse it directly rather than
+						// hand-building an equivalent outcome.
+						contractOutcome := verifyContractEvidence(ctx, r.contractContentFetcher, deps, contractFields, nil)
+						result.ContractEvidence = contractOutcome
+						r.recordContractEvidenceEvent(task.LogExecutionID(), contractOutcome)
+					} else {
+						r.reportProgress(task.ID, "Contract Evidence", 97, "Verifying wire-contract citations...")
 
-					evidence, evErr := r.getContractEvidence(ctx, executionPath, contractFields)
-					if evErr != nil {
-						log.Warn("Contract evidence: fetch failed, treating as zero evidence",
-							slog.String("task_id", task.ID), slog.Any("error", evErr))
-					}
-
-					contractOutcome := verifyContractEvidence(ctx, r.contractContentFetcher, deps, contractFields, evidence)
-					result.ContractEvidence = contractOutcome
-					r.recordContractEvidenceEvent(task.LogExecutionID(), contractOutcome)
-
-					if !contractOutcome.Passed {
-						result.Success = false
-						result.Error = contractOutcome.Summary()
-						r.reportProgress(task.ID, "Contract Evidence Failed", 100, result.Error)
-
-						r.emitAlertEvent(AlertEvent{
-							Type:      AlertEventTypeTaskFailed,
-							TaskID:    task.ID,
-							TaskTitle: task.Title,
-							Project:   task.ProjectPath,
-							Error:     result.Error,
-							Timestamp: time.Now(),
-						})
-
-						r.dispatchWebhook(ctx, webhooks.EventTaskFailed, webhooks.TaskFailedData{
-							TaskID:   task.ID,
-							Title:    task.Title,
-							Project:  task.ProjectPath,
-							Duration: time.Since(start),
-							Error:    result.Error,
-							Phase:    "Contract Evidence",
-						})
-
-						if recorder != nil {
-							recorder.SetModel(result.ModelName)
-							recorder.SetNavigator(state.hasNavigator)
-							if finErr := recorder.Finish("failed"); finErr != nil {
-								log.Warn("Failed to finish recording", slog.Any("error", finErr))
-							}
+						evidence, evErr := r.getContractEvidence(ctx, executionPath, contractFields)
+						if evErr != nil {
+							log.Warn("Contract evidence: fetch failed, treating as zero evidence",
+								slog.String("task_id", task.ID), slog.Any("error", evErr))
 						}
-						return result, nil
+
+						contractOutcome := verifyContractEvidence(ctx, r.contractContentFetcher, deps, contractFields, evidence)
+						result.ContractEvidence = contractOutcome
+						r.recordContractEvidenceEvent(task.LogExecutionID(), contractOutcome)
+
+						if !contractOutcome.Passed {
+							failContractEvidenceGate(contractOutcome.Summary())
+							return result, nil
+						}
 					}
 				}
 			}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -4960,36 +4960,34 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 				}
 			} else {
 				contractRequired, contractFields := detectTouchedContractFields(contractDiff, deps)
-				if contractRequired {
-					if len(contractFields) == 0 {
-						// GH-5021: a contract file was touched but no field
-						// tokens were extracted (e.g. a non-field hunk
-						// inside an allow-listed file) — there is nothing to
-						// cite, so skip the LLM/structured-output
-						// subprocess call entirely. verifyContractEvidence
-						// already reports Required=false/Passed=true for an
-						// empty field set, so reuse it directly rather than
-						// hand-building an equivalent outcome.
-						contractOutcome := verifyContractEvidence(ctx, r.contractContentFetcher, deps, contractFields, nil)
-						result.ContractEvidence = contractOutcome
-						r.recordContractEvidenceEvent(task.LogExecutionID(), contractOutcome)
-					} else {
-						r.reportProgress(task.ID, "Contract Evidence", 97, "Verifying wire-contract citations...")
 
-						evidence, evErr := r.getContractEvidence(ctx, executionPath, contractFields)
-						if evErr != nil {
-							log.Warn("Contract evidence: fetch failed, treating as zero evidence",
-								slog.String("task_id", task.ID), slog.Any("error", evErr))
-						}
+				// GH-5021: a contract file can be touched with zero field
+				// tokens extracted (e.g. a non-field hunk inside an
+				// allow-listed file) — shortCircuitEmptyContractFields
+				// decides whether that means there is nothing to cite, in
+				// which case it hands back the trivial outcome directly and
+				// the getContractEvidence LLM/structured-output subprocess
+				// call below is skipped entirely.
+				contractOutcome, needsContractLLM := shortCircuitEmptyContractFields(ctx, r.contractContentFetcher, deps, contractRequired, contractFields)
+				if contractOutcome != nil {
+					result.ContractEvidence = contractOutcome
+					r.recordContractEvidenceEvent(task.LogExecutionID(), contractOutcome)
+				} else if needsContractLLM {
+					r.reportProgress(task.ID, "Contract Evidence", 97, "Verifying wire-contract citations...")
 
-						contractOutcome := verifyContractEvidence(ctx, r.contractContentFetcher, deps, contractFields, evidence)
-						result.ContractEvidence = contractOutcome
-						r.recordContractEvidenceEvent(task.LogExecutionID(), contractOutcome)
+					evidence, evErr := r.getContractEvidence(ctx, executionPath, contractFields)
+					if evErr != nil {
+						log.Warn("Contract evidence: fetch failed, treating as zero evidence",
+							slog.String("task_id", task.ID), slog.Any("error", evErr))
+					}
 
-						if !contractOutcome.Passed {
-							failContractEvidenceGate(contractOutcome.Summary())
-							return result, nil
-						}
+					contractOutcome := verifyContractEvidence(ctx, r.contractContentFetcher, deps, contractFields, evidence)
+					result.ContractEvidence = contractOutcome
+					r.recordContractEvidenceEvent(task.LogExecutionID(), contractOutcome)
+
+					if !contractOutcome.Passed {
+						failContractEvidenceGate(contractOutcome.Summary())
+						return result, nil
 					}
 				}
 			}

--- a/internal/executor/runner_contract_evidence_test.go
+++ b/internal/executor/runner_contract_evidence_test.go
@@ -47,6 +47,55 @@ func (b *contractFileBackend) Execute(ctx context.Context, opts ExecuteOptions) 
 	return &BackendResult{Success: true, Output: "done"}, nil
 }
 
+// diffErrorBackend simulates a Claude Code invocation that commits a file
+// (same as contractFileBackend) and then severs the repo's ability to
+// resolve a diff against the base branch: it deletes the local base-branch
+// ref and removes the "origin" remote entirely. By the time this runs the
+// task branch is already checked out (branch creation happens before the
+// backend runs), so neither deletion disturbs execution up to this point —
+// but any later git.GetDiffAgainstOrigin(ctx, baseBranch) call (the Contract
+// Evidence gate, GH-5021) fails both its origin/<base> and local <base>
+// fallbacks, exactly reproducing a "can't compute the diff" failure.
+type diffErrorBackend struct {
+	path       string
+	content    string
+	baseBranch string
+}
+
+func (b *diffErrorBackend) Name() string      { return "diff-error-backend" }
+func (b *diffErrorBackend) IsAvailable() bool { return true }
+
+func (b *diffErrorBackend) Execute(ctx context.Context, opts ExecuteOptions) (*BackendResult, error) {
+	full := filepath.Join(opts.ProjectPath, b.path)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(full, []byte(b.content), 0o644); err != nil {
+		return nil, err
+	}
+	for _, args := range [][]string{{"add", "."}, {"commit", "-m", "touch contract file"}} {
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = opts.ProjectPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("git %v: %v (%s)", args, err, out)
+		}
+	}
+
+	base := b.baseBranch
+	if base == "" {
+		base = "main"
+	}
+	for _, args := range [][]string{{"branch", "-D", base}, {"remote", "remove", "origin"}} {
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = opts.ProjectPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("git %v: %v (%s)", args, err, out)
+		}
+	}
+
+	return &BackendResult{Success: true, Output: "done"}, nil
+}
+
 // newContractGateTestRunner sets up a Runner against a real local+origin
 // repo pair (so GetDiffAgainstOrigin behaves exactly as in production),
 // wired to skip preflight/recording noise and with CreatePR=false so
@@ -392,6 +441,120 @@ func TestRunner_ContractEvidence_ValidCitationsSucceed(t *testing.T) {
 	}
 	if fetcher.calls == 0 {
 		t.Errorf("expected the fetcher to be called to verify the citation")
+	}
+}
+
+// TestRunner_ContractEvidence_DiffErrorWithDepsConfigured_FailsGate covers
+// GH-5021(a): a GetDiffAgainstOrigin failure on a project that DOES have
+// contract dependencies configured must route through the standard
+// contract-evidence failure sequence (alert + webhook + recorder,
+// result.Success=false) instead of fail-opening with a Warn log. The error
+// is induced by diffErrorBackend, which deletes the local base branch and
+// removes the "origin" remote after committing, so the gate's
+// GetDiffAgainstOrigin call fails both its fallbacks.
+func TestRunner_ContractEvidence_DiffErrorWithDepsConfigured_FailsGate(t *testing.T) {
+	backend := &diffErrorBackend{
+		path:    "src/lib/api/types.ts",
+		content: "export interface Instance {\n  specVersion: number;\n}\n",
+	}
+	runner, task := newContractGateTestRunner(t, backend)
+
+	deps := []ContractDependency{{Owner: "qf-studio", Repo: "pilot-console", ContractFiles: []string{"*.ts"}}}
+	runner.SetContractDependencyLookup(func(projectPath string) []ContractDependency { return deps })
+
+	alerts := &fakeAlertProcessor{}
+	runner.SetAlertProcessor(alerts)
+	wr := newWebhookRecorder()
+	defer wr.close()
+	runner.SetWebhookManager(wr.manager)
+
+	result, err := runner.Execute(contractGateExecCtx(t), task)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result == nil || result.Success {
+		t.Fatalf("expected failure when the diff can't be computed for a project with configured deps, got %+v", result)
+	}
+	if result.Error == "" {
+		t.Errorf("expected non-empty result.Error")
+	}
+
+	var sawTaskFailed bool
+	for _, e := range alerts.events {
+		if e.Type == AlertEventTypeTaskFailed {
+			sawTaskFailed = true
+		}
+	}
+	if !sawTaskFailed {
+		t.Errorf("expected an AlertEventTypeTaskFailed event, got %+v", alerts.events)
+	}
+	if !wr.received(string(webhooks.EventTaskFailed)) {
+		t.Errorf("expected a dispatched %s webhook, got events %v", webhooks.EventTaskFailed, wr.events)
+	}
+}
+
+// TestRunner_ContractEvidence_DiffErrorWithoutDeps_Unchanged covers
+// GH-5021(a)'s preserved branch: the exact same diff-compute failure on a
+// project with a configured lookup but zero declared dependencies must keep
+// the pre-GH-5021 skip-and-warn behavior — the gate would have been a no-op
+// even with a working diff, so a diff error here must not block the task.
+func TestRunner_ContractEvidence_DiffErrorWithoutDeps_Unchanged(t *testing.T) {
+	backend := &diffErrorBackend{
+		path:    "src/lib/api/types.ts",
+		content: "export interface Instance {\n  specVersion: number;\n}\n",
+	}
+	runner, task := newContractGateTestRunner(t, backend)
+
+	runner.SetContractDependencyLookup(func(projectPath string) []ContractDependency {
+		return nil // configured, but this project declares no dependencies
+	})
+
+	result, err := runner.Execute(contractGateExecCtx(t), task)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result == nil || !result.Success {
+		t.Fatalf("expected success (unchanged skip-and-warn behavior) when no deps are configured, got %+v", result)
+	}
+}
+
+// TestRunner_ContractEvidence_ZeroExtractedFields_NoLLMCall covers
+// GH-5021(b): a diff that touches a configured contract file but adds no
+// line matching either field-token regex (detectTouchedContractFields
+// reports required=true, fields=nil) must short-circuit before
+// getContractEvidence — zero LLM/structured-output subprocess calls — and
+// let the task proceed as passed.
+func TestRunner_ContractEvidence_ZeroExtractedFields_NoLLMCall(t *testing.T) {
+	backend := &contractFileBackend{
+		path:    "src/lib/api/types.ts",
+		content: "export interface Instance {\n  // specVersion tracked upstream, no field token on this line\n}\n",
+	}
+	runner, task := newContractGateTestRunner(t, backend)
+
+	deps := []ContractDependency{{Owner: "qf-studio", Repo: "pilot-console", ContractFiles: []string{"*.ts"}}}
+	runner.SetContractDependencyLookup(func(projectPath string) []ContractDependency { return deps })
+
+	var fetchCalls int
+	runner.contractEvidenceFetchFn = func(ctx context.Context, dir string, fields []string) ([]ContractEvidence, error) {
+		fetchCalls++
+		return nil, nil
+	}
+
+	result, err := runner.Execute(contractGateExecCtx(t), task)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result == nil || !result.Success {
+		t.Fatalf("expected success when zero contract fields are extracted, got %+v", result)
+	}
+	if fetchCalls != 0 {
+		t.Errorf("expected 0 LLM/structured-output calls when zero fields were extracted, got %d", fetchCalls)
+	}
+	if result.ContractEvidence == nil || result.ContractEvidence.Required {
+		t.Errorf("expected a ContractEvidence outcome with Required=false, got %+v", result.ContractEvidence)
+	}
+	if !result.ContractEvidence.Passed {
+		t.Errorf("expected the zero-fields outcome to be recorded as passed, got %+v", result.ContractEvidence)
 	}
 }
 

--- a/internal/executor/runner_contract_evidence_test.go
+++ b/internal/executor/runner_contract_evidence_test.go
@@ -459,6 +459,10 @@ func TestRunner_ContractEvidence_DiffErrorWithDepsConfigured_FailsGate(t *testin
 	}
 	runner, task := newContractGateTestRunner(t, backend)
 
+	recordingsDir := t.TempDir()
+	runner.SetRecordingsPath(recordingsDir)
+	runner.SetRecordingEnabled(true)
+
 	deps := []ContractDependency{{Owner: "qf-studio", Repo: "pilot-console", ContractFiles: []string{"*.ts"}}}
 	runner.SetContractDependencyLookup(func(projectPath string) []ContractDependency { return deps })
 
@@ -490,6 +494,33 @@ func TestRunner_ContractEvidence_DiffErrorWithDepsConfigured_FailsGate(t *testin
 	}
 	if !wr.received(string(webhooks.EventTaskFailed)) {
 		t.Errorf("expected a dispatched %s webhook, got events %v", webhooks.EventTaskFailed, wr.events)
+	}
+
+	entries, err := os.ReadDir(recordingsDir)
+	if err != nil {
+		t.Fatalf("ReadDir(recordingsDir): %v", err)
+	}
+	var foundFailedStatus bool
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		data, readErr := os.ReadFile(filepath.Join(recordingsDir, e.Name(), "metadata.json"))
+		if readErr != nil {
+			continue
+		}
+		var meta struct {
+			Status string `json:"status"`
+		}
+		if jsonErr := json.Unmarshal(data, &meta); jsonErr != nil {
+			t.Fatalf("unmarshal metadata.json for %s: %v", e.Name(), jsonErr)
+		}
+		if meta.Status == "failed" {
+			foundFailedStatus = true
+		}
+	}
+	if !foundFailedStatus {
+		t.Errorf("expected a recording with status=failed under %s, entries=%v", recordingsDir, entries)
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5021.

Closes #5021

## Changes

GitHub Issue GH-5021: fix(executor): close diff-error fail-open crack and guard empty-fields LLM call

<!--autopilot-meta
parent: GH-5019
inherited-spec: true
-->

Parent: GH-5019

Two related defects in the same package. (a) In `internal/executor/runner.go` (~line 4906, from PR#5016), when the contract-dependency lookup is configured AND the project has contract dependencies, a `GetDiffAgainstOrigin` error must route through the standard contract-evidence failure sequence (alert + webhook + recorder) with `result.Success=false`, not skip the gate with a Warn log; preserve the current skip-and-warn behavior when lookup is unset or the project has no deps. (b) In `internal/executor/contract_evidence.go`, when `required=true` but zero field tokens were extracted, short-circuit before `getContractEvidence` (no LLM/structured-output subprocess call) and record the result as passed with `Required=false` consistently. Add tests: configured-project diff-error → contract-evidence failure path fires (assert alert + webhook + recorder); unconfigured project + same failure → unchanged; zero-extracted-fields → call-count assertion proves no LLM invocation and task proceeds. Both defects live in `internal/executor/` — bundled to avoid intra-package merge conflicts.

## Scope fence

Implement ONLY the slice described above. The parent issue GH-5019 is decomposed
into sibling sub-issues that cover the rest of its spec — consult the parent
for context, but do NOT implement parts of it that fall outside this subtask.