### PR TITLE
GH-5045: feat(executor): dispatcher base-presence gate before claim

### DIFF
--- a/internal/executor/base_presence.go
+++ b/internal/executor/base_presence.go
@@ -1,0 +1,277 @@
+// Package executor — GH-5045
+//
+// Dispatch-time "base presence" guard: before a queued task's claim commits
+// to executing, check whether the issue body's own stated prerequisites
+// (an explicit "Depends on: #N" reference, or a backtick-quoted file path)
+// have actually landed on the target repo's default branch yet. A sub-issue
+// authored against a still-open sibling PR, or against a path a prior step
+// hasn't merged yet, has nothing to build on — executing it anyway wastes a
+// run reproducing work that's already in flight or racing a base that
+// doesn't exist.
+//
+// Mirrors issue_state.go's IssueStateChecker/fetchIssueState shape: a
+// narrow probe interface (BasePresenceProbe), a gh-CLI fallback
+// implementation, per-repo registration on Runner
+// (RegisterBasePresenceProbe/basePresenceProbeFor), and a swappable
+// package-level var (checkBasePresence) so dispatcher.go's claim-path check
+// and tests both call the exact same entry point.
+package executor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// resolveOwnerRepoForBasePresence resolves (owner, repo) for the claim-path
+// hold check, mirroring fetchIssueState's resolution order (issue_state.go):
+// task.SourceRepo when populated, else the `origin` remote at projectPath.
+// buildTaskFromExecution never populates SourceRepo, so the dispatcher
+// claim-path call site always falls through to the git-remote path.
+func resolveOwnerRepoForBasePresence(ctx context.Context, task *Task, projectPath string) (string, string, error) {
+	owner, repo := "", ""
+	if task.SourceRepo != "" {
+		owner, repo, _ = strings.Cut(task.SourceRepo, "/")
+	}
+	if owner != "" && repo != "" {
+		return owner, repo, nil
+	}
+	return resolveGitRemote(ctx, projectPath)
+}
+
+// labelPilotNeedsHuman is the escalation label applied once a held task has
+// exhausted DispatcherConfig.BasePresenceHoldMaxCycles held cycles without
+// its prerequisites landing — mirrors labelPilotSuperseded's
+// cycle-avoidance pattern (issue_state.go): defined once here rather than
+// imported from adapters/github to avoid the same import-cycle constraint
+// documented there.
+const labelPilotNeedsHuman = "pilot-needs-human"
+
+// RefState is the live GitHub state of one dependency-ref number, just
+// enough for basePresenceChecker to decide whether it still blocks a
+// dependent task.
+type RefState struct {
+	// Found is false when number resolved to neither a PR nor an issue
+	// (deleted, cross-repo, or a lookup error the caller chose to
+	// swallow). A not-found ref never blocks — there's nothing to wait on.
+	Found bool
+	// IsPR is true when number resolved to a pull request rather than a
+	// plain issue. Only an open PR counts as an unmet prerequisite; an
+	// open issue reference doesn't imply anything about main's state.
+	IsPR bool
+	// Open is true when the resolved PR/issue has not yet been
+	// merged/closed.
+	Open bool
+}
+
+// BasePresenceProbe is the narrow read surface basePresenceChecker needs:
+// one lookup for a referenced issue/PR's live state, one existence check
+// for a referenced file path on the repo's default branch. Kept as an
+// interface (rather than calling gh/adapters directly) so tests inject
+// fakes — mirrors IssueStateChecker (issue_state.go) and
+// ContractContentFetcher (contract_evidence.go).
+type BasePresenceProbe interface {
+	// IssueOrPRState fetches the live state of issue-or-PR `number` in
+	// owner/repo. Implementations must make at most one GitHub API call.
+	IssueOrPRState(ctx context.Context, owner, repo string, number int) (RefState, error)
+	// FileExistsOnDefaultBranch reports whether path exists at HEAD of
+	// owner/repo's default branch.
+	FileExistsOnDefaultBranch(ctx context.Context, owner, repo, path string) (bool, error)
+}
+
+// BasePresenceHold is the result of basePresenceChecker.Check: whether the
+// task should be held back from claiming, and if so, the human-readable
+// reason (used in the log line and execution-event detail).
+type BasePresenceHold struct {
+	Held   bool
+	Reason string
+}
+
+// basePresenceChecker runs BasePresenceProbe lookups over a task's
+// extracted refs/paths and decides whether any of them is an unmet
+// prerequisite. Fails open per-lookup: a probe error is logged by the
+// caller and treated as "not a hold" for that one ref/path, consistent
+// with every other GH-4656-era pickup-time guard's "pipeline availability
+// outranks the guard" stance (issue_state.go).
+type basePresenceChecker struct {
+	probe BasePresenceProbe
+}
+
+// Check returns the first unmet prerequisite found among refs (checked
+// before paths, in caller-supplied order) — an open-PR ref, or a path
+// missing from the default branch. Returns a zero-value (not held) result
+// when nothing blocks, including when probe is nil (no adapter wired for
+// this repo) or every lookup errors.
+func (c basePresenceChecker) Check(ctx context.Context, owner, repo string, refs []int, paths []string) BasePresenceHold {
+	if c.probe == nil {
+		return BasePresenceHold{}
+	}
+
+	for _, n := range refs {
+		state, err := c.probe.IssueOrPRState(ctx, owner, repo, n)
+		if err != nil || !state.Found {
+			continue
+		}
+		if state.IsPR && state.Open {
+			return BasePresenceHold{
+				Held:   true,
+				Reason: fmt.Sprintf("referenced PR #%d is still open (not merged)", n),
+			}
+		}
+	}
+
+	for _, p := range paths {
+		exists, err := c.probe.FileExistsOnDefaultBranch(ctx, owner, repo, p)
+		if err != nil {
+			continue
+		}
+		if !exists {
+			return BasePresenceHold{
+				Held:   true,
+				Reason: fmt.Sprintf("referenced path %q not found on default branch", p),
+			}
+		}
+	}
+
+	return BasePresenceHold{}
+}
+
+// ghCLIBasePresenceProbe is the default fallback BasePresenceProbe: shells
+// out to `gh`, the same idiom used by ghCLIIssueStateChecker (issue_state.go)
+// for repos with no registered SDK-backed probe.
+type ghCLIBasePresenceProbe struct{}
+
+// IssueOrPRState implements BasePresenceProbe by trying `gh pr view` first
+// (a dependency ref is far more often a PR than a bare issue for a
+// "prerequisite not landed" check), falling back to `gh issue view` when
+// the number isn't a PR. Never shells out during `go test`.
+func (ghCLIBasePresenceProbe) IssueOrPRState(ctx context.Context, owner, repo string, number int) (RefState, error) {
+	if testing.Testing() {
+		return RefState{}, fmt.Errorf("ghCLIBasePresenceProbe: shellout disabled under go test")
+	}
+
+	if state, ok, err := ghViewState(ctx, "pr", owner, repo, number); ok {
+		return RefState{Found: true, IsPR: true, Open: state}, nil
+	} else if err != nil {
+		// Fall through to the issue lookup — a "pr view" failure just as
+		// often means "this number is an issue, not a PR" as it does a
+		// real error; the issue lookup below is the tiebreaker.
+		_ = err
+	}
+
+	state, ok, err := ghViewState(ctx, "issue", owner, repo, number)
+	if err != nil {
+		return RefState{}, fmt.Errorf("gh pr/issue view %d in %s/%s: %w", number, owner, repo, err)
+	}
+	if !ok {
+		return RefState{}, nil
+	}
+	return RefState{Found: true, IsPR: false, Open: state}, nil
+}
+
+// ghViewState runs `gh <kind> view <number> --repo owner/repo --json
+// state` and reports the parsed open/closed-or-merged state. ok is false
+// when the command failed outright (number doesn't resolve as this kind);
+// err is only non-nil for a genuine transport/parse failure, distinct from
+// "not this kind" (which returns ok=false, err=nil).
+func ghViewState(ctx context.Context, kind, owner, repo string, number int) (open bool, ok bool, err error) {
+	args := []string{kind, "view", strconv.Itoa(number), "--repo", owner + "/" + repo, "--json", "state"}
+	cmd := withGhCredentials(ctx, exec.CommandContext(ctx, "gh", args...))
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if runErr := cmd.Run(); runErr != nil {
+		return false, false, nil
+	}
+
+	var resp struct {
+		State string `json:"state"`
+	}
+	if jsonErr := json.Unmarshal(stdout.Bytes(), &resp); jsonErr != nil {
+		return false, false, fmt.Errorf("parse gh %s view output: %w", kind, jsonErr)
+	}
+	return strings.EqualFold(strings.TrimSpace(resp.State), "OPEN"), true, nil
+}
+
+// FileExistsOnDefaultBranch implements BasePresenceProbe via `gh api
+// repos/<owner>/<repo>/contents/<path>` (no ref query param, so this reads
+// the repo's default branch). A 404 means the path is genuinely absent
+// (returns false, nil error); any other failure is a real lookup error.
+func (ghCLIBasePresenceProbe) FileExistsOnDefaultBranch(ctx context.Context, owner, repo, path string) (bool, error) {
+	if testing.Testing() {
+		return false, fmt.Errorf("ghCLIBasePresenceProbe: shellout disabled under go test")
+	}
+
+	args := []string{"api", fmt.Sprintf("repos/%s/%s/contents/%s", owner, repo, path)}
+	cmd := withGhCredentials(ctx, exec.CommandContext(ctx, "gh", args...))
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if strings.Contains(stderr.String(), "404") {
+			return false, nil
+		}
+		return false, fmt.Errorf("gh api repos/%s/%s/contents/%s: %w (stderr: %s)", owner, repo, path, err, stderr.String())
+	}
+	return true, nil
+}
+
+// RegisterBasePresenceProbe registers a BasePresenceProbe under an explicit
+// key ("adapter:owner/repo"), mirroring RegisterIssueStateChecker
+// (issue_state.go). Registrations happen once at startup, so concurrent
+// tasks from different repos can never observe another repo's probe.
+func (r *Runner) RegisterBasePresenceProbe(key string, probe BasePresenceProbe) {
+	r.basePresenceProbesMu.Lock()
+	defer r.basePresenceProbesMu.Unlock()
+	if r.basePresenceProbes == nil {
+		r.basePresenceProbes = make(map[string]BasePresenceProbe)
+	}
+	r.basePresenceProbes[key] = probe
+}
+
+// basePresenceProbeFor returns the registered probe for key, or nil.
+func (r *Runner) basePresenceProbeFor(key string) BasePresenceProbe {
+	r.basePresenceProbesMu.RLock()
+	defer r.basePresenceProbesMu.RUnlock()
+	return r.basePresenceProbes[key]
+}
+
+// checkBasePresence resolves (owner, repo) for task/projectPath (mirroring
+// fetchIssueState's resolution order, issue_state.go), then resolves the
+// BasePresenceProbe registered for that repo (falling back to the gh-CLI
+// probe when none is registered) and runs basePresenceChecker.Check. A
+// package-level swappable var — mirroring fetchIssueState and
+// mergedPRPreflightCheck (dispatcher.go) — so dispatcher.go's claim-path
+// check and tests both call the exact same entry point instead of tests
+// wiring a real git remote plus a registered probe per case.
+//
+// Returns a non-nil error only when (owner, repo) could not be resolved at
+// all — the caller (ProjectWorker.processQueue) logs that as a fail-open
+// warning and proceeds, exactly like the GH-4656 fetchIssueState guard. A
+// per-ref/per-path probe error is swallowed internally by
+// basePresenceChecker.Check (fail-open there too), since no single
+// "the check failed" signal is worth surfacing for that case.
+var checkBasePresence = func(ctx context.Context, runner *Runner, task *Task, projectPath string, refs []int, paths []string) (BasePresenceHold, error) {
+	if len(refs) == 0 && len(paths) == 0 {
+		return BasePresenceHold{}, nil
+	}
+
+	owner, repo, err := resolveOwnerRepoForBasePresence(ctx, task, projectPath)
+	if err != nil {
+		return BasePresenceHold{}, err
+	}
+
+	var probe BasePresenceProbe
+	if runner != nil {
+		probe = runner.basePresenceProbeFor("github:" + owner + "/" + repo)
+	}
+	if probe == nil {
+		probe = ghCLIBasePresenceProbe{}
+	}
+
+	return basePresenceChecker{probe: probe}.Check(ctx, owner, repo, refs, paths), nil
+}

