### PR TITLE
GH-5032: fix(autopilot): ensure parked PR resumes via existing re-drive path

### DIFF
--- a/.agent/tasks/gh-5032.md
+++ b/.agent/tasks/gh-5032.md
@@ -1,0 +1,43 @@
+# GH-5032
+
+**Created:** 2026-08-20
+
+## Problem
+
+Locate the mechanism that un-parks PRs held for base-mismatch today and confirm/mirror it so that a PR parked for the stacked-superset reason resumes through the same re-drive path once the blocking PR merges.
+
+## Acceptance Criteria
+
+- [x] Located the base-mismatch un-park mechanism: `handleMerging`'s GH-4911
+      block (`internal/autopilot/controller.go`) — re-checks the guard
+      condition every tick, and once it passes, clears `Parked` /
+      `EscalationReason` (matched via `baseMismatchReasonPrefix`) and removes
+      the `autopilot/parked-awaiting-approval` label, letting the merge
+      attempt fall through in the same tick.
+- [x] Added a sibling un-park block, gated on a new `stackedSupersetReasonPrefix`
+      constant (`"stacked on open PR:"`), that re-runs `detectStackedSuperset`
+      (GH-5029, already merged via #5035) each tick a stacked-superset-parked
+      PR is processed. Resolves (un-parks, falls through to merge) once the
+      ancestry probe no longer reports a blocking open PR; otherwise stays
+      parked and returns without attempting a merge. Fails open (un-parks) on
+      a probe error, matching GH-5027 requirement 5's fail-open policy for
+      this exact probe.
+- [x] Regression tests: `controller_gh5032_test.go` covers both directions
+      (resumes + merges once the blocking PR is gone; stays held while it's
+      still open) using the same local-git fixture harness as the
+      `detectStackedSuperset` tests.
+
+### Note on sibling issues (GH-5027 decomposition)
+
+The actual parking primitive this un-park mirrors —
+`parkForStackedSuperset` / setting `Parked=true` with the
+`stackedSupersetReasonPrefix` reason — is GH-5031's scope (PR #5037, open,
+not yet merged as of this task). This PR defines the identical constant
+name/value independently so the un-park logic is functional and testable on
+its own (Parked/EscalationReason are read generically, exactly like the
+GH-4911 base-mismatch case, regardless of which tick/process set them — the
+state may be restored from the state store, GH-4598). Expect a small,
+easily-resolved textual merge conflict on `stackedSupersetReasonPrefix`
+when #5037 lands — not a repeat of the stacked-superset incident itself,
+since neither PR silently absorbs the other's unmerged commits.
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1682,6 +1682,18 @@ const baseMismatchCommentMarker = "<!-- pilot-base-mismatch -->"
 // before clearing it, so it never clobbers an unrelated, still-active park.
 const baseMismatchReasonPrefix = "base branch mismatch:"
 
+// stackedSupersetReasonPrefix identifies an EscalationReason set by
+// parkForStackedSuperset (GH-5027/GH-5031) when a PR is held for being built
+// stacked on another still-open PR's unmerged head — the sibling park cause
+// to baseMismatchReasonPrefix above, sharing the same Parked flag. Value
+// matches parkForStackedSuperset's exactly so the two land compatible
+// regardless of merge order between GH-5031 and this un-park mirror
+// (GH-5032): this file's un-park check below reads Parked/EscalationReason
+// generically, the same way GH-4911's does, and does not require
+// parkForStackedSuperset to have run in this process — the state may equally
+// have been restored from the state store (GH-4598) on a prior tick.
+const stackedSupersetReasonPrefix = "stacked on open PR:"
+
 // basePivotCommentMarker identifies the GH-4872 "merged sideways" comment
 // posted by postBasePivotComment to an issue whose linked PR merged into a
 // non-default base outside autopilot's own guarded merge path (external
