### PR TITLE
GH-5056: fix(dispatch): needs-human park must survive poller re-admission — admission check + retry-ready shed + escalation alert (GH-5052 residuals)

### DIFF
--- a/cmd/pilot/gh5056_needs_human_admission_test.go
+++ b/cmd/pilot/gh5056_needs_human_admission_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	sdkcore "github.com/qf-studio/studio-sdk/sdk/core"
+
+	"github.com/qf-studio/pilot/internal/executor"
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// GH-5056: the SDK poller's own candidate filter (studio-sdk
+// poller.go:742-815) checks pilot-in-progress/done/blocked/needs-
+// clarification/failed/retry-ready but never pilot-needs-human. A park
+// (escalateBasePresenceHold, autopilot's escalateAndHold) strips
+// pilot-in-progress while leaving the pilot trigger label standing, so once
+// isTaskStillQueued goes false the poller unmarks and re-dispatches after
+// its 5-min grace — re-holding/re-escalating on a slow loop. This file
+// covers the host-side admission backstop added to close that loop.
+
+// TestGithubEventHasNeedsHumanLabel is a direct unit test of the label-match
+// helper handleGithubIssueEventSDK's admission check consults.
+func TestGithubEventHasNeedsHumanLabel(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels []string
+		want   bool
+	}{
+		{name: "absent, other pilot labels present", labels: []string{"pilot", "pilot-in-progress"}, want: false},
+		{name: "present alongside other labels", labels: []string{"pilot", "pilot-needs-human"}, want: true},
+		{name: "present alone", labels: []string{"pilot-needs-human"}, want: true},
+		{name: "nil labels", labels: nil, want: false},
+		{name: "empty labels", labels: []string{}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := githubEventHasNeedsHumanLabel(tt.labels); got != tt.want {
+				t.Errorf("githubEventHasNeedsHumanLabel(%v) = %v, want %v", tt.labels, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHandleGithubIssueEventSDK_NeedsHumanLabelBlocksAdmission is GH-5056's
+// primary regression: an issue carrying pilot-needs-human must never be
+// (re-)admitted through the SDK-dispatch chokepoint. This drives the real
+// function with a real dispatcher/store (mirrors newHandlerTestDispatcher in
+// handler_common_test.go) rather than a fake — a fail-when-unwired guard: if
+// a future edit moves the check into a helper nothing actually calls, this
+// test starts failing because a task row IS created, not because a helper
+// unit test alone stops matching.
+func TestHandleGithubIssueEventSDK_NeedsHumanLabelBlocksAdmission(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pilot-test-gh5056-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	dispatcher := executor.NewDispatcher(store, executor.NewRunner(), nil)
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("dispatcher.Start: %v", err)
+	}
+	t.Cleanup(dispatcher.Stop)
+
+	const taskID = "GH-5056"
+	const projectPath = "/nonexistent-gh5056-project"
+
+	ev := sdkcore.IssueEvent{
+		SequenceID: taskID,
+		IssueID:    "5056",
+		Title:      "needs-human parked issue",
+		Labels:     []string{"pilot", "pilot-needs-human"},
+	}
+
+	result, err := handleGithubIssueEventSDK(context.Background(), nil, ev, projectPath, "", dispatcher, nil, nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("handleGithubIssueEventSDK() error = %v, want nil", err)
+	}
+	if result == nil || !result.Skipped {
+		t.Fatalf("handleGithubIssueEventSDK() = %+v, want Skipped=true", result)
+	}
+	if result.SkipReason != "needs_human" {
+		t.Errorf("SkipReason = %q, want %q", result.SkipReason, "needs_human")
+	}
+
+	exec, err := store.GetLatestExecutionByTaskID(taskID, projectPath)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetLatestExecutionByTaskID: %v", err)
+	}
+	if exec != nil {
+		t.Errorf("expected no task row created for a pilot-needs-human labeled issue, got %+v", exec)
+	}
+	if dispatcher.IsActive(taskID, projectPath) {
+		t.Error("expected the needs-human labeled issue to never become an active dispatch")
+	}
+}
+
+// TestGithubHandlerSDK_NeedsHumanAdmissionCheckWired is a source-level guard
+// (mirrors TestGithubHandlerSDK_SpecGuardWired in spec_guard_sdk_test.go):
+// the admission check must run inside handleGithubIssueEventSDK's own body,
+// before the shared dispatch chokepoint (handleIssueGeneric), not merely
+// exist somewhere unreferenced.
+func TestGithubHandlerSDK_NeedsHumanAdmissionCheckWired(t *testing.T) {
+	body := githubFuncBody(t, "handlers.go", "func handleGithubIssueEventSDK(")
+
+	const checkExpr = "githubEventHasNeedsHumanLabel(ev.Labels)"
+	if !strings.Contains(body, checkExpr) {
+		t.Fatalf("handleGithubIssueEventSDK must call %s before dispatch (GH-5056)", checkExpr)
+	}
+
+	checkIdx := strings.Index(body, checkExpr)
+	dispatchIdx := strings.Index(body, "handleIssueGeneric(")
+	if dispatchIdx < 0 {
+		t.Fatal("handleGithubIssueEventSDK must call handleIssueGeneric to dispatch")
+	}
+	if checkIdx > dispatchIdx {
+		t.Error("handleGithubIssueEventSDK must run the pilot-needs-human admission check before handleIssueGeneric, not after")
+	}
+}

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -712,6 +712,27 @@ func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkco
 	taskID := ev.SequenceID // "GH-42"; already prefixed by the SDK adapter — do NOT re-prefix
 	title := ev.Title
 
+	// GH-5056: admission backstop — an issue carrying pilot-needs-human must
+	// never be (re-)admitted through this chokepoint, no matter what
+	// unmarked it. The SDK poller's own candidate filter (studio-sdk
+	// poller.go:742-815) checks pilot-in-progress/done/blocked/needs-
+	// clarification/failed/retry-ready but never pilot-needs-human — and a
+	// park (escalateBasePresenceHold, autopilot's escalateAndHold) strips
+	// pilot-in-progress while leaving the pilot trigger label standing, so
+	// once isTaskStillQueued goes false the poller unmarks and re-dispatches
+	// after its 5-min grace: re-hold, re-escalate, on a slow loop that
+	// re-blocks this project's queue head each cycle. Checked before any
+	// other side effect (spec-guard, pilot-in-progress label/comment, task
+	// construction, dispatch) so a re-admitted needs-human issue costs
+	// nothing beyond this one check.
+	if githubEventHasNeedsHumanLabel(ev.Labels) {
+		logging.WithComponent("github").Info("SDK-dispatch: skipping admission, issue carries pilot-needs-human",
+			slog.String("task_id", taskID),
+			slog.String("reason", labelPilotNeedsHumanSDK),
+		)
+		return &sdkcore.IssueResult{Success: false, Skipped: true, SkipReason: "needs_human"}, nil
+	}
+
 	taskDesc := fmt.Sprintf("GitHub Issue %s: %s\n\n%s", taskID, title, ev.Body)
 	branchName := fmt.Sprintf("pilot/%s", taskID)
 
@@ -963,6 +984,25 @@ func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkco
 	}
 
 	return issueResult, execErr
+}
+
+// labelPilotNeedsHumanSDK mirrors internal/executor's labelPilotNeedsHuman
+// and internal/autopilot's labelNeedsHuman, defined locally here for the
+// same import-cycle-avoidance reason both of those document — cmd/pilot is
+// the one place all three can't simply share one package-level constant
+// without introducing a dependency between the other two.
+const labelPilotNeedsHumanSDK = "pilot-needs-human"
+
+// githubEventHasNeedsHumanLabel reports whether labels carries
+// pilot-needs-human (GH-5056). See handleGithubIssueEventSDK's call site
+// for the re-admission loop this check exists to close.
+func githubEventHasNeedsHumanLabel(labels []string) bool {
+	for _, l := range labels {
+		if l == labelPilotNeedsHumanSDK {
+			return true
+		}
+	}
+	return false
 }
 
 // fetchGithubIssueForSDKTask fetches the real issue via the studio-sdk GitHub client so