--- a/internal/executor/base_presence_test.go
+++ b/internal/executor/base_presence_test.go
@@ -1,0 +1,255 @@
+package executor
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// GH-5045 regression suite for the claim-path base-presence guard
+// (base_presence.go, wired into dispatcher.go's processQueue between the
+// GH-4656 issue-state revalidation and the GH-4141 merged-PR preflight).
+//
+// checkBasePresence is stubbed directly, mirroring stubFetchIssueState
+// (gh4656_issue_state_test.go) — it's the single swappable var both the
+// production call site and these tests share, so no real git remote or
+// GitHub API call is required to drive the decision logic end-to-end
+// through ProjectWorker.processQueue.
+
+// stubCheckBasePresence overrides the package-level checkBasePresence var
+// for the duration of the test and restores the original on cleanup.
+func stubCheckBasePresence(t *testing.T, fn func(ctx context.Context, runner *Runner, task *Task, projectPath string, refs []int, paths []string) (BasePresenceHold, error)) {
+	t.Helper()
+	orig := checkBasePresence
+	checkBasePresence = fn
+	t.Cleanup(func() { checkBasePresence = orig })
+}
+
+// (a) unmet prerequisite -> task held, zero backend invocations, row stays
+// queued with a StageBasePresenceHeld event; prerequisite lands -> next tick
+// proceeds and the backend runs exactly once.
+func TestProcessQueue_BasePresence_HeldThenReleased(t *testing.T) {
+	const branch = "pilot/GH-9201"
+	dir := setupPRGuardRepo(t, branch, false)
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	exec := &memory.Execution{
+		ID:              "exec-gh5045-held-then-released",
+		TaskID:          "GH-9201",
+		ProjectPath:     dir,
+		Status:          "queued",
+		TaskBranch:      branch,
+		TaskCreatePR:    true,
+		TaskDescription: "Depends on: #99",
+	}
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	stubFetchIssueState(t, func(_ context.Context, _ *Runner, _ *Task, _ string) (IssueState, error) {
+		return IssueState{Closed: false}, nil
+	})
+	origMergedPR := mergedPRPreflightCheck
+	mergedPRPreflightCheck = func(_ context.Context, _, _ string) (string, error) { return "", nil }
+	t.Cleanup(func() { mergedPRPreflightCheck = origMergedPR })
+
+	var mu sync.Mutex
+	held := true
+	stubCheckBasePresence(t, func(_ context.Context, _ *Runner, task *Task, _ string, refs []int, _ []string) (BasePresenceHold, error) {
+		if len(refs) != 1 || refs[0] != 99 {
+			t.Fatalf("checkBasePresence called with unexpected refs %v (task %q)", refs, task.ID)
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		if held {
+			return BasePresenceHold{Held: true, Reason: "referenced PR #99 is still open (not merged)"}, nil
+		}
+		return BasePresenceHold{}, nil
+	})
+
+	backend := &mockFixedBackend{result: &BackendResult{Success: true, Output: "analysis complete"}}
+	runner := NewRunnerWithBackend(backend)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+	worker := NewProjectWorker(dir, store, runner, slog.Default())
+
+	// Tick 1: prerequisite still open -> held, no execution.
+	worker.processQueue(context.Background())
+
+	backend.mu.Lock()
+	count := backend.execCount
+	backend.mu.Unlock()
+	if count != 0 {
+		t.Fatalf("expected zero backend invocations while held, got %d", count)
+	}
+
+	got, err := store.GetExecution(exec.ID)
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if got.Status != "queued" {
+		t.Errorf("expected status to remain %q while held, got %q", "queued", got.Status)
+	}
+
+	events, err := store.ListExecutionEvents(exec.ID)
+	if err != nil {
+		t.Fatalf("ListExecutionEvents: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("expected at least one execution event after being held")
+	}
+	last := events[len(events)-1]
+	if last.Stage != memory.StageBasePresenceHeld {
+		t.Errorf("expected last event stage %q, got %q", memory.StageBasePresenceHeld, last.Stage)
+	}
+	if !strings.Contains(last.Detail, "referenced PR #99 is still open") {
+		t.Errorf("expected event detail to name the unmet prerequisite, got %q", last.Detail)
+	}
+
+	// Prerequisite lands -> tick 2 proceeds to execution.
+	mu.Lock()
+	held = false
+	mu.Unlock()
+
+	worker.processQueue(context.Background())
+
+	backend.mu.Lock()
+	count = backend.execCount
+	backend.mu.Unlock()
+	if count == 0 {
+		t.Error("expected the backend to be invoked once the prerequisite landed — hold guard must not have short-circuited")
+	}
+}
+
+// (b) a task held past BasePresenceHoldMaxCycles gets the pilot-needs-human
+// label applied exactly once, and the hold counter resets afterward so a
+// further held cycle doesn't re-escalate immediately.
+func TestProcessQueue_BasePresence_EscalatesAfterMaxCycles(t *testing.T) {
+	logFile := setupFakeGhCLI(t)
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	// escalateBasePresenceHold shells out with cmd.Dir = task.ProjectPath, so
+	// this must be a real directory (unlike the fake project-path strings
+	// used elsewhere in this file, where the backend never runs and no
+	// subprocess needs a working directory).
+	projectPath := t.TempDir()
+	exec := &memory.Execution{
+		ID:              "exec-gh5045-escalate",
+		TaskID:          "GH-9301",
+		ProjectPath:     projectPath,
+		Status:          "queued",
+		TaskBranch:      "pilot/GH-9301",
+		TaskCreatePR:    true,
+		TaskDescription: "Depends on: #1",
+	}
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	stubFetchIssueState(t, func(_ context.Context, _ *Runner, _ *Task, _ string) (IssueState, error) {
+		return IssueState{Closed: false}, nil
+	})
+	stubCheckBasePresence(t, func(_ context.Context, _ *Runner, _ *Task, _ string, _ []int, _ []string) (BasePresenceHold, error) {
+		return BasePresenceHold{Held: true, Reason: "referenced PR #1 is still open (not merged)"}, nil
+	})
+
+	backend := &mockFixedBackend{result: &BackendResult{Success: true, Output: "should never run"}}
+	runner := NewRunnerWithBackend(backend)
+	worker := NewProjectWorker(projectPath, store, runner, slog.Default())
+	worker.setBasePresenceHoldMaxCycles(2)
+
+	for i := 0; i < 3; i++ {
+		worker.processQueue(context.Background())
+	}
+
+	backend.mu.Lock()
+	count := backend.execCount
+	backend.mu.Unlock()
+	if count != 0 {
+		t.Errorf("expected zero backend invocations across all held cycles, got %d", count)
+	}
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read gh CLI log: %v", err)
+	}
+	log := string(data)
+	if got := strings.Count(log, "issue edit 9301"); got != 1 {
+		t.Errorf("expected exactly one `gh issue edit 9301` call after 3 held cycles with max-cycles=2, got %d (log: %q)", got, log)
+	}
+	if !strings.Contains(log, "--add-label pilot-needs-human") {
+		t.Errorf("expected the escalation call to add the pilot-needs-human label, got log: %q", log)
+	}
+}
+
+// (c) a task description with no "Depends on"/"Blocked by" ref and no
+// backtick-quoted path never calls checkBasePresence at all — zero probe
+// calls, byte-identical to the pre-GH-5045 pickup path — and the backend
+// still executes normally.
+func TestProcessQueue_BasePresence_FastPathSkipsCheckWhenNothingExtracted(t *testing.T) {
+	const branch = "pilot/GH-9401"
+	dir := setupPRGuardRepo(t, branch, false)
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	exec := &memory.Execution{
+		ID:              "exec-gh5045-fast-path",
+		TaskID:          "GH-9401",
+		ProjectPath:     dir,
+		Status:          "queued",
+		TaskBranch:      branch,
+		TaskCreatePR:    true,
+		TaskDescription: "Plain-prose task description with no dependency markers or file citations.",
+	}
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	stubFetchIssueState(t, func(_ context.Context, _ *Runner, _ *Task, _ string) (IssueState, error) {
+		return IssueState{Closed: false}, nil
+	})
+	origMergedPR := mergedPRPreflightCheck
+	mergedPRPreflightCheck = func(_ context.Context, _, _ string) (string, error) { return "", nil }
+	t.Cleanup(func() { mergedPRPreflightCheck = origMergedPR })
+
+	var mu sync.Mutex
+	calls := 0
+	stubCheckBasePresence(t, func(_ context.Context, _ *Runner, _ *Task, _ string, _ []int, _ []string) (BasePresenceHold, error) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		return BasePresenceHold{}, nil
+	})
+
+	backend := &mockFixedBackend{result: &BackendResult{Success: true, Output: "analysis complete"}}
+	runner := NewRunnerWithBackend(backend)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+	worker := NewProjectWorker(dir, store, runner, slog.Default())
+
+	worker.processQueue(context.Background())
+
+	mu.Lock()
+	gotCalls := calls
+	mu.Unlock()
+	if gotCalls != 0 {
+		t.Errorf("expected checkBasePresence to never be called when no refs/paths are extracted, got %d calls", gotCalls)
+	}
+
+	backend.mu.Lock()
+	execCount := backend.execCount
+	backend.mu.Unlock()
+	if execCount == 0 {
+		t.Error("expected the backend to run normally when nothing is extracted")
+	}
+}

