### PR TITLE
GH-5030: feat(autopilot): wire ancestry check into handleMerging

### DIFF
--- a/internal/autopilot/conflict_worktree.go
+++ b/internal/autopilot/conflict_worktree.go
@@ -2,6 +2,7 @@ package autopilot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -98,6 +99,58 @@ func conflictedFiles(ctx context.Context, dir string) ([]string, error) {
 		}
 	}
 	return files, nil
+}
+
+// gitIsStrictAncestor fetches ancestorBranch and descendantBranch from
+// origin into a scratch worktree of repoPath — reusing attemptLocalMerge's
+// fetch + `git worktree add --detach` shape above, so this read-only
+// ancestry probe never touches repoPath's own working tree/index while some
+// other goroutine may have it checked out for an unrelated operation (e.g.
+// attemptMechanicalConflictResolution running on the same merging-time
+// path) — and reports whether ancestorSHA is a STRICT ancestor of
+// descendantSHA: reachable via `git merge-base --is-ancestor`, and not the
+// same commit. Used by Controller.headIsStrictDescendant (controller.go)
+// for the GH-5027 stacked-superset ancestry check.
+func gitIsStrictAncestor(ctx context.Context, repoPath, ancestorBranch, ancestorSHA, descendantBranch, descendantSHA string) (bool, error) {
+	if ancestorSHA == descendantSHA {
+		return false, nil
+	}
+
+	if err := runGitCmd(ctx, repoPath, "fetch", "origin", ancestorBranch, descendantBranch); err != nil {
+		return false, fmt.Errorf("fetch origin %s %s: %w", ancestorBranch, descendantBranch, err)
+	}
+
+	worktreePath, err := os.MkdirTemp("", "pilot-ancestry-check-*")
+	if err != nil {
+		return false, fmt.Errorf("create scratch worktree dir: %w", err)
+	}
+	// See attemptLocalMerge above: `git worktree add` refuses to target an
+	// existing directory, so drop the MkdirTemp placeholder first.
+	if err := os.Remove(worktreePath); err != nil {
+		return false, fmt.Errorf("remove scratch worktree placeholder: %w", err)
+	}
+	defer func() {
+		_ = runGitCmd(ctx, repoPath, "worktree", "remove", "--force", worktreePath)
+		_ = os.RemoveAll(worktreePath)
+	}()
+
+	if err := runGitCmd(ctx, repoPath, "worktree", "add", "--detach", worktreePath, "origin/"+descendantBranch); err != nil {
+		return false, fmt.Errorf("worktree add for origin/%s: %w", descendantBranch, err)
+	}
+
+	if _, err := gitOutput(ctx, worktreePath, "merge-base", "--is-ancestor", ancestorSHA, descendantSHA); err != nil {
+		// `--is-ancestor` communicates its answer entirely via exit code:
+		// 0 = ancestor, 1 = not-an-ancestor (a normal, expected answer, not
+		// a detection failure), and anything else (bad revision, missing
+		// object, network) is a genuine error the caller must not silently
+		// treat as "not stacked".
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return false, nil
+		}
+		return false, fmt.Errorf("merge-base --is-ancestor %s %s: %w", ancestorSHA, descendantSHA, err)
+	}
+	return true, nil
 }
 
 func runGitCmd(ctx context.Context, dir string, args ...string) error {

--- a/internal/autopilot/conflict_worktree_test.go
+++ b/internal/autopilot/conflict_worktree_test.go
@@ -152,3 +152,91 @@ func TestAttemptLocalMerge_CleansUpWorktree(t *testing.T) {
 		t.Fatalf("expected worktree %s to be removed, stat err: %v", worktreePath, statErr)
 	}
 }
