### PR TITLE
GH-5031: refactor(autopilot): reuse parkForBaseMismatch pattern for stacked-superset parking

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -667,6 +667,13 @@ type Controller struct {
 	// wrong base doesn't re-alert every poll tick while it stays unresolved.
 	alertedBaseMismatches map[string]bool
 
+	// alertedStackedSupersets deduplicates the stacked-superset escalation
+	// alert (GH-5027/GH-5031) per "PRNumber:stackedOnPRNumber", guarded by
+	// mu. parkForStackedSuperset fires this the first time a PR is held for
+	// being built stacked on another still-open PR's unmerged head, mirroring
+	// alertedBaseMismatches so a parked PR doesn't re-alert every poll tick.
+	alertedStackedSupersets map[string]bool
+
 	// alertedBranchDeleteHolds deduplicates the branch-delete-held escalation
 	// alert (GH-4872) per branch name, guarded by mu — safeDeleteBranch is
 	// called from four independent cleanup sites and a long-lived stacked
@@ -1687,6 +1694,130 @@ const baseMismatchReasonPrefix = "base branch mismatch:"
 // non-default base outside autopilot's own guarded merge path (external
 // merge, or discovered by the recently-merged-PR scanner).
 const basePivotCommentMarker = "<!-- pilot-base-pivot -->"
+
+// stackedSupersetCommentMarker identifies the GH-5027/GH-5031 stacked-superset
+// PR comment posted by postStackedSupersetComment, mirroring
+// baseMismatchCommentMarker so a re-parked tick doesn't re-post it.
+const stackedSupersetCommentMarker = "<!-- pilot-stacked-superset -->"
+
+// stackedSupersetReasonPrefix identifies an EscalationReason set by
+// parkForStackedSuperset, as opposed to any other cause that shares the same
+// Parked flag (e.g. parkForBaseMismatch, or submitAsyncApprovalRequest's
+// misconfig park) — mirrors baseMismatchReasonPrefix.
+const stackedSupersetReasonPrefix = "stacked on open PR:"
+
+// parkForStackedSuperset holds a PR at StageMerging without merging when
+// detectStackedSuperset (GH-5029) finds its head is a strict descendant of
+// another still-open PR's head — i.e. this PR was built stacked on top of
+// stackedOn's unmerged branch rather than off the default branch directly
+// (GH-5027, the #5016/#5017 2026-08-20 incident shape). Reuses the
+// parkForBaseMismatch pattern verbatim (GH-5031): hold + label + alert + PR
+// comment naming the base PR, with no new state-machine states — Parked and
+// EscalationReason are the same fields parkForBaseMismatch uses, just with a
+// distinct reason prefix so the two causes never clobber each other's
+// one-time side effects (mirrors GH-4909's reason-prefix disambiguation).
+// Idempotent via prState.Parked plus prState.EscalationReason, same as
+// parkForBaseMismatch.
+func (c *Controller) parkForStackedSuperset(ctx context.Context, prState *PRState, stackedOn *PRState) {
+	reason := fmt.Sprintf(
+		stackedSupersetReasonPrefix+" PR #%d is stacked on open PR #%d — merge that first",
+		prState.PRNumber, stackedOn.PRNumber,
+	)
+	alreadyParkedForThisStack := prState.Parked && prState.EscalationReason == reason
+	prState.EscalationReason = reason
+	if alreadyParkedForThisStack {
+		// Already logged/commented/alerted on a prior tick — stay parked quietly.
+		return
+	}
+	prState.Parked = true
+	c.log.Warn("handleMerging: PR is stacked on another open PR's unmerged head — holding instead of auto-merging",
+		"pr", prState.PRNumber, "stacked_on_pr", stackedOn.PRNumber)
+
+	if prState.IssueNumber > 0 {
+		if err := c.labeler.AddLabels(ctx, c.owner, c.repo, prState.IssueNumber, []string{labelParkedAwaitingApproval}); err != nil {
+			c.log.Warn("failed to apply parked-awaiting-approval label for stacked superset",
+				"issue", prState.IssueNumber, "pr", prState.PRNumber, "error", err)
+		}
+	}
+	c.alertStackedSupersetOnce(prState.PRNumber, prState.IssueNumber, stackedOn.PRNumber)
+	c.postStackedSupersetComment(ctx, prState, stackedOn.PRNumber)
+}
+
+// alertStackedSupersetOnce fires an escalation alert the first time autopilot
+// holds a pilot/GH-* PR because it is stacked on another still-open PR's
+// unmerged head (GH-5027/GH-5031). Deduplicated per "PRNumber:stackedOnPR"
+// via alertedStackedSupersets (same pattern as alertBaseMismatchOnce).
+func (c *Controller) alertStackedSupersetOnce(prNumber, issueNumber, stackedOnPR int) {
+	key := fmt.Sprintf("%d:%d", prNumber, stackedOnPR)
+
+	c.mu.Lock()
+	if c.alertedStackedSupersets == nil {
+		c.alertedStackedSupersets = make(map[string]bool)
+	}
+	if c.alertedStackedSupersets[key] {
+		c.mu.Unlock()
+		return
+	}
+	c.alertedStackedSupersets[key] = true
+	c.mu.Unlock()
+
+	msg := fmt.Sprintf(
+		"PR #%d (%s) is stacked on open PR #%d — merge that first; auto-merge is held to avoid squash-absorbing #%d's unmerged content",
+		prNumber, c.repoKey(), stackedOnPR, stackedOnPR,
+	)
+	if c.alertsEngine == nil {
+		c.log.Error("stacked_superset alert not delivered: SetAlertsEngine was never called",
+			"pr", prNumber, "stacked_on_pr", stackedOnPR)
+		return
+	}
+	c.alertsEngine.ProcessEvent(alerts.Event{
+		Type:      alerts.EventTypeEscalation,
+		TaskID:    fmt.Sprintf("pr-%d-stacked-superset", prNumber),
+		TaskTitle: fmt.Sprintf("PR #%d stacked on open PR #%d", prNumber, stackedOnPR),
+		Project:   c.repoKey(),
+		Error:     msg,
+		Timestamp: time.Now(),
+		Metadata: map[string]string{
+			"repo":          c.repoKey(),
+			"pr":            strconv.Itoa(prNumber),
+			"issue":         strconv.Itoa(issueNumber),
+			"stacked_on_pr": strconv.Itoa(stackedOnPR),
+		},
+	})
+}
+
+// postStackedSupersetComment posts a single explanatory comment on the PR
+// naming the base PR it is stacked on (GH-5027/GH-5031), idempotent via
+// stackedSupersetCommentMarker so a PR re-checked every poll tick while
+// parked only gets the one-time side effect once (mirrors
+// postBaseMismatchComment).
+func (c *Controller) postStackedSupersetComment(ctx context.Context, prState *PRState, stackedOnPR int) {
+	existing, err := c.ghClient.ListIssueComments(ctx, c.owner, c.repo, prState.PRNumber)
+	if err != nil {
+		c.log.Warn("postStackedSupersetComment: failed to list PR comments, will post anyway",
+			"pr", prState.PRNumber, "error", err)
+	} else {
+		for _, cmt := range existing {
+			if strings.Contains(cmt.Body, stackedSupersetCommentMarker) {
+				c.log.Debug("postStackedSupersetComment: already posted, skipping", "pr", prState.PRNumber)
+				return
+			}
+		}
+	}
+
+	body := fmt.Sprintf(`%s
+🚧 **Merge blocked: stacked on open PR #%d — merge that first**
+
+This PR's branch was built on top of PR #%d's still-open, unmerged branch, rather than off the default branch directly. Auto-merge refuses to land it out of order — merging this PR first would squash-absorb #%d's entire content under this PR's history, exactly the shape that orphaned commit history in a prior incident.
+
+Merge PR #%d first; this PR will resume automatically once that lands.`,
+		stackedSupersetCommentMarker, stackedOnPR, stackedOnPR, stackedOnPR, stackedOnPR)
+
+	if _, postErr := c.ghClient.AddPRComment(ctx, c.owner, c.repo, prState.PRNumber, body); postErr != nil {
+		c.log.Warn("postStackedSupersetComment: failed to post PR comment",
+			"pr", prState.PRNumber, "error", postErr)
+	}
+}
 
 // parkForBaseMismatch holds a PR at StageMerging without merging when its
 // base branch is not the repo's default (GH-4872). Root incident,
@@ -4276,6 +4407,40 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 			if err := c.labeler.RemoveLabel(ctx, c.owner, c.repo, prState.IssueNumber, labelParkedAwaitingApproval); err != nil {
 				c.log.Debug("parked-awaiting-approval label cleanup on un-park", "issue", prState.IssueNumber, "error", err)
 			}
+		}
+	}
+
+	// GH-5027/GH-5031: guard against merging a PR that is stacked on another
+	// still-open PR's unmerged head (the #5016/#5017 2026-08-20 incident
+	// shape — a PR with base==defaultBranch whose head was nonetheless built
+	// on top of a sibling open PR's branch). The base guard above already
+	// confirmed target == defaultBranch, so this only needs to gate on the
+	// second, cheaper precondition: skip the probe entirely when no other
+	// open autopilot PR is tracked for this repo (GH-5027 requirement 4 —
+	// zero added cost in the common case). detectStackedSuperset (GH-5029)
+	// is itself the source of truth for the symmetric case: when prState is
+	// the ANCESTOR/base of another open PR's stack, it returns nil, so that
+	// direction is never held here — only a PR that is a strict DESCENDANT
+	// of another open PR's head is. On a positive detection, park via
+	// parkForStackedSuperset (GH-5031) — the parkForBaseMismatch pattern
+	// reused verbatim (hold + label + alert + PR comment naming the base
+	// PR), not a bare hold.
+	c.mu.RLock()
+	hasOtherOpenPRs := len(c.activePRs) > 1
+	c.mu.RUnlock()
+	if hasOtherOpenPRs {
+		stackedOn, err := c.detectStackedSuperset(ctx, prState)
+		if err != nil {
+			// GH-5027 requirement 5: detection failure fails OPEN. This is a
+			// toil-reducing guard, not a correctness gate — handleMergeConflict
+			// already recovers a stacked PR that slips through, at the cost of
+			// one operator recovery cycle — so a broken ancestry probe must
+			// never wedge merging.
+			c.log.Warn("handleMerging: stacked-superset ancestry check failed, proceeding with merge (fail-open)",
+				"pr", prState.PRNumber, "error", err)
+		} else if stackedOn != nil {
+			c.parkForStackedSuperset(ctx, prState, stackedOn)
+			return nil
 		}
 	}
 

