### PR TITLE
GH-5079: feat(alerts): emit escalation alert + park under pilot-needs-human on ladder exhaustion

### DIFF
--- a/cmd/pilot/handler_common.go
+++ b/cmd/pilot/handler_common.go
@@ -478,17 +478,35 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 	return hr, execErr
 }
 
-// fireLoopBreakerAlert emits AlertTypeDispatchLoopBreaker exactly once per
-// storm — the tick where consecutive first reaches repickLoopBreakerThreshold
-// (GH-4469). consecutive strictly increases while a task keeps dropping and
-// is reset by repickBackoff.recordSuccess on the first genuine dispatch, so
-// comparing for equality (rather than >=) fires the alert once without
-// needing separate dedup state; a nil AlertsEngine (e.g. in tests without one
-// wired) is a no-op.
+// fireLoopBreakerAlert emits an escalation exactly once per storm — the tick
+// where consecutive first reaches repickLoopBreakerThreshold (GH-4469).
+// consecutive strictly increases while a task keeps dropping and is reset by
+// repickBackoff.recordSuccess on the first genuine dispatch, so comparing
+// for equality (rather than >=) fires the alert once without needing
+// separate dedup state; a nil AlertsEngine (e.g. in tests without one wired)
+// is a no-op.
+//
+// GH-5079: this call sits on the HasTerminalCompletion skip (the block right
+// above this function's call site) whose main real-world trigger — an
+// opened-but-never-merged PR that later dies leaving the ledger vouching for
+// it forever (label-clear retries silently no-op'ing) — was fixed at the
+// root by #5070's StageFailed reclassification, so a genuine 10-consecutive
+// storm through this specific skip is not expected to recur. Rather than
+// dropping the alert coverage outright, this reroutes it onto the same
+// EventTypeEscalation pathway the new pilot-failed-retry-exhausted hook uses
+// (title_rejection.go): the underlying condition here — a task GitHub keeps
+// re-admitting that this dispatcher chokepoint keeps having to refuse — is
+// the same "stuck, needs a human to look" signal, just from a different
+// gate, so it renders through the PR#5069 event.Error fallback rather than
+// the dedicated (and now effectively idle) AlertTypeDispatchLoopBreaker rule.
 func fireLoopBreakerAlert(deps HandlerDeps, taskID, title, projectPath string, consecutive int) {
 	if consecutive != repickLoopBreakerThreshold {
 		return
 	}
+	reason := fmt.Sprintf(
+		"task %s rejected %d+ consecutive times at the terminal-completion dispatch gate, stopping until operator action or backoff expiry",
+		taskID, consecutive,
+	)
 	logging.WithComponent("dispatch").Warn(
 		"dispatch loop breaker: task rejected 10+ consecutive times, stopping until operator action or backoff expiry",
 		slog.String("task_id", taskID), slog.Int("consecutive_drops", consecutive))
@@ -496,12 +514,14 @@ func fireLoopBreakerAlert(deps HandlerDeps, taskID, title, projectPath string, c
 		return
 	}
 	deps.AlertsEngine.ProcessEvent(alerts.Event{
-		Type:      alerts.EventTypeDispatchLoopBreaker,
+		Type:      alerts.EventTypeEscalation,
 		TaskID:    taskID,
 		TaskTitle: title,
 		Project:   projectPath,
+		Error:     reason,
 		Metadata: map[string]string{
 			"consecutive_drops": fmt.Sprintf("%d", consecutive),
+			"reason":            reason,
 		},
 		Timestamp: time.Now(),
 	})

--- a/cmd/pilot/handler_common_test.go
+++ b/cmd/pilot/handler_common_test.go
@@ -699,10 +699,14 @@ func waitForAlertCount(t *testing.T, ch *testAlertChannel, n int, timeout time.D
 
 // TestHandleIssueGeneric_LoopBreakerAlert_FiresOnceAtThreshold is the GH-4469
 // deliverable-4 regression test: repeatedly hitting the same gate (here, the
-// terminal-completion re-check) must fire exactly one
-// AlertTypeDispatchLoopBreaker WARNING when the consecutive-drop count first
-// reaches repickLoopBreakerThreshold (10) — not before, and not again on
-// every subsequent tick past it.
+// terminal-completion re-check) must fire exactly one escalation alert when
+// the consecutive-drop count first reaches repickLoopBreakerThreshold (10) —
+// not before, and not again on every subsequent tick past it. GH-5079:
+// fireLoopBreakerAlert now routes through alerts.EventTypeEscalation rather
+// than the dispatch-loop-breaker-specific event type (see that function's
+// doc comment) — this test registers the "escalation" rule and asserts the
+// delivered alert actually carries the consecutive-drop reason via
+// event.Error (the PR#5069 fallback), not a blank template.
 func TestHandleIssueGeneric_LoopBreakerAlert_FiresOnceAtThreshold(t *testing.T) {
 	taskID := "GH-4469-LOOP-BREAKER"
 	projectPath := "/tmp/pilot-gh-4469-loop-breaker-does-not-exist"
@@ -733,8 +737,8 @@ func TestHandleIssueGeneric_LoopBreakerAlert_FiresOnceAtThreshold(t *testing.T) 
 		},
 		Rules: []alerts.AlertRule{
 			{
-				Name:     "dispatch_loop_breaker",
-				Type:     alerts.AlertTypeDispatchLoopBreaker,
+				Name:     "escalation",
+				Type:     alerts.AlertTypeEscalation,
 				Enabled:  true,
 				Severity: alerts.SeverityWarning,
 				Channels: []string{"test-channel"},
@@ -786,6 +790,19 @@ func TestHandleIssueGeneric_LoopBreakerAlert_FiresOnceAtThreshold(t *testing.T) 
 	waitForAlertCount(t, testCh, 1, 2*time.Second)
 	if got := testCh.count(); got != 1 {
 		t.Fatalf("expected exactly 1 alert at the threshold, got %d", got)
+	}
+	// GH-5079: the rerouted escalation must render via the PR#5069
+	// event.Error fallback, not the blank circuit-breaker template
+	// (handleEscalation's default case: "Escalation event received for ...
+	// with no message content").
+	testCh.mu.Lock()
+	msg := testCh.alerts[0].Message
+	testCh.mu.Unlock()
+	if !strings.Contains(msg, taskID) || !strings.Contains(msg, "consecutive") {
+		t.Errorf("expected alert message to name the task and the consecutive-drop reason, got: %q", msg)
+	}
+	if strings.Contains(msg, "no message content") {
+		t.Errorf("alert rendered the blank circuit-breaker template instead of event.Error, got: %q", msg)
 	}
 
 	// An 11th drop must not fire a second alert.

--- a/internal/executor/alerts.go
+++ b/internal/executor/alerts.go
@@ -78,6 +78,18 @@ const (
 	AlertEventTypeDeadManAttempt AlertEventType = "dead_man_attempt"
 	AlertEventTypeDeadManSuccess AlertEventType = "dead_man_success"
 	AlertEventTypeDeadManFailure AlertEventType = "dead_man_failure"
+
+	// AlertEventTypeEscalation (GH-5079) mirrors alerts.EventTypeEscalation
+	// ("escalation") byte-for-byte — EngineAdapter.ProcessEvent forwards
+	// AlertEventType values across the executor/alerts package boundary via a
+	// direct string cast (adapter.go), so this value must match exactly.
+	// Routes through alerts.Engine.handleEscalation, which (post-PR#5069)
+	// falls back to rendering event.Error when the circuit-breaker-only
+	// metadata (trips_in_hour/escalation_threshold/last_pr/last_reason) is
+	// absent — every non-circuit-breaker escalation emitter, including the
+	// pilot-failed-retry-exhausted hook (title_rejection.go), populates
+	// Error rather than that metadata.
+	AlertEventTypeEscalation AlertEventType = "escalation"
 )
 
 // SelfReviewDeadManTrackerName is the alerts.DeadManTracker registration

--- a/internal/executor/gh5079_exhaustion_escalation_test.go
+++ b/internal/executor/gh5079_exhaustion_escalation_test.go
@@ -1,0 +1,202 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// GH-5079: once postTitleRejectionEscalation (title_rejection.go) advances
+// the pilot-failed-retry ladder to its terminal pilot-failed-retry-exhausted
+// rung (GH-5077/PR#5081), it must also apply pilot-needs-human (so the issue
+// parks under the GH-5056 admission check, cmd/pilot/handlers.go:751) and
+// fire an escalation-class alert that renders through the PR#5069
+// event.Error fallback — not just advance the ladder label silently. Both
+// must fire on the exhausted transition only: every earlier rung
+// (none->retry-1, retry-1->retry-2) must leave pilot-needs-human/pilot-
+// retry-ready untouched and emit no alert.
+
+// runPostTitleRejectionEscalationWithAlerts mirrors
+// runPostTitleRejectionEscalation (gh5077_failed_retry_ladder_test.go) but
+// also wires a fakeAlertProcessor so tests can assert on emitted alert
+// events, not just the gh CLI label mutation.
+func runPostTitleRejectionEscalationWithAlerts(t *testing.T, issueNum int, existingLabels []string) (calls string, events []AlertEvent) {
+	t.Helper()
+	logFile := setupFakeGhCLI(t)
+
+	stubFetchIssueState(t, func(_ context.Context, _ *Runner, _ *Task, _ string) (IssueState, error) {
+		return IssueState{Closed: false, Labels: existingLabels}, nil
+	})
+
+	r := newSilentRunnerTask359()
+	processor := &fakeAlertProcessor{}
+	r.SetAlertProcessor(processor)
+	task := &Task{
+		ID:            "GH-" + strconv.Itoa(issueNum),
+		Title:         "not a conventional title",
+		ProjectPath:   t.TempDir(),
+		SourceAdapter: "github",
+		SourceIssueID: strconv.Itoa(issueNum),
+	}
+
+	if err := r.postTitleRejectionEscalation(context.Background(), task); err != nil {
+		t.Fatalf("postTitleRejectionEscalation: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("expected gh CLI to be invoked: %v", err)
+	}
+	return string(logBytes), processor.events
+}
+
+// TestPostTitleRejectionEscalation_ExhaustedTransition_ParksNeedsHumanAndAlerts
+// covers the retry-2 -> exhausted transition: the same `gh issue edit` call
+// that stamps pilot-failed-retry-exhausted must also add pilot-needs-human
+// and remove pilot-retry-ready, and exactly one escalation alert must fire
+// with non-blank, task-identifying content.
+func TestPostTitleRejectionEscalation_ExhaustedTransition_ParksNeedsHumanAndAlerts(t *testing.T) {
+	calls, events := runPostTitleRejectionEscalationWithAlerts(t, 9301, []string{labelPilotFailedRetry2})
+
+	if !strings.Contains(calls, "--add-label "+labelPilotFailedRetryExhausted) {
+		t.Errorf("expected %s to be added, got calls:\n%s", labelPilotFailedRetryExhausted, calls)
+	}
+	editLines := grepLinesStartingWith(calls, "issue edit")
+	if len(editLines) != 1 {
+		t.Fatalf("expected exactly 1 `gh issue edit` call, got %d:\n%s", len(editLines), calls)
+	}
+	edit := editLines[0]
+	if !strings.Contains(edit, "--add-label "+labelPilotFailedRetryExhausted) {
+		t.Errorf("expected exhausted rung in the issue edit call, got: %q", edit)
+	}
+	if !strings.Contains(edit, "--add-label "+labelPilotNeedsHuman) {
+		t.Errorf("expected pilot-needs-human to be added in the same mutation, got: %q", edit)
+	}
+	if !strings.Contains(edit, "--remove-label "+labelPilotRetryReady) {
+		t.Errorf("expected pilot-retry-ready to be removed in the same mutation (GH-5042/PR#5048 never-coexist invariant), got: %q", edit)
+	}
+
+	if len(events) != 1 {
+		t.Fatalf("expected exactly 1 alert event, got %d: %+v", len(events), events)
+	}
+	event := events[0]
+	if event.Type != AlertEventTypeEscalation {
+		t.Errorf("event.Type = %q, want %q", event.Type, AlertEventTypeEscalation)
+	}
+	if event.TaskID != "GH-9301" {
+		t.Errorf("event.TaskID = %q, want %q", event.TaskID, "GH-9301")
+	}
+	if event.Error == "" {
+		t.Fatal("event.Error must be populated so handleEscalation's PR#5069 fallback renders real content, not a blank template")
+	}
+	if !strings.Contains(event.Error, "9301") {
+		t.Errorf("event.Error should name the issue, got: %q", event.Error)
+	}
+	if !strings.Contains(event.Error, labelPilotFailedRetryExhausted) {
+		t.Errorf("event.Error should name the exhausted rung, got: %q", event.Error)
+	}
+}
+
+// TestPostTitleRejectionEscalation_NonExhaustedTransitions_NoEscalation covers
+// the earlier rungs (none -> retry-1, retry-1 -> retry-2): neither must apply
+// pilot-needs-human/remove pilot-retry-ready, nor fire any alert — escalation
+// is reserved for the exhausted transition only.
+func TestPostTitleRejectionEscalation_NonExhaustedTransitions_NoEscalation(t *testing.T) {
+	tests := []struct {
+		name           string
+		existingLabels []string
+	}{
+		{name: "no ladder label yet -> retry-1", existingLabels: nil},
+		{name: "retry-1 present -> retry-2", existingLabels: []string{labelPilotFailedRetry1}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls, events := runPostTitleRejectionEscalationWithAlerts(t, 9302, tt.existingLabels)
+
+			if strings.Contains(calls, "--add-label "+labelPilotNeedsHuman) {
+				t.Errorf("expected no pilot-needs-human on a non-exhausted transition, got calls:\n%s", calls)
+			}
+			if strings.Contains(calls, "--remove-label "+labelPilotRetryReady) {
+				t.Errorf("expected no pilot-retry-ready removal on a non-exhausted transition, got calls:\n%s", calls)
+			}
+			if len(events) != 0 {
+				t.Errorf("expected no alert events on a non-exhausted transition, got %d: %+v", len(events), events)
+			}
+		})
+	}
+}
+
+// TestPostTitleRejectionEscalation_AlreadyExhausted_NoDuplicateEscalation
+// covers the terminal-rung idempotence guard: a repeat pilot-failed
+// application against an issue already at pilot-failed-retry-exhausted must
+// not re-fire the escalation (it already fired the first time the ladder
+// reached that rung) — nextFailedRetryLabel returns no further advancement
+// past exhaustion, so `exhausted` must stay false here too.
+func TestPostTitleRejectionEscalation_AlreadyExhausted_NoDuplicateEscalation(t *testing.T) {
+	calls, events := runPostTitleRejectionEscalationWithAlerts(t, 9303, []string{labelPilotFailedRetryExhausted})
+
+	if strings.Contains(calls, "--add-label "+labelPilotNeedsHuman) {
+		t.Errorf("expected no duplicate pilot-needs-human application, got calls:\n%s", calls)
+	}
+	if len(events) != 0 {
+		t.Errorf("expected no duplicate escalation alert, got %d: %+v", len(events), events)
+	}
+}
+
+// setupFakeGhCLI_FailEditOnly installs a fake `gh` binary that succeeds for
+// every invocation except `gh issue edit` (which exits 1, simulating a
+// transient GitHub API error on the label mutation specifically) —
+// postTitleRejectionEscalation's comment step must still go through so
+// execution reaches the ladder/escalation logic below it.
+func setupFakeGhCLI_FailEditOnly(t *testing.T) {
+	t.Helper()
+	fakeBin := t.TempDir()
+	script := filepath.Join(fakeBin, "gh")
+	content := "#!/bin/sh\n" +
+		`if [ "$1" = "issue" ] && [ "$2" = "edit" ]; then echo "simulated gh issue edit failure" >&2; exit 1; fi` +
+		"\nexit 0\n"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	origPATH := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+origPATH)
+}
+
+// TestPostTitleRejectionEscalation_ExhaustedAlertFiresEvenWhenLabelCallFails
+// mirrors TestEscalateBasePresenceHold_AlertFiresEvenWhenLabelCallFails
+// (base_presence_escalation_gh5056_test.go): the escalation alert must not
+// be gated on the best-effort `gh issue edit` mutation actually succeeding —
+// a labeling failure must not also silently swallow operator visibility.
+func TestPostTitleRejectionEscalation_ExhaustedAlertFiresEvenWhenLabelCallFails(t *testing.T) {
+	setupFakeGhCLI_FailEditOnly(t)
+
+	stubFetchIssueState(t, func(_ context.Context, _ *Runner, _ *Task, _ string) (IssueState, error) {
+		return IssueState{Closed: false, Labels: []string{labelPilotFailedRetry2}}, nil
+	})
+
+	r := newSilentRunnerTask359()
+	processor := &fakeAlertProcessor{}
+	r.SetAlertProcessor(processor)
+	task := &Task{
+		ID:            "GH-9304",
+		Title:         "not a conventional title",
+		ProjectPath:   t.TempDir(),
+		SourceAdapter: "github",
+		SourceIssueID: "9304",
+	}
+
+	if err := r.postTitleRejectionEscalation(context.Background(), task); err != nil {
+		t.Fatalf("postTitleRejectionEscalation: %v", err)
+	}
+
+	if len(processor.events) != 1 {
+		t.Fatalf("expected the alert to still fire despite the label call failing, got %d events: %+v", len(processor.events), processor.events)
+	}
+	if processor.events[0].TaskID != task.ID {
+		t.Errorf("event.TaskID = %q, want %q", processor.events[0].TaskID, task.ID)
+	}
+}

--- a/internal/executor/title_rejection.go
+++ b/internal/executor/title_rejection.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 	"unicode"
 )
 
@@ -296,19 +297,60 @@ func (r *Runner) postTitleRejectionEscalation(ctx context.Context, task *Task) e
 	// pilot-failed: a repeat escalation for an already-failed issue (e.g. the
 	// same non-conventional title rejected a 3rd, 4th... time) is a duplicate
 	// fail-label event and must not advance the ladder again.
+	var exhausted bool
 	if stateErr == nil && !state.HasLabel(labelPilotFailed) {
 		if add, remove := nextFailedRetryLabel(state.Labels); add != "" {
 			addLabels = append(addLabels, add)
 			if remove != "" {
 				removeLabels = append(removeLabels, remove)
 			}
+			exhausted = add == labelPilotFailedRetryExhausted
 		}
+	}
+	// GH-5079: the ladder reaching its terminal rung means the retry budget
+	// declared for this issue is spent — park it under pilot-needs-human
+	// (GH-5056's admission check, handlers.go:751, then refuses to
+	// re-dispatch it) in the same mutation, mirroring escalateBasePresenceHold
+	// (dispatcher.go) and autopilot's escalateAndHold: sheds pilot-retry-ready
+	// too, enforcing the GH-5042/PR#5048 never-coexist invariant at this site.
+	if exhausted {
+		addLabels = append(addLabels, labelPilotNeedsHuman)
+		removeLabels = append(removeLabels, labelPilotRetryReady)
 	}
 
 	// Best-effort; log but don't fail.
 	if err := ghEditLabels(ctx, task.ProjectPath, issueNum, addLabels, removeLabels); err != nil {
 		r.log.Warn("title-rejection: failed to add labels",
 			"task_id", task.ID, "issue", issueNum, "error", err)
+	}
+
+	// GH-5079: fire the exhaustion escalation regardless of whether the label
+	// mutation above succeeded — mirrors escalateBasePresenceHold's stance
+	// (dispatcher.go) that operator visibility must not rest entirely on a
+	// gh CLI call that can itself fail. Routes as alerts.EventTypeEscalation
+	// (AlertEventTypeEscalation) so it renders through the PR#5069
+	// event.Error fallback in handleEscalation, rather than the blank
+	// circuit-breaker template.
+	if exhausted {
+		reason := fmt.Sprintf(
+			"issue #%s exhausted its pilot-failed-retry ladder (%s) after repeated non-conventional-title rejections — parked pilot-needs-human",
+			issueNum, labelPilotFailedRetryExhausted,
+		)
+		r.emitAlertEvent(AlertEvent{
+			Type:      AlertEventTypeEscalation,
+			TaskID:    task.ID,
+			TaskTitle: task.Title,
+			Project:   task.ProjectPath,
+			Error:     reason,
+			Timestamp: time.Now(),
+			Metadata: map[string]string{
+				"task_id": task.ID,
+				"issue":   issueNum,
+				"project": task.ProjectPath,
+				"reason":  reason,
+				"label":   labelPilotNeedsHuman,
+			},
+		})
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5079.

Closes #5079

## Changes

Wire the exhaustion event: when the executor advances the ladder to pilot-failed-retry-exhausted (from subtask 1), fire an escalation-class alert that renders through the PR#5069 event.Error path and apply pilot-needs-human so the issue parks under the GH-5056 admission check. Also address the dead loop-breaker branch in cmd/pilot/handler_common.go:237 (fireLoopBreakerAlert currently sits on the has-terminal-completion skip that no longer fires post-#5070) — either remove the dead branch or reroute it to the new exhaustion hook, whichever keeps the dispatch loop alert-covered. Add tests asserting alert content renders and needs-human label is applied on the exhausted transition only.