+
+// TestGitIsStrictAncestor_StrictDescendant covers the core GH-5027 shape:
+// feature/child was branched from feature/parent and carries an extra
+// commit on top, so feature/parent's head is a strict ancestor of
+// feature/child's head.
+func TestGitIsStrictAncestor_StrictDescendant(t *testing.T) {
+	local := newFixtureRepo(t)
+	ctx := context.Background()
+
+	runFixtureGit(t, local, "checkout", "-b", "feature/parent")
+	writeFixtureFile(t, local, "parent.txt", "from parent\n")
+	runFixtureGit(t, local, "add", "parent.txt")
+	runFixtureGit(t, local, "commit", "-m", "parent commit")
+	runFixtureGit(t, local, "push", "origin", "feature/parent")
+	parentSHA := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	runFixtureGit(t, local, "checkout", "-b", "feature/child")
+	writeFixtureFile(t, local, "child.txt", "from child\n")
+	runFixtureGit(t, local, "add", "child.txt")
+	runFixtureGit(t, local, "commit", "-m", "child commit stacked on parent")
+	runFixtureGit(t, local, "push", "origin", "feature/child")
+	childSHA := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	isAncestor, err := gitIsStrictAncestor(ctx, local, "feature/parent", parentSHA, "feature/child", childSHA)
+	if err != nil {
+		t.Fatalf("gitIsStrictAncestor: %v", err)
+	}
+	if !isAncestor {
+		t.Fatal("expected feature/parent's head to be a strict ancestor of feature/child's head")
+	}
+
+	// Symmetric direction must be false: the parent's head is not a
+	// descendant of the child's head.
+	reversed, err := gitIsStrictAncestor(ctx, local, "feature/child", childSHA, "feature/parent", parentSHA)
+	if err != nil {
+		t.Fatalf("gitIsStrictAncestor (reversed): %v", err)
+	}
+	if reversed {
+		t.Fatal("expected feature/child's head NOT to be an ancestor of feature/parent's head")
+	}
+}
+
+// TestGitIsStrictAncestor_Unrelated covers two branches with disjoint
+// histories off main — neither head is an ancestor of the other.
+func TestGitIsStrictAncestor_Unrelated(t *testing.T) {
+	local := newFixtureRepo(t)
+	ctx := context.Background()
+
+	runFixtureGit(t, local, "checkout", "-b", "feature/a")
+	writeFixtureFile(t, local, "a.txt", "from a\n")
+	runFixtureGit(t, local, "add", "a.txt")
+	runFixtureGit(t, local, "commit", "-m", "add a.txt")
+	runFixtureGit(t, local, "push", "origin", "feature/a")
+	aSHA := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	runFixtureGit(t, local, "checkout", "main")
+	runFixtureGit(t, local, "checkout", "-b", "feature/b")
+	writeFixtureFile(t, local, "b.txt", "from b\n")
+	runFixtureGit(t, local, "add", "b.txt")
+	runFixtureGit(t, local, "commit", "-m", "add b.txt")
+	runFixtureGit(t, local, "push", "origin", "feature/b")
+	bSHA := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	isAncestor, err := gitIsStrictAncestor(ctx, local, "feature/a", aSHA, "feature/b", bSHA)
+	if err != nil {
+		t.Fatalf("gitIsStrictAncestor: %v", err)
+	}
+	if isAncestor {
+		t.Fatal("expected unrelated branches to report no ancestry relationship")
+	}
+}
+
+// TestGitIsStrictAncestor_SameCommit covers the identical-SHA case, which
+// must report false (not a STRICT ancestor of itself) without even
+// shelling out to git.
+func TestGitIsStrictAncestor_SameCommit(t *testing.T) {
+	local := newFixtureRepo(t)
+	ctx := context.Background()
+	headSHA := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	isAncestor, err := gitIsStrictAncestor(ctx, local, "main", headSHA, "main", headSHA)
+	if err != nil {
+		t.Fatalf("gitIsStrictAncestor: %v", err)
+	}
+	if isAncestor {
+		t.Fatal("expected identical SHAs to report no strict-ancestry relationship")
+	}
+}

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -6229,6 +6229,137 @@ func (c *Controller) attemptMechanicalConflictResolution(ctx context.Context, pr
 	return true, nil
 }
 