--- a/internal/autopilot/controller_gh5031_test.go
+++ b/internal/autopilot/controller_gh5031_test.go
@@ -1,0 +1,204 @@
+package autopilot
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestController_ParkForStackedSuperset_HoldsLabelsAlertsAndComments is the
+// GH-5031 regression: on a positive detectStackedSuperset result,
+// parkForStackedSuperset must reuse the parkForBaseMismatch pattern verbatim
+// — hold (Parked=true), apply labelParkedAwaitingApproval, fire exactly one
+// escalation alert, and post exactly one PR comment naming the base PR with
+// "stacked on open PR #<N> — merge that first" wording. A second call for
+// the SAME stack relationship must stay quiet (idempotent), mirroring
+// TestController_ParkForBaseMismatch_DistinctFromMisconfigPark.
+func TestController_ParkForStackedSuperset_HoldsLabelsAlertsAndComments(t *testing.T) {
+	var (
+		commentPosted atomic.Int32
+		labelApplied  atomic.Int32
+		commentBody   atomic.Value
+	)
+	commentBody.Store("")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues/117/comments" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			if commentPosted.Load() == 0 {
+				_, _ = w.Write([]byte("[]"))
+			} else {
+				_, _ = w.Write([]byte(`[{"id":1,"body":"` + stackedSupersetCommentMarker + `\nposted"}]`))
+			}
+		case r.URL.Path == "/repos/owner/repo/issues/117/comments" && r.Method == http.MethodPost:
+			body, _ := readRequestBody(r)
+			commentBody.Store(body)
+			commentPosted.Add(1)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":1,"body":"posted"}`))
+		case r.URL.Path == "/repos/owner/repo/issues/74/labels" && r.Method == http.MethodPost:
+			labelApplied.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	prState := &PRState{
+		PRNumber:    117,
+		IssueNumber: 74,
+		Stage:       StageMerging,
+	}
+	stackedOn := &PRState{PRNumber: 116}
+
+	c.parkForStackedSuperset(context.Background(), prState, stackedOn)
+
+	if !prState.Parked {
+		t.Error("Parked should be true after a positive stacked-superset detection")
+	}
+	if !strings.HasPrefix(prState.EscalationReason, stackedSupersetReasonPrefix) {
+		t.Errorf("EscalationReason = %q, want prefix %q", prState.EscalationReason, stackedSupersetReasonPrefix)
+	}
+	if labelApplied.Load() != 1 {
+		t.Errorf("parked-awaiting-approval label applied %d times, want 1", labelApplied.Load())
+	}
+	if commentPosted.Load() != 1 {
+		t.Errorf("PR comment posted %d times, want 1", commentPosted.Load())
+	}
+	if body, _ := commentBody.Load().(string); !strings.Contains(body, "stacked on open PR #116") || !strings.Contains(body, "merge that first") {
+		t.Errorf("comment body = %q, want it to name PR #116 with 'stacked on open PR #N — merge that first' wording", body)
+	}
+	if len(sink.events) != 1 {
+		t.Fatalf("alerts fired %d times, want 1", len(sink.events))
+	}
+
+	// A second call for the SAME stack relationship must stay quiet (idempotent).
+	c.parkForStackedSuperset(context.Background(), prState, stackedOn)
+	if commentPosted.Load() != 1 {
+		t.Errorf("PR comment posted %d times after repeat call, want 1 (idempotent)", commentPosted.Load())
+	}
+	if len(sink.events) != 1 {
+		t.Fatalf("alerts fired %d times after repeat call, want 1 (idempotent)", len(sink.events))
+	}
+}
+
+// TestController_HandleMerging_StackedSuperset_HoldsInsteadOfMerging is the
+// GH-5031 end-to-end wiring check: two open PRs where #17's head descends
+// from #16's still-open head (both base==main). Driving #17 through
+// handleMerging via ProcessPR must NOT call MergePR — it must hold via
+// parkForStackedSuperset instead, naming #16 in the PR comment.
+func TestController_HandleMerging_StackedSuperset_HoldsInsteadOfMerging(t *testing.T) {
+	local := newFixtureRepo(t)
+	ctx := context.Background()
+
+	runFixtureGit(t, local, "checkout", "-b", "pilot/GH-16")
+	writeFixtureFile(t, local, "base.txt", "from base PR\n")
+	runFixtureGit(t, local, "add", "base.txt")
+	runFixtureGit(t, local, "commit", "-m", "GH-16 work")
+	runFixtureGit(t, local, "push", "origin", "pilot/GH-16")
+	baseSHA := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	runFixtureGit(t, local, "checkout", "-b", "pilot/GH-17")
+	writeFixtureFile(t, local, "stacked.txt", "from stacked PR\n")
+	runFixtureGit(t, local, "add", "stacked.txt")
+	runFixtureGit(t, local, "commit", "-m", "GH-17 work, stacked on GH-16")
+	runFixtureGit(t, local, "push", "origin", "pilot/GH-17")
+	stackedSHA := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	var mergeCalled atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/17/merge" && r.Method == http.MethodPut:
+			mergeCalled.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"sha":"mergedSHA","merged":true,"message":"merged"}`))
+		case r.URL.Path == "/repos/owner/repo/issues/17/comments" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithProjectPath(local))
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	c.mu.Lock()
+	c.activePRs[16] = &PRState{
+		PRNumber:     16,
+		BranchName:   "pilot/GH-16",
+		HeadSHA:      baseSHA,
+		TargetBranch: "main",
+		Stage:        StageWaitingCI,
+		CreatedAt:    time.Now(),
+	}
+	c.activePRs[17] = &PRState{
+		PRNumber:     17,
+		IssueNumber:  117,
+		BranchName:   "pilot/GH-17",
+		HeadSHA:      stackedSHA,
+		TargetBranch: "main",
+		Stage:        StageMerging,
+		CreatedAt:    time.Now(),
+	}
+	c.mu.Unlock()
+
+	ghPR := &github.PullRequest{
+		Number: 17,
+		Head:   github.PRRef{SHA: stackedSHA},
+		Base:   github.PRRef{Ref: "main"},
+	}
+	if err := c.ProcessPR(ctx, 17, ghPR); err != nil {
+		t.Fatalf("ProcessPR: %v", err)
+	}
+
+	if mergeCalled.Load() != 0 {
+		t.Errorf("MergePR called %d times, want 0 — a PR stacked on another open PR must be held", mergeCalled.Load())
+	}
+	pr, ok := c.GetPRState(17)
+	if !ok {
+		t.Fatal("PR 17 should still be tracked")
+	}
+	if pr.Stage != StageMerging {
+		t.Errorf("Stage = %s, want %s (still held)", pr.Stage, StageMerging)
+	}
+	if !pr.Parked {
+		t.Error("Parked should be true")
+	}
+	if !strings.Contains(pr.EscalationReason, "PR #16") {
+		t.Errorf("EscalationReason = %q, want it to name PR #16", pr.EscalationReason)
+	}
+	if len(sink.events) != 1 {
+		t.Fatalf("alerts fired %d times, want 1", len(sink.events))
+	}
+}
+
+func readRequestBody(r *http.Request) (string, error) {
+	b, err := io.ReadAll(r.Body)
+	return string(b), err
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5031.

Closes #5031

## Changes

On positive stacked-superset detection, reuse the parkForBaseMismatch pattern verbatim: hold the PR, apply the label, send the alert, and post a PR comment naming the base PR with wording like 'stacked on open PR #N — merge that first'. Do not introduce any new state-machine states.