### PR TITLE
GH-5077: feat(executor): advance pilot-failed-retry ladder at failure-labeling site

### DIFF
--- a/internal/executor/gh5077_failed_retry_ladder_test.go
+++ b/internal/executor/gh5077_failed_retry_ladder_test.go
@@ -1,0 +1,220 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// GH-5077: the pilot-failed-retry-N ladder (adapters/github/types.go:159-169,
+// FailedRetryStateLabels) must advance none -> pilot-failed-retry-1 ->
+// pilot-failed-retry-2 -> pilot-failed-retry-exhausted every time
+// postTitleRejectionEscalation (title_rejection.go) stamps pilot-failed onto
+// an issue for the first time, must not advance again on a duplicate
+// fail-label event for an issue that already carries pilot-failed, and must
+// not advance past the terminal exhausted rung.
+
+// TestNextFailedRetryLabel_RungTransitions is the pure-function unit test for
+// the ladder-advancement decision: no GitHub/gh-CLI involved.
+func TestNextFailedRetryLabel_RungTransitions(t *testing.T) {
+	tests := []struct {
+		name       string
+		labels     []string
+		wantAdd    string
+		wantRemove string
+	}{
+		{
+			name:       "no ladder label yet -> retry-1",
+			labels:     nil,
+			wantAdd:    labelPilotFailedRetry1,
+			wantRemove: "",
+		},
+		{
+			name:       "unrelated labels only -> retry-1",
+			labels:     []string{"bug", "pilot"},
+			wantAdd:    labelPilotFailedRetry1,
+			wantRemove: "",
+		},
+		{
+			name:       "retry-1 present -> retry-2, removes retry-1",
+			labels:     []string{labelPilotFailedRetry1},
+			wantAdd:    labelPilotFailedRetry2,
+			wantRemove: labelPilotFailedRetry1,
+		},
+		{
+			name:       "retry-2 present -> exhausted, removes retry-2",
+			labels:     []string{labelPilotFailedRetry2},
+			wantAdd:    labelPilotFailedRetryExhausted,
+			wantRemove: labelPilotFailedRetry2,
+		},
+		{
+			name:       "exhausted present -> no further advancement",
+			labels:     []string{labelPilotFailedRetryExhausted},
+			wantAdd:    "",
+			wantRemove: "",
+		},
+		{
+			name:       "case-insensitive match on existing rung",
+			labels:     []string{"PILOT-FAILED-RETRY-1"},
+			wantAdd:    labelPilotFailedRetry2,
+			wantRemove: labelPilotFailedRetry1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAdd, gotRemove := nextFailedRetryLabel(tt.labels)
+			if gotAdd != tt.wantAdd || gotRemove != tt.wantRemove {
+				t.Errorf("nextFailedRetryLabel(%v) = (%q, %q), want (%q, %q)",
+					tt.labels, gotAdd, gotRemove, tt.wantAdd, tt.wantRemove)
+			}
+		})
+	}
+}
+
+// runPostTitleRejectionEscalation drives postTitleRejectionEscalation with a
+// stubbed fetchIssueState (existingLabels) and a fake gh CLI, returning every
+// gh invocation's argv (one line per call) for assertion.
+func runPostTitleRejectionEscalation(t *testing.T, issueNum int, existingLabels []string) string {
+	t.Helper()
+	logFile := setupFakeGhCLI(t)
+
+	stubFetchIssueState(t, func(_ context.Context, _ *Runner, _ *Task, _ string) (IssueState, error) {
+		return IssueState{Closed: false, Labels: existingLabels}, nil
+	})
+
+	r := newSilentRunnerTask359()
+	task := &Task{
+		ID:            "unused",
+		Title:         "not a conventional title",
+		ProjectPath:   t.TempDir(),
+		SourceAdapter: "github",
+		SourceIssueID: strconv.Itoa(issueNum),
+	}
+
+	if err := r.postTitleRejectionEscalation(context.Background(), task); err != nil {
+		t.Fatalf("postTitleRejectionEscalation: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("expected gh CLI to be invoked: %v", err)
+	}
+	return string(logBytes)
+}
+
+// TestPostTitleRejectionEscalation_FreshFailure_StampsFirstRung verifies that
+// a fresh pilot-failed application (issue not yet labeled pilot-failed, no
+// prior ladder rung) applies pilot-failed-retry-1 in the same `gh issue edit`
+// call that applies pilot-failed.
+func TestPostTitleRejectionEscalation_FreshFailure_StampsFirstRung(t *testing.T) {
+	calls := runPostTitleRejectionEscalation(t, 9201, nil)
+
+	if !strings.Contains(calls, "--add-label pilot-failed") {
+		t.Errorf("expected pilot-failed to be added, got calls:\n%s", calls)
+	}
+	if !strings.Contains(calls, "--add-label "+labelPilotFailedRetry1) {
+		t.Errorf("expected %s to be added, got calls:\n%s", labelPilotFailedRetry1, calls)
+	}
+	if strings.Contains(calls, "--remove-label "+labelPilotFailedRetry1) ||
+		strings.Contains(calls, "--remove-label "+labelPilotFailedRetry2) ||
+		strings.Contains(calls, "--remove-label "+labelPilotFailedRetryExhausted) {
+		t.Errorf("expected no ladder label removal on first rung, got calls:\n%s", calls)
+	}
+
+	// Single mutation: exactly one `gh issue edit` invocation carries both the
+	// pilot-failed label and the ladder rung — not two separate calls. Match
+	// on a line *starting with* "issue edit" (the fake gh CLI's echoed argv
+	// for a real invocation) rather than merely containing it, since the
+	// posted comment's body itself quotes a "gh issue edit ..." snippet as
+	// re-dispatch instructions and would otherwise be misidentified as a
+	// second call.
+	editLines := grepLinesStartingWith(calls, "issue edit")
+	if len(editLines) != 1 {
+		t.Fatalf("expected exactly 1 `gh issue edit` call, got %d:\n%s", len(editLines), calls)
+	}
+	if !strings.Contains(editLines[0], "--add-label pilot-failed") || !strings.Contains(editLines[0], "--add-label "+labelPilotFailedRetry1) {
+		t.Errorf("expected pilot-failed and %s in the same issue edit call, got:\n%s", labelPilotFailedRetry1, editLines[0])
+	}
+}
+
+// TestPostTitleRejectionEscalation_RungTransitions covers retry-1 -> retry-2
+// and retry-2 -> exhausted through the full escalation path (not just the
+// pure function), confirming the previous rung label is removed in the same
+// call the next rung is added.
+func TestPostTitleRejectionEscalation_RungTransitions(t *testing.T) {
+	t.Run("retry-1 -> retry-2", func(t *testing.T) {
+		calls := runPostTitleRejectionEscalation(t, 9202, []string{labelPilotFailedRetry1})
+
+		if !strings.Contains(calls, "--add-label "+labelPilotFailedRetry2) {
+			t.Errorf("expected %s to be added, got calls:\n%s", labelPilotFailedRetry2, calls)
+		}
+		if !strings.Contains(calls, "--remove-label "+labelPilotFailedRetry1) {
+			t.Errorf("expected %s to be removed, got calls:\n%s", labelPilotFailedRetry1, calls)
+		}
+	})
+
+	t.Run("retry-2 -> exhausted", func(t *testing.T) {
+		calls := runPostTitleRejectionEscalation(t, 9203, []string{labelPilotFailedRetry2})
+
+		if !strings.Contains(calls, "--add-label "+labelPilotFailedRetryExhausted) {
+			t.Errorf("expected %s to be added, got calls:\n%s", labelPilotFailedRetryExhausted, calls)
+		}
+		if !strings.Contains(calls, "--remove-label "+labelPilotFailedRetry2) {
+			t.Errorf("expected %s to be removed, got calls:\n%s", labelPilotFailedRetry2, calls)
+		}
+	})
+}
+
+// TestPostTitleRejectionEscalation_ExhaustedTerminal_NoFurtherAdvancement
+// verifies that once the ladder has reached pilot-failed-retry-exhausted, a
+// fresh pilot-failed application does not add or remove any ladder label —
+// exhausted is terminal.
+func TestPostTitleRejectionEscalation_ExhaustedTerminal_NoFurtherAdvancement(t *testing.T) {
+	calls := runPostTitleRejectionEscalation(t, 9204, []string{labelPilotFailedRetryExhausted})
+
+	if !strings.Contains(calls, "--add-label pilot-failed") {
+		t.Errorf("expected pilot-failed to still be added, got calls:\n%s", calls)
+	}
+	for _, l := range []string{labelPilotFailedRetry1, labelPilotFailedRetry2, labelPilotFailedRetryExhausted} {
+		if strings.Contains(calls, "--add-label "+l) {
+			t.Errorf("expected no further --add-label %s past exhaustion, got calls:\n%s", l, calls)
+		}
+		if strings.Contains(calls, "--remove-label "+l) {
+			t.Errorf("expected no --remove-label %s past exhaustion, got calls:\n%s", l, calls)
+		}
+	}
+}
+
+// TestPostTitleRejectionEscalation_DuplicateFailEvent_DoesNotAdvanceLadder is
+// the idempotence guard: an issue that already carries pilot-failed (a repeat
+// escalation for the same still-broken title, e.g. the 3rd/4th consecutive
+// rejection) must not advance the ladder again, even though a ladder rung is
+// already present.
+func TestPostTitleRejectionEscalation_DuplicateFailEvent_DoesNotAdvanceLadder(t *testing.T) {
+	calls := runPostTitleRejectionEscalation(t, 9205, []string{labelPilotFailed, labelPilotFailedRetry1})
+
+	if strings.Contains(calls, "--add-label "+labelPilotFailedRetry2) {
+		t.Errorf("duplicate fail-label event must not advance the ladder, got calls:\n%s", calls)
+	}
+	if strings.Contains(calls, "--remove-label "+labelPilotFailedRetry1) {
+		t.Errorf("duplicate fail-label event must not remove the current rung, got calls:\n%s", calls)
+	}
+	// pilot-failed re-application itself is still fine (idempotent add).
+	if !strings.Contains(calls, "--add-label pilot-failed") {
+		t.Errorf("expected pilot-failed re-applied (idempotent), got calls:\n%s", calls)
+	}
+}
+
+// grepLinesStartingWith returns every line of calls that begins with prefix.
+func grepLinesStartingWith(calls, prefix string) []string {
+	var out []string
+	for _, line := range strings.Split(calls, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), prefix) {
+			out = append(out, line)
+		}
+	}
+	return out
+}

