### PR TITLE
GH-5044: feat(github): add base-presence probe helpers

### DIFF
--- a/internal/adapters/github/repo_state.go
+++ b/internal/adapters/github/repo_state.go
@@ -1,0 +1,55 @@
+package github
+
+import "context"
+
+// FileExistsOnDefaultBranch reports whether path exists in owner/repo on the
+// repository's default branch. It wraps GetFileContent with an empty ref
+// (which GetFileContent already treats as "use the default branch") and
+// collapses a 404 into (false, nil) rather than an error, since "the file
+// isn't there" is an expected, non-exceptional outcome for this check.
+// Any other failure (auth, rate limit, network) is still returned as an
+// error so callers don't silently treat a broken request as "file missing".
+func (c *Client) FileExistsOnDefaultBranch(ctx context.Context, owner, repo, path string) (bool, error) {
+	_, err := c.GetFileContent(ctx, owner, repo, path, "")
+	if err != nil {
+		if isNotFoundError(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// IssueOrPRState fetches #number via the Issues API and reports what it is.
+// GitHub numbers issues and pull requests from the same sequence and the
+// Issues API (GET /repos/{owner}/{repo}/issues/{number}) returns both; a
+// non-nil pull_request field on the response is GitHub's own signal that
+// the numbered item is a PR rather than a plain issue (see Issue.PullRequest).
+//
+// kind is "issue" or "pr". state mirrors GitHub's PR lifecycle: "open",
+// "closed", or "merged" (a merged PR still reports state "closed" from the
+// Issues/Pulls API, so callers wanting to distinguish merged-vs-abandoned
+// need the extra GetPullRequest round trip this function makes to check
+// Merged). For kind "issue", state is the issue's own "open"/"closed".
+func (c *Client) IssueOrPRState(ctx context.Context, owner, repo string, number int) (kind, state string, err error) {
+	issue, err := c.GetIssue(ctx, owner, repo, number)
+	if err != nil {
+		return "", "", err
+	}
+
+	if issue.PullRequest == nil {
+		return "issue", issue.State, nil
+	}
+
+	// #number is a PR. Re-fetch via the Pulls API to get the Merged flag —
+	// the Issues API alone can't distinguish a merged PR from one closed
+	// without merging (both report state "closed").
+	pr, err := c.GetPullRequest(ctx, owner, repo, number)
+	if err != nil {
+		return "", "", err
+	}
+	if pr.Merged {
+		return "pr", "merged", nil
+	}
+	return "pr", pr.State, nil
+}

--- a/internal/adapters/github/repo_state_test.go
+++ b/internal/adapters/github/repo_state_test.go
@@ -1,0 +1,212 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+func TestFileExistsOnDefaultBranch_Exists(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/owner/repo/contents/README.md" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.RawQuery != "" {
+			t.Errorf("expected no ref query param on default branch, got %q", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"content":  "aGVsbG8=",
+			"encoding": "base64",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	got, err := client.FileExistsOnDefaultBranch(context.Background(), "owner", "repo", "README.md")
+	if err != nil {
+		t.Fatalf("FileExistsOnDefaultBranch() error = %v", err)
+	}
+	if !got {
+		t.Errorf("FileExistsOnDefaultBranch() = false, want true")
+	}
+}
+
+func TestFileExistsOnDefaultBranch_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "Not Found"})
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	got, err := client.FileExistsOnDefaultBranch(context.Background(), "owner", "repo", "missing.md")
+	if err != nil {
+		t.Fatalf("FileExistsOnDefaultBranch() error = %v, want nil (404 should be absorbed)", err)
+	}
+	if got {
+		t.Errorf("FileExistsOnDefaultBranch() = true, want false for 404 response")
+	}
+}
+
+func TestFileExistsOnDefaultBranch_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "Internal Server Error"})
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	got, err := client.FileExistsOnDefaultBranch(context.Background(), "owner", "repo", "README.md")
+	if err == nil {
+		t.Fatal("FileExistsOnDefaultBranch() error = nil, want error for 500 response")
+	}
+	if got {
+		t.Errorf("FileExistsOnDefaultBranch() = true, want false alongside a propagated error")
+	}
+}
+
+func TestIssueOrPRState_PlainIssue(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/owner/repo/issues/42" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"number": 42,
+			"state":  "open",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	kind, state, err := client.IssueOrPRState(context.Background(), "owner", "repo", 42)
+	if err != nil {
+		t.Fatalf("IssueOrPRState() error = %v", err)
+	}
+	if kind != "issue" || state != "open" {
+		t.Errorf("IssueOrPRState() = (%q, %q), want (\"issue\", \"open\")", kind, state)
+	}
+}
+
+func TestIssueOrPRState_OpenPR(t *testing.T) {
+	var calls []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls = append(calls, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/owner/repo/issues/7":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"number":       7,
+				"state":        "open",
+				"pull_request": map[string]interface{}{},
+			})
+		case "/repos/owner/repo/pulls/7":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"number": 7,
+				"state":  "open",
+				"merged": false,
+			})
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	kind, state, err := client.IssueOrPRState(context.Background(), "owner", "repo", 7)
+	if err != nil {
+		t.Fatalf("IssueOrPRState() error = %v", err)
+	}
+	if kind != "pr" || state != "open" {
+		t.Errorf("IssueOrPRState() = (%q, %q), want (\"pr\", \"open\")", kind, state)
+	}
+	if len(calls) != 2 {
+		t.Errorf("expected 2 requests (issues then pulls), got %v", calls)
+	}
+}
+
+func TestIssueOrPRState_MergedPR(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/owner/repo/issues/9":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"number":       9,
+				"state":        "closed",
+				"pull_request": map[string]interface{}{},
+			})
+		case "/repos/owner/repo/pulls/9":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"number": 9,
+				"state":  "closed",
+				"merged": true,
+			})
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	kind, state, err := client.IssueOrPRState(context.Background(), "owner", "repo", 9)
+	if err != nil {
+		t.Fatalf("IssueOrPRState() error = %v", err)
+	}
+	if kind != "pr" || state != "merged" {
+		t.Errorf("IssueOrPRState() = (%q, %q), want (\"pr\", \"merged\")", kind, state)
+	}
+}
+
+func TestIssueOrPRState_ClosedUnmergedPR(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/owner/repo/issues/11":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"number":       11,
+				"state":        "closed",
+				"pull_request": map[string]interface{}{},
+			})
+		case "/repos/owner/repo/pulls/11":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"number": 11,
+				"state":  "closed",
+				"merged": false,
+			})
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	kind, state, err := client.IssueOrPRState(context.Background(), "owner", "repo", 11)
+	if err != nil {
+		t.Fatalf("IssueOrPRState() error = %v", err)
+	}
+	if kind != "pr" || state != "closed" {
+		t.Errorf("IssueOrPRState() = (%q, %q), want (\"pr\", \"closed\")", kind, state)
+	}
+}
+
+func TestIssueOrPRState_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "Not Found"})
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	_, _, err := client.IssueOrPRState(context.Background(), "owner", "repo", 999)
+	if err == nil {
+		t.Fatal("IssueOrPRState() error = nil, want error for 404 response")
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5044.

Closes #5044

## Changes

In internal/adapters/github/, add two thin, testable helpers on the existing client: FileExistsOnDefaultBranch(ctx, owner, repo, path) (bool, error) (wraps GetContents on the repo's default branch; treats 404 as false, nil) and IssueOrPRState(ctx, owner, repo, number) (kind, state string, err error) (returns whether #N is an issue with an open/merged/closed PR attached, or an open/merged PR itself — reuses go-github's pulls/issues endpoints). Ship with httptest-driven unit tests covering the 404-as-absent, open-PR, and merged-PR shapes. Nothing else calls these yet, so no wiring beyond the client file + its _test.go. This exists purely so subtask 2 can consume it without cross-package churn.