--- a/internal/executor/base_presence.go
+++ b/internal/executor/base_presence.go
@@ -61,6 +61,14 @@ func resolveOwnerRepoForBasePresence(ctx context.Context, task *Task, projectPat
 // documented there.
 const labelPilotNeedsHuman = "pilot-needs-human"
 
+// labelPilotRetryReady mirrors adapters/github.LabelRetryReady, defined
+// locally for the same import-cycle reason as labelPilotNeedsHuman above.
+// GH-5056: escalateBasePresenceHold must strip this label in the same
+// mutation that applies labelPilotNeedsHuman — the GH-5042/PR#5048
+// never-coexist invariant autopilot's escalateAndHold (controller.go)
+// already enforces for its own escalation path.
+const labelPilotRetryReady = "pilot-retry-ready"
+
 // BasePresenceProbe is the narrow read surface basePresenceChecker needs:
 // one lookup for a referenced issue/PR's live state, one lookup for the PR
 // number(s) attached to a referenced issue (the "Depends on: #N" where #N is

--- a/internal/executor/base_presence_escalation_gh5056_test.go
+++ b/internal/executor/base_presence_escalation_gh5056_test.go
@@ -1,0 +1,159 @@
+package executor
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// GH-5056 (PR#5054 review residuals 2 & 3): escalateBasePresenceHold must
+// shed pilot-retry-ready in the same mutation that applies
+// pilot-needs-human (mirroring autopilot's escalateAndHold, controller.go,
+// and the GH-5042/PR#5048 never-coexist invariant), and must emit an
+// alerts-engine event so operator visibility doesn't rest entirely on
+// label-watching.
+
+// TestEscalateBasePresenceHold_ShedsRetryReadyInSameMutation covers defect 2:
+// the escalation `gh issue edit` call must add pilot-needs-human AND remove
+// pilot-retry-ready in one mutation, not just apply the needs-human label.
+func TestEscalateBasePresenceHold_ShedsRetryReadyInSameMutation(t *testing.T) {
+	logFile := setupFakeGhCLI(t)
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runner := NewRunner()
+	worker := NewProjectWorker(t.TempDir(), store, runner, slog.Default())
+
+	task := &Task{
+		ID:            "GH-9500",
+		Title:         "escalation retry-ready shed",
+		ProjectPath:   t.TempDir(),
+		SourceAdapter: "github",
+	}
+
+	worker.escalateBasePresenceHold(context.Background(), task, "referenced PR #1 is still open (not merged)")
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read gh CLI log: %v", err)
+	}
+	log := string(data)
+	if got := strings.Count(log, "issue edit 9500"); got != 1 {
+		t.Fatalf("expected exactly one `gh issue edit 9500` call, got %d (log: %q)", got, log)
+	}
+	if !strings.Contains(log, "--add-label pilot-needs-human") {
+		t.Errorf("expected the escalation call to add pilot-needs-human, got log: %q", log)
+	}
+	if !strings.Contains(log, "--remove-label pilot-retry-ready") {
+		t.Errorf("expected the escalation call to remove pilot-retry-ready in the same mutation (GH-5042/PR#5048 never-coexist invariant), got log: %q", log)
+	}
+	// Both label mutations must ride the single `gh issue edit` call this
+	// test already asserted fires exactly once above — a second, separate
+	// invocation would defeat the "same mutation" guarantee even if both
+	// substrings were individually present in the log.
+	editLine := ""
+	for _, line := range strings.Split(strings.TrimSpace(log), "\n") {
+		if strings.HasPrefix(line, "issue edit 9500") {
+			editLine = line
+			break
+		}
+	}
+	if !strings.Contains(editLine, "--add-label pilot-needs-human") || !strings.Contains(editLine, "--remove-label pilot-retry-ready") {
+		t.Errorf("expected a single `gh issue edit 9500` call carrying both label mutations, got line: %q", editLine)
+	}
+}
+
+// TestEscalateBasePresenceHold_EmitsAlertsEngineEvent covers defect 3: the
+// escalation must fire an alerts-engine event (mirroring escalateAndHold's
+// AlertEventTypeTaskFailed emission), not just label + log + EmitProgress.
+func TestEscalateBasePresenceHold_EmitsAlertsEngineEvent(t *testing.T) {
+	setupFakeGhCLI(t)
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runner := NewRunner()
+	processor := &fakeAlertProcessor{}
+	runner.SetAlertProcessor(processor)
+	worker := NewProjectWorker(t.TempDir(), store, runner, slog.Default())
+
+	task := &Task{
+		ID:            "GH-9501",
+		Title:         "escalation alert coverage",
+		ProjectPath:   t.TempDir(),
+		SourceAdapter: "github",
+	}
+	reason := "referenced PR #2 is still open (not merged)"
+
+	worker.escalateBasePresenceHold(context.Background(), task, reason)
+
+	if len(processor.events) != 1 {
+		t.Fatalf("expected exactly 1 alert event, got %d: %+v", len(processor.events), processor.events)
+	}
+	event := processor.events[0]
+	if event.Type != AlertEventTypeTaskFailed {
+		t.Errorf("event.Type = %q, want %q", event.Type, AlertEventTypeTaskFailed)
+	}
+	if event.TaskID != task.ID {
+		t.Errorf("event.TaskID = %q, want %q", event.TaskID, task.ID)
+	}
+	if event.Project != task.ProjectPath {
+		t.Errorf("event.Project = %q, want %q", event.Project, task.ProjectPath)
+	}
+	if event.Error != reason {
+		t.Errorf("event.Error = %q, want %q", event.Error, reason)
+	}
+}
+
+// TestEscalateBasePresenceHold_AlertFiresEvenWhenLabelCallFails documents
+// that the alert is not gated on the (best-effort, non-fatal per this
+// function's own doc comment) label mutation succeeding — a labeling
+// failure must not also silently swallow operator visibility into the
+// escalation itself.
+func TestEscalateBasePresenceHold_AlertFiresEvenWhenLabelCallFails(t *testing.T) {
+	setupFailingFakeGhCLI(t)
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runner := NewRunner()
+	processor := &fakeAlertProcessor{}
+	runner.SetAlertProcessor(processor)
+	worker := NewProjectWorker(t.TempDir(), store, runner, slog.Default())
+
+	task := &Task{
+		ID:            "GH-9502",
+		Title:         "escalation alert survives label failure",
+		ProjectPath:   t.TempDir(),
+		SourceAdapter: "github",
+	}
+	reason := "referenced PR #3 is still open (not merged)"
+
+	worker.escalateBasePresenceHold(context.Background(), task, reason)
+
+	if len(processor.events) != 1 {
+		t.Fatalf("expected the alert to still fire despite the label call failing, got %d events: %+v", len(processor.events), processor.events)
+	}
+	if processor.events[0].TaskID != task.ID {
+		t.Errorf("event.TaskID = %q, want %q", processor.events[0].TaskID, task.ID)
+	}
+}
+
+// setupFailingFakeGhCLI installs a fake `gh` binary on PATH that exits 1 for
+// the duration of the test — mirrors setupFakeGhCLI (gh4817_issue_open_state_test.go)
+// but simulates every `gh` invocation failing (e.g. a transient API error).
+func setupFailingFakeGhCLI(t *testing.T) {
+	t.Helper()
+	fakeBin := t.TempDir()
+	script := filepath.Join(fakeBin, "gh")
+	content := "#!/bin/sh\necho \"simulated gh failure\" >&2\nexit 1\n"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write failing fake gh: %v", err)
+	}
+	origPATH := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+origPATH)
+}

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -3178,6 +3178,18 @@ func (w *ProjectWorker) recordExecutionEvent(executionID string, stage memory.St
 // labeling failure is logged, not fatal — the caller parks the row
 // (ExecStatusSkipped) and clears the hold counter regardless, so a stuck
 // GitHub call here never wedges the hold accounting itself.
+//
+// GH-5056: two residuals from the PR#5054 review closed here. (1) sheds
+// pilot-retry-ready in the same `gh issue edit` mutation that applies
+// pilot-needs-human — mirrors autopilot's escalateAndHold (controller.go),
+// which enforces the GH-5042/PR#5048 never-coexist invariant identically;
+// without this, a retry-ready re-arm that landed before this escalation
+// fired would sit alongside the needs-human hold unpollable (the GH-5032
+// incident class this site had not been hardened against). (2) fires the
+// alerts-engine equivalent of escalateAndHold's alert — before this,
+// operator visibility into a base-presence escalation rested entirely on
+// label-watching (EmitProgress's "NeedsHuman" phase is dashboard-only, not
+// alerts-engine-routed).
 func (w *ProjectWorker) escalateBasePresenceHold(ctx context.Context, task *Task, reason string) {
 	if task.SourceAdapter != "" && task.SourceAdapter != "github" {
 		return
@@ -3193,15 +3205,32 @@ func (w *ProjectWorker) escalateBasePresenceHold(ctx context.Context, task *Task
 	labelCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	if err := ghEditLabels(labelCtx, task.ProjectPath, issueNum, []string{labelPilotNeedsHuman}, nil); err != nil {
+	if err := ghEditLabels(labelCtx, task.ProjectPath, issueNum, []string{labelPilotNeedsHuman}, []string{labelPilotRetryReady}); err != nil {
 		w.log.Warn("base-presence hold escalation: failed to apply label",
 			slog.String("task_id", task.ID), slog.Any("error", err))
-		return
+	} else {
+		w.log.Info("base-presence hold escalation: applied pilot-needs-human label",
+			slog.String("task_id", task.ID),
+			slog.String("reason", reason),
+		)
 	}
-	w.log.Info("base-presence hold escalation: applied pilot-needs-human label",
-		slog.String("task_id", task.ID),
-		slog.String("reason", reason),
-	)
+
+	if w.runner != nil {
+		w.runner.EmitAlertEvent(AlertEvent{
+			Type:      AlertEventTypeTaskFailed,
+			TaskID:    task.ID,
+			TaskTitle: task.Title,
+			Project:   task.ProjectPath,
+			Error:     reason,
+			Timestamp: time.Now(),
+			Metadata: map[string]string{
+				"task_id": task.ID,
+				"project": task.ProjectPath,
+				"reason":  reason,
+				"label":   labelPilotNeedsHuman,
+			},
+		})
+	}
 }
 
 // hasTerminalSuccessLedger reports whether the TASK-394 execution ledger


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5056.

Closes #5056

## Changes

GitHub Issue GH-5056: fix(dispatch): needs-human park must survive poller re-admission — admission check + retry-ready shed + escalation alert (GH-5052 residuals)

## Context

PR#5054 (GH-5052, base-presence gate v2) parks an escalated issue via `pilot-needs-human` + `Finish(ExecStatusSkipped)`. Its review (see PR#5054 verdict comment) verified the row-level contract but found the park is **not durable against poller re-admission** — plus two smaller escalation-site gaps. Filed pre-merge so GH-5050's "no head-of-line wedge" holds at the *issue* level, not just the row level.

⚠ **Sequencing: do NOT label `pilot` until PR#5054 merges** — item 2 patches code that only exists on `pilot/GH-5052` until then.

## Defects

1. **Poller re-admission loop (primary).** The SDK poller's candidate filter (studio-sdk v0.35.2 `poller.go:742-815`) checks `pilot-in-progress`/`done`/`blocked`/`needs-clarification`/`failed`/`retry-ready` but **never `pilot-needs-human`**. Park strips `pilot-in-progress` (`requiresInProgressLabelStrip` includes Skipped) and leaves the `pilot` trigger label, so once `isTaskStillQueued` goes false the poller unmarks and re-dispatches after the 5-min grace → re-hold (re-blocking the project queue head up to another max-cycles window ≈ ~100 min) → re-escalate, on a slow loop.
   **Fix (host-side, no sdk change):** at the dispatch chokepoint (`handleGithubIssueEventSDK` / `handler_common`), skip admission when `ev.Labels` contains `pilot-needs-human` (log at INFO with the label as reason). This also hardens every OTHER needs-human park (autopilot `escalateAndHold`) against the same re-admission shape.
2. **`escalateBasePresenceHold` doesn't remove `pilot-retry-ready`** — asymmetric with autopilot's `escalateAndHold` (controller.go:~6840), which enforces the GH-5042/PR#5048 never-coexist invariant in the same mutation. Add the defensive removal.
3. **No alerts-engine event on base-presence escalation** — `escalateAndHold` fires an alert; this site only labels + logs + `EmitProgress("NeedsHuman")`. Emit the equivalent alert so operator visibility doesn't rest on label-watching.

## Acceptance Criteria

- [ ] An issue carrying `pilot-needs-human` is never admitted by the dispatch path; test drives the chokepoint with a labeled event and asserts no task row is created (fail-when-unwired: assert the check exists at the chokepoint, not in a helper nothing calls).
- [ ] `escalateBasePresenceHold` sheds `pilot-retry-ready` in the same mutation that applies `pilot-needs-human`; test asserts never-coexist.
- [ ] Base-presence escalation emits an alerts-engine event; test asserts dispatch.
- [ ] Existing base-presence gate tests (PR#5054) untouched and green.

## Non-goals

- sdk-side candidate-filter change (host-side check suffices; sdk leg can follow independently if wanted).
- The gh-CLI fallback `LinkedPRNumbers` bare-number search imprecision (noted in the PR#5054 review; bounded by escalation — separate nit).

## Refs

PR#5054 review verdict comment · GH-5050 req "escalated row resumes only via needs-human resolution" · GH-5042/PR#5048 label-lifecycle invariants · studio-sdk poller.go:742-815 (v0.35.2)