+// detectStackedSuperset is the GH-5027 stacked-superset ancestry probe: for
+// prState — a PR whose own base is already the repo's default branch (a PR
+// with an explicit non-default Base.Ref is instead caught by the separate,
+// cheaper GH-4872 check at handleMerging:4254, and is not re-checked here)
+// — it walks every OTHER currently-open autopilot PR tracked by this
+// controller and asks whether prState's head commit is a STRICT descendant
+// of that PR's head: i.e. prState's branch was built on top of that PR's
+// still-unmerged content rather than off the default branch directly.
+//
+// This is the detection primitive behind the 2026-08-20 incident GH-5027
+// traces to: PR#5017 was built stacked on PR#5016's branch (same working
+// tree, sequential execution, no `Depends on:` marker so no
+// wait_for_merge). Autopilot merged #5017 first purely on CI/approval
+// timing and squash-absorbed #5016's entire content under #5017's history;
+// #5016 then went CONFLICTING against content already on main.
+//
+// Returns the other PRState prState is stacked on (nil if prState is not a
+// descendant of any other open PR's head — including the normal case of no
+// relationship, and the symmetric case where prState is itself the BASE of
+// a stack, i.e. an ANCESTOR of another open PR's head: merging the base is
+// correct and must never be blocked by this check), or a non-nil error if
+// ancestry could not be determined for at least one candidate.
+//
+// This function is detection ONLY: it never mutates prState or any other
+// PRState. Wiring the result into handleMerging's merge gate (park + label
+// + comment, mirroring parkForBaseMismatch) is the parent issue's remaining
+// scope (GH-5027) and is deliberately NOT done here — see that issue's
+// scope fence. Per GH-5027's acceptance criteria, any future caller that
+// DOES wire this in must fail OPEN on a non-nil error: this is a
+// toil-reducing guard, not a correctness gate, and handleMergeConflict
+// downstream already recovers a stacked PR that slips through, at the cost
+// of one operator recovery cycle.
+func (c *Controller) detectStackedSuperset(ctx context.Context, prState *PRState) (*PRState, error) {
+	if prState == nil || prState.HeadSHA == "" {
+		return nil, nil
+	}
+	if defaultBranch := c.resolveMainBranchName(); prState.TargetBranch != "" && prState.TargetBranch != defaultBranch {
+		return nil, nil
+	}
+
+	// Collect live pointers under c.mu, then release it before touching any
+	// individual prState.mu — mirrors GetActivePRs/SetApprovalDecision above
+	// (TASK-324 no-deadlock invariant: never hold c.mu while taking a
+	// prState.mu). The caller of detectStackedSuperset (ProcessPR) already
+	// holds prState.mu for the PR being evaluated; the per-candidate
+	// other.mu lock below is taken and released one at a time, exactly as
+	// GetActivePRs does, and is safe to nest under the caller's prState.mu
+	// because ProcessPR only ever runs one PR at a time on this controller
+	// (processAllPRs's per-PR loop is sequential, not concurrent) — so no
+	// second goroutine can ever hold a candidate's mu while waiting on
+	// prState's.
+	c.mu.RLock()
+	candidates := make([]*PRState, 0, len(c.activePRs))
+	for _, other := range c.activePRs {
+		candidates = append(candidates, other)
+	}
+	c.mu.RUnlock()
+
+	for _, other := range candidates {
+		if other.PRNumber == prState.PRNumber {
+			continue
+		}
+		other.mu.Lock()
+		otherHead := other.HeadSHA
+		otherBranch := other.BranchName
+		otherNumber := other.PRNumber
+		other.mu.Unlock()
+		if otherHead == "" {
+			continue
+		}
+
+		isDescendant, err := c.headIsStrictDescendant(ctx, prState.BranchName, prState.HeadSHA, otherBranch, otherHead)
+		if err != nil {
+			return nil, fmt.Errorf("ancestry check: pr #%d against pr #%d: %w", prState.PRNumber, otherNumber, err)
+		}
+		if isDescendant {
+			return other, nil
+		}
+	}
+	return nil, nil
+}
+
+// headIsStrictDescendant reports whether descendantSHA (on descendantBranch)
+// is a strict descendant of ancestorSHA (on ancestorBranch) — i.e. ancestorSHA
+// is reachable from descendantSHA but they are not the same commit.
+//
+// Local-git-first: gitIsStrictAncestor (`git merge-base --is-ancestor` in a
+// scratch worktree of c.projectPath, reusing attemptLocalMerge's
+// fetch/worktree primitives from conflict_worktree.go) is tried before the
+// GitHub compare API for two reasons, both about the caller's shape
+// (detectStackedSuperset calls this once per OTHER open PR):
+//  1. Cost: for a repo with N open PRs this is N local `merge-base` calls
+//     behind two `git fetch`es total, versus N GitHub REST round-trips (the
+//     compare API has no batch form) — git's local object-graph walk is far
+//     cheaper than N HTTP calls, and this controller already pays an
+//     equivalent fetch+worktree cost on the same merging-time path
+//     (attemptMechanicalConflictResolution, just above).
+//  2. Consistency: attemptMechanicalConflictResolution already trusts local
+//     git for the adjacent "does this PR's content conflict with base"
+//     ancestry-shaped question on this exact code path, so operators only
+//     need to understand one ancestry-detection failure mode here, not two.
+//
+// The GitHub compare API (CompareStatus — used elsewhere in this file,
+// checkPRWorkOnMain, for the identical "is X an ancestor of Y" question) is
+// kept as the FALLBACK for the one case local git cannot serve:
+// c.projectPath unset (no local clone available on this daemon/test
+// environment), or a local git error (network, corrupt fetch, missing
+// object). It is a fallback, not a substitute — a transient local-git
+// failure alone never silently resolves to "not stacked"; it falls through
+// to the API instead, and only a failure of BOTH is surfaced as an error.
+func (c *Controller) headIsStrictDescendant(ctx context.Context, descendantBranch, descendantSHA, ancestorBranch, ancestorSHA string) (bool, error) {
+	if descendantSHA == ancestorSHA {
+		return false, nil
+	}
+
+	if c.projectPath != "" && descendantBranch != "" && ancestorBranch != "" {
+		isAncestor, err := gitIsStrictAncestor(ctx, c.projectPath, ancestorBranch, ancestorSHA, descendantBranch, descendantSHA)
+		if err == nil {
+			return isAncestor, nil
+		}
+		c.log.Warn("headIsStrictDescendant: local ancestry check failed, falling back to GitHub compare API",
+			"descendant_branch", descendantBranch, "ancestor_branch", ancestorBranch, "error", err)
+	}
+
+	status, err := c.ghClient.CompareStatus(ctx, c.owner, c.repo, ancestorSHA, descendantSHA)
+	if err != nil {
+		return false, fmt.Errorf("compare status fallback %s...%s: %w", ShortSHA(ancestorSHA), ShortSHA(descendantSHA), err)
+	}
+	return status == "ahead", nil
+}
+
 // checkPRWorkOnMain reports whether prState.HeadSHA's changes are already
 // present on the repo's base branch. GH-4696: the GH-4657 closed-issue
 // short-circuit below assumed "source issue closed" always means "a sibling

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -4279,6 +4279,43 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 		}
 	}
 