--- a/internal/executor/dependency_detector.go
+++ b/internal/executor/dependency_detector.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 // DependencyReason identifies why a sub-issue is treated as depending on a
@@ -93,4 +94,109 @@ func subIssueDisplayRef(issue CreatedIssue) string {
 		return issue.Identifier
 	}
 	return "unknown"
+}
+
+// ExtractDependencyRefs returns every issue/PR number referenced via an
+// explicit "Depends on: #N" / "Blocked by: #N" marker in body, in
+// first-seen order with duplicates removed (GH-5045).
+//
+// This generalizes detectChildDependency's dependencyRefRe usage by
+// dropping the siblingNumbers scoping: that scoping exists because
+// detectChildDependency runs at decomposition time, when the current
+// epic's own child set is known and a ref to an unrelated issue elsewhere
+// in the tracker must not force a wait. The dispatch-time base-presence
+// check this feeds (base_presence.go) has no such sibling context — it
+// runs once per queued issue, independent of any epic — so every explicit
+// ref is a candidate prerequisite worth probing.
+func ExtractDependencyRefs(body string) []int {
+	if body == "" {
+		return nil
+	}
+	seen := make(map[int]bool)
+	var refs []int
+	for _, m := range dependencyRefRe.FindAllStringSubmatch(body, -1) {
+		num, err := strconv.Atoi(m[1])
+		if err != nil || num <= 0 || seen[num] {
+			continue
+		}
+		seen[num] = true
+		refs = append(refs, num)
+	}
+	return refs
+}
+
+// backtickSpanRe matches the content of a single-line backtick-quoted span,
+// e.g. the `internal/foo.go` in "see `internal/foo.go` for details".
+var backtickSpanRe = regexp.MustCompile("`([^`\n]+)`")
+
+// pathLineRefSuffixRe strips an optional trailing "line" or "line-range"
+// reference (":42" or ":42-58") so a citation like
+// `internal/executor/runner.go:42` still resolves to the bare file path.
+var pathLineRefSuffixRe = regexp.MustCompile(`:\d+(?:-\d+)?$`)
+
+// referencedPathIgnorePrefixes excludes URLs from ExtractReferencedPaths —
+// a backtick-quoted link is not a repo file path even though it may
+// contain slashes and a dot.
+var referencedPathIgnorePrefixes = []string{"http://", "https://"}
+
+// ExtractReferencedPaths returns every backtick-quoted repo-relative file
+// path mentioned in body, in first-seen order with duplicates removed
+// (GH-5045).
+//
+// Heuristic, validated by hand against real issue bodies (GH-5021, ui
+// GH-120/124/139): backtick content counts as a path when it (1) is not a
+// URL, (2) contains a "/", (3) contains no whitespace, and (4) ends in a
+// dot-extension once an optional trailing ":<line>" or ":<start>-<end>"
+// line-ref suffix is stripped. This is intentionally conservative — it
+// catches genuine file citations (`internal/boardapi/dto.go`,
+// `internal/fleet/tenantres.go:42`) while excluding shell commands
+// (`aws s3 cp`, `make test`), bare API routes with no extension
+// (`/api/v1/orgs`), and extensionless filenames with no path separator
+// (`0008_board.up.sql`).
+func ExtractReferencedPaths(body string) []string {
+	if body == "" {
+		return nil
+	}
+	seen := make(map[string]bool)
+	var paths []string
+	for _, m := range backtickSpanRe.FindAllStringSubmatch(body, -1) {
+		candidate := strings.TrimSpace(m[1])
+		if candidate == "" || strings.ContainsAny(candidate, " \t") {
+			continue
+		}
+
+		isURL := false
+		for _, prefix := range referencedPathIgnorePrefixes {
+			if strings.HasPrefix(candidate, prefix) {
+				isURL = true
+				break
+			}
+		}
+		if isURL || !strings.Contains(candidate, "/") {
+			continue
+		}
+
+		stripped := pathLineRefSuffixRe.ReplaceAllString(candidate, "")
+		if !hasFileExtension(stripped) {
+			continue
+		}
+
+		if seen[stripped] {
+			continue
+		}
+		seen[stripped] = true
+		paths = append(paths, stripped)
+	}
+	return paths
+}
+
+// hasFileExtension reports whether s ends in a "." followed by at least one
+// character within its final path segment (i.e. the dot is not itself part
+// of a directory component).
+func hasFileExtension(s string) bool {
+	idx := strings.LastIndex(s, ".")
+	if idx < 0 || idx == len(s)-1 {
+		return false
+	}
+	return !strings.Contains(s[idx:], "/")
 }

