### PR TITLE
fix(autopilot): retarget stacked descendants before branch delete (GH-5071)

### DIFF
--- a/.agent/tasks/gh-5071.md
+++ b/.agent/tasks/gh-5071.md
@@ -1,0 +1,36 @@
+# GH-5071
+
+**Created:** 2026-08-21
+
+## Problem
+
+GitHub Issue GH-5071: fix(autopilot): close the stacked-PR resume loop — retarget descendants on base merge before branch delete (PR#5068 residual)
+
+## Summary
+
+PR#5068 (GH-5066) parks a stacked-base PR at the CI-wait deadline and un-parks it when GitHub retargets it to the default branch. Post-merge review found the loop doesn't close autonomously: **the retarget that triggers the un-park is withheld by our own deletion guard.** `safeDeleteBranch` (controller.go:2019-2031) refuses to delete a merged base's branch while a descendant PR still targets it (correct — GH-4872 protection), but GitHub only auto-retargets child PRs **when the base branch is deleted**. So in a fully autopilot-managed stack: base merges → branch delete refused (because descendant exists) → no retarget → descendant parked forever, waiting for a human.
+
+Tonight's incident recovered only because the operator merged the base manually and GitHub happened to retarget on the branch delete that followed. The gh5034 un-park test models the retarget as given.
+
+## Fix
+
+When a stack base reaches `StageMerged`, explicitly close the loop for its descendants, in order:
+1. For each open PR whose `Base.Ref == mergedPR.BranchName` (already computed by `branchIsBaseOfOpenPR`, :1996): retarget it to the default branch via the GitHub API (`PATCH /pulls/{n}` with `base`), THEN
+2. proceed with `safeDeleteBranch` — which now finds no dependent PRs and deletes cleanly.
+3. The existing WaitingCI un-park guard (:2792-2806) picks the retargeted PR up on the next tick via ProcessPR's `TargetBranch` refresh; no changes needed there.
+
+Constraints: retarget only PRs the controller tracks (activePRs) OR any open PR on the branch? — decide and state (recommendation: any open PR with that base, since untracked descendants otherwise permanently block branch deletion). Idempotent + fail-open: a retarget API failure logs WARN and leaves today's behavior (delete refused, descendant parked, alert fired with blocking_pr per PR#5069).
+
+## Acceptance Criteria
+
+- [ ] Test: base at StageMerged with a parked descendant targeting its branch → descendant is retargeted to default via the API (assert the PATCH), branch delete then succeeds, and the descendant un-parks and merges on subsequent ticks (extend the gh5034 e2e — the retarget is now produced by the controller, not modeled as given).
+- [ ] Test: retarget API failure → WARN, branch delete still refused (existing behavior), blocking_pr alert unchanged.
+- [ ] No retarget attempted for closed/merged descendants.
+- [ ] Existing gh4872/gh5034/gh5066 tests untouched and green.
+
+## Refs
+
+PR#5068 review note 1 · controller.go:2019 (safeDeleteBranch guard), :2792 (WaitingCI un-park), :1996 (branchIsBaseOfOpenPR) · PR#5069 (blocking_pr alert) · incident 2026-08-21 07:54Z
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2051,6 +2051,105 @@ func (c *Controller) safeDeleteBranch(ctx context.Context, branchName string, pr
 	return true, nil
 }
 
+// retargetDescendants closes the stacked-PR resume loop (GH-5071 — PR#5068
+// residual): GitHub only auto-retargets a child PR onto the repo's default
+// branch when its current base branch is DELETED, but safeDeleteBranch
+// (GH-4872, just above) refuses that delete while any open PR still targets
+// the branch. In a fully autopilot-managed stack that's a deadlock: base
+// merges -> branch delete refused (descendant still targets it) -> no
+// GitHub-side retarget ever fires -> the descendant's WaitingCI un-park
+// guard (which watches TargetBranch) never sees a change and the PR parks
+// forever, waiting for a human to intervene. The 2026-08-21 incident only
+// recovered because an operator merged the base by hand and GitHub happened
+// to retarget on the branch delete that followed.
+//
+// Call this BEFORE safeDeleteBranch on any branch that has just genuinely
+// merged: it retargets every open PR based on branchName onto
+// defaultBranch, so safeDeleteBranch's own branchIsBaseOfOpenPR check finds
+// no dependents left and the delete proceeds normally.
+//
+// Scoped to any open PR with this base, not just activePRs-tracked ones —
+// an untracked descendant would otherwise permanently block the branch
+// delete the same way, which defeats the point of this fix.
+//
+// Best-effort / fail-open: a retarget failure is logged as a WARN and
+// otherwise ignored here — the caller's subsequent safeDeleteBranch call
+// re-checks independently and will refuse the delete + fire the existing
+// blocking_pr alert (PR#5069) exactly as it did before this fix, so a
+// flaky retarget degrades to today's behavior rather than forcing a delete
+// that would orphan the still-blocked descendant's content.
+func (c *Controller) retargetDescendants(ctx context.Context, branchName, defaultBranch string) {
+	if branchName == "" || defaultBranch == "" || branchName == defaultBranch {
+		return
+	}
+	openPRs, err := c.ghClient.ListPullRequests(ctx, c.owner, c.repo, "open")
+	if err != nil {
+		c.log.Warn("retargetDescendants: failed to list open PRs — skipping retarget this cycle, safeDeleteBranch will fail-closed as before",
+			"branch", branchName, "error", err)
+		return
+	}
+	for _, pr := range openPRs {
+		if pr.Base.Ref != branchName {
+			continue
+		}
+		if err := c.retargetPR(ctx, pr.Number, defaultBranch); err != nil {
+			c.log.Warn("retargetDescendants: failed to retarget descendant PR off merged base branch — safeDeleteBranch will refuse the delete and alert as before",
+				"branch", branchName, "descendant_pr", pr.Number, "default_branch", defaultBranch, "error", err)
+			continue
+		}
+		c.log.Info("retargetDescendants: retargeted descendant PR off merged base branch",
+			"branch", branchName, "descendant_pr", pr.Number, "default_branch", defaultBranch)
+	}
+}
+
+// retargetPR moves an open PR onto newBase via GitHub's updatePullRequest
+// GraphQL mutation. The studio-sdk client this controller is built against
+// (ghClient) has no REST helper for changing a PR's base branch, so this
+// goes directly through the already-exported ExecuteGraphQL path the same
+// client uses elsewhere (epic_reconcile.go's sub-issue linking, the project
+// board sync). It first resolves the PR's own GraphQL node ID with a plain
+// query by number — deliberately not reusing GetIssueNodeID's REST
+// issues-endpoint lookup (built for actual issues, not PRs) — then issues
+// the mutation. Both round trips share ctx's deadline/cancellation.
+func (c *Controller) retargetPR(ctx context.Context, prNumber int, newBase string) error {
+	const idQuery = `query($owner: String!, $repo: String!, $number: Int!) {
+		repository(owner: $owner, name: $repo) {
+			pullRequest(number: $number) { id }
+		}
+	}`
+	var idResult struct {
+		Repository struct {
+			PullRequest struct {
+				ID string `json:"id"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	}
+	if err := c.ghClient.ExecuteGraphQL(ctx, idQuery, map[string]interface{}{
+		"owner":  c.owner,
+		"repo":   c.repo,
+		"number": prNumber,
+	}, &idResult); err != nil {
+		return fmt.Errorf("resolve node id for PR #%d: %w", prNumber, err)
+	}
+	nodeID := idResult.Repository.PullRequest.ID
+	if nodeID == "" {
+		return fmt.Errorf("PR #%d returned empty node id", prNumber)
+	}
+
+	const mutation = `mutation($id: ID!, $base: String!) {
+		updatePullRequest(input: {pullRequestId: $id, baseRefName: $base}) {
+			pullRequest { number }
+		}
+	}`
+	if err := c.ghClient.ExecuteGraphQL(ctx, mutation, map[string]interface{}{
+		"id":   nodeID,
+		"base": newBase,
+	}, nil); err != nil {
+		return fmt.Errorf("retarget PR #%d to %q: %w", prNumber, newBase, err)
+	}
+	return nil
+}
+
 // alertBranchDeleteHeldOnce fires an escalation alert the first time
 // safeDeleteBranch refuses to delete a given branch because it is the base
 // of another open PR (GH-4872), deduplicated per branch name via
@@ -4748,6 +4847,10 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 	// Branch is safe to delete — it's fully merged. If GitHub already deleted it
 	// (delete_branch_on_merge setting), the API returns 404/422 which we ignore.
 	if prState.BranchName != "" {
+		// GH-5071: retarget any stacked descendant off this branch BEFORE
+		// attempting the delete — see retargetDescendants for why this can't
+		// be left to GitHub's own delete-triggered auto-retarget here.
+		c.retargetDescendants(ctx, prState.BranchName, c.resolveMainBranchName())
 		if deleted, err := c.safeDeleteBranch(ctx, prState.BranchName, prState.PRNumber); err != nil {
 			c.log.Warn("failed to delete branch after merge", "branch", prState.BranchName, "pr", prState.PRNumber, "error", err)
 		} else if deleted {
@@ -8697,6 +8800,15 @@ func (c *Controller) checkExternalMergeOrClose(ctx context.Context, prState *PRS
 		}
 		c.recordExecutionEvent(prState, memory.StageMerged,
 			fmt.Sprintf("pr #%d: merged externally (%s)", prState.PRNumber, prURL))
+
+		// GH-5071: same stacked-PR resume loop closed on the internal
+		// handleMerging path above — an externally merged base (a human ran
+		// `gh pr merge`, or GitHub's UI) hits the exact same
+		// safeDeleteBranch(GH-4872) deadlock via removePR below, so retarget
+		// any stacked descendant before removePR attempts the branch delete.
+		if prState.BranchName != "" {
+			c.retargetDescendants(ctx, prState.BranchName, c.resolveMainBranchName())
+		}
 
 		c.removePR(prState.PRNumber)
 		return true

--- a/internal/autopilot/controller_gh5034_test.go
+++ b/internal/autopilot/controller_gh5034_test.go
@@ -3,6 +3,7 @@ package autopilot
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/qf-studio/pilot/internal/alerts"
 	"github.com/qf-studio/pilot/internal/testutil"
 	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 )
@@ -727,5 +729,384 @@ func TestController_HandleWaitingCI_BaseMismatchPark_UnparksAfterBaseMerges_GH50
 	}
 	if mergeCalled.Load() != 1 {
 		t.Errorf("merge called %d times, want 1 — B must merge exactly once after un-parking", mergeCalled.Load())
+	}
+}
+
+// TestController_HandleMerging_RetargetsParkedDescendant_GH5071 is the
+// GH-5071 fix regression (PR#5068 residual, 2026-08-21 incident): GitHub
+// only auto-retargets a child PR onto the default branch when its current
+// base branch is DELETED, but safeDeleteBranch (GH-4872) refuses that
+// delete while an open PR still targets the branch — so in a fully
+// autopilot-managed stack, merging the base used to deadlock: branch delete
+// refused (descendant still targets it) -> no retarget ever fires ->
+// descendant parks forever.
+//
+// Unlike TestController_HandleWaitingCI_BaseMismatchPark_UnparksAfterBaseMerges_GH5066
+// above (which models the base's merge as a raw stage flip and the
+// resulting GitHub-side retarget as a given, already-applied fact — see
+// its comment ~line 655), this test drives PR#16 through the REAL
+// handleMerging flow via ProcessPR so the retarget is something the
+// controller itself must produce: it asserts the updatePullRequest GraphQL
+// mutation actually fires (the only retarget primitive the studio-sdk
+// client this controller is built against exposes — there is no REST PATCH
+// helper), that the branch delete then succeeds instead of being held, and
+// that no branch_delete_held escalation fires. It then reuses the GH-5066
+// suite's already-covered un-park mechanics for the "merges on subsequent
+// ticks" leg.
+func TestController_HandleMerging_RetargetsParkedDescendant_GH5071(t *testing.T) {
+	const baseNumber = 16
+	const prNumber = 17
+
+	local := newFixtureRepo(t)
+	ctx := context.Background()
+
+	runFixtureGit(t, local, "checkout", "-b", "pilot/GH-16")
+	writeFixtureFile(t, local, "base.txt", "from base PR\n")
+	runFixtureGit(t, local, "add", "base.txt")
+	runFixtureGit(t, local, "commit", "-m", "GH-16 work")
+	runFixtureGit(t, local, "push", "origin", "pilot/GH-16")
+	baseSHA := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	runFixtureGit(t, local, "checkout", "-b", "pilot/GH-17")
+	writeFixtureFile(t, local, "stacked.txt", "from stacked PR\n")
+	runFixtureGit(t, local, "add", "stacked.txt")
+	runFixtureGit(t, local, "commit", "-m", "GH-17 work, stacked on GH-16")
+	runFixtureGit(t, local, "push", "origin", "pilot/GH-17")
+	stackedSHA := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	var mergeCalled, deleteBranchCalled, retargetMutationCalled, idQueryCalled atomic.Int32
+	var lastMutationBase, lastMutationPR atomic.Value
+	var pr17Retargeted atomic.Bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/16/merge" && r.Method == http.MethodPut:
+			mergeCalled.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"sha":"mergedSHA16","merged":true,"message":"merged"}`))
+		case r.URL.Path == "/repos/owner/repo/issues/16/comments" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case r.URL.Path == "/repos/owner/repo/pulls" && r.Method == http.MethodGet:
+			// branchIsBaseOfOpenPR / retargetDescendants: PR#17 is still open;
+			// its base reflects pilot/GH-16 until the controller's own
+			// updatePullRequest mutation (below) actually retargets it — this
+			// stateful flip is what proves safeDeleteBranch's later re-check
+			// sees a REAL controller-produced retarget, not a hardcoded fixture.
+			w.WriteHeader(http.StatusOK)
+			base := "pilot/GH-16"
+			if pr17Retargeted.Load() {
+				base = "main"
+			}
+			_, _ = w.Write([]byte(`[{"number":17,"state":"open","base":{"ref":"` + base + `"},"head":{"ref":"pilot/GH-17","sha":"` + stackedSHA + `"}}]`))
+		case r.URL.Path == "/graphql" && r.Method == http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			bodyStr := string(body)
+			switch {
+			case strings.Contains(bodyStr, "updatePullRequest"):
+				retargetMutationCalled.Add(1)
+				if strings.Contains(bodyStr, `"base":"main"`) {
+					lastMutationBase.Store("main")
+				}
+				if strings.Contains(bodyStr, `"id":"PR_kwDOgh507117"`) {
+					lastMutationPR.Store(17)
+				}
+				pr17Retargeted.Store(true)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"data":{"updatePullRequest":{"pullRequest":{"number":17}}}}`))
+			case strings.Contains(bodyStr, "pullRequest(number:"):
+				idQueryCalled.Add(1)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"data":{"repository":{"pullRequest":{"id":"PR_kwDOgh507117"}}}}`))
+			default:
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"data":{}}`))
+			}
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/git/refs/heads/pilot/GH-16") && r.Method == http.MethodDelete:
+			deleteBranchCalled.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		case r.URL.Path == "/repos/owner/repo/commits/"+stackedSHA+"/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns:  []github.CheckRun{{Name: "ci", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess}},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/repos/owner/repo/pulls/17/files":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case r.URL.Path == "/repos/owner/repo/issues/17" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"number":17,"title":"GH-17 work, stacked on GH-16"}`))
+		case r.URL.Path == "/repos/owner/repo/pulls/17/merge" && r.Method == http.MethodPut:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"sha":"mergedSHA17","merged":true,"message":"merged"}`))
+		case strings.HasSuffix(r.URL.Path, "/issues/17/comments"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithProjectPath(local))
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	c.mu.Lock()
+	c.activePRs[baseNumber] = &PRState{
+		PRNumber:     baseNumber,
+		BranchName:   "pilot/GH-16",
+		HeadSHA:      baseSHA,
+		TargetBranch: "main",
+		Stage:        StageMerging, // A is ready to merge, driven for real below
+		CreatedAt:    time.Now(),
+	}
+	// B is already parked on A (mirrors the end of tick 1 in the GH-5066
+	// suite above) — targeting A's branch directly, the base-mismatch shape
+	// parkForBaseMismatch produces.
+	c.activePRs[prNumber] = &PRState{
+		PRNumber:         prNumber,
+		IssueNumber:      prNumber,
+		BranchName:       "pilot/GH-17",
+		HeadSHA:          stackedSHA,
+		TargetBranch:     "pilot/GH-16",
+		Stage:            StageWaitingCI,
+		CIStatus:         CIPending,
+		CIWaitStartedAt:  time.Now().Add(-45 * time.Minute),
+		Parked:           true,
+		EscalationReason: baseMismatchReasonPrefix + `PR targets "pilot/GH-16", not the default branch "main"`,
+		CreatedAt:        time.Now(),
+	}
+	c.mu.Unlock()
+
+	ghPR16 := &github.PullRequest{
+		Number: baseNumber,
+		Head:   github.PRRef{SHA: baseSHA},
+		Base:   github.PRRef{Ref: "main"},
+	}
+
+	// Tick: A merges for real through handleMerging.
+	if err := c.ProcessPR(ctx, baseNumber, ghPR16); err != nil {
+		t.Fatalf("ProcessPR(16): %v", err)
+	}
+	if mergeCalled.Load() != 1 {
+		t.Fatalf("merge called %d times, want 1", mergeCalled.Load())
+	}
+	pr16, ok := c.GetPRState(baseNumber)
+	if !ok || pr16.Stage != StageMerged {
+		t.Fatalf("PR 16 stage = %v (ok=%v), want %s", pr16, ok, StageMerged)
+	}
+
+	// The controller — not the test — must have produced the retarget: the
+	// id-lookup query and the updatePullRequest mutation both fired, naming
+	// PR#17 and "main".
+	if idQueryCalled.Load() != 1 {
+		t.Errorf("PR node-id query called %d times, want 1", idQueryCalled.Load())
+	}
+	if retargetMutationCalled.Load() != 1 {
+		t.Fatalf("retarget mutation called %d times, want 1 — the controller must retarget PR #17 off the merged base branch before deleting it", retargetMutationCalled.Load())
+	}
+	if v, _ := lastMutationBase.Load().(string); v != "main" {
+		t.Errorf("retarget mutation base = %q, want %q", v, "main")
+	}
+	if v, _ := lastMutationPR.Load().(int); v != 17 {
+		t.Errorf("retarget mutation target PR node id did not match PR #17 (got tracked value %v)", v)
+	}
+
+	// Retargeting must have cleared safeDeleteBranch's GH-4872 guard: the
+	// delete now succeeds instead of being refused.
+	if deleteBranchCalled.Load() != 1 {
+		t.Fatalf("branch delete called %d times, want 1 — retargeting PR #17 should have cleared safeDeleteBranch's guard", deleteBranchCalled.Load())
+	}
+	for _, ev := range sink.events {
+		if strings.Contains(ev.TaskID, "delete-held") {
+			t.Errorf("branch_delete_held alert fired unexpectedly: %+v", ev)
+		}
+	}
+
+	// B un-parks and merges on subsequent ticks, exactly as GH-5066 proves —
+	// reusing that same mechanism here confirms the retarget this fix
+	// produces is the real trigger, not a coincidence of test setup.
+	ghPR17Retargeted := &github.PullRequest{
+		Number: prNumber,
+		Head:   github.PRRef{SHA: stackedSHA},
+		Base:   github.PRRef{Ref: "main"},
+	}
+	const maxTicks = 6
+	for i := 0; i < maxTicks; i++ {
+		if err := c.ProcessPR(ctx, prNumber, ghPR17Retargeted); err != nil {
+			t.Fatalf("post-retarget tick %d: ProcessPR: %v", i, err)
+		}
+		pr17, ok := c.GetPRState(prNumber)
+		if !ok {
+			t.Fatal("PR 17 should still be tracked")
+		}
+		if pr17.Stage == StageFailed || pr17.Stage == StageCIFailed {
+			t.Fatalf("post-retarget tick %d: Stage = %s — B must merge cleanly once retargeted", i, pr17.Stage)
+		}
+		if pr17.Stage == StageMerged {
+			break
+		}
+	}
+	pr17, ok := c.GetPRState(prNumber)
+	if !ok {
+		t.Fatal("PR 17 should still be tracked")
+	}
+	if pr17.Stage != StageMerged {
+		t.Fatalf("Stage = %s, want %s — B should have proceeded through to a completed merge", pr17.Stage, StageMerged)
+	}
+	if pr17.Parked {
+		t.Error("Parked should be false — un-parking must have cleared it")
+	}
+}
+
+// TestController_RetargetDescendants_APIFailureFailsClosed_GH5071 covers the
+// other half of the GH-5071 contract: if the retarget mutation itself fails
+// (e.g. a transient GitHub API error), retargetDescendants must fail open —
+// log a WARN and NOT abort the merge-finalization flow — while
+// safeDeleteBranch's own independent check still refuses the delete exactly
+// as it did before this fix (the descendant's base was never actually
+// changed), firing the existing blocking_pr branch_delete_held alert
+// (PR#5069) unchanged.
+func TestController_RetargetDescendants_APIFailureFailsClosed_GH5071(t *testing.T) {
+	const baseNumber = 16
+	const prNumber = 17
+
+	local := newFixtureRepo(t)
+	ctx := context.Background()
+
+	runFixtureGit(t, local, "checkout", "-b", "pilot/GH-16")
+	writeFixtureFile(t, local, "base.txt", "from base PR\n")
+	runFixtureGit(t, local, "add", "base.txt")
+	runFixtureGit(t, local, "commit", "-m", "GH-16 work")
+	runFixtureGit(t, local, "push", "origin", "pilot/GH-16")
+	baseSHA := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	runFixtureGit(t, local, "checkout", "-b", "pilot/GH-17")
+	writeFixtureFile(t, local, "stacked.txt", "from stacked PR\n")
+	runFixtureGit(t, local, "add", "stacked.txt")
+	runFixtureGit(t, local, "commit", "-m", "GH-17 work, stacked on GH-16")
+	runFixtureGit(t, local, "push", "origin", "pilot/GH-17")
+	stackedSHA := strings.TrimSpace(runFixtureGit(t, local, "rev-parse", "HEAD"))
+
+	var mergeCalled, deleteBranchCalled, retargetAttempted atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/16/merge" && r.Method == http.MethodPut:
+			mergeCalled.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"sha":"mergedSHA16","merged":true,"message":"merged"}`))
+		case r.URL.Path == "/repos/owner/repo/issues/16/comments" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case r.URL.Path == "/repos/owner/repo/pulls" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"number":17,"state":"open","base":{"ref":"pilot/GH-16"},"head":{"ref":"pilot/GH-17","sha":"` + stackedSHA + `"}}]`))
+		case r.URL.Path == "/graphql" && r.Method == http.MethodPost:
+			// Every GraphQL call (id lookup and mutation alike) fails
+			// transiently — retargetDescendants must swallow this as a WARN.
+			retargetAttempted.Add(1)
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"internal error"}`))
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/git/refs/heads/pilot/GH-16") && r.Method == http.MethodDelete:
+			deleteBranchCalled.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	// Retries would make this test slow for no benefit — the assertion is
+	// about the fail-open contract, not retry backoff behavior.
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithProjectPath(local))
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	c.mu.Lock()
+	c.activePRs[baseNumber] = &PRState{
+		PRNumber:     baseNumber,
+		BranchName:   "pilot/GH-16",
+		HeadSHA:      baseSHA,
+		TargetBranch: "main",
+		Stage:        StageMerging,
+		CreatedAt:    time.Now(),
+	}
+	c.activePRs[prNumber] = &PRState{
+		PRNumber:         prNumber,
+		IssueNumber:      prNumber,
+		BranchName:       "pilot/GH-17",
+		HeadSHA:          stackedSHA,
+		TargetBranch:     "pilot/GH-16",
+		Stage:            StageWaitingCI,
+		CIStatus:         CIPending,
+		CIWaitStartedAt:  time.Now().Add(-45 * time.Minute),
+		Parked:           true,
+		EscalationReason: baseMismatchReasonPrefix + `PR targets "pilot/GH-16", not the default branch "main"`,
+		CreatedAt:        time.Now(),
+	}
+	c.mu.Unlock()
+
+	ghPR16 := &github.PullRequest{
+		Number: baseNumber,
+		Head:   github.PRRef{SHA: baseSHA},
+		Base:   github.PRRef{Ref: "main"},
+	}
+
+	if err := c.ProcessPR(ctx, baseNumber, ghPR16); err != nil {
+		t.Fatalf("ProcessPR(16): %v", err)
+	}
+	if mergeCalled.Load() != 1 {
+		t.Fatalf("merge called %d times, want 1", mergeCalled.Load())
+	}
+	pr16, ok := c.GetPRState(baseNumber)
+	if !ok || pr16.Stage != StageMerged {
+		t.Fatalf("PR 16 stage = %v (ok=%v), want %s — a retarget failure must not abort merge finalization", pr16, ok, StageMerged)
+	}
+	if retargetAttempted.Load() == 0 {
+		t.Fatal("retarget was never attempted — expected at least one GraphQL call before it failed")
+	}
+
+	// Existing behavior, unchanged: the delete is refused (PR#17's base was
+	// never actually changed, since the retarget call failed) and the
+	// blocking_pr alert fires exactly as before this fix.
+	if deleteBranchCalled.Load() != 0 {
+		t.Errorf("branch delete called %d times, want 0 — a failed retarget must leave safeDeleteBranch's guard in place", deleteBranchCalled.Load())
+	}
+	pr17, ok := c.GetPRState(prNumber)
+	if !ok {
+		t.Fatal("PR 17 should still be tracked")
+	}
+	if !pr17.Parked {
+		t.Error("PR 17 should still be parked — the retarget failed, so it was never actually un-blocked")
+	}
+
+	var held *alerts.Event
+	for i := range sink.events {
+		if strings.Contains(sink.events[i].TaskID, "delete-held") {
+			held = &sink.events[i]
+			break
+		}
+	}
+	if held == nil {
+		t.Fatal("expected a branch_delete_held escalation alert, got none")
+	}
+	if held.Metadata["blocking_pr"] != "17" {
+		t.Errorf("blocking_pr = %q, want %q", held.Metadata["blocking_pr"], "17")
 	}
 }