+	// GH-5027/GH-5030: guard against merging a PR that is stacked on another
+	// still-open PR's unmerged head (the #5016/#5017 incident shape — a PR
+	// with base==defaultBranch whose head was nonetheless built on top of a
+	// sibling open PR's branch). The base guard above already confirmed
+	// target == defaultBranch, so this only needs to gate on the second,
+	// cheaper precondition: skip the probe entirely when no other open
+	// autopilot PR is tracked for this repo (GH-5027 requirement 4 — zero
+	// added cost in the common case). detectStackedSuperset (GH-5029) is
+	// itself the source of truth for the symmetric case: when prState is
+	// the ANCESTOR/base of another open PR's stack, it returns nil, so that
+	// direction is never held here — only a PR that is a strict DESCENDANT
+	// of another open PR's head is.
+	c.mu.RLock()
+	hasOtherOpenPRs := len(c.activePRs) > 1
+	c.mu.RUnlock()
+	if hasOtherOpenPRs {
+		stackedOn, err := c.detectStackedSuperset(ctx, prState)
+		if err != nil {
+			// GH-5027 requirement 5: detection failure fails OPEN. This is a
+			// toil-reducing guard, not a correctness gate — handleMergeConflict
+			// already recovers a stacked PR that slips through, at the cost of
+			// one operator recovery cycle — so a broken ancestry probe must
+			// never wedge merging.
+			c.log.Warn("handleMerging: stacked-superset ancestry check failed, proceeding with merge (fail-open)",
+				"pr", prState.PRNumber, "error", err)
+		} else if stackedOn != nil {
+			// Hold this tick without merging; re-checked (and re-detected)
+			// on the next tick once the stacked-on PR merges. Reusing the
+			// parkForBaseMismatch pattern (label + alert + PR comment naming
+			// the base PR) instead of a bare hold is GH-5031's separately
+			// scoped follow-on.
+			c.log.Warn("handleMerging: PR is stacked on another open PR's unmerged head — holding merge",
+				"pr", prState.PRNumber, "stacked_on_pr", stackedOn.PRNumber)
+			return nil
+		}
+	}
+
 	prState.MergeAttempts++
 
 	c.log.Info("handleMerging: attempting merge",

--- a/internal/autopilot/controller_handlemerging_stacked_superset_test.go
+++ b/internal/autopilot/controller_handlemerging_stacked_superset_test.go
@@ -1,0 +1,190 @@
+package autopilot
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestController_handleMerging_StackedSuperset_HoldsMerge covers GH-5030:
+// handleMerging must invoke detectStackedSuperset (GH-5029) when this PR's
+// base is the default branch and another open autopilot PR is tracked for
+// the repo, and must hold rather than merge when the result is non-nil —
+// reproducing the #5016/#5017 incident shape (PR#17 built stacked on
+// still-open PR#16, both targeting main).
+func TestController_handleMerging_StackedSuperset_HoldsMerge(t *testing.T) {
+	local := newFixtureRepo(t)
+	ctx := context.Background()
+
+	runFixtureGit(t, local, "checkout", "-b", "pilot/GH-16")
+	writeFixtureFile(t, local, "base.txt", "from base PR\n")
+	runFixtureGit(t, local, "add", "base.txt")
+	runFixtureGit(t, local, "commit", "-m", "GH-16 work")
+	runFixtureGit(t, local, "push", "origin", "pilot/GH-16")
+	baseSHA := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	runFixtureGit(t, local, "checkout", "-b", "pilot/GH-17")
+	writeFixtureFile(t, local, "stacked.txt", "from stacked PR\n")
+	runFixtureGit(t, local, "add", "stacked.txt")
+	runFixtureGit(t, local, "commit", "-m", "GH-17 work, stacked on GH-16")
+	runFixtureGit(t, local, "push", "origin", "pilot/GH-17")
+	stackedSHA := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	commentCount := 0
+	server := mergeMockServer(t, 17, 17, &commentCount)
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.RequiredChecks = []string{"build"}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithProjectPath(local))
+	c.mu.Lock()
+	c.activePRs[16] = &PRState{
+		PRNumber:     16,
+		BranchName:   "pilot/GH-16",
+		HeadSHA:      baseSHA,
+		TargetBranch: "main",
+		Stage:        StageWaitingCI,
+		CreatedAt:    time.Now(),
+	}
+	stackedState := &PRState{
+		PRNumber:     17,
+		IssueNumber:  17,
+		BranchName:   "pilot/GH-17",
+		HeadSHA:      stackedSHA,
+		TargetBranch: "main",
+		Stage:        StageMerging,
+		CreatedAt:    time.Now(),
+	}
+	c.activePRs[17] = stackedState
+	c.mu.Unlock()
+
+	if err := c.handleMerging(ctx, stackedState); err != nil {
+		t.Fatalf("handleMerging returned error: %v", err)
+	}
+
+	if stackedState.Stage != StageMerging {
+		t.Errorf("Stage = %s, want %s (PR should be held, not advanced)", stackedState.Stage, StageMerging)
+	}
+	if stackedState.MergeAttempts != 0 {
+		t.Errorf("MergeAttempts = %d, want 0 (merge must not be attempted while stacked)", stackedState.MergeAttempts)
+	}
+	if commentCount != 0 {
+		t.Errorf("comment count = %d, want 0 (no completion comment while held)", commentCount)
+	}
+}
+
+// TestController_handleMerging_StackedSuperset_BaseOfStackNotBlocked covers
+// the GH-5027 symmetric-case requirement: the PR that is the BASE of a
+// stack (i.e. an ANCESTOR of another open PR's head) must merge unhindered
+// — detectStackedSuperset only holds the DESCENDANT side.
+func TestController_handleMerging_StackedSuperset_BaseOfStackNotBlocked(t *testing.T) {
+	local := newFixtureRepo(t)
+	ctx := context.Background()
+
+	runFixtureGit(t, local, "checkout", "-b", "pilot/GH-16")
+	writeFixtureFile(t, local, "base.txt", "from base PR\n")
+	runFixtureGit(t, local, "add", "base.txt")
+	runFixtureGit(t, local, "commit", "-m", "GH-16 work")
+	runFixtureGit(t, local, "push", "origin", "pilot/GH-16")
+	baseSHA := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	runFixtureGit(t, local, "checkout", "-b", "pilot/GH-17")
+	writeFixtureFile(t, local, "stacked.txt", "from stacked PR\n")
+	runFixtureGit(t, local, "add", "stacked.txt")
+	runFixtureGit(t, local, "commit", "-m", "GH-17 work, stacked on GH-16")
+	runFixtureGit(t, local, "push", "origin", "pilot/GH-17")
+	stackedSHA := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	commentCount := 0
+	server := mergeMockServer(t, 16, 16, &commentCount)
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.RequiredChecks = []string{"build"}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithProjectPath(local))
+	c.mu.Lock()
+	baseState := &PRState{
+		PRNumber:     16,
+		IssueNumber:  16,
+		BranchName:   "pilot/GH-16",
+		HeadSHA:      baseSHA,
+		TargetBranch: "main",
+		Stage:        StageMerging,
+		CreatedAt:    time.Now(),
+	}
+	c.activePRs[16] = baseState
+	c.activePRs[17] = &PRState{
+		PRNumber:     17,
+		BranchName:   "pilot/GH-17",
+		HeadSHA:      stackedSHA,
+		TargetBranch: "main",
+		Stage:        StageWaitingCI,
+		CreatedAt:    time.Now(),
+	}
+	c.mu.Unlock()
+
+	if err := c.handleMerging(ctx, baseState); err != nil {
+		t.Fatalf("handleMerging returned error: %v", err)
+	}
+
+	if baseState.MergeAttempts != 1 {
+		t.Errorf("MergeAttempts = %d, want 1 (base of stack must merge, not be held)", baseState.MergeAttempts)
+	}
+	if commentCount != 1 {
+		t.Errorf("comment count = %d, want 1 (merge completion comment expected)", commentCount)
+	}
+}
+
+// TestController_handleMerging_StackedSuperset_SkippedWhenNoOtherOpenPRs
+// covers GH-5027 requirement 4 at the wiring layer: with no other open
+// autopilot PR tracked, handleMerging must skip the ancestry probe
+// entirely (no local git / GitHub compare cost) and merge normally. Uses
+// no WithProjectPath and a server that has no compare-API handler, so a
+// wrongly-invoked probe would surface as a request/merge failure.
+func TestController_handleMerging_StackedSuperset_SkippedWhenNoOtherOpenPRs(t *testing.T) {
+	ctx := context.Background()
+
+	commentCount := 0
+	server := mergeMockServer(t, 30, 30, &commentCount)
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.RequiredChecks = []string{"build"}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.mu.Lock()
+	soloState := &PRState{
+		PRNumber:     30,
+		IssueNumber:  30,
+		BranchName:   "pilot/GH-30",
+		HeadSHA:      "deadbeef",
+		TargetBranch: "main",
+		Stage:        StageMerging,
+		CreatedAt:    time.Now(),
+	}
+	c.activePRs[30] = soloState
+	c.mu.Unlock()
+
+	if err := c.handleMerging(ctx, soloState); err != nil {
+		t.Fatalf("handleMerging returned error: %v", err)
+	}
+
+	if soloState.MergeAttempts != 1 {
+		t.Errorf("MergeAttempts = %d, want 1 (solo PR must merge normally)", soloState.MergeAttempts)
+	}
+	if commentCount != 1 {
+		t.Errorf("comment count = %d, want 1", commentCount)
+	}
+}

