### PR TITLE
GH-5066: fix(autopilot): stacked-base PR dies of CI-timeout to terminal StageFailed before any park logic runs; no re-arm on base retarget (4th sequencing incident)

### DIFF
--- a/.agent/tasks/archive/gh-5066-3.md
+++ b/.agent/tasks/archive/gh-5066-3.md
@@ -1,0 +1,23 @@
+# GH-5066-3
+
+**Created:** 2026-08-21
+
+## Problem
+
+## Subtask 3 of 4
+
+**Parent Task:** GH-5066 - fix(autopilot): stacked-base PR dies of CI-timeout to terminal StageFailed before any park logic runs; no re-arm on base retarget (4th sequencing incident)
+
+## Objective
+
+Test: StageFailed PR whose GitHub base has been retargeted to default is re-driven (stage leaves StageFailed); the no-checks-after-retarget behavior is decided, documented, and tested.
+
+## Context
+
+This is part of a larger task that has been decomposed for better execution.
+Focus on this specific objective. Other subtasks will handle the remaining work.
+
+
+
+## Acceptance Criteria
+

--- a/.agent/tasks/archive/gh-5066-4.md
+++ b/.agent/tasks/archive/gh-5066-4.md
@@ -1,0 +1,43 @@
+# GH-5066-4
+
+**Created:** 2026-08-21
+
+## Problem
+
+## Subtask 4 of 4
+
+**Parent Task:** GH-5066 - fix(autopilot): stacked-base PR dies of CI-timeout to terminal StageFailed before any park logic runs; no re-arm on base retarget (4th sequencing incident)
+
+## Objective
+
+Existing gh5033/gh5034/base-presence tests untouched and green.
+
+## Context
+
+This is part of a larger task that has been decomposed for better execution.
+Focus on this specific objective. Other subtasks will handle the remaining work.
+
+**Note:** This is the final subtask. Ensure all previous subtasks are complete before finishing.
+
+
+## Acceptance Criteria
+
+## Result (2026-08-21)
+
+Verification gate over GH-5066 subtasks 1-3, no source change required.
+
+- `internal/autopilot/controller_gh5033_test.go` — zero diff vs `origin/main`
+  (fully untouched). All 4 tests pass.
+- `internal/autopilot/controller_gh5034_test.go` — 213 insertions / 0
+  deletions vs `origin/main`: subtask 2 (commit `f837ed14`) appended
+  `TestController_HandleWaitingCI_BaseMismatchPark_UnparksAfterBaseMerges_GH5066`
+  after the last pre-existing test; no existing test body was modified. All
+  6 tests pass, including the new one.
+- `internal/executor/base_presence_test.go` — zero diff vs `origin/main`
+  (fully untouched). All 15 tests pass.
+- `go build ./...` — clean.
+- `go vet ./internal/autopilot/... ./internal/executor/...` — clean.
+- `go test ./internal/autopilot/... ./internal/executor/...` — full package
+  runs green (9.9s / 62.1s), no regressions from the GH-5066 stage-transition
+  changes in `controller.go` (commits `802366ef`, `f837ed14`, `0be90e36`).
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2898,6 +2898,27 @@ func (c *Controller) handleWaitingCI(ctx context.Context, prState *PRState, ghPR
 
 	if deadlineExceeded {
 		waited := time.Since(prState.CIWaitStartedAt)
+		// GH-5066: a PR stacked on a non-default base (sibling pilot/GH-*
+		// branch) never reaches handleMerging's parkForBaseMismatch guard
+		// when the repo's CI workflow is scoped to the default branch only
+		// (this repo's own ci.yml:6-7, `pull_request: branches: [main]`) —
+		// zero checks ever run for it, so CI-wait always exhausts this
+		// deadline. Before this fix that fell straight through to the
+		// terminal branch below (StageFailed, a dead end per
+		// `case StageFailed: return nil` in ProcessPR) even though the PR
+		// might merge cleanly once its base lands. Incident 2026-08-21:
+		// PR#5055 (base pilot/GH-5052) died this way; the founder's merge of
+		// the base PR retargeted #5055 to main on GitHub, but a StageFailed
+		// PR never re-enters ProcessPR's body, so recovery was fully manual.
+		// Park exactly as handleMerging's stacked path does instead, so the
+		// existing resume-on-merge path (GH-5049/PR#5051: base reaches
+		// StageMerged → descendant un-parks) handles the rest for free.
+		if defaultBranch := c.resolveMainBranchName(); prState.TargetBranch != "" && prState.TargetBranch != defaultBranch {
+			c.log.Warn("handleWaitingCI: CI-wait deadline exceeded on a non-default base — parking instead of failing",
+				"pr", prState.PRNumber, "target_branch", prState.TargetBranch, "default_branch", defaultBranch, "waited", waited, "last_status", status)
+			c.parkForBaseMismatch(ctx, prState, prState.TargetBranch, defaultBranch)
+			return nil
+		}
 		c.log.Warn("CI timeout confirmed by same-tick poll",
 			"pr", prState.PRNumber, "waited", waited, "last_status", status)
 		prState.Stage = StageFailed

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -6989,6 +6989,97 @@ func (c *Controller) reAdoptHeldRebasePR(ctx context.Context, prState *PRState, 
 	}
 }
 
+// redriveFailedPRForBaseRetarget is GH-5066's second leg for a PR that
+// already reached the terminal StageFailed: mirrors reAdoptHeldRebasePR's
+// revival shape (GH-4610) immediately above, but the resolving signal is a
+// base retarget rather than a new push, and there is no explicit hold flag
+// to narrow on (RebaseHoldActive/BreakerHoldActive have no equivalent here).
+//
+// A PR that reached StageFailed while its TargetBranch was NOT the repo's
+// default branch implicates a base mismatch rather than a genuine,
+// unrecoverable failure. handleMerging's own base guard (controller.go
+// ~4437) already refuses to let a non-default-base PR reach ANY of its
+// terminal branches (merge-attempt cap, etc.) — it parks via
+// parkForBaseMismatch instead, which is not terminal. So the only ways a
+// StageFailed PR ends up with a stale non-default TargetBranch are paths
+// that fail without checking the base at all: a pre-fix straggler (a row
+// already sitting in StageFailed before subtask 1/2 of GH-5066 landed:
+// commits 802366ef/f837ed14 only guard handleWaitingCI's confirmed-timeout
+// branch and handleWaitingCI's own re-park, not every StageFailed exit),
+// plus two still-unguarded base-agnostic exits: the consecutive-CI-API-
+// failure branch (controller.go ~2881) and applyCIOutcome's CIConfigMismatch
+// branch (~3000). If GitHub has since retargeted the PR back to the default
+// branch — typically because its base PR merged and GitHub auto-retargets
+// orphaned PRs — give it one more shot at CI rather than leaving it dead
+// forever requiring a fully manual rebase+push+merge (the GH-5066 root
+// incident, PR#5055, 2026-08-21 07:54Z-08:11Z).
+//
+// Decision — "no checks after retarget" (GH-5066 acceptance criterion 3):
+// a bare retarget does not guarantee GitHub runs a fresh check. This repo's
+// own ci.yml (and any repo scoped `pull_request: branches: [<default>]`
+// without an explicit `types:` list) triggers only on the default
+// pull_request action types (opened, synchronize, reopened) — NOT "edited",
+// which is the action GitHub fires for a base-branch change with no new
+// commit. So this function does not attempt to force a fresh check run (no
+// synthetic synchronize, no pre-redrive CI-existence probe) — it simply
+// re-enters StageWaitingCI with a fresh CIWaitStartedAt, identically to
+// parkForBaseMismatch's own un-park path (handleWaitingCI, GH-5066 leg 2a,
+// commit f837ed14). Two outcomes follow, both already handled correctly by
+// the existing state machine with no further change needed:
+//   - A later push (or a check that fires for an unrelated reason) resolves
+//     CI normally, and the PR proceeds like any other.
+//   - CI never posts, and the wait times out again — but by then
+//     TargetBranch already equals the default branch, so the timeout falls
+//     through to the pre-existing GENUINE-timeout branch (handleWaitingCI's
+//     deadlineExceeded block, TargetBranch == default — controller.go
+//     ~2953), not back into this function, whose precondition (a stale
+//     non-default TargetBranch) no longer holds once this function itself
+//     has updated it. That is a normal, once-only re-fail, not an infinite
+//     loop: the narrowing signal is consumed by the very update that fires
+//     it, so — unlike ReadoptCount/BreakerReadoptCount above — no readopt-
+//     attempt cap is needed here.
+func (c *Controller) redriveFailedPRForBaseRetarget(ctx context.Context, prState *PRState, ghPR *github.PullRequest) {
+	if ghPR == nil || prState.Stage != StageFailed {
+		return
+	}
+	defaultBranch := c.resolveMainBranchName()
+	if prState.TargetBranch == "" || prState.TargetBranch == defaultBranch {
+		// This failure doesn't implicate a base mismatch — a genuine
+		// terminal failure (real CI failure, merge-attempt cap, rebase cap,
+		// config mismatch against the correct base, etc.) must stay parked
+		// for a human regardless of what GitHub's base field says now.
+		return
+	}
+	newBase := ghPR.Base.Ref
+	if newBase == "" || newBase != defaultBranch {
+		// Not yet retargeted to the default branch — nothing to do.
+		return
+	}
+
+	prevTarget := prState.TargetBranch
+	prevError := prState.Error
+	prState.TargetBranch = newBase
+	prState.Stage = StageWaitingCI
+	prState.CIWaitStartedAt = time.Now()
+	prState.TerminalLabel = ""
+	prState.Error = ""
+
+	c.log.Info("redriveFailedPRForBaseRetarget: StageFailed PR retargeted to default branch, re-entering pipeline",
+		"pr", prState.PRNumber, "issue", prState.IssueNumber,
+		"prior_target", prevTarget, "new_target", newBase, "prior_error", prevError,
+	)
+
+	if prState.IssueNumber > 0 {
+		comment := fmt.Sprintf(
+			"🔄 **Re-driven**: this PR failed while targeting `%s`; GitHub has since retargeted it to the default branch `%s` — autopilot is re-entering the pipeline for a fresh CI wait.",
+			prevTarget, newBase,
+		)
+		if _, err := c.ghClient.AddPRComment(ctx, c.owner, c.repo, prState.PRNumber, comment); err != nil {
+			c.log.Warn("redriveFailedPRForBaseRetarget: failed to post PR comment", "pr", prState.PRNumber, "error", err)
+		}
+	}
+}
+
 // maxBreakerReadoptAttempts caps how many times ReDriveBreakerHeldPRs
 // (GH-4792) may revive a single PR from a platform-outage breaker hold.
 // Mirrors maxReadoptAttempts's reasoning above: a PR whose own failure
@@ -8282,6 +8373,14 @@ func (c *Controller) processAllPRs(ctx context.Context) {
 			// ProcessPR, which treats StageFailed as terminal and would never
 			// look at this PR again otherwise.
 			c.reAdoptHeldRebasePR(ctx, pr, ghPR)
+
+			// GH-5066 leg 2b: revive a StageFailed PR whose failure implicated
+			// a non-default base once GitHub has retargeted it back to the
+			// default branch — a no-op for every PR whose TargetBranch was
+			// already the default (a genuine, unrelated terminal failure). Must
+			// also run before ProcessPR for the same reason as reAdoptHeldRebasePR
+			// above.
+			c.redriveFailedPRForBaseRetarget(ctx, pr, ghPR)
 
 			// Detect changes_requested reviews in polling mode (webhook mode uses OnReviewRequested).
 			// Only check PRs that haven't already been transitioned to review_requested.

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2774,6 +2774,37 @@ func (c *Controller) handleWaitingCI(ctx context.Context, prState *PRState, ghPR
 	}
 	deadlineExceeded := time.Since(prState.CIWaitStartedAt) > ciTimeout
 
+	// GH-5066 (parent title clause 2, "no re-arm on base retarget"): a PR
+	// parked below via parkForBaseMismatch stays in StageWaitingCI, so it
+	// never reaches handleMerging's own un-park guard (GH-4911,
+	// controller.go ~line 4422) — that only runs once Stage reaches
+	// StageMerging. ProcessPR already refreshes TargetBranch from
+	// ghPR.Base.Ref unconditionally every tick (GH-4909 defect 1) before
+	// this handler runs, so a GitHub-side retarget (e.g. the base branch
+	// merged and was deleted) is visible here. Without this guard, a
+	// retargeted-but-still-Parked PR fell straight into the stale
+	// deadlineExceeded branch below on the very next tick — the CI-wait
+	// clock was never reset — reproducing the exact terminal StageFailed
+	// dead end this park exists to avoid. Mirror the handleMerging pattern:
+	// once TargetBranch resolves back to the default branch, clear the
+	// park and re-arm the wait clock so the PR gets a fresh CI-wait window
+	// against its corrected base instead of an instant re-fail.
+	if prState.Parked && strings.HasPrefix(prState.EscalationReason, baseMismatchReasonPrefix) {
+		if defaultBranch := c.resolveMainBranchName(); prState.TargetBranch == defaultBranch {
+			c.log.Info("handleWaitingCI: un-parking PR — base mismatch resolved, retargeted to default branch",
+				"pr", prState.PRNumber, "issue", prState.IssueNumber, "prior_reason", prState.EscalationReason)
+			prState.Parked = false
+			prState.EscalationReason = ""
+			prState.CIWaitStartedAt = time.Now()
+			deadlineExceeded = false
+			if prState.IssueNumber > 0 {
+				if err := c.labeler.RemoveLabel(ctx, c.owner, c.repo, prState.IssueNumber, labelParkedAwaitingApproval); err != nil {
+					c.log.Debug("parked-awaiting-approval label cleanup on un-park", "issue", prState.IssueNumber, "error", err)
+				}
+			}
+		}
+	}
+
 	// GH-419, GH-457: Always refresh HeadSHA from GitHub before checking CI.
 	// Self-review or other post-creation commits can change the HEAD,
 	// and OnPRCreated may have been called with an empty or stale CommitSHA.

--- a/internal/autopilot/controller_gh5034_test.go
+++ b/internal/autopilot/controller_gh5034_test.go
@@ -2,6 +2,7 @@ package autopilot
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -514,5 +515,217 @@ func TestController_HandleMerging_StackedSuperset_DetectionErrorFailsOpen(t *tes
 	}
 	if len(sink.events) != 0 {
 		t.Fatalf("alerts fired %d times, want 0 — a detection error is not itself an escalation", len(sink.events))
+	}
+}
+
+// TestController_HandleWaitingCI_BaseMismatchPark_UnparksAfterBaseMerges_GH5066
+// extends this suite (GH-5066, subtask 2/4) to the OTHER park entry point:
+// GH-5066/PR (commit 802366ef) taught handleWaitingCI's confirmed-CI-timeout
+// branch to park a non-default-base PR (via parkForBaseMismatch) instead of
+// failing terminally — but that park leaves the PR in StageWaitingCI, never
+// StageMerging. TestController_HandleMerging_StackedSuperset_UnparksAfterBaseMerges
+// above proves the resume path for a PR parked INSIDE handleMerging (already
+// in StageMerging); this test proves — or disproves — the analogous claim
+// for a PR parked from handleWaitingCI: does it, too, un-park and proceed
+// once its base (A) reaches StageMerged, exactly as the parent GH-5066 title's
+// "no re-arm on base retarget" clause asks?
+func TestController_HandleWaitingCI_BaseMismatchPark_UnparksAfterBaseMerges_GH5066(t *testing.T) {
+	const sha = "gh5066resume01"
+	const baseSHA = "gh5066base01"
+	const prNumber = 17
+	const baseNumber = 16
+
+	var ciResolved atomic.Bool
+	var mergeCalled, labelApplied, labelRemoved atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/"+sha+"/check-runs":
+			// CI never resolves while still stacked on the sibling branch —
+			// mirrors the PR#5055 incident, where the repo's workflow is
+			// scoped to the default branch only so a stacked PR's checks
+			// never run. Once retargeted to main (ciResolved flips below),
+			// a fresh check run can actually complete.
+			status := github.CheckRunInProgress
+			conclusion := ""
+			if ciResolved.Load() {
+				status = github.CheckRunCompleted
+				conclusion = github.ConclusionSuccess
+			}
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns:  []github.CheckRun{{Name: "ci", Status: status, Conclusion: conclusion}},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/repos/owner/repo/pulls/17/files":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case r.URL.Path == "/repos/owner/repo/issues/17" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"number":17,"title":"GH-17 work, stacked on GH-16"}`))
+		case r.URL.Path == "/repos/owner/repo/pulls/17/merge" && r.Method == http.MethodPut:
+			mergeCalled.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"sha":"mergedSHA","merged":true,"message":"merged"}`))
+		case strings.HasSuffix(r.URL.Path, "/issues/17/comments") && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case strings.HasSuffix(r.URL.Path, "/issues/17/comments") && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":1,"body":"posted"}`))
+		case r.URL.Path == "/repos/owner/repo/issues/17/labels" && r.Method == http.MethodPost:
+			labelApplied.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case r.URL.Path == "/repos/owner/repo/issues/17/labels/"+labelParkedAwaitingApproval && r.Method == http.MethodDelete:
+			labelRemoved.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/17/labels/") && r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	c.mu.Lock()
+	c.activePRs[baseNumber] = &PRState{
+		PRNumber:     baseNumber,
+		BranchName:   "pilot/GH-16",
+		HeadSHA:      baseSHA,
+		TargetBranch: "main",
+		Stage:        StageWaitingCI, // A hasn't cleared CI yet
+		CreatedAt:    time.Now(),
+	}
+	c.activePRs[prNumber] = &PRState{
+		PRNumber:     prNumber,
+		IssueNumber:  prNumber,
+		BranchName:   "pilot/GH-17",
+		HeadSHA:      sha,
+		TargetBranch: "pilot/GH-16", // stacked on A's still-open branch
+		Stage:        StageWaitingCI,
+		CIStatus:     CIPending,
+		// Deadline already exceeded, mirroring the PR#5055 incident: CI never
+		// ran because this repo's workflow is scoped to the default branch.
+		CIWaitStartedAt: time.Now().Add(-45 * time.Minute),
+		CreatedAt:       time.Now(),
+	}
+	c.mu.Unlock()
+
+	ghPRStacked := &github.PullRequest{
+		Number: prNumber,
+		Head:   github.PRRef{SHA: sha},
+		Base:   github.PRRef{Ref: "pilot/GH-16"},
+	}
+
+	// Tick 1: A is still open, B's CI never ran and the wait deadline has
+	// passed — B must park via parkForBaseMismatch (GH-5066) rather than
+	// fail terminally.
+	if err := c.ProcessPR(context.Background(), prNumber, ghPRStacked); err != nil {
+		t.Fatalf("tick 1: ProcessPR: %v", err)
+	}
+	pr17, ok := c.GetPRState(prNumber)
+	if !ok {
+		t.Fatal("PR 17 should still be tracked")
+	}
+	if pr17.Stage != StageWaitingCI {
+		t.Fatalf("tick 1: Stage = %s, want %s (parked, not failed)", pr17.Stage, StageWaitingCI)
+	}
+	if !pr17.Parked {
+		t.Fatal("tick 1: Parked should be true")
+	}
+	if !strings.HasPrefix(pr17.EscalationReason, baseMismatchReasonPrefix) {
+		t.Fatalf("tick 1: EscalationReason = %q, want prefix %q", pr17.EscalationReason, baseMismatchReasonPrefix)
+	}
+	if labelApplied.Load() != 1 {
+		t.Fatalf("tick 1: parked-awaiting-approval label applied %d times, want 1", labelApplied.Load())
+	}
+
+	// A merges: modeled exactly as
+	// TestController_HandleMerging_StackedSuperset_UnparksAfterBaseMerges
+	// models it above — a stage transition to StageMerged while STILL
+	// tracked in activePRs (GH-5049 requirement 3), plus the GitHub-side
+	// consequence of a merged-and-deleted base branch: the PR is auto-
+	// retargeted to A's own base ("main"), which ProcessPR refreshes into
+	// TargetBranch unconditionally every tick (GH-4909 defect 1, line
+	// ~2614) before any stage handler runs.
+	c.mu.Lock()
+	c.activePRs[baseNumber].Stage = StageMerged
+	c.mu.Unlock()
+	ghPRRetargeted := &github.PullRequest{
+		Number: prNumber,
+		Head:   github.PRRef{SHA: sha},
+		Base:   github.PRRef{Ref: "main"},
+	}
+
+	// Tick 2: A has merged and B has been retargeted to main — B must
+	// un-park (base mismatch resolved) and get a fresh CI-wait window
+	// instead of falling into the stale-deadline StageFailed branch it was
+	// parked to avoid.
+	if err := c.ProcessPR(context.Background(), prNumber, ghPRRetargeted); err != nil {
+		t.Fatalf("tick 2: ProcessPR: %v", err)
+	}
+	pr17, ok = c.GetPRState(prNumber)
+	if !ok {
+		t.Fatal("PR 17 should still be tracked")
+	}
+	if pr17.Parked {
+		t.Error("tick 2: Parked should be false — the base-mismatch park must clear once the PR is retargeted to the default branch")
+	}
+	if pr17.EscalationReason != "" {
+		t.Errorf("tick 2: EscalationReason = %q, want empty — cleared alongside Parked", pr17.EscalationReason)
+	}
+	if pr17.Stage != StageWaitingCI {
+		t.Fatalf("tick 2: Stage = %s, want %s — un-parking must not itself fail or skip stages, just resume the normal CI wait", pr17.Stage, StageWaitingCI)
+	}
+	if labelRemoved.Load() != 1 {
+		t.Errorf("tick 2: parked-awaiting-approval label removed %d times, want 1", labelRemoved.Load())
+	}
+
+	// Now let CI actually resolve against the corrected base (main), exactly
+	// as it would in reality once the PR is properly retargeted. B must
+	// proceed all the way through to a completed merge — driving ProcessPR
+	// repeatedly, same as the real poll loop, since each call advances at
+	// most one stage.
+	ciResolved.Store(true)
+	const maxTicks = 6
+	for i := 0; i < maxTicks; i++ {
+		if err := c.ProcessPR(context.Background(), prNumber, ghPRRetargeted); err != nil {
+			t.Fatalf("post-resume tick %d: ProcessPR: %v", i, err)
+		}
+		pr17, ok = c.GetPRState(prNumber)
+		if !ok {
+			t.Fatal("PR 17 should still be tracked")
+		}
+		if pr17.Stage == StageFailed || pr17.Stage == StageCIFailed {
+			t.Fatalf("post-resume tick %d: Stage = %s — B must merge cleanly once retargeted, CI passing", i, pr17.Stage)
+		}
+		if pr17.Stage == StageMerged {
+			break
+		}
+	}
+	pr17, ok = c.GetPRState(prNumber)
+	if !ok {
+		t.Fatal("PR 17 should still be tracked")
+	}
+	if pr17.Stage != StageMerged {
+		t.Fatalf("Stage = %s, want %s — B should have proceeded through to a completed merge", pr17.Stage, StageMerged)
+	}
+	if pr17.Parked {
+		t.Error("Parked should still be false after merging")
+	}
+	if mergeCalled.Load() != 1 {
+		t.Errorf("merge called %d times, want 1 — B must merge exactly once after un-parking", mergeCalled.Load())
 	}
 }