@@ -4276,6 +4288,54 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 			if err := c.labeler.RemoveLabel(ctx, c.owner, c.repo, prState.IssueNumber, labelParkedAwaitingApproval); err != nil {
 				c.log.Debug("parked-awaiting-approval label cleanup on un-park", "issue", prState.IssueNumber, "error", err)
 			}
+		}
+	}
+
+	// GH-5032: mirrors the GH-4911 un-park immediately above, for the
+	// sibling stacked-superset park (GH-5027/GH-5031, parkForStackedSuperset)
+	// instead of the base-mismatch one. Unlike the base-mismatch case, the
+	// resolving condition ("is the PR this one was stacked on still an open
+	// ancestor?") isn't a field already re-read earlier in this function, so
+	// this re-runs detectStackedSuperset (GH-5029) directly rather than
+	// trusting the stale park reason — the PR this one was stacked on may
+	// have merged, been closed, or the stack may have been rebased away
+	// since the park was set. Same idempotent Parked/EscalationReason/label
+	// residue-cleanup shape as GH-4911, and likewise does not depend on
+	// parkForStackedSuperset having fired in this process — the park state
+	// may equally have been restored from the state store (GH-4598) on a
+	// prior tick, same as the base-mismatch case.
+	//
+	// Fails OPEN (un-parks) on a detection error, matching GH-5027
+	// requirement 5's fail-open policy for this exact probe: it's a
+	// toil-reducing guard, not a correctness gate, and a transient ancestry
+	// lookup failure must never wedge a PR parked here indefinitely —
+	// handleMergeConflict downstream still recovers a genuinely-stacked PR
+	// that slips through, at the cost of one operator recovery cycle.
+	if prState.Parked && strings.HasPrefix(prState.EscalationReason, stackedSupersetReasonPrefix) {
+		stackedOn, err := c.detectStackedSuperset(ctx, prState)
+		if err != nil {
+			c.log.Warn("handleMerging: stacked-superset re-check failed while parked — un-parking anyway (fail-open, mirrors GH-5027 requirement 5)",
+				"pr", prState.PRNumber, "error", err)
+		}
+		if err != nil || stackedOn == nil {
+			c.log.Info("handleMerging: un-parking PR — stacked-superset resolved, blocking PR no longer an open ancestor",
+				"pr", prState.PRNumber, "issue", prState.IssueNumber, "prior_reason", prState.EscalationReason)
+			prState.Parked = false
+			prState.EscalationReason = ""
+			if prState.IssueNumber > 0 {
+				if err := c.labeler.RemoveLabel(ctx, c.owner, c.repo, prState.IssueNumber, labelParkedAwaitingApproval); err != nil {
+					c.log.Debug("parked-awaiting-approval label cleanup on un-park", "issue", prState.IssueNumber, "error", err)
+				}
+			}
+		} else {
+			// Still stacked on stackedOn's still-open head — stay parked and
+			// re-check again next tick, exactly like parkForStackedSuperset's
+			// own hold (and unlike the base-mismatch guard above, which
+			// already returned early via parkForBaseMismatch before this
+			// point ever runs). Do not fall through to a merge attempt.
+			c.log.Debug("handleMerging: PR still stacked on an open PR — staying parked",
+				"pr", prState.PRNumber, "stacked_on_pr", stackedOn.PRNumber)
+			return nil
 		}
 	}
 