--- a/internal/executor/title_rejection.go
+++ b/internal/executor/title_rejection.go
@@ -22,6 +22,60 @@ import (
 // second failure (same title) escalates.
 const titleRejectionMaxCount = 2
 
+// labelPilotFailed mirrors adapters/github.LabelFailed, defined locally for
+// the same import-cycle reason as labelPilotSuperseded (issue_state.go):
+// adapters/github imports internal/comms, which imports internal/executor.
+const labelPilotFailed = "pilot-failed"
+
+// GH-5077: pilot-failed-retry-N ladder labels mirror
+// adapters/github.LabelFailedRetry1/2/Exhausted (types.go:159-161), defined
+// locally for the same import-cycle reason as labelPilotSuperseded
+// (issue_state.go). Escalation order matches
+// adapters/github.FailedRetryStateLabels (types.go:169).
+const (
+	labelPilotFailedRetry1         = "pilot-failed-retry-1"
+	labelPilotFailedRetry2         = "pilot-failed-retry-2"
+	labelPilotFailedRetryExhausted = "pilot-failed-retry-exhausted"
+)
+
+// nextFailedRetryLabel computes the pilot-failed-retry-N ladder mutation
+// (none -> pilot-failed-retry-1 -> pilot-failed-retry-2 ->
+// pilot-failed-retry-exhausted) for a single, fresh pilot-failed
+// application. currentLabels is the issue's live label set read immediately
+// before this event's mutation. Returns the label to add and (if any) the
+// label to remove — the ladder holds exactly one rung label at a time, so
+// advancing always removes the previous rung.
+//
+// Both return values are empty once the issue has already reached the
+// terminal pilot-failed-retry-exhausted rung: GH-5077 requires no further
+// advancement past exhaustion.
+//
+// Callers must only invoke this for a fresh pilot-failed application (the
+// issue did not already carry pilot-failed) — a repeat escalation for an
+// issue that's already failed is a duplicate fail-label event and must not
+// advance the ladder again. See postTitleRejectionEscalation's
+// already-failed guard.
+func nextFailedRetryLabel(currentLabels []string) (add, remove string) {
+	has := func(name string) bool {
+		for _, l := range currentLabels {
+			if strings.EqualFold(l, name) {
+				return true
+			}
+		}
+		return false
+	}
+	switch {
+	case has(labelPilotFailedRetryExhausted):
+		return "", ""
+	case has(labelPilotFailedRetry2):
+		return labelPilotFailedRetryExhausted, labelPilotFailedRetry2
+	case has(labelPilotFailedRetry1):
+		return labelPilotFailedRetry2, labelPilotFailedRetry1
+	default:
+		return labelPilotFailedRetry1, ""
+	}
+}
+
 // titleRejection tracks consecutive rejections for a single issue.
 type titleRejection struct {
 	hash  string // sha256 of the rejected title (hex)
@@ -216,9 +270,10 @@ func (r *Runner) postTitleRejectionEscalation(ctx context.Context, task *Task) e
 	// positive evidence the issue is already closed (fail open on lookup
 	// error — never block the existing best-effort path on an unrelated
 	// GitHub read failure).
-	if state, err := fetchIssueState(ctx, r, task, task.ProjectPath); err != nil {
+	state, stateErr := fetchIssueState(ctx, r, task, task.ProjectPath)
+	if stateErr != nil {
 		r.log.Warn("title-rejection escalation: failed to check issue state before labeling; proceeding (fail-open)",
-			"task_id", task.ID, "issue", issueNum, "error", err)
+			"task_id", task.ID, "issue", issueNum, "error", stateErr)
 	} else if state.Closed {
 		r.log.Info("title-rejection escalation: issue already closed, skipping comment and labels",
 			"task_id", task.ID, "issue", issueNum)
@@ -230,8 +285,28 @@ func (r *Runner) postTitleRejectionEscalation(ctx context.Context, task *Task) e
 	if err := ghIssueComment(ctx, task.ProjectPath, issueNum, comment); err != nil {
 		return fmt.Errorf("post comment: %w", err)
 	}
-	// Both labels are best-effort; log but don't fail.
-	if err := ghAddLabels(ctx, task.ProjectPath, issueNum, []string{"pilot-failed", "pilot-title-rejected"}); err != nil {
+
+	addLabels := []string{labelPilotFailed, "pilot-title-rejected"}
+	var removeLabels []string
+	// GH-5077: advance the pilot-failed-retry-N ladder in the same label
+	// mutation as the pilot-failed application itself — a separate follow-up
+	// call would leave a race window where another reader observes
+	// pilot-failed without its ladder rung. Only advance when the state read
+	// above succeeded (stateErr == nil) and the issue did not already carry
+	// pilot-failed: a repeat escalation for an already-failed issue (e.g. the
+	// same non-conventional title rejected a 3rd, 4th... time) is a duplicate
+	// fail-label event and must not advance the ladder again.
+	if stateErr == nil && !state.HasLabel(labelPilotFailed) {
+		if add, remove := nextFailedRetryLabel(state.Labels); add != "" {
+			addLabels = append(addLabels, add)
+			if remove != "" {
+				removeLabels = append(removeLabels, remove)
+			}
+		}
+	}
+
+	// Best-effort; log but don't fail.
+	if err := ghEditLabels(ctx, task.ProjectPath, issueNum, addLabels, removeLabels); err != nil {
 		r.log.Warn("title-rejection: failed to add labels",
 			"task_id", task.ID, "issue", issueNum, "error", err)
 	}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5077.

Closes #5077

## Changes

In internal/executor/runner.go (the site that stamps pilot-failed), read the current ladder label via FailedRetryStateLabels (already declared in internal/adapters/github/types.go:159-169) and advance it: none → pilot-failed-retry-1 → pilot-failed-retry-2 → pilot-failed-retry-exhausted. Ladder advancement must be idempotent per fail-label event and must happen alongside the existing pilot-failed application (single label mutation, no race window). Add unit tests in internal/executor/ covering each rung transition, idempotence on duplicate fail events, and the exhausted terminal state (no further advancement). No changes required to types.go beyond confirming constants are exported for executor consumption.