### PR TITLE
GH-5053: feat(cmd/pilot): register adapter-backed base-presence probe in composition root

### DIFF
--- a/.agent/tasks/gh-5053.md
+++ b/.agent/tasks/gh-5053.md
@@ -1,0 +1,10 @@
+# GH-5053
+
+**Created:** 2026-08-20
+
+## Problem
+
+In cmd/pilot/, register the internal/adapters/github adapter as the concrete FileExistsOnDefaultBranch / IssueOrPRState probe on the dispatcher/executor at wiring time (composition root), replacing the gh-CLI shellout in production paths (shellout stays only as the explicit unregistered fallback defined in subtask 1). Add a wiring test that constructs the production composition and asserts the probe is registered on the dispatcher; the test must fail if the registration line is removed. This subtask depends on subtask 1 landing (or its interface being available) since it consumes the probe interface defined there.
+
+## Acceptance Criteria
+

--- a/cmd/pilot/github_base_presence_probe.go
+++ b/cmd/pilot/github_base_presence_probe.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/config"
+	"github.com/qf-studio/pilot/internal/executor"
+)
+
+// githubBasePresenceProbe adapts internal/adapters/github.Client to
+// executor.BasePresenceProbe (GH-5053). *github.Client already implements
+// FileExistsOnDefaultBranch and IssueOrPRState with signatures matching
+// executor.BasePresenceProbe byte-for-byte (repo_state.go, GH-5046) — this
+// wrapper only needs to add LinkedPRNumbers, via the existing
+// SearchPRsForIssue GitHub Search API call (client.go).
+type githubBasePresenceProbe struct {
+	*github.Client
+}
+
+// LinkedPRNumbers implements executor.BasePresenceProbe by mapping
+// SearchPRsForIssue's []*github.PullRequest results down to bare PR
+// numbers — basePresenceChecker only needs the number to re-probe each
+// candidate via IssueOrPRState.
+func (p githubBasePresenceProbe) LinkedPRNumbers(ctx context.Context, owner, repo string, issueNumber int) ([]int, error) {
+	prs, err := p.SearchPRsForIssue(ctx, owner, repo, issueNumber)
+	if err != nil {
+		return nil, err
+	}
+	numbers := make([]int, 0, len(prs))
+	for _, pr := range prs {
+		numbers = append(numbers, pr.Number)
+	}
+	return numbers, nil
+}
+
+// newGitHubBasePresenceProbe builds a base-presence probe (GH-5053) over an
+// in-tree GitHub client whose token is re-resolved per request
+// (newGitHubClient, main.go — GH-4747), for registration at composition
+// time in place of the gh-CLI shellout fallback (ghCLIBasePresenceProbe,
+// internal/executor/base_presence.go) — that fallback remains the
+// unregistered default for any repo this probe is never registered for.
+// Returned as the executor.BasePresenceProbe interface so callers
+// (poller_github.go) never need to import internal/adapters/github
+// directly — that file is SDK-poller-only by convention
+// (TestGithubPollerNoLegacyImport, poller_github_test.go).
+func newGitHubBasePresenceProbe(cfg *config.Config) executor.BasePresenceProbe {
+	return githubBasePresenceProbe{Client: newGitHubClient(cfg)}
+}

