### PR TITLE
GH-5049: fix(autopilot): stacked-park resume-on-merge + candidate stage filtering + fail-when-unwired assertions (GH-5032 residual, items 2-4)

### DIFF
--- a/.agent/tasks/gh-5049.md
+++ b/.agent/tasks/gh-5049.md
@@ -1,0 +1,37 @@
+# GH-5049
+
+**Created:** 2026-08-20
+
+## Problem
+
+GitHub Issue GH-5049: fix(autopilot): stacked-park resume-on-merge + candidate stage filtering + fail-when-unwired assertions (GH-5032 residual, items 2-4)
+
+## Context
+
+GH-5032 closed as delivered via PR#5043 (merged 2026-08-20 20:33Z), but post-merge review found it delivered only **1 of the 4 items its body marked "REQUIRED, not optional"**. Delivered: the GH-4911-style un-park cleanup (Parked=false, EscalationReason cleared, parked label removed, correctly skipped when detection errored). Undelivered (this issue's scope — do NOT re-implement item 1):
+
+## Requirements
+
+1. **Resume on base MERGE, not base finalization.** The stacked-parked descendant currently un-parks only when the base PR leaves `activePRs` (after post-merge CI + release). Un-park when the base reaches StageMerged — or equivalently filter `detectStackedSuperset` (`internal/autopilot/controller.go:6429`) candidates by stage so merged/finalizing PRs no longer count as stack bases. Pick one mechanism, document why. Today's behavior is resume latency in the normal case and a PERMANENT park if the base wedges tracked in a terminal stage post-merge.
+2. **Candidate-stage filtering**: exclude merged-but-still-tracked and StageFailed PRs from the "stacked on" candidate set (also flagged in PR#5035's review — a StageFailed PR should never hold a descendant hostage).
+3. **The fail-when-unwired assertions** PR#5040 deliberately left to GH-5032 and PR#5043 never added: extend the controller_gh5034 regression tests so tick 2 asserts `Parked==false` AND parked-label removal (these pass now — item 1 shipped — so they pin it against regression), AND model the base's merge as a stage transition (StageMerged, still tracked) rather than `delete(activePRs, ...)` — this version FAILS against today's main (resume-on-finalization) and proves requirement 1 when it goes green.
+
+## Acceptance Criteria
+
+- [ ] Test: base PR at StageMerged (still in activePRs) → descendant un-parks and merges on the next tick. Fails before the fix, passes after.
+- [ ] Test: base PR at StageFailed → descendant is NOT considered stacked (merges normally).
+- [ ] Tick-2 assertions include Parked==false + parked-label removal.
+- [ ] No change to the enter-park path or the fail-open behavior (existing gh5033/gh5034 tests untouched and green).
+
+## Out of scope
+
+- Re-implementing the un-park cleanup (delivered in PR#5043).
+- The dispatcher base-presence gate (#5028/#5045 track).
+
+## Refs
+
+- Prior: GH-5032 body §"Review-discovered scope additions" items 2–4 (verbatim source of this issue) · PR#5043 (partial delivery) · PR#5037 review (APPROVE-w-DEFECTS) · PR#5040 review notes
+- Process note: GH-5032 closing as done with 3 of 4 required body items undelivered is a delivery-evidence data point (TASK-460 class — scope-completeness leg).
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -6443,6 +6443,22 @@ func (c *Controller) attemptMechanicalConflictResolution(ctx context.Context, pr
 // timing and squash-absorbed #5016's entire content under #5017's history;
 // #5016 then went CONFLICTING against content already on main.
 //
+// GH-5049 (GH-5032 residual, items 1-2): candidates are additionally
+// filtered by Stage via isStackBaseCandidateStage — a PR that has already
+// reached StageMerged (and the post-merge bookkeeping stages that follow it,
+// StagePostMergeCI/StageReleasing, while still tracked in activePRs) no
+// longer holds "still-unmerged content" in the sense this function's own
+// doc above describes, so it must stop counting as a stack base the instant
+// it merges rather than only once handleMerged/handleReleasing finishes and
+// evicts it from activePRs — the old behavior added resume latency in the
+// normal case and risked a PERMANENT park if the base ever wedged tracked
+// in one of those terminal-ish stages post-merge. A PR at StageFailed will
+// never merge at all, so it can never legitimately be "merge that first"
+// either (PR#5035 review). Filtering the candidate set here — rather than,
+// say, only checking activePRs membership at resume time — is the single
+// mechanism behind both the detection (park) and resume (un-park) sides of
+// this check, since both read through detectStackedSuperset.
+//
 // Returns the other PRState prState is stacked on (nil if prState is not a
 // descendant of any other open PR's head — including the normal case of no
 // relationship, and the symmetric case where prState is itself the BASE of
@@ -6493,8 +6509,12 @@ func (c *Controller) detectStackedSuperset(ctx context.Context, prState *PRState
 		otherHead := other.HeadSHA
 		otherBranch := other.BranchName
 		otherNumber := other.PRNumber
+		otherStage := other.Stage
 		other.mu.Unlock()
 		if otherHead == "" {
+			continue
+		}
+		if !isStackBaseCandidateStage(otherStage) {
 			continue
 		}
 
@@ -6507,6 +6527,31 @@ func (c *Controller) detectStackedSuperset(ctx context.Context, prState *PRState
 		}
 	}
 	return nil, nil
+}
+
+// isStackBaseCandidateStage reports whether a PR at the given stage can
+// still legitimately hold a descendant parked as its "stacked on" base
+// (GH-5049, GH-5032 residual items 1-2). Excluded:
+//   - StageMerged, StagePostMergeCI, StageReleasing: the PR has already
+//     landed on the default branch — it may still be tracked in activePRs
+//     while post-merge CI/release bookkeeping runs, but its content is no
+//     longer "still-unmerged" in the sense a descendant needs to wait on.
+//     Requirement 1: this is what makes resume happen the instant the base
+//     reaches StageMerged, not only once it's fully finalized and evicted.
+//   - StageFailed: a terminal failure that will never merge. Holding a
+//     descendant hostage to a base that is never landing (PR#5035 review)
+//     is worse than the resume-latency case above — it's a permanent park.
+//
+// Every other stage (including StageMerging itself — the base may be
+// mid-merge-attempt on this very tick) still represents genuinely open,
+// unmerged content and remains a valid stack base.
+func isStackBaseCandidateStage(stage PRStage) bool {
+	switch stage {
+	case StageMerged, StagePostMergeCI, StageReleasing, StageFailed:
+		return false
+	default:
+		return true
+	}
 }
 
 // headIsStrictDescendant reports whether descendantSHA (on descendantBranch)

--- a/internal/autopilot/controller_gh5034_test.go
+++ b/internal/autopilot/controller_gh5034_test.go
@@ -19,11 +19,174 @@ import (
 // targeting main. B clears CI first and reaches StageMerging before A does —
 // driving B through ProcessPR (the state-machine test harness, exactly as
 // controller_gh5031_test.go's HoldsInsteadOfMerging test does) must park it
-// naming A instead of merging out of order. Once A merges — modeled here the
-// same way the real lifecycle removes a fully finalized PR, by dropping it
-// from activePRs — a later tick for B must un-park and proceed to merge
-// normally, with no extra escalation firing on the way through.
+// naming A instead of merging out of order. Once A merges — modeled here as
+// a stage transition to StageMerged while STILL tracked in activePRs
+// (GH-5049 requirement 3: the real lifecycle keeps a merged PR tracked
+// through post-merge CI/release bookkeeping before eventually evicting it;
+// dropping it from activePRs outright, as this test used to, only exercises
+// the finalization-eviction resume path and can't distinguish it from
+// resuming on the base reaching StageMerged — this version fails against
+// pre-GH-5049 main, which resumed only on eviction) — a later tick for B
+// must un-park (Parked=false, parked-awaiting-approval label removed) and
+// proceed to merge normally, with no extra escalation firing on the way
+// through.
 func TestController_HandleMerging_StackedSuperset_UnparksAfterBaseMerges(t *testing.T) {
+	local := newFixtureRepo(t)
+	ctx := context.Background()
+
+	runFixtureGit(t, local, "checkout", "-b", "pilot/GH-16")
+	writeFixtureFile(t, local, "base.txt", "from base PR\n")
+	runFixtureGit(t, local, "add", "base.txt")
+	runFixtureGit(t, local, "commit", "-m", "GH-16 work")
+	runFixtureGit(t, local, "push", "origin", "pilot/GH-16")
+	baseSHA := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	runFixtureGit(t, local, "checkout", "-b", "pilot/GH-17")
+	writeFixtureFile(t, local, "stacked.txt", "from stacked PR\n")
+	runFixtureGit(t, local, "add", "stacked.txt")
+	runFixtureGit(t, local, "commit", "-m", "GH-17 work, stacked on GH-16")
+	runFixtureGit(t, local, "push", "origin", "pilot/GH-17")
+	stackedSHA := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	var mergeCalled, labelApplied, labelRemoved atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/17/merge" && r.Method == http.MethodPut:
+			mergeCalled.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"sha":"mergedSHA","merged":true,"message":"merged"}`))
+		case r.URL.Path == "/repos/owner/repo/issues/17/comments" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case r.URL.Path == "/repos/owner/repo/issues/17/labels" && r.Method == http.MethodPost:
+			labelApplied.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case r.URL.Path == "/repos/owner/repo/issues/17/labels/"+labelParkedAwaitingApproval && r.Method == http.MethodDelete:
+			labelRemoved.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/17/labels/") && r.Method == http.MethodDelete:
+			// Other label removals fired by the post-merge "delivered" bookkeeping
+			// (pilot-in-progress/pilot-failed/pilot-retry-* cleanup) — not under
+			// test here, just acknowledged so they don't 404-noise the log.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithProjectPath(local))
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	c.mu.Lock()
+	c.activePRs[16] = &PRState{
+		PRNumber:     16,
+		BranchName:   "pilot/GH-16",
+		HeadSHA:      baseSHA,
+		TargetBranch: "main",
+		Stage:        StageWaitingCI, // A hasn't cleared CI yet
+		CreatedAt:    time.Now(),
+	}
+	c.activePRs[17] = &PRState{
+		PRNumber:     17,
+		IssueNumber:  17, // GH-5049: needed so the un-park path's label removal actually fires
+		BranchName:   "pilot/GH-17",
+		HeadSHA:      stackedSHA,
+		TargetBranch: "main",
+		Stage:        StageMerging, // B cleared CI first
+		CreatedAt:    time.Now(),
+	}
+	c.mu.Unlock()
+
+	ghPR17 := &github.PullRequest{
+		Number: 17,
+		Head:   github.PRRef{SHA: stackedSHA},
+		Base:   github.PRRef{Ref: "main"},
+	}
+
+	// Tick 1: A is still open — B must park naming A instead of merging.
+	if err := c.ProcessPR(ctx, 17, ghPR17); err != nil {
+		t.Fatalf("tick 1: ProcessPR: %v", err)
+	}
+	if mergeCalled.Load() != 0 {
+		t.Fatalf("tick 1: merge called %d times, want 0 — B must not merge ahead of A", mergeCalled.Load())
+	}
+	pr17, ok := c.GetPRState(17)
+	if !ok {
+		t.Fatal("PR 17 should still be tracked")
+	}
+	if !pr17.Parked {
+		t.Error("tick 1: Parked should be true")
+	}
+	if !strings.Contains(pr17.EscalationReason, "PR #16") {
+		t.Errorf("tick 1: EscalationReason = %q, want it to name PR #16", pr17.EscalationReason)
+	}
+	if pr17.Stage != StageMerging {
+		t.Errorf("tick 1: Stage = %s, want %s (parked, not merged)", pr17.Stage, StageMerging)
+	}
+	if len(sink.events) != 1 {
+		t.Fatalf("tick 1: alerts fired %d times, want 1", len(sink.events))
+	}
+	if labelApplied.Load() != 1 {
+		t.Errorf("tick 1: parked-awaiting-approval label applied %d times, want 1", labelApplied.Load())
+	}
+
+	// A merges: modeled as a stage transition to StageMerged while STILL
+	// tracked in activePRs (GH-5049 requirement 1/3) — NOT removal from
+	// activePRs. The real lifecycle keeps a merged PR tracked through
+	// post-merge CI/release bookkeeping (handleMerged/handleReleasing)
+	// before eventually evicting it via removePR; a resume mechanism that
+	// only reacts to eviction resumes late in the normal case and can wedge
+	// permanently if the base ever gets stuck tracked in a post-merge stage.
+	// This step must be enough, on its own, to un-park B on the next tick.
+	c.mu.Lock()
+	c.activePRs[16].Stage = StageMerged
+	c.mu.Unlock()
+
+	// Tick 2: A has merged (still tracked, StageMerged) — B must un-park and
+	// proceed to merge.
+	if err := c.ProcessPR(ctx, 17, ghPR17); err != nil {
+		t.Fatalf("tick 2: ProcessPR: %v", err)
+	}
+	if mergeCalled.Load() != 1 {
+		t.Fatalf("tick 2: merge called %d times, want 1 — B must merge once A reaches StageMerged", mergeCalled.Load())
+	}
+	pr17, ok = c.GetPRState(17)
+	if !ok {
+		t.Fatal("PR 17 should still be tracked")
+	}
+	if pr17.Parked {
+		t.Error("tick 2: Parked should be false — the stacked-superset park must clear once the base reaches StageMerged")
+	}
+	if labelRemoved.Load() != 1 {
+		t.Errorf("tick 2: parked-awaiting-approval label removed %d times, want 1", labelRemoved.Load())
+	}
+	if pr17.Stage != StageMerged {
+		t.Errorf("tick 2: Stage = %s, want %s — B should have proceeded through to a completed merge", pr17.Stage, StageMerged)
+	}
+	// No new escalation should fire on the way through — un-parking is not
+	// itself an event.
+	if len(sink.events) != 1 {
+		t.Errorf("tick 2: alerts fired %d times total, want 1 (no new escalation on un-park)", len(sink.events))
+	}
+}
+
+// TestController_HandleMerging_StackedSuperset_FailedBaseNotBlocking is the
+// GH-5049 (GH-5032 residual, requirement 2) regression flagged in PR#5035's
+// review: a base PR (A) that reached StageFailed will never merge, so it can
+// never legitimately be "merge that first" — a descendant built on top of
+// its still-unmerged branch must NOT be parked on it and must merge normally
+// through handleMerging via ProcessPR.
+func TestController_HandleMerging_StackedSuperset_FailedBaseNotBlocking(t *testing.T) {
 	local := newFixtureRepo(t)
 	ctx := context.Background()
 
@@ -72,7 +235,7 @@ func TestController_HandleMerging_StackedSuperset_UnparksAfterBaseMerges(t *test
 		BranchName:   "pilot/GH-16",
 		HeadSHA:      baseSHA,
 		TargetBranch: "main",
-		Stage:        StageWaitingCI, // A hasn't cleared CI yet
+		Stage:        StageFailed, // A will never merge
 		CreatedAt:    time.Now(),
 	}
 	c.activePRs[17] = &PRState{
@@ -80,7 +243,7 @@ func TestController_HandleMerging_StackedSuperset_UnparksAfterBaseMerges(t *test
 		BranchName:   "pilot/GH-17",
 		HeadSHA:      stackedSHA,
 		TargetBranch: "main",
-		Stage:        StageMerging, // B cleared CI first
+		Stage:        StageMerging,
 		CreatedAt:    time.Now(),
 	}
 	c.mu.Unlock()
@@ -91,56 +254,24 @@ func TestController_HandleMerging_StackedSuperset_UnparksAfterBaseMerges(t *test
 		Base:   github.PRRef{Ref: "main"},
 	}
 
-	// Tick 1: A is still open — B must park naming A instead of merging.
 	if err := c.ProcessPR(ctx, 17, ghPR17); err != nil {
-		t.Fatalf("tick 1: ProcessPR: %v", err)
+		t.Fatalf("ProcessPR: %v", err)
 	}
-	if mergeCalled.Load() != 0 {
-		t.Fatalf("tick 1: merge called %d times, want 0 — B must not merge ahead of A", mergeCalled.Load())
+	if mergeCalled.Load() != 1 {
+		t.Fatalf("merge called %d times, want 1 — a StageFailed base must never hold a descendant hostage", mergeCalled.Load())
 	}
 	pr17, ok := c.GetPRState(17)
 	if !ok {
 		t.Fatal("PR 17 should still be tracked")
 	}
-	if !pr17.Parked {
-		t.Error("tick 1: Parked should be true")
-	}
-	if !strings.Contains(pr17.EscalationReason, "PR #16") {
-		t.Errorf("tick 1: EscalationReason = %q, want it to name PR #16", pr17.EscalationReason)
-	}
-	if pr17.Stage != StageMerging {
-		t.Errorf("tick 1: Stage = %s, want %s (parked, not merged)", pr17.Stage, StageMerging)
-	}
-	if len(sink.events) != 1 {
-		t.Fatalf("tick 1: alerts fired %d times, want 1", len(sink.events))
-	}
-
-	// A merges: it is no longer tracked as an open autopilot PR, mirroring
-	// the real lifecycle where a fully finalized PR is removed from
-	// activePRs (controller.go deletes the entry once handleMerged/the
-	// external-merge path finishes with it).
-	c.mu.Lock()
-	delete(c.activePRs, 16)
-	c.mu.Unlock()
-
-	// Tick 2: A is gone — B must un-park and proceed to merge.
-	if err := c.ProcessPR(ctx, 17, ghPR17); err != nil {
-		t.Fatalf("tick 2: ProcessPR: %v", err)
-	}
-	if mergeCalled.Load() != 1 {
-		t.Fatalf("tick 2: merge called %d times, want 1 — B must merge once A is gone", mergeCalled.Load())
-	}
-	pr17, ok = c.GetPRState(17)
-	if !ok {
-		t.Fatal("PR 17 should still be tracked")
+	if pr17.Parked {
+		t.Errorf("Parked should be false — a StageFailed base is not a valid stacked-superset candidate, got reason=%q", pr17.EscalationReason)
 	}
 	if pr17.Stage != StageMerged {
-		t.Errorf("tick 2: Stage = %s, want %s — B should have proceeded through to a completed merge", pr17.Stage, StageMerged)
+		t.Errorf("Stage = %s, want %s", pr17.Stage, StageMerged)
 	}
-	// No new escalation should fire on the way through — un-parking is not
-	// itself an event.
-	if len(sink.events) != 1 {
-		t.Errorf("tick 2: alerts fired %d times total, want 1 (no new escalation on un-park)", len(sink.events))
+	if len(sink.events) != 0 {
+		t.Fatalf("alerts fired %d times, want 0 — merging past a StageFailed base must not escalate", len(sink.events))
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5049.

Closes #5049

## Changes

GitHub Issue GH-5049: fix(autopilot): stacked-park resume-on-merge + candidate stage filtering + fail-when-unwired assertions (GH-5032 residual, items 2-4)

## Context

GH-5032 closed as delivered via PR#5043 (merged 2026-08-20 20:33Z), but post-merge review found it delivered only **1 of the 4 items its body marked "REQUIRED, not optional"**. Delivered: the GH-4911-style un-park cleanup (Parked=false, EscalationReason cleared, parked label removed, correctly skipped when detection errored). Undelivered (this issue's scope — do NOT re-implement item 1):

## Requirements

1. **Resume on base MERGE, not base finalization.** The stacked-parked descendant currently un-parks only when the base PR leaves `activePRs` (after post-merge CI + release). Un-park when the base reaches StageMerged — or equivalently filter `detectStackedSuperset` (`internal/autopilot/controller.go:6429`) candidates by stage so merged/finalizing PRs no longer count as stack bases. Pick one mechanism, document why. Today's behavior is resume latency in the normal case and a PERMANENT park if the base wedges tracked in a terminal stage post-merge.
2. **Candidate-stage filtering**: exclude merged-but-still-tracked and StageFailed PRs from the "stacked on" candidate set (also flagged in PR#5035's review — a StageFailed PR should never hold a descendant hostage).
3. **The fail-when-unwired assertions** PR#5040 deliberately left to GH-5032 and PR#5043 never added: extend the controller_gh5034 regression tests so tick 2 asserts `Parked==false` AND parked-label removal (these pass now — item 1 shipped — so they pin it against regression), AND model the base's merge as a stage transition (StageMerged, still tracked) rather than `delete(activePRs, ...)` — this version FAILS against today's main (resume-on-finalization) and proves requirement 1 when it goes green.

## Acceptance Criteria

- [ ] Test: base PR at StageMerged (still in activePRs) → descendant un-parks and merges on the next tick. Fails before the fix, passes after.
- [ ] Test: base PR at StageFailed → descendant is NOT considered stacked (merges normally).
- [ ] Tick-2 assertions include Parked==false + parked-label removal.
- [ ] No change to the enter-park path or the fail-open behavior (existing gh5033/gh5034 tests untouched and green).

## Out of scope

- Re-implementing the un-park cleanup (delivered in PR#5043).
- The dispatcher base-presence gate (#5028/#5045 track).

## Refs

- Prior: GH-5032 body §"Review-discovered scope additions" items 2–4 (verbatim source of this issue) · PR#5043 (partial delivery) · PR#5037 review (APPROVE-w-DEFECTS) · PR#5040 review notes
- Process note: GH-5032 closing as done with 3 of 4 required body items undelivered is a delivery-evidence data point (TASK-460 class — scope-completeness leg).