### PR DESCRIPTION
## Summary

PR#5068 (GH-5066) parks a stacked-base PR at the CI-wait deadline and un-parks it when GitHub retargets it to the default branch. But GitHub only auto-retargets a child PR when its base branch is **deleted**, and `safeDeleteBranch` (GH-4872 guard) refuses to delete a merged base's branch while a descendant PR still targets it. In a fully autopilot-managed stack: base merges → branch delete refused → no retarget ever fires → descendant parks forever, needing human intervention.

The 2026-08-21 07:54Z incident only recovered because an operator manually merged the base and GitHub happened to retarget on the subsequent branch delete.

## Fix

When a stack base reaches `StageMerged` (both the internal `handleMerging` auto-merge path and the external `checkExternalMergeOrClose` path), close the loop before attempting the branch delete:

1. `retargetDescendants` lists all **open** PRs (not just tracked ones) whose `Base.Ref` equals the merged branch, and retargets each to the default branch via a GraphQL `updatePullRequest` mutation (the studio-sdk GitHub client has no REST PR-retarget helper, so this resolves the PR's node ID and issues the mutation directly).
2. `safeDeleteBranch` then runs as before — with no remaining dependent PRs, the delete succeeds.
3. The existing WaitingCI un-park guard (unchanged) picks up the retargeted PR on the next `ProcessPR` tick via its `TargetBranch` refresh.

Fails open: a retarget API failure logs WARN and leaves today's behavior intact — delete refused, descendant parked, `blocking_pr` alert fires per PR#5069.

## Test plan

- [x] `TestController_HandleMerging_RetargetsParkedDescendant_GH5071` — base at `StageMerged` with a parked descendant targeting its branch: asserts the GraphQL retarget mutation fires exactly once with the right PR/base, branch delete then succeeds, and the descendant un-parks and merges on subsequent ticks.
- [x] `TestController_RetargetDescendants_APIFailureFailsClosed_GH5071` — retarget API failure: asserts WARN path taken, branch delete still refused, descendant stays parked, `blocking_pr` alert still fires.
- [x] No retarget attempted for closed/merged descendants (structural — `ListPullRequests(..., "open")` only returns open PRs).
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean.
- [x] Full `go test ./internal/autopilot/...` green (existing gh4872/gh5034/gh5066 tests untouched).