### PR TITLE
GH-5065: fix(alerts): handleEscalation discards event.Error — every non-circuit-breaker escalation renders a blank template (incident a695c90e)

### DIFF
--- a/.agent/tasks/gh-5065.md
+++ b/.agent/tasks/gh-5065.md
@@ -1,0 +1,31 @@
+# GH-5065
+
+**Created:** 2026-08-21
+
+## Problem
+
+GitHub Issue GH-5065: fix(alerts): handleEscalation discards event.Error — every non-circuit-breaker escalation renders a blank template (incident a695c90e)
+
+## Summary
+
+`handleEscalation` (`internal/alerts/engine.go:1440-1465`) is the single handler for every `EventTypeEscalation` source, but its message template is built only from `event.Metadata["trips_in_hour"/"escalation_threshold"/"last_pr"/"last_reason"]` — fields only the circuit-breaker-trips emitter (`metrics_alerter.go`) populates. The four autopilot emitters (`alertStackedSupersetOnce`, `alertBaseMismatchOnce`, `alertBranchDeleteHeldOnce`, `alertUnresolvableBaseOnce`) put their real diagnostic text in `event.Error` — **which handleEscalation never reads**.
+
+Confirmed live 2026-08-21 07:54:36Z (alert `a695c90e`, box daemon.log): `alertBranchDeleteHeldOnce` fired for PR#5054's branch `pilot/GH-5052` (correct detection — PR#5055 still based on it) but the Slack delivery rendered the circuit-breaker template with empty fields: `Circuit breaker escalation:  trips in 1 hour (threshold: ). Last: PR # -`.
+
+## Fixes
+
+1. `handleEscalation`: when the circuit-breaker metadata fields are absent/empty, render from `event.Error` (the emitters' purpose-built message) instead of the blank template. Keep the circuit-breaker path byte-identical when its metadata IS present.
+2. The three branch/base emitters' metadata never names the *blocking/related* PR (only the cleanup PR). Add it: `alertBranchDeleteHeldOnce` knows the blocking open PR from `branchIsBaseOfOpenPR` (`controller.go:1995`) — thread its number into metadata (`blocking_pr`) and the message.
+3. Flag-only (state decision in PR, no behavior change required): the 1h `escalation` rule cooldown is keyed globally by `rule.Name` (`engine.go:1062-1076`), so circuit-breaker trips and autopilot escalations share one cooldown bucket and can suppress each other — note it in a code comment or split the key if trivial.
+
+## Acceptance Criteria
+
+- [x] Test: an `EventTypeEscalation` with `event.Error` set and no circuit-breaker metadata renders the Error text (assert message content, not just dispatch).
+- [x] Test: circuit-breaker event with full metadata renders exactly as today.
+- [x] `alertBranchDeleteHeldOnce` metadata + message include the blocking PR number; test asserts it.
+- [x] `go test ./internal/alerts/... ./internal/autopilot/...` green.
+
+## Refs
+
+Incident 2026-08-21 07:54Z (alert a695c90e, daemon.log lines ~333591-333609) · engine.go:1440 · controller.go:2047 (alertBranchDeleteHeldOnce) · types.go:472 (escalation rule)
+

--- a/internal/alerts/engine.go
+++ b/internal/alerts/engine.go
@@ -1437,12 +1437,34 @@ func (e *Engine) handleEvalRegression(ctx context.Context, event Event) {
 
 // handleEscalation processes escalation events (GH-885).
 // These are critical alerts that should route to PagerDuty.
+//
+// EventTypeEscalation is shared by every escalation emitter in the codebase,
+// but only the circuit-breaker trip emitter (metrics_alerter.go
+// emitEscalationAlert) populates the trips_in_hour/escalation_threshold/
+// last_pr/last_reason metadata this handler used to render exclusively. The
+// autopilot emitters (alertStackedSupersetOnce, alertBaseMismatchOnce,
+// alertBranchDeleteHeldOnce, alertUnresolvableBaseOnce) put their real
+// diagnostic text in event.Error instead — this handler never read it, so
+// every non-circuit-breaker escalation rendered a blank template (GH-5065,
+// incident a695c90e: alertBranchDeleteHeldOnce fired correctly but Slack
+// delivered "Circuit breaker escalation:  trips in 1 hour (threshold: ).
+// Last: PR # -"). Fall back to event.Error whenever the circuit-breaker
+// metadata is absent so those emitters' messages actually reach the alert.
 func (e *Engine) handleEscalation(ctx context.Context, event Event) {
 	for _, rule := range e.config.Rules {
 		if !rule.Enabled || rule.Type != AlertTypeEscalation {
 			continue
 		}
 
+		// NOTE (GH-5065 item 3): this 1h cooldown is keyed globally by
+		// rule.Name ("escalation") in e.lastAlertTimes (shouldFire below,
+		// engine.go ~1062), so a circuit-breaker trip and an unrelated
+		// autopilot escalation (stacked-superset, base-mismatch,
+		// branch-delete-held, unresolvable-base) share one bucket — whichever
+		// fires first can suppress the other for up to an hour even though
+		// they're unrelated conditions. Left as-is per GH-5065 (flag-only;
+		// splitting the cooldown key per-source is a follow-up if this proves
+		// to actually suppress a real escalation).
 		if !e.shouldFire(rule) {
 			continue
 		}
@@ -1452,10 +1474,20 @@ func (e *Engine) handleEscalation(ctx context.Context, event Event) {
 		lastPR := event.Metadata["last_pr"]
 		lastReason := event.Metadata["last_reason"]
 
-		message := fmt.Sprintf(
-			"Circuit breaker escalation: %s trips in 1 hour (threshold: %s). Last: PR #%s - %s",
-			tripsInHour, threshold, lastPR, lastReason,
-		)
+		var message string
+		switch {
+		case tripsInHour != "" || threshold != "":
+			// Circuit-breaker path — keep byte-identical to the pre-GH-5065
+			// template when this metadata is present.
+			message = fmt.Sprintf(
+				"Circuit breaker escalation: %s trips in 1 hour (threshold: %s). Last: PR #%s - %s",
+				tripsInHour, threshold, lastPR, lastReason,
+			)
+		case event.Error != "":
+			message = event.Error
+		default:
+			message = fmt.Sprintf("Escalation event received for %s with no message content", event.TaskTitle)
+		}
 
 		alert := e.createAlert(rule, event, message)
 		// Force critical severity for escalations

--- a/internal/alerts/engine_gh5065_test.go
+++ b/internal/alerts/engine_gh5065_test.go
@@ -1,0 +1,134 @@
+package alerts
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// GH-5065: handleEscalation (engine.go) is the single handler for every
+// EventTypeEscalation source, but it used to build its message exclusively
+// from the circuit-breaker trip metadata (trips_in_hour/escalation_threshold/
+// last_pr/last_reason) — fields only metrics_alerter.go's emitEscalationAlert
+// populates. The autopilot emitters (alertStackedSupersetOnce,
+// alertBaseMismatchOnce, alertBranchDeleteHeldOnce, alertUnresolvableBaseOnce)
+// put their diagnostic text in event.Error instead, which handleEscalation
+// never read — every one of their escalations rendered a blank template
+// (incident a695c90e, 2026-08-21).
+
+func mkGH5065EscalationEngine(t *testing.T) (*Engine, *mockChannel) {
+	t.Helper()
+	config := &AlertConfig{
+		Enabled: true,
+		Channels: []ChannelConfig{
+			{Name: "pagerduty", Type: "pagerduty", Enabled: true, Severities: []Severity{SeverityCritical}},
+		},
+		Rules: []AlertRule{
+			{
+				Name:        "escalation",
+				Type:        AlertTypeEscalation,
+				Enabled:     true,
+				Condition:   RuleCondition{EscalationRetries: 3},
+				Severity:    SeverityCritical,
+				Channels:    []string{"pagerduty"},
+				Cooldown:    0,
+				Description: "Escalate to PagerDuty after repeated failures for the same source",
+			},
+		},
+	}
+
+	mockCh := newMockChannel("pagerduty", "pagerduty")
+	dispatcher := NewDispatcher(config)
+	dispatcher.RegisterChannel(mockCh)
+
+	engine := NewEngine(config, WithDispatcher(dispatcher))
+	return engine, mockCh
+}
+
+// TestHandleEscalation_AutopilotEmitterRendersEventError covers the
+// alertStackedSupersetOnce/alertBaseMismatchOnce/alertBranchDeleteHeldOnce/
+// alertUnresolvableBaseOnce shape: no circuit-breaker metadata, diagnostic
+// text in event.Error. Before the GH-5065 fix, this rendered
+// "Circuit breaker escalation:  trips in 1 hour (threshold: ). Last: PR # -".
+func TestHandleEscalation_AutopilotEmitterRendersEventError(t *testing.T) {
+	engine, mockCh := mkGH5065EscalationEngine(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = engine.Start(ctx)
+	defer engine.Stop()
+
+	wantMsg := `refused to delete branch "pilot/GH-5052" (from PR #5054 cleanup) because it is the base of open PR #5055 in qf-studio/pilot — deleting it would orphan that PR's content the same way GH-4872 did`
+
+	engine.ProcessEvent(Event{
+		Type:      EventTypeEscalation,
+		TaskID:    "branch-pilot/GH-5052-delete-held",
+		TaskTitle: "Branch delete held: pilot/GH-5052 is the base of an open PR",
+		Project:   "qf-studio/pilot",
+		Error:     wantMsg,
+		Timestamp: time.Now(),
+		Metadata: map[string]string{
+			"repo":        "qf-studio/pilot",
+			"branch":      "pilot/GH-5052",
+			"pr":          "5054",
+			"blocking_pr": "5055",
+		},
+	})
+
+	waitForAlerts(t, mockCh, 1, 2*time.Second)
+
+	alerts := mockCh.getAlerts()
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(alerts))
+	}
+	if alerts[0].Message != wantMsg {
+		t.Errorf("alert message = %q, want %q", alerts[0].Message, wantMsg)
+	}
+	if strings.Contains(alerts[0].Message, "Circuit breaker escalation") {
+		t.Errorf("alert message must not render the circuit-breaker template for an event with no circuit-breaker metadata: %q", alerts[0].Message)
+	}
+	if alerts[0].Severity != SeverityCritical {
+		t.Errorf("expected severity %s, got %s", SeverityCritical, alerts[0].Severity)
+	}
+}
+
+// TestHandleEscalation_CircuitBreakerRendersExistingTemplate is the
+// byte-identical-when-present guard from GH-5065: an escalation event
+// carrying the full circuit-breaker metadata (metrics_alerter.go
+// emitEscalationAlert's shape) must render exactly the pre-GH-5065 template,
+// unaffected by the new event.Error fallback path.
+func TestHandleEscalation_CircuitBreakerRendersExistingTemplate(t *testing.T) {
+	engine, mockCh := mkGH5065EscalationEngine(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = engine.Start(ctx)
+	defer engine.Stop()
+
+	engine.ProcessEvent(Event{
+		Type:      EventTypeEscalation,
+		TaskID:    "autopilot-circuit-breaker",
+		TaskTitle: "Autopilot Circuit Breaker Escalation",
+		Project:   "qf-studio/pilot",
+		Timestamp: time.Now(),
+		Metadata: map[string]string{
+			"trips_in_hour":        "5",
+			"escalation_threshold": "3",
+			"last_pr":              "5054",
+			"last_reason":          "ci_timeout",
+			"severity":             string(SeverityCritical),
+		},
+	})
+
+	waitForAlerts(t, mockCh, 1, 2*time.Second)
+
+	alerts := mockCh.getAlerts()
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(alerts))
+	}
+	want := "Circuit breaker escalation: 5 trips in 1 hour (threshold: 3). Last: PR #5054 - ci_timeout"
+	if alerts[0].Message != want {
+		t.Errorf("alert message = %q, want %q", alerts[0].Message, want)
+	}
+}

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1989,20 +1989,21 @@ A human needs to check whether `+"`%s`"+` still needs to be merged into `+"`%s`"
 }
 
 // branchIsBaseOfOpenPR reports whether branchName is currently the base
-// ("Base.Ref") of any open PR in this repo (GH-4872). ListPullRequests has
-// no base= filter, so this is a client-side scan over all open PRs — cheap
-// at Pilot's PR volumes.
-func (c *Controller) branchIsBaseOfOpenPR(ctx context.Context, branchName string) (bool, error) {
+// ("Base.Ref") of any open PR in this repo (GH-4872), and if so, that PR's
+// number (GH-5065: callers need to name the blocking PR in their alert, not
+// just report "held"). ListPullRequests has no base= filter, so this is a
+// client-side scan over all open PRs — cheap at Pilot's PR volumes.
+func (c *Controller) branchIsBaseOfOpenPR(ctx context.Context, branchName string) (bool, int, error) {
 	openPRs, err := c.ghClient.ListPullRequests(ctx, c.owner, c.repo, "open")
 	if err != nil {
-		return false, err
+		return false, 0, err
 	}
 	for _, pr := range openPRs {
 		if pr.Base.Ref == branchName {
-			return true, nil
+			return true, pr.Number, nil
 		}
 	}
-	return false, nil
+	return false, 0, nil
 }
 
 // safeDeleteBranch deletes branchName unless it is currently the base of
@@ -2020,7 +2021,7 @@ func (c *Controller) safeDeleteBranch(ctx context.Context, branchName string, pr
 	if branchName == "" {
 		return false, nil
 	}
-	isBase, checkErr := c.branchIsBaseOfOpenPR(ctx, branchName)
+	isBase, blockingPR, checkErr := c.branchIsBaseOfOpenPR(ctx, branchName)
 	if checkErr != nil {
 		c.log.Warn("safeDeleteBranch: failed to check whether branch is the base of an open PR — skipping delete this cycle (fail-closed)",
 			"branch", branchName, "pr", prNumber, "error", checkErr)
@@ -2028,8 +2029,8 @@ func (c *Controller) safeDeleteBranch(ctx context.Context, branchName string, pr
 	}
 	if isBase {
 		c.log.Warn("safeDeleteBranch: refusing to delete branch — it is the base of another open PR",
-			"branch", branchName, "pr", prNumber)
-		c.alertBranchDeleteHeldOnce(branchName, prNumber)
+			"branch", branchName, "pr", prNumber, "blocking_pr", blockingPR)
+		c.alertBranchDeleteHeldOnce(branchName, prNumber, blockingPR)
 		return false, nil
 	}
 	if err := c.ghClient.DeleteBranch(ctx, c.owner, c.repo, branchName); err != nil {
@@ -2043,8 +2044,11 @@ func (c *Controller) safeDeleteBranch(ctx context.Context, branchName string, pr
 // of another open PR (GH-4872), deduplicated per branch name via
 // alertedBranchDeleteHolds — safeDeleteBranch is called from four
 // independent cleanup sites, any of which could re-offer the same branch
-// for deletion before the underlying stack is resolved.
-func (c *Controller) alertBranchDeleteHeldOnce(branchName string, prNumber int) {
+// for deletion before the underlying stack is resolved. blockingPR is the
+// open PR currently based on branchName (from branchIsBaseOfOpenPR) — named
+// explicitly (GH-5065) so the alert tells a human which PR to look at
+// instead of just naming the cleanup PR that got held.
+func (c *Controller) alertBranchDeleteHeldOnce(branchName string, prNumber, blockingPR int) {
 	c.mu.Lock()
 	if c.alertedBranchDeleteHolds == nil {
 		c.alertedBranchDeleteHolds = make(map[string]bool)
@@ -2057,11 +2061,11 @@ func (c *Controller) alertBranchDeleteHeldOnce(branchName string, prNumber int) 
 	c.mu.Unlock()
 
 	msg := fmt.Sprintf(
-		"refused to delete branch %q (from PR #%d cleanup) because it is the base of another open PR in %s — deleting it would orphan that PR's content the same way GH-4872 did",
-		branchName, prNumber, c.repoKey(),
+		"refused to delete branch %q (from PR #%d cleanup) because it is the base of open PR #%d in %s — deleting it would orphan that PR's content the same way GH-4872 did",
+		branchName, prNumber, blockingPR, c.repoKey(),
 	)
 	if c.alertsEngine == nil {
-		c.log.Error("branch_delete_held alert not delivered: SetAlertsEngine was never called", "branch", branchName, "pr", prNumber)
+		c.log.Error("branch_delete_held alert not delivered: SetAlertsEngine was never called", "branch", branchName, "pr", prNumber, "blocking_pr", blockingPR)
 		return
 	}
 	c.alertsEngine.ProcessEvent(alerts.Event{
@@ -2072,9 +2076,10 @@ func (c *Controller) alertBranchDeleteHeldOnce(branchName string, prNumber int) 
 		Error:     msg,
 		Timestamp: time.Now(),
 		Metadata: map[string]string{
-			"repo":   c.repoKey(),
-			"branch": branchName,
-			"pr":     strconv.Itoa(prNumber),
+			"repo":        c.repoKey(),
+			"branch":      branchName,
+			"pr":          strconv.Itoa(prNumber),
+			"blocking_pr": strconv.Itoa(blockingPR),
 		},
 	})
 }

--- a/internal/autopilot/gh4872_test.go
+++ b/internal/autopilot/gh4872_test.go
@@ -586,6 +586,55 @@ func TestSafeDeleteBranch_HeldAlertsOncePerBranch(t *testing.T) {
 	}
 }
 
+// TestSafeDeleteBranch_HeldAlertNamesBlockingPR is the GH-5065 regression:
+// alertBranchDeleteHeldOnce's alert used to name only the held cleanup PR,
+// leaving a human to go find which open PR was actually blocking the delete.
+// branchIsBaseOfOpenPR already knows that PR's number — it must be threaded
+// into both the alert Metadata (blocking_pr) and the message text.
+func TestSafeDeleteBranch_HeldAlertNamesBlockingPR(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_ = writeJSON(w, []*github.PullRequest{
+				{Number: 5055, State: "open", Head: github.PRRef{Ref: "pilot/GH-5053"}, Base: github.PRRef{Ref: "pilot/GH-5052"}},
+			})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	deleted, err := c.safeDeleteBranch(context.Background(), "pilot/GH-5052", 5054)
+	if err != nil {
+		t.Fatalf("safeDeleteBranch returned error: %v", err)
+	}
+	if deleted {
+		t.Fatal("expected delete to be held (branch is the base of an open PR)")
+	}
+
+	if len(sink.events) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(sink.events))
+	}
+	event := sink.events[0]
+	if got := event.Metadata["blocking_pr"]; got != "5055" {
+		t.Errorf("Metadata[blocking_pr] = %q, want %q", got, "5055")
+	}
+	if got := event.Metadata["pr"]; got != "5054" {
+		t.Errorf("Metadata[pr] = %q, want %q (the held cleanup PR, unchanged)", got, "5054")
+	}
+	if !strings.Contains(event.Error, "open PR #5055") {
+		t.Errorf("alert message must name the blocking PR #5055, got %q", event.Error)
+	}
+}
+
 // writeJSON is a small test helper to encode a JSON response body while
 // satisfying errcheck on the Write/Encode call.
 func writeJSON(w http.ResponseWriter, v interface{}) error {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5065.

Closes #5065

## Changes

GitHub Issue GH-5065: fix(alerts): handleEscalation discards event.Error — every non-circuit-breaker escalation renders a blank template (incident a695c90e)

## Summary

`handleEscalation` (`internal/alerts/engine.go:1440-1465`) is the single handler for every `EventTypeEscalation` source, but its message template is built only from `event.Metadata["trips_in_hour"/"escalation_threshold"/"last_pr"/"last_reason"]` — fields only the circuit-breaker-trips emitter (`metrics_alerter.go`) populates. The four autopilot emitters (`alertStackedSupersetOnce`, `alertBaseMismatchOnce`, `alertBranchDeleteHeldOnce`, `alertUnresolvableBaseOnce`) put their real diagnostic text in `event.Error` — **which handleEscalation never reads**.

Confirmed live 2026-08-21 07:54:36Z (alert `a695c90e`, box daemon.log): `alertBranchDeleteHeldOnce` fired for PR#5054's branch `pilot/GH-5052` (correct detection — PR#5055 still based on it) but the Slack delivery rendered the circuit-breaker template with empty fields: `Circuit breaker escalation:  trips in 1 hour (threshold: ). Last: PR # -`.

## Fixes

1. `handleEscalation`: when the circuit-breaker metadata fields are absent/empty, render from `event.Error` (the emitters' purpose-built message) instead of the blank template. Keep the circuit-breaker path byte-identical when its metadata IS present.
2. The three branch/base emitters' metadata never names the *blocking/related* PR (only the cleanup PR). Add it: `alertBranchDeleteHeldOnce` knows the blocking open PR from `branchIsBaseOfOpenPR` (`controller.go:1995`) — thread its number into metadata (`blocking_pr`) and the message.
3. Flag-only (state decision in PR, no behavior change required): the 1h `escalation` rule cooldown is keyed globally by `rule.Name` (`engine.go:1062-1076`), so circuit-breaker trips and autopilot escalations share one cooldown bucket and can suppress each other — note it in a code comment or split the key if trivial.

## Acceptance Criteria

- [ ] Test: an `EventTypeEscalation` with `event.Error` set and no circuit-breaker metadata renders the Error text (assert message content, not just dispatch).
- [ ] Test: circuit-breaker event with full metadata renders exactly as today.
- [ ] `alertBranchDeleteHeldOnce` metadata + message include the blocking PR number; test asserts it.
- [ ] `go test ./internal/alerts/... ./internal/autopilot/...` green.

## Refs

Incident 2026-08-21 07:54Z (alert a695c90e, daemon.log lines ~333591-333609) · engine.go:1440 · controller.go:2047 (alertBranchDeleteHeldOnce) · types.go:472 (escalation rule)