### PR TITLE
fix(executor): parse bare pilot-signal lines emitted outside fences

### DIFF
--- a/internal/executor/signal.go
+++ b/internal/executor/signal.go
@@ -79,6 +79,19 @@ func (p *SignalParser) ParseSignals(text string) []PilotSignal {
 		signals = append(signals, signal)
 	}
 
+	// Models also emit payloads as bare lines outside a fence; fenced blocks are removed first so nothing parses twice.
+	for _, line := range strings.Split(signalBlockRegex.ReplaceAllString(text, ""), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, `{"v":`) || !strings.HasSuffix(trimmed, "}") {
+			continue
+		}
+		var signal PilotSignal
+		if err := json.Unmarshal([]byte(trimmed), &signal); err != nil {
+			continue
+		}
+		signals = append(signals, p.validateSignal(signal))
+	}
+
 	return signals
 }
 

--- a/internal/executor/signal_test.go
+++ b/internal/executor/signal_test.go
@@ -74,6 +74,54 @@ func TestSignalParser_ParseSignals(t *testing.T) {
 			expectedProg:  -1, // No status signal, so GetLatestProgress returns -1
 			expectedExit:  true,
 		},
+		{
+			name:          "bare exit signal outside a fence",
+			input:         "Task complete.\n{\"v\":2,\"type\":\"exit\",\"exit_signal\":true,\"success\":true}\nDone.",
+			expectedCount: 1,
+			expectedPhase: "",
+			expectedProg:  -1,
+			expectedExit:  true,
+		},
+		{
+			name:          "bare status signal outside a fence",
+			input:         "{\"v\":2,\"type\":\"status\",\"phase\":\"IMPL\",\"progress\":40}",
+			expectedCount: 1,
+			expectedPhase: "IMPL",
+			expectedProg:  40,
+			expectedExit:  false,
+		},
+		{
+			name:          "fenced signal is not double-counted by the bare scan",
+			input:         "```pilot-signal\n{\"v\":2,\"type\":\"exit\",\"exit_signal\":true,\"success\":true}\n```",
+			expectedCount: 1,
+			expectedPhase: "",
+			expectedProg:  -1,
+			expectedExit:  true,
+		},
+		{
+			name:          "fenced and bare signals both parse once each",
+			input:         "```pilot-signal\n{\"v\":2,\"type\":\"status\",\"phase\":\"RESEARCH\",\"progress\":25}\n```\n{\"v\":2,\"type\":\"exit\",\"exit_signal\":true,\"success\":true}",
+			expectedCount: 2,
+			expectedPhase: "RESEARCH",
+			expectedProg:  25,
+			expectedExit:  true,
+		},
+		{
+			name:          "bare line with invalid JSON is skipped",
+			input:         "{\"v\":2,\"type\":\"exit\",",
+			expectedCount: 0,
+			expectedPhase: "",
+			expectedProg:  -1,
+			expectedExit:  false,
+		},
+		{
+			name:          "bare JSON line without the v prefix is ignored",
+			input:         "{\"type\":\"exit\",\"exit_signal\":true}",
+			expectedCount: 0,
+			expectedPhase: "",
+			expectedProg:  -1,
+			expectedExit:  false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -256,6 +304,18 @@ func TestSignalParser_NoOpExitReason(t *testing.T) {
 			input:        "```pilot-signal\n{\"v\":2,\"type\":\"exit\",\"exit_signal\":true,\"success\":true,\"no_op\":true,\"reason\":\"watch ticket unchanged\"}\n```",
 			expectedOK:   true,
 			expectedText: "watch ticket unchanged",
+		},
+		{
+			name:         "bare unfenced no_op with reason is valid",
+			input:        "{\"v\":2,\"type\":\"exit\",\"exit_signal\":true,\"success\":true,\"no_op\":true,\"reason\":\"watch ticket unchanged\"}",
+			expectedOK:   true,
+			expectedText: "watch ticket unchanged",
+		},
+		{
+			name:         "bare unfenced mandatory exit signal is never a no-op",
+			input:        "{\"v\":2,\"type\":\"exit\",\"exit_signal\":true,\"success\":true}",
+			expectedOK:   false,
+			expectedText: "",
 		},
 		{
 			name:         "no_op with empty reason is rejected",


### PR DESCRIPTION
## Summary

Residual of #4901, per the review there: everything the landed GH-4964 contract (#4977) covers has been dropped; this carries only the bare-signal parser fix.

The prompt mandates fenced `pilot-signal` blocks, but in production the model emits the payloads as bare `{"v":...}` lines (observed live on a watch-only ticket — trace in the #4901 thread). Those lines never match `signalBlockRegex`, so the whole signal surface — including the `no_op:true`+reason decline contract — is unreachable for that shape.

## Changes

- `ParseSignals` scans for bare signal lines after stripping fenced blocks, so nothing parses twice. Lines must start `{"v":` and parse as JSON; anything else is skipped.
- `signal_test.go` coverage: bare exit/status/no_op parsing, fence dedup, invalid-JSON and non-signal-JSON skips, and `NoOpExitReason` returning the reason from an unfenced `no_op` signal.

## Testing

`go test ./internal/executor/...` green (executor, ghguard, workflow).