--- a/internal/executor/dependency_detector_gh5045_test.go
+++ b/internal/executor/dependency_detector_gh5045_test.go
@@ -1,0 +1,198 @@
+package executor
+
+import (
+	"reflect"
+	"testing"
+)
+
+// GH-5045: table-driven regression tests for the two dispatch-time
+// extractors added to dependency_detector.go. The path-extraction cases use
+// real issue bodies (fetched verbatim from GH-5021 @ qf-studio/pilot and
+// GH-120/124/139 @ qf-studio/pilot-console, the "ui" repo referenced in the
+// GH-5045 task text) so the heuristic is validated against genuine prose
+// rather than only hand-picked synthetic strings.
+
+// gh5021Body is the real issue body of qf-studio/pilot#5021 at the time this
+// test was written — two Go source-file citations, no "Depends on"/"Blocked
+// by" marker.
+const gh5021Body = "" +
+	"<!--autopilot-meta\n" +
+	"parent: GH-5019\n" +
+	"inherited-spec: true\n" +
+	"-->\n\n" +
+	"Parent: GH-5019\n\n" +
+	"Two related defects in the same package. (a) In `internal/executor/runner.go` (~line 4906, from PR#5016), when the contract-dependency lookup is configured AND the project has contract dependencies, a `GetDiffAgainstOrigin` error must route through the standard contract-evidence failure sequence (alert + webhook + recorder) with `result.Success=false`, not skip the gate with a Warn log; preserve the current skip-and-warn behavior when lookup is unset or the project has no deps. (b) In `internal/executor/contract_evidence.go`, when `required=true` but zero field tokens were extracted, short-circuit before `getContractEvidence` (no LLM/structured-output subprocess call) and record the result as passed with `Required=false` consistently. Add tests: configured-project diff-error -> contract-evidence failure path fires (assert alert + webhook + recorder); unconfigured project + same failure -> unchanged; zero-extracted-fields -> call-count assertion proves no LLM invocation and task proceeds. Both defects live in `internal/executor/` -- bundled to avoid intra-package merge conflicts.\n\n" +
+	"## Scope fence\n\n" +
+	"Implement ONLY the slice described above."
+
+// ui120Body is the real issue body of qf-studio/pilot-console#120 at the
+// time this test was written.
+const ui120Body = "## Problem\n\n" +
+	"`GET /api/v1/board/activity` is a conflict journal wearing an activity feed's name: it reads only `sync_conflicts`, the DTO's `kind` is hardcoded `\"conflict\"` (`internal/boardapi/dto.go`, `toActivityDTO`), and only two things ever write -- the sync reconciler's LWW conflicts and the C14 decision route (which shoehorns decisions in as pseudo-conflicts: `AppendConflict{Field:\"decision\", ...}`, `internal/boardapi/decision.go:136`). Dispatch, status changes -- the events the bell popover and board activity feed are designed around (`design/approvals-v1.html` activity glance) -- journal nothing.\n\n" +
+	"## Context (verified at merge of PR#119)\n\n" +
+	"- Activity route + limit semantics: `internal/boardapi/handlers.go` `handleActivity` (default 50, max 200, 400 non-numeric).\n" +
+	"- Current storage: `sync_conflicts` (migration `0008_board.up.sql`) -- conflict-specific columns (`field`, `board_value`, `remote_value`, `winner`). Writers: `internal/syncengine/engine.go:129` (`CommitReconcile`) and the decision route.\n" +
+	"- Migrations: next free number **0011**.\n" +
+	"- Dispatch handler: `internal/boardapi/dispatch.go` `handleDispatch` (:72).\n\n" +
+	"## Acceptance\n\n" +
+	"1. Migration `0011_activity_journal` (+`.down.sql`).\n" +
+	"2. aws s3 cp is not relevant here, this is `make test` territory.\n" +
+	"3. `GET /api/v1/board/activity` serves the union.\n\n" +
+	"## Refs\n\n" +
+	"- Design: `design/approvals-v1.html` (activity glance + annotations) @ pilot-console-ui"
+
+// ui124Body is the real issue body of qf-studio/pilot-console#124.
+const ui124Body = "## Problem\n\n" +
+	"Settings -> General (design: `settings-v1.html` screen 3) needs org rename. Today the org name is written once at `POST /api/v1/orgs` and never changeable -- no PUT/PATCH route exists on `/api/v1/org`.\n\n" +
+	"## Context (verified at origin/main)\n\n" +
+	"- Org model + store: `internal/orgs/store.go` (`organizations.name`); create-side validation lives in `handleCreateOrg` (`internal/orgs/handlers.go:72`) -- reuse its name rules exactly.\n" +
+	"- Route registration: `internal/orgs/handlers.go:72-78`; house pattern for mutations: `Authenticate` + `bff.CSRFGuard`.\n\n" +
+	"## Acceptance\n\n" +
+	"1. `PUT /api/v1/org` -- body `{\"name\": \"...\"}` -> 200 with the updated org.\n" +
+	"2. Store method (`RenameOrg` or equivalent) updates `name` only.\n\n" +
+	"## Refs\n\n" +
+	"- Design: `design/settings-v1.html` screen 3 (General) @ pilot-console-ui\n" +
+	"- Program: TASK-478 @ qf-studio/pilot `.agent/tasks/` (CON-4)"
+
+// ui139Body is the real issue body of qf-studio/pilot-console#139.
+const ui139Body = "## Summary\n\n" +
+	"Automated PR created by Pilot for task GH-138.\n\n" +
+	"Closes #138\n\n" +
+	"## Context\n\n" +
+	"Live factory-path testing (2026-08-16 evening, un-patched ship-test re-run) proved PR#133's exists-path convergence is unreachable for existing tenants: `ensureInstanceProfile` (`internal/fleet/tenantres.go:195-205` @ `f2e8c81`) returns the profile ARN as soon as `GetInstanceProfile` succeeds -- `ensureRole` is only called on the profile-not-found branch. Observed live: a role created before `BinaryS3URI` was configured never gained the `s3:GetObject` statement across multiple provisions -> box `aws s3 cp` AccessDenied -> no binary -> ready check exit 7 -> `provision.failed`, repeatably.\n\n" +
+	"## Fix\n\n" +
+	"`ensureInstanceProfile`'s exists-path must still call `f.ensureRole(ctx, orgID, name)` before returning the existing profile ARN. `BinaryS3Bucket/BinaryS3ReleasesPrefix` and `tenantres.created` are unaffected.\n\n" +
+	"## Refs\n\n" +
+	"GH-126 -> GH-132/PR#133 lineage -- found live in TASK-405 un-patched re-run 2026-08-16"
+
+func TestExtractReferencedPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{
+			name: "empty body",
+			body: "",
+			want: nil,
+		},
+		{
+			name: "GH-5021 real body: two Go source citations, directory-only ref excluded",
+			body: gh5021Body,
+			want: []string{
+				"internal/executor/runner.go",
+				"internal/executor/contract_evidence.go",
+			},
+		},
+		{
+			name: "ui#120 real body: line-ref suffix stripped, dedup across repeats, shell/URL/bare-name noise excluded",
+			body: ui120Body,
+			want: []string{
+				"internal/boardapi/dto.go",
+				"internal/boardapi/decision.go",
+				"design/approvals-v1.html",
+				"internal/boardapi/handlers.go",
+				"internal/syncengine/engine.go",
+				"internal/boardapi/dispatch.go",
+			},
+		},
+		{
+			name: "ui#124 real body: extensionless API routes and bare filenames excluded, range-ref suffix stripped",
+			body: ui124Body,
+			want: []string{
+				"internal/orgs/store.go",
+				"internal/orgs/handlers.go",
+				"design/settings-v1.html",
+			},
+		},
+		{
+			name: "ui#139 real body: bare SHA, slash-but-no-extension, and shell-command noise excluded",
+			body: ui139Body,
+			want: []string{
+				"internal/fleet/tenantres.go",
+			},
+		},
+		{
+			name: "excludes URLs even with a path-like shape",
+			body: "See `https://example.com/owner/repo/blob/main/internal/foo.go` for context.",
+			want: nil,
+		},
+		{
+			name: "excludes whitespace-containing backtick spans (shell commands)",
+			body: "Run `make test` and `aws s3 cp foo/bar.txt s3://bucket/` before merging.",
+			want: nil,
+		},
+		{
+			name: "excludes extensionless bare filenames with no path separator",
+			body: "See `0008_board.up.sql` for the migration.",
+			want: nil,
+		},
+		{
+			name: "excludes bare API routes with no extension",
+			body: "Route is `/api/v1/orgs`, not `/api/v1/org/rename`.",
+			want: nil,
+		},
+		{
+			name: "dedups repeated citations of the same path",
+			body: "See `internal/foo.go` and again `internal/foo.go`.",
+			want: []string{"internal/foo.go"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractReferencedPaths(tt.body)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ExtractReferencedPaths() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractDependencyRefs(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want []int
+	}{
+		{
+			name: "empty body",
+			body: "",
+			want: nil,
+		},
+		{
+			name: "no explicit ref marker in prose alone (GH-5021 real body)",
+			body: gh5021Body,
+			want: nil,
+		},
+		{
+			name: "no explicit ref marker in prose alone (ui#139 real body, has '->' lineage but no marker)",
+			body: ui139Body,
+			want: nil,
+		},
+		{
+			name: "single explicit Depends on ref",
+			body: "This sub-issue depends on prior work.\n\nDepends on: #123",
+			want: []int{123},
+		},
+		{
+			name: "Blocked by phrasing, case-insensitive",
+			body: "blocked BY: #456",
+			want: []int{456},
+		},
+		{
+			name: "multiple distinct refs, first-seen order",
+			body: "Depends on: #10\nSome text.\nBlocked by: #20\nDepends on:#10",
+			want: []int{10, 20},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractDependencyRefs(tt.body)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ExtractDependencyRefs() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -111,14 +111,27 @@ type DispatcherConfig struct {
 	// StaleRecoveryInterval is how often the periodic stale-recovery loop
 	// runs. Default: 5 minutes.
 	StaleRecoveryInterval time.Duration
+
+	// BasePresenceHoldMaxCycles bounds how many consecutive claim-path
+	// held cycles (GH-5045: an explicit "Depends on: #N" ref still an open
+	// PR, or a referenced file path missing from the default branch) a
+	// task can accumulate before ProjectWorker.processQueue escalates by
+	// applying the pilot-needs-human label and clearing the hold counter.
+	// Generous default (20) — a held task is retried only when the
+	// project's worker is signalled again (a new poll tick, a new task
+	// queued for the same project, or the periodic stale-recovery loop),
+	// not on a tight timer, so this is meant to tolerate a genuinely slow
+	// prerequisite landing rather than churn through cycles quickly.
+	BasePresenceHoldMaxCycles int
 }
 
 // DefaultDispatcherConfig returns default dispatcher settings.
 func DefaultDispatcherConfig() *DispatcherConfig {
 	return &DispatcherConfig{
-		StaleRunningThreshold: 30 * time.Minute,
-		StaleQueuedThreshold:  5 * time.Minute,
-		StaleRecoveryInterval: 5 * time.Minute,
+		StaleRunningThreshold:     30 * time.Minute,
+		StaleQueuedThreshold:      5 * time.Minute,
+		StaleRecoveryInterval:     5 * time.Minute,
+		BasePresenceHoldMaxCycles: 20,
 	}
 }
 
@@ -131,6 +144,9 @@ func (c *DispatcherConfig) resolveDefaults() {
 	}
 	if c.StaleRecoveryInterval == 0 {
 		c.StaleRecoveryInterval = 5 * time.Minute
+	}
+	if c.BasePresenceHoldMaxCycles == 0 {
+		c.BasePresenceHoldMaxCycles = 20
 	}
 }
 
@@ -2241,6 +2257,7 @@ func (d *Dispatcher) ensureWorker(projectPath string) {
 	// Create new worker
 	worker := NewProjectWorker(projectPath, d.store, d.runner, d.log)
 	worker.setAdmissionPaused(d.admissionPaused)
+	worker.setBasePresenceHoldMaxCycles(d.config.BasePresenceHoldMaxCycles)
 	d.workers[projectPath] = worker
 
 	// Start worker in background
@@ -2569,6 +2586,16 @@ type ProjectWorker struct {
 	// as "never paused", preserving prior behavior for any caller that
 	// doesn't wire it. GH-4683.
 	admissionPaused *atomic.Bool
+
+	// basePresenceHoldMaxCycles mirrors DispatcherConfig.BasePresenceHoldMaxCycles
+	// (GH-5045), threaded in post-construction the same way admissionPaused
+	// is (see setBasePresenceHoldMaxCycles/ensureWorker) since the many
+	// existing NewProjectWorker(...) call sites — production and test alike
+	// — shouldn't need a signature change. Zero for a ProjectWorker built
+	// directly (e.g. tests) — processQueue falls back to
+	// DefaultDispatcherConfig()'s value in that case rather than treating 0
+	// as "escalate immediately."
+	basePresenceHoldMaxCycles int
 }
 
 // NewProjectWorker creates a new project worker.
@@ -2645,6 +2672,25 @@ func (w *ProjectWorker) Signal() {
 // updating; only Dispatcher.ensureWorker calls this. GH-4683.
 func (w *ProjectWorker) setAdmissionPaused(p *atomic.Bool) {
 	w.admissionPaused = p
+}
+
+// setBasePresenceHoldMaxCycles wires DispatcherConfig.BasePresenceHoldMaxCycles
+// (GH-5045) from the owning Dispatcher. Kept as a post-construction setter
+// for the same reason as setAdmissionPaused: only Dispatcher.ensureWorker
+// calls this, so the many existing direct NewProjectWorker(...) call sites
+// don't need updating.
+func (w *ProjectWorker) setBasePresenceHoldMaxCycles(n int) {
+	w.basePresenceHoldMaxCycles = n
+}
+
+// resolvedBasePresenceHoldMaxCycles returns basePresenceHoldMaxCycles when
+// set, else DefaultDispatcherConfig()'s value — covers a ProjectWorker
+// built directly (e.g. tests) without going through ensureWorker.
+func (w *ProjectWorker) resolvedBasePresenceHoldMaxCycles() int {
+	if w.basePresenceHoldMaxCycles > 0 {
+		return w.basePresenceHoldMaxCycles
+	}
+	return DefaultDispatcherConfig().BasePresenceHoldMaxCycles
 }
 
 // Status returns the current worker status.
@@ -2781,6 +2827,68 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 			slog.String("title", exec.TaskTitle),
 		)
 
+		// Build task from execution record (full details stored when queued)
+		// GH-2326: restore Labels so runner-side no-decompose / autopilot-fix
+		// gates see the same labels the dispatch-time Decompose() saw.
+		//
+		// GH-5045: built here, before the running-status transition below,
+		// so the base-presence check that follows can read task.Description
+		// without having already committed this row to ExecStatusRunning —
+		// a held task must stay picklable by the next GetQueuedTasksForProject
+		// call (queued/pending only), not get stranded in "running" forever.
+		task := buildTaskFromExecution(exec)
+
+		// GH-5045: base-presence hold. Before committing to execute (and
+		// before the running-status transition just below), check whether
+		// the issue body's own stated prerequisites — an explicit "Depends
+		// on: #N"/"Blocked by: #N" ref still an open PR, or a backtick-quoted
+		// file path missing from the target repo's default branch — have
+		// actually landed on main yet. When neither refs nor paths are
+		// extracted this whole block is skipped: zero probe calls,
+		// byte-identical to the pre-GH-5045 call path.
+		if refs, paths := ExtractDependencyRefs(task.Description), ExtractReferencedPaths(task.Description); len(refs) > 0 || len(paths) > 0 {
+			hold, checkErr := checkBasePresence(ctx, w.runner, task, exec.ProjectPath, refs, paths)
+			if checkErr != nil {
+				w.log.Warn("base-presence check: failed to resolve repo; proceeding (fail-open)",
+					slog.String("execution_id", exec.ID),
+					slog.String("task_id", exec.TaskID),
+					slog.Any("error", checkErr))
+			} else if hold.Held {
+				detail := fmt.Sprintf("held: prerequisite not on main (%s)", hold.Reason)
+				key := repickBackoffKey(exec.ProjectPath, exec.TaskID)
+				count, _, cErr := w.store.GetBasePresenceHoldCount(key)
+				if cErr != nil {
+					w.log.Warn("base-presence hold: failed to read hold count",
+						slog.String("execution_id", exec.ID), slog.Any("error", cErr))
+				}
+				count++
+				if sErr := w.store.SetBasePresenceHoldCount(key, count); sErr != nil {
+					w.log.Error("base-presence hold: failed to persist hold count",
+						slog.String("execution_id", exec.ID), slog.Any("error", sErr))
+				}
+
+				w.log.Info("Task held: prerequisite not on main",
+					slog.String("execution_id", exec.ID),
+					slog.String("task_id", exec.TaskID),
+					slog.String("reason", hold.Reason),
+					slog.Int("hold_count", count),
+				)
+				w.recordExecutionEvent(exec.ID, memory.StageBasePresenceHeld, detail)
+				w.runner.EmitProgress(exec.TaskID, "Held", 0, detail)
+
+				if count >= w.resolvedBasePresenceHoldMaxCycles() {
+					w.escalateBasePresenceHold(ctx, task, hold.Reason)
+					if clrErr := w.store.SetBasePresenceHoldCount(key, 0); clrErr != nil {
+						w.log.Error("base-presence hold: failed to clear hold count after escalation",
+							slog.String("execution_id", exec.ID), slog.Any("error", clrErr))
+					}
+				}
+
+				w.currentTaskID.Store("")
+				return
+			}
+		}
+
 		// Update status to running
 		if err := w.lifecycle.Transition(exec.ID, ExecStatusRunning); err != nil {
 			w.log.Error("Failed to update status to running", slog.Any("error", err))
@@ -2792,11 +2900,6 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 
 		// Emit progress callback for task started
 		w.runner.EmitProgress(exec.TaskID, "Running", 2, fmt.Sprintf("Worker started: %s", truncateForLog(exec.TaskTitle, 40)))
-
-		// Build task from execution record (full details stored when queued)
-		// GH-2326: restore Labels so runner-side no-decompose / autopilot-fix
-		// gates see the same labels the dispatch-time Decompose() saw.
-		task := buildTaskFromExecution(exec)
 
 		// GH-4656: revalidate the issue's live GitHub state at pickup time.
 		// Closes the 2026-07-31 GH-4649 incident window: a retry's claim was
@@ -3003,6 +3106,39 @@ func (w *ProjectWorker) recordExecutionEvent(executionID string, stage memory.St
 			slog.String("stage", string(stage)),
 			slog.Any("error", err))
 	}
+}
+
+// escalateBasePresenceHold applies the pilot-needs-human label once a held
+// task (GH-5045) has exhausted BasePresenceHoldMaxCycles held cycles
+// without its extracted refs/paths landing on main. Best-effort and
+// GitHub-only, mirroring Dispatcher.surfaceStalledIssue's stance: a
+// labeling failure is logged, not fatal — the caller has already recorded
+// this cycle's hold event and clears the counter regardless, so a stuck
+// GitHub call here never wedges the hold accounting itself.
+func (w *ProjectWorker) escalateBasePresenceHold(ctx context.Context, task *Task, reason string) {
+	if task.SourceAdapter != "" && task.SourceAdapter != "github" {
+		return
+	}
+	issueNum := strings.TrimPrefix(task.ID, "GH-")
+	if task.SourceIssueID != "" {
+		issueNum = task.SourceIssueID
+	}
+	if issueNum == "" {
+		return
+	}
+
+	labelCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	if err := ghEditLabels(labelCtx, task.ProjectPath, issueNum, []string{labelPilotNeedsHuman}, nil); err != nil {
+		w.log.Warn("base-presence hold escalation: failed to apply label",
+			slog.String("task_id", task.ID), slog.Any("error", err))
+		return
+	}
+	w.log.Info("base-presence hold escalation: applied pilot-needs-human label",
+		slog.String("task_id", task.ID),
+		slog.String("reason", reason),
+	)
 }
 
 // hasTerminalSuccessLedger reports whether the TASK-394 execution ledger

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -799,6 +799,12 @@ type Runner struct {
 	// PR-creation preflight guards.
 	issueStateCheckers   map[string]IssueStateChecker
 	issueStateCheckersMu sync.RWMutex
+	// GH-5045: basePresenceProbes holds startup-registered per-repo
+	// BasePresenceProbes keyed "adapter:owner/repo" — same key shape and
+	// registration timing as issueStateCheckers above (see base_presence.go).
+	// Used by checkBasePresence for the dispatch claim-path guard.
+	basePresenceProbes   map[string]BasePresenceProbe
+	basePresenceProbesMu sync.RWMutex
 	// GH-2211: SubIssueLinker for native GitHub sub-issue API linking
 	subIssueLinker SubIssueLinker // Optional linker for native GitHub parent→child wiring
 	// GH-1599: Execution log store for milestone entries

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -451,6 +451,13 @@ func (s *Store) migrate() error {
 		// reasoning exactly but for a different prior-claim status. See
 		// Dispatcher.priorClaimWasInfra.
 		`ALTER TABLE repick_backoff ADD COLUMN infra_drops INTEGER NOT NULL DEFAULT 0`,
+		// GH-5045: base_presence_holds tracks consecutive claim-path holds
+		// (an unmet "Depends on: #N" or referenced-path prerequisite,
+		// base_presence.go) toward DispatcherConfig.BasePresenceHoldMaxCycles
+		// — same key shape and lifecycle as stall_drops/infra_drops above,
+		// on its own column since a hold is neither a stall-kill nor a
+		// failure classification, just "not yet".
+		`ALTER TABLE repick_backoff ADD COLUMN base_presence_holds INTEGER NOT NULL DEFAULT 0`,
 		// GH-4773: project identity on approval records. The gateway approvals
 		// surface (PR#4752) attributed rows only via the best-effort
 		// executions.approval_request_id join and dropped unlinked rows
@@ -1065,6 +1072,17 @@ const (
 	// operator to judge whether the attempted call indicates a prompt/task
 	// problem worth investigating.
 	StageGhGuardDenied Stage = "executor.gh_guard_denied"
+	// StageBasePresenceHeld records a GH-5045 claim-path hold: the task's
+	// issue body referenced a prerequisite (an explicit "Depends on: #N"
+	// still an open PR, or a backtick-quoted file path missing from the
+	// target repo's default branch) that hasn't landed yet, so the
+	// dispatcher declined to claim/execute it this cycle. Detail is a
+	// human-readable reason string (e.g. "held: prerequisite not on main
+	// (referenced PR #123 is still open (not merged))"). Not a terminal
+	// status — the task stays queued and is re-checked the next time its
+	// project worker is signalled; see ProjectWorker.processQueue and
+	// base_presence.go.
+	StageBasePresenceHeld Stage = "executor.base_presence_held"
 )
 
 // Event represents a single stage-transition record for an execution.
@@ -1494,7 +1512,7 @@ var ErrApprovalAlreadyDecided = errors.New("approval already decided")
 // SetApprovalDecision records an approval decision on the execution linked to requestID.
 // It sets approval_decision, approval_decision_at, and approval_decision_by on the row
 // whose approval_request_id matches. The UPDATE is guarded by
-// `AND approval_decision = ''` so two racing callers (e.g. a POST racing a
+// `AND approval_decision = ”` so two racing callers (e.g. a POST racing a
 // Telegram/Slack button tap, or two concurrent POSTs) can never both win: only
 // the first writer's UPDATE matches a row, the second affects zero rows and
 // gets ErrApprovalAlreadyDecided rather than silently overwriting the first
@@ -3267,6 +3285,42 @@ func (s *Store) SetClaimLostBackoff(key string, claimLostDrops int, nextAllowedA
 			claim_lost_drops = excluded.claim_lost_drops,
 			updated_at = CURRENT_TIMESTAMP
 	`, key, nextAllowedAt, claimLostDrops)
+	return err
+}
+
+// GetBasePresenceHoldCount returns the persisted count of consecutive
+// claim-path base-presence holds for key (GH-5045) — the same
+// "project_path|task_id" string repickBackoffKey mints. found is false when
+// no hold has ever been recorded for key. Distinct from consecutive_drops
+// on the same row: a hold is never a failure (the task simply hasn't
+// claimed yet), so it must not count toward dispatcherRepickHardCap.
+func (s *Store) GetBasePresenceHoldCount(key string) (count int, found bool, err error) {
+	err = s.db.QueryRow(`
+		SELECT base_presence_holds FROM repick_backoff WHERE key = ?
+	`, key).Scan(&count)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	return count, true, nil
+}
+
+// SetBasePresenceHoldCount persists count as the base-presence hold count
+// for key (GH-5045), creating the repick_backoff row if key has no prior
+// state. consecutive_drops/next_allowed_at are only supplied for a
+// brand-new row — an existing row's genuine-failure counter and backoff
+// window are left untouched by the ON CONFLICT clause, since a hold must
+// not perturb genuine-failure accounting.
+func (s *Store) SetBasePresenceHoldCount(key string, count int) error {
+	_, err := s.db.Exec(`
+		INSERT INTO repick_backoff (key, consecutive_drops, next_allowed_at, base_presence_holds, updated_at)
+		VALUES (?, 0, CURRENT_TIMESTAMP, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT (key) DO UPDATE SET
+			base_presence_holds = excluded.base_presence_holds,
+			updated_at = CURRENT_TIMESTAMP
+	`, key, count)
 	return err
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5045.

Closes #5045

## Changes

All work in internal/executor/. (a) Extend dependency_detector.go with two exported extractors reused at dispatch time: ExtractDependencyRefs(body string) []int (generalizes the existing dependencyRefRe — no sibling scoping, since at dispatch we don't have a sibling set) and ExtractReferencedPaths(body string) []string (backtick-quoted path heuristic with a small ignore-list for URLs). (b) Introduce a basePresenceChecker with a probe-interface satisfied by the subtask-1 helpers (kept as an interface so tests inject fakes; the concrete adapter wiring lives at the dispatcher construction seam already used for other GitHub access). (c) In the claim path in dispatcher.go, before the label pickup commits to executing: if the issue body yields any refs or paths, run the probes; on any open-PR ref or missing-path hit, do NOT claim — record a hold in the existing ledger/journal with a distinct reason string (held: prerequisite not on main), increment a per-issue hold counter (new memory-store column or reuse the existing backoff row shape near RepickBackoffState / ClaimLostDropCount), and emit a structured log line at info level. (d) After a bounded number of held cycles (add DispatcherConfig.BasePresenceHoldMaxCycles with a generous default), escalate by applying the pilot-needs-human label via the existing GitHub adapter path and clear the hold counter. (e) When no refs and no paths are extracted, the call path must be byte-identical to today — enforce with a call-count assertion in tests (zero probe calls). Tests: table-driven extractor tests using real bodies from GH-5021, ui GH-120/124/139 as fixtures; a claim-path integration test with a fake tracker/probe that flips PR state from open→merged across two poll ticks and asserts claim only on the second tick; an escalation test that runs N+1 cycles and asserts pilot-needs-human was applied and the hold cleared; and a 'no refs, no paths' fast-path test asserting zero probe calls.