### PR TITLE
GH-5060: fix(executor): gate re-check after retry still runs on the exhausted attempt ctx — false task_failed after a successful fresh-ctx retry (GH-4876 residual)

### DIFF
--- a/internal/executor/gh4129_test.go
+++ b/internal/executor/gh4129_test.go
@@ -375,7 +375,6 @@ func TestDirectPath_QualityGateRetryEndToEnd(t *testing.T) {
 		Description: "First check fails and retries, second check passes",
 		ProjectPath: t.TempDir(),
 		LocalMode:   true,
-		CreatePR:    true,
 	}
 	if err := store.SaveExecution(&memory.Execution{ID: task.LogExecutionID(), TaskID: task.ID, Status: "running"}); err != nil {
 		t.Fatalf("SaveExecution failed: %v", err)

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -4415,7 +4415,26 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 					r.saveLogEntry(task.LogExecutionID(), "info", "Running tests...")
 
 					checker := r.qualityCheckerFactory(task.ID, executionPath)
-					outcome, qErr := checker.Check(ctx)
+
+					// GH-5060: the first-pass gate check (retryAttempt == 0) stays on
+					// the attempt ctx - correct, it should not outlive the attempt.
+					// But retry-pass re-checks (retryAttempt > 0) must not run on that
+					// same ctx: GH-4876 gave the reset (line ~4523) and re-invoke (line
+					// ~4593) legs fresh contexts so an exhausted attempt deadline can't
+					// doom an otherwise-recoverable retry, but the gate re-check itself
+					// was left on the old ctx. A ctx-respecting checker whose deadline
+					// already passed by the time the fresh-ctx re-invoke completes would
+					// die here with "context deadline exceeded", producing a false
+					// task_failed right after a successful retry.
+					var outcome *QualityOutcome
+					var qErr error
+					if retryAttempt > 0 {
+						checkCtx, checkCancel := context.WithTimeout(context.Background(), timeout)
+						outcome, qErr = checker.Check(checkCtx)
+						checkCancel()
+					} else {
+						outcome, qErr = checker.Check(ctx)
+					}
 					if qErr != nil {
 						log.Error("Quality gate check error", slog.Any("error", qErr))
 						result.Success = false

--- a/internal/executor/runner_gh5060_test.go
+++ b/internal/executor/runner_gh5060_test.go
@@ -1,0 +1,111 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+// ctxRespectingQualityChecker is the GH-5060 regression mock: unlike
+// sleepThenFailQualityChecker (runner_gh4876_test.go), which unconditionally
+// ignores the ctx it's given, this checker actually consumes it on the
+// retry-pass re-check (its second+ call) — mirroring how a real checker
+// built on exec.CommandContext behaves: if the ctx is already expired when
+// the command would start, it returns ctx.Err() instead of running.
+//
+// The first call always sleeps past the (short) outer attempt ctx deadline
+// and fails with ShouldRetry, exactly like sleepThenFailQualityChecker, so
+// this checker can stand in for it in the "outer ctx expires before the
+// retry" scenario while remaining able to detect a stale ctx on the
+// re-check.
+type ctxRespectingQualityChecker struct {
+	sleep time.Duration
+	calls int
+}
+
+func (c *ctxRespectingQualityChecker) Check(ctx context.Context) (*QualityOutcome, error) {
+	c.calls++
+	if c.calls == 1 {
+		time.Sleep(c.sleep)
+		return &QualityOutcome{
+			Passed:        false,
+			ShouldRetry:   true,
+			RetryFeedback: "synthetic gate failure",
+			Attempt:       c.calls,
+		}, nil
+	}
+	// Retry-pass re-check: consume the ctx, exactly as a real
+	// exec.CommandContext-backed checker would.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return &QualityOutcome{Passed: true, Attempt: c.calls}, nil
+}
+
+// TestQualityGateRetry_RecheckUsesFreshContext is the GH-5060 regression
+// guard. PR#5058 (GH-4876) gave the pre-retry reset (runner.go ~4523) and
+// the retry backend re-invoke (runner.go ~4593) fresh
+// context.Background()-derived deadlines, but the retry-pass gate re-check
+// itself — checker.Check(ctx) — was left running on the original (possibly
+// exhausted) attempt ctx. A real, ctx-respecting checker whose ctx has
+// already expired by the time the re-check runs dies immediately with
+// "context deadline exceeded", producing a false task_failed right after a
+// successful fresh-ctx retry — and the doomed-retry shape is now *more*
+// expensive than before #5058, since the re-invoke burns a full backend run
+// first.
+//
+// sleepThenFailQualityChecker (used by
+// TestQualityGateRetry_UsesFreshContextForResetAndReinvoke) cannot catch
+// this: it ignores its ctx unconditionally, so it structurally cannot tell
+// a fresh ctx from a stale one. ctxRespectingQualityChecker fixes that by
+// consuming ctx.Err() on its retry-pass call.
+//
+// The outer ctx is given a short deadline. The checker's first call
+// (running on the still-live outer ctx) sleeps past that deadline and
+// always fails with ShouldRetry, forcing a retry. By the time the reset +
+// backend re-invoke (both on their own fresh contexts, per #5058) complete,
+// the outer attempt ctx has expired. Pre-fix, the retry-pass re-check reuses
+// that expired ctx and fails with "context deadline exceeded"; post-fix, it
+// runs on a fresh ctx and observes the checker's second call pass.
+func TestQualityGateRetry_RecheckUsesFreshContext(t *testing.T) {
+	localRepo, remoteRepo := setupTestRepoWithRemote(t)
+	defer func() { _ = os.RemoveAll(localRepo) }()
+	defer func() { _ = os.RemoveAll(remoteRepo) }()
+
+	backend := &stackingAttemptBackend{}
+	runner := NewRunnerWithBackend(backend)
+	runner.config = &BackendConfig{UseWorktree: false, SkipSelfReview: true}
+	runner.SetSkipPreflightChecks(true)
+	runner.SetRecordingEnabled(false)
+
+	checker := &ctxRespectingQualityChecker{sleep: 1200 * time.Millisecond}
+	runner.SetQualityCheckerFactory(func(taskID, projectPath string) QualityChecker {
+		return checker
+	})
+
+	task := &Task{
+		ID:          "GH-5060-RECHECK",
+		Title:       "quality gate re-check must not reuse an exhausted attempt ctx",
+		Description: "first gate check fails and retries; the attempt ctx expires before the re-check runs",
+		ProjectPath: localRepo,
+		Branch:      "pilot/GH-5060-recheck",
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 700*time.Millisecond)
+	defer cancel()
+
+	result, _ := runner.Execute(ctx, task)
+	if result == nil {
+		t.Fatal("Execute() returned nil result")
+	}
+	if !result.Success {
+		t.Fatalf("expected the retry to complete successfully on a fresh re-check ctx, got failure: %s", result.Error)
+	}
+	if checker.calls != 2 {
+		t.Fatalf("quality checker called %d times, want 2 (fail then pass)", checker.calls)
+	}
+	if calls := backend.callCount(); calls != 2 {
+		t.Fatalf("expected exactly 2 backend calls (initial + one retry), got %d", calls)
+	}
+}

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -3569,7 +3569,6 @@ func TestLocalModeRunsQualityGates(t *testing.T) {
 		Description: "Quality gates should run in LocalMode",
 		ProjectPath: projectDir,
 		LocalMode:   true,
-		CreatePR:    true,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5060.

Closes #5060

## Changes

GitHub Issue GH-5060: fix(executor): gate re-check after retry still runs on the exhausted attempt ctx — false task_failed after a successful fresh-ctx retry (GH-4876 residual)

## Context

PR#5058 (GH-4876) gave the gate-retry path fresh contexts for reset (runner.go:4523) and re-invoke (runner.go:4593). Post-merge review found the loop's third leg still on the old deadline: the gate check itself — `checker.Check(ctx)` at `internal/executor/runner.go:4418` — runs on the **attempt ctx**.

## Defect

Sequence on an attempt ctx that expires during gates: gates fail → reset succeeds (fresh ctx) → re-invoke succeeds (fresh ctx, burns a full backend run) → loop re-checks gates on the **exhausted** attempt ctx → a real checker that respects its ctx dies with `quality gate error: context deadline exceeded` → false `task_failed`. The doomed-retry shape survives for tasks whose attempt ctx expires during gates — and is now *more expensive* than pre-#5058 because the re-invoke completes first.

Why tests are green anyway: `TestQualityGateRetry_UsesFreshContextForResetAndReinvoke` uses `sleepThenFailQualityChecker.Check(_ context.Context)` — the mock **ignores its ctx**, so it structurally cannot detect this (TASK-460 class: test proves reset+re-invoke freshness, not loop survival).

## Fix

Run the gate re-check on a fresh deadline when `retryAttempt > 0` (same idiom as the reset/re-invoke legs: `context.Background()` + a bounded timeout). First-pass gate check stays on the attempt ctx (correct — it should not outlive the attempt).

## Acceptance Criteria

- [ ] Retry-pass gate check runs on a fresh bounded ctx; first-pass behavior unchanged.
- [ ] Test with a ctx-RESPECTING mock checker (returns ctx.Err() when expired) + an already-exhausted attempt ctx: pre-fix it must fail at the re-check; post-fix the retry completes. The mock must consume its ctx — no argument-discarding mocks (repo CI gate).
- [ ] Cleanup fold-in: revert the vestigial `CreatePR: true` additions in `gh4129_test.go:378` and `runner_test.go:3572` (final semantics ignore CreatePR; keep honest CreatePR=false gate coverage).
- [ ] `go test ./internal/executor/...` green.

## Refs

PR#5058 post-merge review comment · GH-4876 (lkshrk report) · fresh-ctx idiom: runner.go:4523 (reset), :4593 (re-invoke), :3177 (dirt-discard), :3766 (smart-retry)