--- a/cmd/pilot/github_base_presence_probe_test.go
+++ b/cmd/pilot/github_base_presence_probe_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/config"
+	"github.com/qf-studio/pilot/internal/executor"
+)
+
+// githubBasePresenceProbe must satisfy executor.BasePresenceProbe at
+// compile time — a build-time guard that catches a signature drift between
+// this shim and the interface it's registered against (GH-5053).
+var _ executor.BasePresenceProbe = githubBasePresenceProbe{}
+
+// TestGithubBasePresenceProbe_LinkedPRNumbers confirms the one method this
+// shim adds beyond *github.Client's own FileExistsOnDefaultBranch/
+// IssueOrPRState (repo_state.go, GH-5046): LinkedPRNumbers maps
+// SearchPRsForIssue's []*github.PullRequest results down to bare numbers
+// against a real HTTP round trip, and IssueOrPRState (inherited directly
+// via the embedded *github.Client) keeps working through the same wrapper.
+func TestGithubBasePresenceProbe_LinkedPRNumbers(t *testing.T) {
+	var gotPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPaths = append(gotPaths, r.URL.Path)
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/search/issues"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"items":[{"id":1,"number":42,"title":"fix","state":"open"},{"id":2,"number":43,"title":"fix2","state":"closed","pull_request":{"merged_at":"2026-01-01T00:00:00Z"}}]}`))
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/7"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"number":7,"state":"open"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+		}
+	}))
+	defer server.Close()
+
+	probe := githubBasePresenceProbe{Client: github.NewClientWithBaseURL("test-token", server.URL)}
+
+	numbers, err := probe.LinkedPRNumbers(context.Background(), "owner", "repo", 7)
+	if err != nil {
+		t.Fatalf("LinkedPRNumbers: unexpected error: %v", err)
+	}
+	if len(numbers) != 2 || numbers[0] != 42 || numbers[1] != 43 {
+		t.Errorf("LinkedPRNumbers = %v, want [42 43]", numbers)
+	}
+
+	kind, state, err := probe.IssueOrPRState(context.Background(), "owner", "repo", 7)
+	if err != nil {
+		t.Fatalf("IssueOrPRState: unexpected error: %v", err)
+	}
+	if kind != "issue" || state != "open" {
+		t.Errorf("IssueOrPRState = (%q, %q), want (\"issue\", \"open\")", kind, state)
+	}
+
+	if len(gotPaths) != 2 {
+		t.Fatalf("expected 2 HTTP requests against the test server, got %d: %v", len(gotPaths), gotPaths)
+	}
+}
+
+// TestNewGitHubBasePresenceProbe_ReturnsGithubBackedProbe confirms
+// newGitHubBasePresenceProbe(cfg) — the exact call
+// startGithubSDKPollerForRepo wires into RegisterBasePresenceProbe — returns
+// a githubBasePresenceProbe backed by a real, non-nil *github.Client (built
+// via newGitHubClient, whose token is re-resolved per request rather than
+// frozen at construction — GH-4747), not a stub or nil probe.
+func TestNewGitHubBasePresenceProbe_ReturnsGithubBackedProbe(t *testing.T) {
+	cfg := &config.Config{Adapters: &config.AdaptersConfig{
+		GitHub: &github.Config{Enabled: true, Token: "test-token"},
+	}}
+
+	probe := newGitHubBasePresenceProbe(cfg)
+
+	shim, ok := probe.(githubBasePresenceProbe)
+	if !ok {
+		t.Fatalf("newGitHubBasePresenceProbe returned %T, want githubBasePresenceProbe", probe)
+	}
+	if shim.Client == nil {
+		t.Fatal("newGitHubBasePresenceProbe returned a probe with a nil *github.Client")
+	}
+}
+
+// TestStartGithubSDKPollerForRepo_RegistersBasePresenceProbe is a
+// source-level guard (mirrors
+// TestStartGithubSDKPollerForRepo_RegistersPerRepoLabelLifecycleTracker's
+// established pattern for this otherwise-unexercisable startup function,
+// label_lifecycle_deadman_test.go): startGithubSDKPollerForRepo must
+// register the in-tree github adapter as this repo's base-presence probe
+// via RegisterBasePresenceProbe(..., newGitHubBasePresenceProbe(deps.Cfg))
+// (GH-5053) — replacing the gh-CLI shellout fallback in production. This
+// test fails if that registration line is ever removed or reverted to a
+// different (e.g. gh-CLI-backed) probe.
+func TestStartGithubSDKPollerForRepo_RegistersBasePresenceProbe(t *testing.T) {
+	body := githubFuncBody(t, "poller_github.go", "func startGithubSDKPollerForRepo(")
+
+	if !strings.Contains(body, `deps.Runner.RegisterBasePresenceProbe("github:"+target.repoFullName, newGitHubBasePresenceProbe(deps.Cfg))`) {
+		t.Error("startGithubSDKPollerForRepo must register the in-tree github adapter as the base-presence probe via " +
+			`deps.Runner.RegisterBasePresenceProbe("github:"+target.repoFullName, newGitHubBasePresenceProbe(deps.Cfg)) (GH-5053), ` +
+			"replacing the gh-CLI shellout in the production wiring path")
+	}
+
+	// Registration must live alongside the sibling PR-creator/issue-state
+	// registrations under the same deps.Runner != nil guard, not gated
+	// separately — mirrors the label-lifecycle guard's sibling-ordering check.
+	prCreatorIdx := strings.Index(body, "RegisterPRCreator(")
+	basePresenceIdx := strings.Index(body, "RegisterBasePresenceProbe(")
+	if prCreatorIdx < 0 || basePresenceIdx < 0 {
+		t.Fatal("expected both the PR-creator and base-presence-probe registrations in startGithubSDKPollerForRepo")
+	}
+}

--- a/cmd/pilot/poller_github.go
+++ b/cmd/pilot/poller_github.go
@@ -608,6 +608,13 @@ func startGithubSDKPollerForRepo(ctx context.Context, deps *PollerDeps, log *slo
 		// PR creator, on the same sdkClient — in-process, ghbudget-visible
 		// reads for the pickup-time and PR-creation preflight guards.
 		deps.Runner.RegisterIssueStateChecker("github:"+target.repoFullName, sdkshim.NewGitHubIssueStateChecker(sdkClient))
+		// GH-5053: register the in-tree github adapter (github_base_presence_probe.go)
+		// as this repo's base-presence probe — an in-process
+		// FileExistsOnDefaultBranch/IssueOrPRState/LinkedPRNumbers implementation for
+		// the GH-5052 dispatcher claim-path hold check, replacing the gh-CLI shellout
+		// fallback (ghCLIBasePresenceProbe, base_presence.go) that only applies when
+		// no probe is registered for a repo.
+		deps.Runner.RegisterBasePresenceProbe("github:"+target.repoFullName, newGitHubBasePresenceProbe(deps.Cfg))
 	}
 
 	// TASK-461 Leg 2: WithAdapterClient injects the shared TokenFunc-backed


### PR DESCRIPTION
## Summary
- Registers the in-tree `internal/adapters/github` client as the production `executor.BasePresenceProbe` at composition time (`startGithubSDKPollerForRepo`, `cmd/pilot/poller_github.go`), replacing the gh-CLI shellout in the production wiring path — the shellout remains only as the unregistered fallback.
- Adds `githubBasePresenceProbe`, a thin wrapper supplying `LinkedPRNumbers` on top of `*github.Client`'s existing `FileExistsOnDefaultBranch`/`IssueOrPRState` (`cmd/pilot/github_base_presence_probe.go`).
- Adds a source-scoped wiring test that fails if the `RegisterBasePresenceProbe(...)` registration line is removed or reverted to a different probe (`cmd/pilot/github_base_presence_probe_test.go`).

## Stacking note
This depends on the `executor.BasePresenceProbe` interface / dispatcher gate from #5054 (GH-5052), which is still open. This PR is based on `pilot/GH-5052` rather than `main` so the diff here only shows the GH-5053-specific wiring (4 files, +182) — merge #5054 first, then rebase/merge this on top.

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/pilot/... ./internal/executor/...`