--- a/internal/autopilot/controller_stacked_superset_test.go
+++ b/internal/autopilot/controller_stacked_superset_test.go
@@ -1,0 +1,247 @@
+package autopilot
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestController_DetectStackedSuperset_LocalGit_Descendant reproduces the
+// GH-5027/GH-5029 shape via the local-git-first detection path: PR#17's
+// branch was built on top of PR#16's still-open branch (one extra commit),
+// both targeting main. detectStackedSuperset, called for PR#17, must report
+// PR#16 as the PR it is stacked on.
+func TestController_DetectStackedSuperset_LocalGit_Descendant(t *testing.T) {
+	local := newFixtureRepo(t)
+	ctx := context.Background()
+
+	runFixtureGit(t, local, "checkout", "-b", "pilot/GH-16")
+	writeFixtureFile(t, local, "base.txt", "from base PR\n")
+	runFixtureGit(t, local, "add", "base.txt")
+	runFixtureGit(t, local, "commit", "-m", "GH-16 work")
+	runFixtureGit(t, local, "push", "origin", "pilot/GH-16")
+	baseSHA := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	runFixtureGit(t, local, "checkout", "-b", "pilot/GH-17")
+	writeFixtureFile(t, local, "stacked.txt", "from stacked PR\n")
+	runFixtureGit(t, local, "add", "stacked.txt")
+	runFixtureGit(t, local, "commit", "-m", "GH-17 work, stacked on GH-16")
+	runFixtureGit(t, local, "push", "origin", "pilot/GH-17")
+	stackedSHA := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected GitHub API call on the local-git-first path: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithProjectPath(local))
+	c.mu.Lock()
+	c.activePRs[16] = &PRState{
+		PRNumber:     16,
+		BranchName:   "pilot/GH-16",
+		HeadSHA:      baseSHA,
+		TargetBranch: "main",
+		Stage:        StageWaitingCI,
+		CreatedAt:    time.Now(),
+	}
+	c.activePRs[17] = &PRState{
+		PRNumber:     17,
+		BranchName:   "pilot/GH-17",
+		HeadSHA:      stackedSHA,
+		TargetBranch: "main",
+		Stage:        StageMerging,
+		CreatedAt:    time.Now(),
+	}
+	c.mu.Unlock()
+
+	stackedOn, err := c.detectStackedSuperset(ctx, c.activePRs[17])
+	if err != nil {
+		t.Fatalf("detectStackedSuperset: %v", err)
+	}
+	if stackedOn == nil {
+		t.Fatal("expected PR#17 to be detected as stacked on PR#16")
+	}
+	if stackedOn.PRNumber != 16 {
+		t.Fatalf("stackedOn.PRNumber = %d, want 16", stackedOn.PRNumber)
+	}
+
+	// Symmetric case (GH-5027 requirement 5): PR#16 is the BASE of the
+	// stack — its head is an ANCESTOR, not a descendant, of PR#17's head —
+	// so detecting from PR#16's side must report no stacking.
+	stackedOn, err = c.detectStackedSuperset(ctx, c.activePRs[16])
+	if err != nil {
+		t.Fatalf("detectStackedSuperset (base direction): %v", err)
+	}
+	if stackedOn != nil {
+		t.Fatalf("expected PR#16 (the stack's base) to merge unhindered, but got stacked on PR#%d", stackedOn.PRNumber)
+	}
+}
+
+// TestController_DetectStackedSuperset_LocalGit_Unrelated covers two open
+// PRs with disjoint ancestry off main — neither should be flagged.
+func TestController_DetectStackedSuperset_LocalGit_Unrelated(t *testing.T) {
+	local := newFixtureRepo(t)
+	ctx := context.Background()
+
+	runFixtureGit(t, local, "checkout", "-b", "pilot/GH-20")
+	writeFixtureFile(t, local, "twenty.txt", "from GH-20\n")
+	runFixtureGit(t, local, "add", "twenty.txt")
+	runFixtureGit(t, local, "commit", "-m", "GH-20 work")
+	runFixtureGit(t, local, "push", "origin", "pilot/GH-20")
+	sha20 := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	runFixtureGit(t, local, "checkout", "main")
+	runFixtureGit(t, local, "checkout", "-b", "pilot/GH-21")
+	writeFixtureFile(t, local, "twentyone.txt", "from GH-21\n")
+	runFixtureGit(t, local, "add", "twentyone.txt")
+	runFixtureGit(t, local, "commit", "-m", "GH-21 work")
+	runFixtureGit(t, local, "push", "origin", "pilot/GH-21")
+	sha21 := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, "http://unused.invalid")
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithProjectPath(local))
+	c.mu.Lock()
+	c.activePRs[20] = &PRState{PRNumber: 20, BranchName: "pilot/GH-20", HeadSHA: sha20, TargetBranch: "main", Stage: StageMerging, CreatedAt: time.Now()}
+	c.activePRs[21] = &PRState{PRNumber: 21, BranchName: "pilot/GH-21", HeadSHA: sha21, TargetBranch: "main", Stage: StageMerging, CreatedAt: time.Now()}
+	c.mu.Unlock()
+
+	if stackedOn, err := c.detectStackedSuperset(ctx, c.activePRs[20]); err != nil || stackedOn != nil {
+		t.Fatalf("PR#20: got stackedOn=%v err=%v, want (nil, nil)", stackedOn, err)
+	}
+	if stackedOn, err := c.detectStackedSuperset(ctx, c.activePRs[21]); err != nil || stackedOn != nil {
+		t.Fatalf("PR#21: got stackedOn=%v err=%v, want (nil, nil)", stackedOn, err)
+	}
+}
+
+// TestController_DetectStackedSuperset_NoOtherOpenPRs covers GH-5027
+// requirement 4: with no other open autopilot PRs tracked, the check must
+// be a no-op (and, on the local-git path, must not even attempt a git
+// fetch — there is nothing to compare against).
+func TestController_DetectStackedSuperset_NoOtherOpenPRs(t *testing.T) {
+	local := newFixtureRepo(t)
+	ctx := context.Background()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, "http://unused.invalid")
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithProjectPath(local))
+	c.mu.Lock()
+	c.activePRs[30] = &PRState{PRNumber: 30, BranchName: "pilot/GH-30", HeadSHA: "deadbeef", TargetBranch: "main", Stage: StageMerging, CreatedAt: time.Now()}
+	c.mu.Unlock()
+
+	stackedOn, err := c.detectStackedSuperset(ctx, c.activePRs[30])
+	if err != nil {
+		t.Fatalf("detectStackedSuperset: %v", err)
+	}
+	if stackedOn != nil {
+		t.Fatalf("expected no stacking with no other open PRs, got PR#%d", stackedOn.PRNumber)
+	}
+}
+
+// TestController_DetectStackedSuperset_NonDefaultBase covers the
+// documented precondition: a PR whose own TargetBranch is not the default
+// branch is out of scope for this check (GH-4872's parkForBaseMismatch
+// already handles that shape) — detectStackedSuperset must no-op rather
+// than run the (moot) ancestry probe.
+func TestController_DetectStackedSuperset_NonDefaultBase(t *testing.T) {
+	ctx := context.Background()
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, "http://unused.invalid")
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.mu.Lock()
+	c.activePRs[40] = &PRState{PRNumber: 40, BranchName: "pilot/GH-40", HeadSHA: "aaaa", TargetBranch: "pilot/GH-39", Stage: StageMerging, CreatedAt: time.Now()}
+	c.activePRs[39] = &PRState{PRNumber: 39, BranchName: "pilot/GH-39", HeadSHA: "bbbb", TargetBranch: "main", Stage: StageWaitingCI, CreatedAt: time.Now()}
+	c.mu.Unlock()
+
+	stackedOn, err := c.detectStackedSuperset(ctx, c.activePRs[40])
+	if err != nil {
+		t.Fatalf("detectStackedSuperset: %v", err)
+	}
+	if stackedOn != nil {
+		t.Fatalf("expected no-op for a non-default-base PR, got stacked on PR#%d", stackedOn.PRNumber)
+	}
+}
+
+// TestController_HeadIsStrictDescendant_FallsBackToCompareAPI covers the
+// documented fallback: with no local clone available (c.projectPath ==
+// ""), headIsStrictDescendant must use the GitHub compare API instead of
+// erroring out.
+func TestController_HeadIsStrictDescendant_FallsBackToCompareAPI(t *testing.T) {
+	ctx := context.Background()
+
+	var comparedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/repos/owner/repo/compare/") {
+			comparedPath = r.URL.Path
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"ahead"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	// No WithProjectPath — forces the fallback.
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	isDescendant, err := c.headIsStrictDescendant(ctx, "pilot/GH-17", "stackedsha", "pilot/GH-16", "basesha")
+	if err != nil {
+		t.Fatalf("headIsStrictDescendant: %v", err)
+	}
+	if !isDescendant {
+		t.Fatal("expected compare-API fallback to report a strict descendant for status=ahead")
+	}
+	wantPath := "/repos/owner/repo/compare/basesha...stackedsha"
+	if comparedPath != wantPath {
+		t.Fatalf("compare path = %q, want %q", comparedPath, wantPath)
+	}
+}
+
+// TestController_HeadIsStrictDescendant_CompareAPIIdenticalIsNotDescendant
+// verifies "identical" (base and head are the same commit) is NOT treated
+// as a strict descendant via the fallback path, mirroring the local-git
+// same-commit short-circuit.
+func TestController_HeadIsStrictDescendant_CompareAPIIdenticalIsNotDescendant(t *testing.T) {
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"identical"}`))
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	isDescendant, err := c.headIsStrictDescendant(ctx, "pilot/GH-17", "samesha-on-both", "pilot/GH-16", "othersha")
+	if err != nil {
+		t.Fatalf("headIsStrictDescendant: %v", err)
+	}
+	if isDescendant {
+		t.Fatal("expected status=identical to NOT be reported as a strict descendant")
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5030.

Closes #5030

## Changes

Extend handleMerging (around controller.go:4198ff, alongside the existing parkForBaseMismatch call at :4237-4244) to invoke detectStackedSuperset only when the PR's base is the default branch and at least one other open autopilot PR exists for the repo. Do not block the symmetric case where this PR's head is an ancestor of another open PR's head, since that represents a valid stack base.