--- a/internal/autopilot/controller_gh5032_test.go
+++ b/internal/autopilot/controller_gh5032_test.go
@@ -1,0 +1,220 @@
+package autopilot
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestController_ProcessPR_StackedSuperset_UnparksAndResumesOnceBlockingPRGone
+// is the GH-5032 regression: a PR parked for the stacked-superset reason
+// (GH-5027/GH-5031, parkForStackedSuperset — reproduced here directly on
+// PRState the same way GH-4909's base-mismatch resume test does, since
+// Parked/EscalationReason persist across ticks via the state store, GH-4598,
+// regardless of which prior tick or process set them) must resume and merge
+// on the very next tick once the PR it was stacked on is no longer an open
+// ancestor — mirroring GH-4911's base-mismatch un-park path exactly, with no
+// manual `gh pr merge`.
+func TestController_ProcessPR_StackedSuperset_UnparksAndResumesOnceBlockingPRGone(t *testing.T) {
+	local := newFixtureRepo(t)
+	ctx := context.Background()
+
+	runFixtureGit(t, local, "checkout", "-b", "pilot/GH-16")
+	writeFixtureFile(t, local, "base.txt", "from base PR\n")
+	runFixtureGit(t, local, "add", "base.txt")
+	runFixtureGit(t, local, "commit", "-m", "GH-16 work")
+	runFixtureGit(t, local, "push", "origin", "pilot/GH-16")
+
+	runFixtureGit(t, local, "checkout", "-b", "pilot/GH-17")
+	writeFixtureFile(t, local, "stacked.txt", "from stacked PR\n")
+	runFixtureGit(t, local, "add", "stacked.txt")
+	runFixtureGit(t, local, "commit", "-m", "GH-17 work, stacked on GH-16")
+	runFixtureGit(t, local, "push", "origin", "pilot/GH-17")
+	stackedSHA := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	var (
+		mergeCalled      atomic.Int32
+		labelRemoveCalls atomic.Int32
+	)
+
+	const labelPath = "/repos/owner/repo/issues/174/labels"
+	const labelRemovePath = labelPath + "/autopilot/parked-awaiting-approval"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/17/merge" && r.Method == http.MethodPut:
+			mergeCalled.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"sha":"mergedSHA","merged":true,"message":"merged"}`))
+		case r.URL.Path == labelRemovePath && r.Method == http.MethodDelete:
+			labelRemoveCalls.Add(1)
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == labelPath && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithProjectPath(local))
+	c.SetAlertsEngine(&fakeAlertSink{})
+
+	c.mu.Lock()
+	// PR#16 (the PR #17 was stacked on) has already merged and is no longer
+	// tracked as an active/open PR — detectStackedSuperset only ever
+	// compares against c.activePRs, so removing it here is the same signal
+	// a real merge produces (removePR drops the entry from activePRs).
+	c.activePRs[17] = &PRState{
+		PRNumber:         17,
+		IssueNumber:      174,
+		BranchName:       "pilot/GH-17",
+		HeadSHA:          stackedSHA,
+		TargetBranch:     "main",
+		Stage:            StageMerging,
+		Parked:           true,
+		EscalationReason: "stacked on open PR: PR #17 is stacked on open PR #16 — merge that first",
+		CreatedAt:        time.Now(),
+	}
+	c.mu.Unlock()
+
+	ghPR := &github.PullRequest{
+		Number: 17,
+		Head:   github.PRRef{SHA: stackedSHA},
+		Base:   github.PRRef{Ref: "main"},
+	}
+
+	if err := c.ProcessPR(ctx, 17, ghPR); err != nil {
+		t.Fatalf("ProcessPR returned error: %v", err)
+	}
+
+	if mergeCalled.Load() != 1 {
+		t.Errorf("merge called %d times, want 1 — PR#17 must resume auto-merge without manual intervention once PR#16 is gone", mergeCalled.Load())
+	}
+
+	pr, ok := c.GetPRState(17)
+	if !ok {
+		t.Fatal("PR 17 should still be tracked")
+	}
+	if pr.Stage != StageMerged {
+		t.Errorf("Stage = %s, want %s", pr.Stage, StageMerged)
+	}
+	if pr.Parked {
+		t.Error("Parked should be false after the stacked-superset block resolved and the PR merged")
+	}
+	if pr.EscalationReason != "" {
+		t.Errorf("EscalationReason = %q, want empty after un-park", pr.EscalationReason)
+	}
+	if labelRemoveCalls.Load() != 1 {
+		t.Errorf("parked-awaiting-approval label removal calls = %d, want 1", labelRemoveCalls.Load())
+	}
+}
+
+// TestController_ProcessPR_StackedSuperset_StaysParkedWhileBlockingPRStillOpen
+// covers the negative case: PR#17 is still parked and PR#16 (the PR it is
+// stacked on) is still open/tracked — detectStackedSuperset must still
+// report the stacking, so the un-park check must leave the PR parked and
+// must NOT attempt a merge.
+func TestController_ProcessPR_StackedSuperset_StaysParkedWhileBlockingPRStillOpen(t *testing.T) {
+	local := newFixtureRepo(t)
+	ctx := context.Background()
+
+	runFixtureGit(t, local, "checkout", "-b", "pilot/GH-16")
+	writeFixtureFile(t, local, "base.txt", "from base PR\n")
+	runFixtureGit(t, local, "add", "base.txt")
+	runFixtureGit(t, local, "commit", "-m", "GH-16 work")
+	runFixtureGit(t, local, "push", "origin", "pilot/GH-16")
+	baseSHA := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	runFixtureGit(t, local, "checkout", "-b", "pilot/GH-17")
+	writeFixtureFile(t, local, "stacked.txt", "from stacked PR\n")
+	runFixtureGit(t, local, "add", "stacked.txt")
+	runFixtureGit(t, local, "commit", "-m", "GH-17 work, stacked on GH-16")
+	runFixtureGit(t, local, "push", "origin", "pilot/GH-17")
+	stackedSHA := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	var mergeCalled atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/17/merge" && r.Method == http.MethodPut:
+			mergeCalled.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"sha":"mergedSHA","merged":true,"message":"merged"}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithProjectPath(local))
+	c.SetAlertsEngine(&fakeAlertSink{})
+
+	c.mu.Lock()
+	c.activePRs[16] = &PRState{
+		PRNumber:     16,
+		BranchName:   "pilot/GH-16",
+		HeadSHA:      baseSHA,
+		TargetBranch: "main",
+		Stage:        StageWaitingCI,
+		CreatedAt:    time.Now(),
+	}
+	c.activePRs[17] = &PRState{
+		PRNumber:         17,
+		IssueNumber:      174,
+		BranchName:       "pilot/GH-17",
+		HeadSHA:          stackedSHA,
+		TargetBranch:     "main",
+		Stage:            StageMerging,
+		Parked:           true,
+		EscalationReason: "stacked on open PR: PR #17 is stacked on open PR #16 — merge that first",
+		CreatedAt:        time.Now(),
+	}
+	c.mu.Unlock()
+
+	ghPR := &github.PullRequest{
+		Number: 17,
+		Head:   github.PRRef{SHA: stackedSHA},
+		Base:   github.PRRef{Ref: "main"},
+	}
+
+	if err := c.ProcessPR(ctx, 17, ghPR); err != nil {
+		t.Fatalf("ProcessPR returned error: %v", err)
+	}
+
+	if mergeCalled.Load() != 0 {
+		t.Errorf("merge called %d times, want 0 — PR#17 must stay held while PR#16 is still open", mergeCalled.Load())
+	}
+
+	pr, ok := c.GetPRState(17)
+	if !ok {
+		t.Fatal("PR 17 should still be tracked")
+	}
+	if pr.Stage != StageMerging {
+		t.Errorf("Stage = %s, want %s (must not advance while still stacked)", pr.Stage, StageMerging)
+	}
+	if !pr.Parked {
+		t.Error("Parked should remain true while PR#16 is still open")
+	}
+	if !strings.HasPrefix(pr.EscalationReason, stackedSupersetReasonPrefix) {
+		t.Errorf("EscalationReason = %q, want it to still carry the stacked-superset reason", pr.EscalationReason)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5032.

Closes #5032

## Changes

Locate the mechanism that un-parks PRs held for base-mismatch today and confirm/mirror it so that a PR parked for the stacked-superset reason resumes through the same re-drive path once the blocking PR merges.