--- a/internal/autopilot/controller_gh5066_test.go
+++ b/internal/autopilot/controller_gh5066_test.go
@@ -186,3 +186,348 @@ func TestHandleWaitingCI_DefaultTargetBranch_StillFailsAtDeadline_GH5066(t *test
 		t.Errorf("parked-awaiting-approval label applied %d times, want 0", labelApplied.Load())
 	}
 }
+
+// TestRedriveFailedPRForBaseRetarget_RevivesOnRetargetToDefault covers
+// GH-5066's second leg for a PR that already reached the terminal
+// StageFailed with a stale non-default TargetBranch (a pre-fix straggler, or
+// one of the base-agnostic StageFailed exits legs 1/2 don't guard — see the
+// function doc comment): once GitHub retargets it back to the default
+// branch, it must be revived to StageWaitingCI with a fresh CI-wait clock,
+// exactly like reAdoptHeldRebasePR (GH-4610) revives a rebase hold on a new
+// head SHA.
+func TestRedriveFailedPRForBaseRetarget_RevivesOnRetargetToDefault(t *testing.T) {
+	rec, srv := newRecordingGHServer()
+	defer srv.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:      5055,
+		IssueNumber:   5052,
+		BranchName:    "pilot/GH-5055",
+		HeadSHA:       "gh5066redrive01",
+		TargetBranch:  "pilot/GH-5052",
+		Stage:         StageFailed,
+		Error:         "CI timeout after 30m0s (last confirmed status: pending)",
+		TerminalLabel: github.LabelFailed,
+	}
+
+	ghPR := &github.PullRequest{Number: 5055, Base: github.PRRef{Ref: "main"}}
+	c.redriveFailedPRForBaseRetarget(context.Background(), prState, ghPR)
+
+	if prState.Stage != StageWaitingCI {
+		t.Errorf("Stage = %v, want StageWaitingCI", prState.Stage)
+	}
+	if prState.TargetBranch != "main" {
+		t.Errorf("TargetBranch = %q, want %q", prState.TargetBranch, "main")
+	}
+	if prState.Error != "" {
+		t.Errorf("Error = %q, want empty after redrive", prState.Error)
+	}
+	if prState.TerminalLabel != "" {
+		t.Errorf("TerminalLabel = %q, want empty after redrive — no longer terminal", prState.TerminalLabel)
+	}
+	if prState.CIWaitStartedAt.IsZero() {
+		t.Error("CIWaitStartedAt should be reset for a fresh CI-wait window")
+	}
+	// AddPRComment posts to the PR's own issues/<PRNumber>/comments endpoint
+	// (a PR is an "issue" in GitHub's model) — not the linked ticket's
+	// IssueNumber, which can differ (5052 above).
+	if n := rec.count(http.MethodPost, "/repos/owner/repo/issues/5055/comments"); n != 1 {
+		t.Errorf("PR comment calls = %d, want 1 (redrive notice)", n)
+	}
+}
+
+// TestRedriveFailedPRForBaseRetarget_IgnoresDefaultBaseFailures is the
+// negative control: a StageFailed PR whose TargetBranch was ALREADY the
+// default branch failed for a genuine, unrelated reason (real CI failure,
+// merge-attempt cap, config mismatch, etc.) — GitHub's base field can't
+// resolve that, so it must stay parked for a human regardless of what the
+// fresh ghPR reports.
+func TestRedriveFailedPRForBaseRetarget_IgnoresDefaultBaseFailures(t *testing.T) {
+	_, srv := newRecordingGHServer()
+	defer srv.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:     6001,
+		IssueNumber:  6001,
+		TargetBranch: "main",
+		Stage:        StageFailed,
+		Error:        "CI timeout after 30m0s (last confirmed status: failure)",
+	}
+
+	ghPR := &github.PullRequest{Number: 6001, Base: github.PRRef{Ref: "main"}}
+	c.redriveFailedPRForBaseRetarget(context.Background(), prState, ghPR)
+
+	if prState.Stage != StageFailed {
+		t.Errorf("Stage = %v, want StageFailed (genuine failure, not base-mismatch-shaped)", prState.Stage)
+	}
+	if prState.Error == "" {
+		t.Error("Error should be preserved — this failure was never redriven")
+	}
+}
+
+// TestRedriveFailedPRForBaseRetarget_NotYetRetargeted covers the "still
+// stacked" case: a StageFailed PR whose TargetBranch is non-default AND
+// GitHub still reports that same non-default base must stay put — there is
+// nothing to redrive until an actual retarget happens.
+func TestRedriveFailedPRForBaseRetarget_NotYetRetargeted(t *testing.T) {
+	_, srv := newRecordingGHServer()
+	defer srv.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:     5056,
+		IssueNumber:  5053,
+		TargetBranch: "pilot/GH-5053",
+		Stage:        StageFailed,
+		Error:        "CI timeout after 30m0s (last confirmed status: pending)",
+	}
+
+	ghPR := &github.PullRequest{Number: 5056, Base: github.PRRef{Ref: "pilot/GH-5053"}}
+	c.redriveFailedPRForBaseRetarget(context.Background(), prState, ghPR)
+
+	if prState.Stage != StageFailed {
+		t.Errorf("Stage = %v, want StageFailed (base unchanged, still stacked)", prState.Stage)
+	}
+	if prState.TargetBranch != "pilot/GH-5053" {
+		t.Errorf("TargetBranch = %q, want unchanged %q", prState.TargetBranch, "pilot/GH-5053")
+	}
+}
+
+// TestController_ProcessAllPRs_RedrivesFailedPRAndMerges is an end-to-end
+// check through processAllPRs (the real poll loop entry point, GH-5066): a
+// StageFailed PR retargeted to the default branch must be revived AND
+// actually re-enter processing within the same tick (mirrors
+// TestController_ProcessAllPRs_ReAdoptsHeldRebasePR's shape for GH-4610),
+// then — once CI genuinely resolves against the corrected base — proceed all
+// the way through to a completed merge.
+func TestController_ProcessAllPRs_RedrivesFailedPRAndMerges(t *testing.T) {
+	const sha = "gh5066redrive02"
+	const prNumber = 5057
+
+	var ciResolved atomic.Bool
+	var mergeCalled, commentPosts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/5057" && r.Method == http.MethodGet:
+			resp := github.PullRequest{
+				Number:  prNumber,
+				State:   "open",
+				HTMLURL: "https://github.com/owner/repo/pull/5057",
+				Head:    github.PRRef{SHA: sha, Ref: "pilot/GH-5057"},
+				Base:    github.PRRef{Ref: "main"},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/repos/owner/repo/commits/"+sha+"/check-runs":
+			status := github.CheckRunInProgress
+			conclusion := ""
+			if ciResolved.Load() {
+				status = github.CheckRunCompleted
+				conclusion = github.ConclusionSuccess
+			}
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns:  []github.CheckRun{{Name: "ci", Status: status, Conclusion: conclusion}},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/repos/owner/repo/pulls/5057/files":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case r.URL.Path == "/repos/owner/repo/pulls/5057/merge" && r.Method == http.MethodPut:
+			mergeCalled.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"sha":"mergedSHA","merged":true,"message":"merged"}`))
+		case strings.HasSuffix(r.URL.Path, "/comments") && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case strings.HasSuffix(r.URL.Path, "/comments") && r.Method == http.MethodPost:
+			commentPosts.Add(1)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":1,"body":"posted"}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer srv.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:      prNumber,
+		IssueNumber:   prNumber,
+		PRURL:         "https://github.com/owner/repo/pull/5057",
+		BranchName:    "pilot/GH-5057",
+		HeadSHA:       sha,
+		TargetBranch:  "pilot/GH-9999", // stale: base was non-default when this failed
+		Stage:         StageFailed,
+		Error:         "CI timeout after 30m0s (last confirmed status: pending)",
+		TerminalLabel: github.LabelFailed,
+		CreatedAt:     time.Now(),
+	}
+	c.mu.Lock()
+	c.activePRs[prNumber] = prState
+	c.mu.Unlock()
+
+	// Tick 1: ghPR now reports base=main — the redrive must fire and this
+	// same tick must carry the PR through ProcessPR into StageWaitingCI.
+	c.processAllPRs(context.Background())
+
+	got, ok := c.GetPRState(prNumber)
+	if !ok {
+		t.Fatal("PR should still be tracked")
+	}
+	if got.Stage != StageWaitingCI {
+		t.Fatalf("tick 1: Stage = %v, want StageWaitingCI (redriven and processed in the same tick)", got.Stage)
+	}
+	if got.TargetBranch != "main" {
+		t.Errorf("tick 1: TargetBranch = %q, want %q", got.TargetBranch, "main")
+	}
+	if commentPosts.Load() != 1 {
+		t.Errorf("tick 1: comment calls = %d, want 1 (redrive notice)", commentPosts.Load())
+	}
+
+	// Now let CI actually resolve against the corrected base, exactly as it
+	// would in reality. The PR must proceed all the way through to a
+	// completed merge — driving ProcessPR repeatedly, same as the real poll
+	// loop, since each call advances at most one stage.
+	ciResolved.Store(true)
+	ghPRRetargeted := &github.PullRequest{Number: prNumber, Head: github.PRRef{SHA: sha}, Base: github.PRRef{Ref: "main"}}
+	const maxTicks = 6
+	for i := 0; i < maxTicks; i++ {
+		if err := c.ProcessPR(context.Background(), prNumber, ghPRRetargeted); err != nil {
+			t.Fatalf("post-redrive tick %d: ProcessPR: %v", i, err)
+		}
+		got, ok = c.GetPRState(prNumber)
+		if !ok {
+			t.Fatal("PR should still be tracked")
+		}
+		if got.Stage == StageFailed {
+			t.Fatalf("post-redrive tick %d: Stage = %s — PR must merge cleanly once retargeted, CI passing", i, got.Stage)
+		}
+		if got.Stage == StageMerged {
+			break
+		}
+	}
+	got, ok = c.GetPRState(prNumber)
+	if !ok {
+		t.Fatal("PR should still be tracked")
+	}
+	if got.Stage != StageMerged {
+		t.Fatalf("Stage = %s, want StageMerged — PR should have proceeded through to a completed merge", got.Stage)
+	}
+	if mergeCalled.Load() != 1 {
+		t.Errorf("merge called %d times, want 1", mergeCalled.Load())
+	}
+}
+
+// TestController_ProcessAllPRs_RedrivenPR_NoChecksAfterRetarget_RefailsCleanly
+// pins the GH-5066 acceptance-criterion-3 decision explicitly: retargeting a
+// PR does not itself guarantee GitHub runs any check (see the "no checks
+// after retarget" decision documented on redriveFailedPRForBaseRetarget) —
+// this repo's CI only triggers on opened/synchronize/reopened, not the
+// "edited" action a bare retarget fires. If checks genuinely never post
+// after redrive, the PR must time out again through the ordinary
+// TargetBranch==default CI-timeout branch and land back at StageFailed —
+// not loop forever, and not get redriven a second time (its TargetBranch is
+// now the default branch, so redriveFailedPRForBaseRetarget's own
+// precondition no longer matches).
+func TestController_ProcessAllPRs_RedrivenPR_NoChecksAfterRetarget_RefailsCleanly(t *testing.T) {
+	const sha = "gh5066redrive03"
+	const prNumber = 5058
+
+	var commentPosts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/"+sha+"/check-runs":
+			// Zero checks ever post for this SHA — mirrors the PR#5055
+			// incident where the workflow scoped to the default branch never
+			// fired for the stacked-base PR, and a bare retarget alone (no new
+			// push) doesn't trigger a fresh run either.
+			resp := github.CheckRunsResponse{TotalCount: 0}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case strings.HasSuffix(r.URL.Path, "/comments") && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case strings.HasSuffix(r.URL.Path, "/comments") && r.Method == http.MethodPost:
+			commentPosts.Add(1)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":1,"body":"posted"}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer srv.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:      prNumber,
+		IssueNumber:   prNumber,
+		HeadSHA:       sha,
+		TargetBranch:  "pilot/GH-9998",
+		Stage:         StageFailed,
+		Error:         "CI timeout after 30m0s (last confirmed status: pending)",
+		TerminalLabel: github.LabelFailed,
+	}
+
+	ghPR := &github.PullRequest{Number: prNumber, Head: github.PRRef{SHA: sha}, Base: github.PRRef{Ref: "main"}}
+	c.redriveFailedPRForBaseRetarget(context.Background(), prState, ghPR)
+
+	if prState.Stage != StageWaitingCI {
+		t.Fatalf("Stage = %v, want StageWaitingCI immediately after redrive", prState.Stage)
+	}
+
+	// Fast-forward the CI-wait clock past the deadline, exactly as the
+	// existing GH-5066/GH-4851 tests do, then drive one more ProcessPR tick
+	// with zero checks ever posted.
+	prState.CIWaitStartedAt = time.Now().Add(-45 * time.Minute)
+	c.mu.Lock()
+	c.activePRs[prNumber] = prState
+	c.mu.Unlock()
+
+	if err := c.ProcessPR(context.Background(), prNumber, ghPR); err != nil {
+		t.Fatalf("ProcessPR: %v", err)
+	}
+
+	got, ok := c.GetPRState(prNumber)
+	if !ok {
+		t.Fatal("PR should still be tracked")
+	}
+	if got.Stage != StageFailed {
+		t.Fatalf("Stage = %v, want StageFailed — no checks ever posted, the redriven CI-wait must time out again, not loop forever", got.Stage)
+	}
+	if !strings.Contains(got.Error, "CI timeout") {
+		t.Errorf("Error = %q, want it to mention the CI timeout (a genuine re-fail, not a base-mismatch park)", got.Error)
+	}
+	if got.Parked {
+		t.Error("Parked should be false — TargetBranch is now the default branch, so this is a genuine timeout, not a base-mismatch park")
+	}
+
+	// One more processAllPRs tick must NOT redrive it a second time — the
+	// precondition (stale non-default TargetBranch) no longer holds since
+	// TargetBranch is now "main".
+	c.processAllPRs(context.Background())
+	got, ok = c.GetPRState(prNumber)
+	if !ok {
+		t.Fatal("PR should still be tracked")
+	}
+	if got.Stage != StageFailed {
+		t.Errorf("Stage = %v, want StageFailed — must not be redriven a second time", got.Stage)
+	}
+}

--- a/internal/autopilot/controller_gh5066_test.go
+++ b/internal/autopilot/controller_gh5066_test.go
@@ -1,0 +1,188 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GH-5066 regression test.
+//
+// Incident 2026-08-21: PR#5055 was stacked on sibling branch pilot/GH-5052
+// (base != main). This repo's own CI workflow is scoped
+// `pull_request: branches: [main]` (ci.yml:6-7), so zero checks ever ran for
+// #5055 — CheckCI stayed CIPending forever. handleWaitingCI's confirmed-
+// timeout branch (controller.go, deadlineExceeded) sent it straight to the
+// terminal StageFailed (`case StageFailed: return nil` in ProcessPR), a dead
+// end the stacked-PR protections (parkForBaseMismatch, parkForStackedSuperset)
+// never got a chance to run — those are wired only inside handleMerging.
+// When the founder merged the base PR, GitHub retargeted #5055 to main, but a
+// StageFailed PR never re-enters ProcessPR's body, so recovery was fully
+// manual.
+//
+// This test pins the fix's first leg: a tracked PR sitting in StageWaitingCI
+// whose TargetBranch is not the repo's default branch must, at the CI-wait
+// deadline, park via parkForBaseMismatch (Parked=true, EscalationReason
+// naming the mismatch, labelParkedAwaitingApproval applied, exactly one
+// alert/comment) instead of transitioning to StageFailed.
+
+// gh5066PendingCheckHandler serves a repo whose CI never resolves for the
+// given sha (always CheckRunInProgress) plus the issue comment/label
+// endpoints parkForBaseMismatch needs.
+func gh5066PendingCheckHandler(sha string, commentPosted, labelApplied *atomic.Int32) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/"+sha+"/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns:  []github.CheckRun{{Name: "ci", Status: github.CheckRunInProgress}},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case strings.HasSuffix(r.URL.Path, "/comments") && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case strings.HasSuffix(r.URL.Path, "/comments") && r.Method == http.MethodPost:
+			commentPosted.Add(1)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":1,"body":"posted"}`))
+		case strings.HasSuffix(r.URL.Path, "/labels") && r.Method == http.MethodPost:
+			labelApplied.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}
+}
+
+func TestHandleWaitingCI_NonDefaultTargetBranch_ParksInsteadOfFailing_GH5066(t *testing.T) {
+	const sha = "gh5066stacked01"
+	const prNumber = 5055
+	const issueNumber = 5052
+
+	var commentPosted, labelApplied atomic.Int32
+	server := httptest.NewServer(gh5066PendingCheckHandler(sha, &commentPosted, &labelApplied))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	c.mu.Lock()
+	c.activePRs[prNumber] = &PRState{
+		PRNumber:    prNumber,
+		IssueNumber: issueNumber,
+		Stage:       StageWaitingCI,
+		CIStatus:    CIPending,
+		// Deadline already exceeded, mirroring the PR#5055 incident: CI never
+		// ran because this repo's workflow is scoped to the default branch.
+		CIWaitStartedAt: time.Now().Add(-45 * time.Minute),
+	}
+	c.mu.Unlock()
+
+	// Stacked on a sibling branch, not the repo default ("main").
+	ghPR := &github.PullRequest{
+		Number: prNumber,
+		Head:   github.PRRef{SHA: sha},
+		Base:   github.PRRef{Ref: "pilot/GH-5052"},
+	}
+
+	if err := c.ProcessPR(context.Background(), prNumber, ghPR); err != nil {
+		t.Fatalf("ProcessPR returned unexpected error: %v", err)
+	}
+
+	pr, ok := c.GetPRState(prNumber)
+	if !ok {
+		t.Fatal("PR should still be tracked")
+	}
+	if pr.Stage != StageWaitingCI {
+		t.Fatalf("Stage = %s, want %s — a non-default-base PR must park, not transition to a terminal stage at the CI-wait deadline", pr.Stage, StageWaitingCI)
+	}
+	if !pr.Parked {
+		t.Error("Parked should be true — the PR must be held for a human, not silently dropped")
+	}
+	if !strings.HasPrefix(pr.EscalationReason, baseMismatchReasonPrefix) {
+		t.Errorf("EscalationReason = %q, want prefix %q", pr.EscalationReason, baseMismatchReasonPrefix)
+	}
+	if !strings.Contains(pr.EscalationReason, "pilot/GH-5052") {
+		t.Errorf("EscalationReason = %q, want it to name the actual target branch %q", pr.EscalationReason, "pilot/GH-5052")
+	}
+	if pr.TerminalLabel == github.LabelFailed {
+		t.Error("TerminalLabel should not be set to failed — parking is not a terminal outcome")
+	}
+	if strings.Contains(pr.Error, "CI timeout") {
+		t.Errorf("Error = %q should not mention CI timeout — this PR was parked for a base mismatch, not a genuine CI timeout", pr.Error)
+	}
+	if labelApplied.Load() != 1 {
+		t.Errorf("parked-awaiting-approval label applied %d times, want 1", labelApplied.Load())
+	}
+	if commentPosted.Load() != 1 {
+		t.Errorf("PR comment posted %d times, want 1", commentPosted.Load())
+	}
+	if len(sink.events) != 1 {
+		t.Fatalf("alerts fired %d times, want 1", len(sink.events))
+	}
+}
+
+// TestHandleWaitingCI_DefaultTargetBranch_StillFailsAtDeadline_GH5066 is the
+// negative control: a PR whose base IS the repo default branch must still
+// hit the pre-existing confirmed-timeout path (StageFailed) — the GH-5066
+// park behavior is scoped strictly to non-default bases, it must not swallow
+// genuine CI timeouts on normal PRs.
+func TestHandleWaitingCI_DefaultTargetBranch_StillFailsAtDeadline_GH5066(t *testing.T) {
+	const sha = "gh5066default01"
+	const prNumber = 6001
+
+	var commentPosted, labelApplied atomic.Int32
+	server := httptest.NewServer(gh5066PendingCheckHandler(sha, &commentPosted, &labelApplied))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	c.mu.Lock()
+	c.activePRs[prNumber] = &PRState{
+		PRNumber:        prNumber,
+		Stage:           StageWaitingCI,
+		CIStatus:        CIPending,
+		CIWaitStartedAt: time.Now().Add(-45 * time.Minute),
+	}
+	c.mu.Unlock()
+
+	ghPR := &github.PullRequest{
+		Number: prNumber,
+		Head:   github.PRRef{SHA: sha},
+		Base:   github.PRRef{Ref: "main"},
+	}
+
+	if err := c.ProcessPR(context.Background(), prNumber, ghPR); err != nil {
+		t.Fatalf("ProcessPR returned unexpected error: %v", err)
+	}
+
+	pr, ok := c.GetPRState(prNumber)
+	if !ok {
+		t.Fatal("PR should still be tracked")
+	}
+	if pr.Stage != StageFailed {
+		t.Fatalf("Stage = %s, want %s — a default-base PR past the CI-wait deadline must still fail terminally", pr.Stage, StageFailed)
+	}
+	if pr.Parked {
+		t.Error("Parked should be false — a default-base PR has no base mismatch to park for")
+	}
+	if labelApplied.Load() != 0 {
+		t.Errorf("parked-awaiting-approval label applied %d times, want 0", labelApplied.Load())
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5066.

Closes #5066

## Changes

GitHub Issue GH-5066: fix(autopilot): stacked-base PR dies of CI-timeout to terminal StageFailed before any park logic runs; no re-arm on base retarget (4th sequencing incident)

## Summary

The stacked-PR protections (`parkForBaseMismatch` controller.go:1844, `parkForStackedSuperset` :1721) are wired ONLY inside `handleMerging` (call sites :4386, :4448 — StageMerging). A stacked PR whose base is a sibling branch never gets there when repo CI is scoped `pull_request: branches: [main]` (this repo's own config, ci.yml:6-7): zero checks ever run, CI-wait times out, and the confirmed-timeout branch (controller.go:2899-2911) sends it straight to `StageFailed` — a terminal dead end (`case StageFailed: return nil`, controller.go:2643-2646). All the GH-5027/5049/5051 machinery is dead code for this shape.

Confirmed live 2026-08-21: PR#5055 (base `pilot/GH-5052`) died of CI-timeout at stage `failed`; when the founder merged base PR#5054 at 07:54Z, GitHub retargeted #5055 to main — but a StageFailed PR never re-enters ProcessPR's body, so even its `TargetBranch` field is never refreshed. Recovery was fully manual (rebase + push + merge at 08:11Z).

## Fixes (two legs, one coherent lifecycle)

1. **Park early, don't fail.** In `handlePRCreated`/`handleWaitingCI`, before committing to the CI-wait deadline: if the PR's `TargetBranch` is not the repo default branch, park it exactly as `handleMerging`'s stacked path does (stacked-park labels + EscalationReason + Parked=true), instead of letting CI-wait time out into StageFailed. The existing resume-on-merge path (GH-5049/PR#5051: base reaches StageMerged → descendant un-parks) then handles the rest for free.
2. **Re-arm on base retarget.** A reconciler pass (mirror the `ReDriveBreakerHeldPRs` idiom) that, for parked-stacked AND StageFailed PRs whose failure/park implicates a non-default base: re-reads `ghPR.Base.Ref`; if GitHub has retargeted it to the default branch, re-drive to `StageWaitingCI` (and clear Parked/TerminalLabel). Note the CI-won't-fire-on-retarget wrinkle: re-driving into CI-wait on a retargeted PR with zero checks will time out again — the re-drive should either trigger a synchronize (empty-commit push is out; prefer detecting checkSuites==0 and treating "no checks configured for this base" as an escalation-with-accurate-reason, or re-request via the API if available). State the chosen behavior explicitly.

## Acceptance Criteria

- [ ] Test: tracked PR with non-default TargetBranch in StageWaitingCI parks (with labels + reason) rather than transitioning to StageFailed at deadline.
- [ ] Test: parked descendant un-parks and proceeds when base reaches StageMerged (extends the gh5034 suite; should mostly pass already via GH-5049).
- [ ] Test: StageFailed PR whose GitHub base has been retargeted to default is re-driven (stage leaves StageFailed); the no-checks-after-retarget behavior is decided, documented, and tested.
- [ ] Existing gh5033/gh5034/base-presence tests untouched and green.

## Out of scope

Ledger-side completion invalidation (separate issue) · alert message rendering (separate issue).

## Refs

Incident 2026-08-21 07:54Z · controller.go:2622-2646 (StageFailed dead end), :2899-2911 (timeout→failed), :1721/:1844 (park paths), :4386/:4448 (only call sites) · ci.yml:6-7 · GH-5049/PR#5051 resume-on-merge · ReDriveBreakerHeldPRs idiom