### PR TITLE
GH-5073: fix(memory): ledger reclassify on StageFailed must skip post-merge stages — merged work transiently demoted to failed (PR#5070 residual)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2335,7 +2335,14 @@ func executionEventStageFor(prStage PRStage) (memory.Stage, bool) {
 // are logged and swallowed: the audit trail is a diagnostic aid, not load-
 // bearing for the state machine, so a lookup miss must never fail the PR's
 // processing cycle.
-func (c *Controller) recordExecutionEvent(prState *PRState, stage memory.Stage, detail string) {
+//
+// previousStage is the PR's stage immediately before this transition, as
+// captured by the caller's own transition detector (ProcessPR's
+// previousStage local, see the switch above) — never re-derived from
+// prState.Stage here, since by call time prState.Stage has already been
+// mutated to the new stage. GH-5073: it gates the StageFailed reclassify
+// below to pre-merge transitions only.
+func (c *Controller) recordExecutionEvent(prState *PRState, previousStage PRStage, stage memory.Stage, detail string) {
 	if c.memoryStore == nil {
 		return
 	}
@@ -2386,7 +2393,25 @@ func (c *Controller) recordExecutionEvent(prState *PRState, stage memory.Stage, 
 		// issue) heals it back via SelfHealExecutionAfterMerge, same as the
 		// GH-3818/D10 notifyExternalClose reclassify this mirrors for PRs
 		// that die without ever being closed on GitHub.
-		if err := c.memoryStore.ReclassifyCompletionAsFailed(taskID, c.projectPath, detail); err != nil {
+		//
+		// GH-5073: PR#5070 fired this unconditionally on every StageFailed
+		// entry, including the post-merge ones — StagePostMergeCI CI
+		// failures/timeouts/config mismatches and a failed release
+		// (escalateReleasingFailed). Those demote the ledger row of a PR
+		// that already merged: the work shipped, and a post-merge pipeline
+		// failure is a different fact than delivery failure (already
+		// alerted on its own paths). Self-healing exists
+		// (ScanRecentlyMergedPRs' 30-min ticker, the startup 72h sweep) but
+		// leaves a transient reverse-direction honesty gap outside that
+		// window — HasCompletedExecution/history would report undelivered
+		// for work that is, in fact, merged. Skip the reclassify (not the
+		// CAS finalize above, which keeps its GH-4620 behavior unchanged)
+		// whenever the PR was already past merge before this StageFailed
+		// transition.
+		if previousStage == StageMerged || previousStage == StagePostMergeCI || previousStage == StageReleasing {
+			c.log.Info("execution audit trail: skipping ledger reclassify on StageFailed — PR already shipped (post-merge stage)",
+				"pr", prState.PRNumber, "task_id", taskID, "previous_stage", previousStage)
+		} else if err := c.memoryStore.ReclassifyCompletionAsFailed(taskID, c.projectPath, detail); err != nil {
 			c.log.Warn("execution audit trail: failed to reclassify completed ledger row on StageFailed",
 				"pr", prState.PRNumber, "task_id", taskID, "error", err)
 		}
@@ -2800,7 +2825,7 @@ func (c *Controller) ProcessPR(ctx context.Context, prNumber int, ghPR *github.P
 		// audit trail. Best-effort — see recordExecutionEvent.
 		if eventStage, ok := executionEventStageFor(prState.Stage); ok {
 			detail := fmt.Sprintf("pr #%d: %s -> %s", prNumber, previousStage, prState.Stage)
-			c.recordExecutionEvent(prState, eventStage, detail)
+			c.recordExecutionEvent(prState, previousStage, eventStage, detail)
 		}
 	}
 
@@ -3237,7 +3262,7 @@ func (c *Controller) handleCIPassed(ctx context.Context, prState *PRState) error
 		}
 		if testEvidenceHeld {
 			c.postTestEvidenceHoldComment(ctx, prState, escalateReason)
-			c.recordExecutionEvent(prState, memory.StageAwaitingApproval,
+			c.recordExecutionEvent(prState, StageCIPassed, memory.StageAwaitingApproval,
 				fmt.Sprintf("test_evidence_hold: %s", escalateReason))
 		}
 		return nil
@@ -6078,7 +6103,7 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 	// successful release never changes prState.Stage (it stays StageReleasing
 	// until removePR below), so it can't be caught by ProcessPR's stage-diff
 	// hook — record it explicitly here instead.
-	c.recordExecutionEvent(prState, memory.StageReleased,
+	c.recordExecutionEvent(prState, StageReleasing, memory.StageReleased,
 		fmt.Sprintf("pr #%d: released %s (tag %s)", prState.PRNumber, prState.ReleaseVersion, tagName))
 
 	if isScope {
@@ -8798,7 +8823,7 @@ func (c *Controller) checkExternalMergeOrClose(ctx context.Context, prState *PRS
 		if prURL == "" {
 			prURL = prState.PRURL
 		}
-		c.recordExecutionEvent(prState, memory.StageMerged,
+		c.recordExecutionEvent(prState, prState.Stage, memory.StageMerged,
 			fmt.Sprintf("pr #%d: merged externally (%s)", prState.PRNumber, prURL))
 
 		// GH-5071: same stacked-PR resume loop closed on the internal

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -8640,6 +8640,21 @@ func (c *Controller) evictNotFoundPR(prNumber int) {
 // Returns true if the PR was removed from tracking, false otherwise.
 // Accepts cached ghPR to avoid redundant API calls.
 func (c *Controller) checkExternalMergeOrClose(ctx context.Context, prState *PRState, ghPR *github.PullRequest) bool {
+	// GH-5073: snapshot the pre-transition stage once, at entry, the same
+	// way ProcessPR's own transition detector does (previousStage local,
+	// see the switch there) — never re-derive it from prState.Stage at the
+	// recordExecutionEvent call site below. The guards immediately below
+	// already return early for StagePostMergeCI/StageReleasing/StageMerged,
+	// and the only other mutations of prState.Stage in this function
+	// (StagePostMergeCI/StageReleasing further down) each return
+	// immediately after, so today this snapshot is always identical to a
+	// re-read at the call site — but a re-read is one stray line away from
+	// silently observing this function's own StagePostMergeCI/StageReleasing
+	// write instead of the true previous stage, which would wrongly suppress
+	// (or wrongly allow) the StageFailed reclassify guard in
+	// recordExecutionEvent for an externally-merged PR.
+	previousStage := prState.Stage
+
 	// GH-3990: this PRState is a scope-release carrier, not the real PR entry
 	// for prState.PRNumber (its anchor is an already-merged member PR reused
 	// as the release vehicle). The external-merge hijack must never touch it —
@@ -8823,7 +8838,7 @@ func (c *Controller) checkExternalMergeOrClose(ctx context.Context, prState *PRS
 		if prURL == "" {
 			prURL = prState.PRURL
 		}
-		c.recordExecutionEvent(prState, prState.Stage, memory.StageMerged,
+		c.recordExecutionEvent(prState, previousStage, memory.StageMerged,
 			fmt.Sprintf("pr #%d: merged externally (%s)", prState.PRNumber, prURL))
 
 		// GH-5071: same stacked-PR resume loop closed on the internal

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -10104,7 +10104,7 @@ func TestController_RecordExecutionEvent_StageFailed_RespectsTerminalRow(t *test
 	c.memoryStore = mock
 
 	prState := &PRState{PRNumber: 43, IssueNumber: 11}
-	c.recordExecutionEvent(prState, memory.StageFailed, "pr #43: pr_created -> failed")
+	c.recordExecutionEvent(prState, StagePRCreated, memory.StageFailed, "pr #43: pr_created -> failed")
 
 	if got := mock.execStatus["exec-2"]; got != "cancelled" {
 		t.Errorf("execution row status = %q, want %q (terminal row must not be overwritten)", got, "cancelled")
@@ -10163,7 +10163,7 @@ func TestController_RecordExecutionEvent_StageFailed_ReclassifiesLedgerRow(t *te
 	c.memoryStore = store
 
 	prState := &PRState{PRNumber: 55, IssueNumber: 55}
-	c.recordExecutionEvent(prState, memory.StageFailed, "pr #55: waiting_ci -> failed (max CI retries)")
+	c.recordExecutionEvent(prState, StageWaitingCI, memory.StageFailed, "pr #55: waiting_ci -> failed (max CI retries)")
 
 	if completed, err := store.HasCompletedExecution("GH-55", ""); err != nil {
 		t.Fatalf("HasCompletedExecution (post-check): %v", err)
@@ -10175,6 +10175,66 @@ func TestController_RecordExecutionEvent_StageFailed_ReclassifiesLedgerRow(t *te
 		t.Fatalf("HasTerminalCompletion (post-check): %v", err)
 	} else if terminal {
 		t.Error("GH-5067: HasTerminalCompletion still true after StageFailed — a label-clear retry would still no-op at the dispatch guard")
+	}
+}
+
+// TestController_RecordExecutionEvent_StageFailed_PostMergeCI_DoesNotReclassify
+// is the GH-5073 regression (PR#5070 review follow-up): PR#5070 fired
+// ReclassifyCompletionAsFailed on EVERY StageFailed entry, including the
+// post-merge ones — a StagePostMergeCI failure (CI failed/timeout/config
+// mismatch after merge) demoted the ledger row of a PR that already
+// shipped. Unlike TestController_RecordExecutionEvent_StageFailed_
+// ReclassifiesLedgerRow above (previousStage=StageWaitingCI, a genuine
+// pre-merge death), a StagePostMergeCI -> StageFailed transition must leave
+// the "completed" row untouched: the work merged, so HasCompletedExecution
+// must keep vouching for it. Drives the real store (real SQLite), per the
+// acceptance criteria.
+func TestController_RecordExecutionEvent_StageFailed_PostMergeCI_DoesNotReclassify(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// Seed a genuine "completed" row exactly as the merged PR would have
+	// left it: status=completed, no error, a PR URL deliverable.
+	if err := store.SaveExecution(&memory.Execution{
+		ID:     "exec-gh-56",
+		TaskID: "GH-56",
+		Status: "completed",
+		PRUrl:  "https://github.com/owner/repo/pull/56",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	// Sanity: confirm the seeded row genuinely counts as completed before
+	// the StageFailed transition — otherwise this test would trivially pass.
+	if completed, err := store.HasCompletedExecution("GH-56", ""); err != nil {
+		t.Fatalf("HasCompletedExecution (pre-check): %v", err)
+	} else if !completed {
+		t.Fatal("expected seeded row to count as completed before the StageFailed transition")
+	}
+
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.memoryStore = store
+
+	prState := &PRState{PRNumber: 56, IssueNumber: 56}
+	c.recordExecutionEvent(prState, StagePostMergeCI, memory.StageFailed,
+		"pr #56: post_merge_ci -> failed (post-merge CI failed)")
+
+	if completed, err := store.HasCompletedExecution("GH-56", ""); err != nil {
+		t.Fatalf("HasCompletedExecution (post-check): %v", err)
+	} else if !completed {
+		t.Error("GH-5073: HasCompletedExecution false after StagePostMergeCI -> StageFailed — reclassify must not fire for already-merged work")
+	}
+
+	if status, err := store.GetExecution("exec-gh-56"); err != nil {
+		t.Fatalf("GetExecution (post-check): %v", err)
+	} else if status.Status != "completed" {
+		t.Errorf("execution row status = %q, want %q (StagePostMergeCI -> StageFailed must not reclassify a merged PR's row)", status.Status, "completed")
 	}
 }
 
@@ -10198,7 +10258,7 @@ func TestController_RecordExecutionEvent_StageFailed_MissingLedgerRow(t *testing
 	prState := &PRState{PRNumber: 77, IssueNumber: 77}
 
 	// Must not panic and must not attempt either finalize call.
-	c.recordExecutionEvent(prState, memory.StageFailed, "pr #77: waiting_ci -> failed")
+	c.recordExecutionEvent(prState, StageWaitingCI, memory.StageFailed, "pr #77: waiting_ci -> failed")
 
 	if len(mock.statusUpdateCalls) != 0 {
 		t.Errorf("expected no UpdateExecutionStatusIfNotTerminal calls when the ledger row is missing, got %d", len(mock.statusUpdateCalls))
@@ -10232,7 +10292,7 @@ func TestController_RecordExecutionEvent_NonStageFailed_NoReclassify(t *testing.
 	c.memoryStore = mock
 
 	prState := &PRState{PRNumber: 88, IssueNumber: 88}
-	c.recordExecutionEvent(prState, memory.StageMerged, "pr #88: merging -> merged")
+	c.recordExecutionEvent(prState, StageMerging, memory.StageMerged, "pr #88: merging -> merged")
 
 	if len(mock.reclassifyCalls) != 0 {
 		t.Errorf("expected no ReclassifyCompletionAsFailed calls on the merged path, got %d: %+v",


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5073.

Closes #5073

## Changes

GitHub Issue GH-5073: fix(memory): ledger reclassify on StageFailed must skip post-merge stages — merged work transiently demoted to failed (PR#5070 residual)

## Summary

PR#5070's ledger reclassify fires on EVERY entry into `StageFailed` via `recordExecutionEvent`'s chokepoint (controller.go:2269-2295) — including the post-merge ones: `StagePostMergeCI` failures (:5488 CI failed, :5306 timeout, :5510 config mismatch) and `escalateReleasingFailed` (:6074). Those demote the completed ledger row of a PR that **did merge**. Self-healing exists (`ScanRecentlyMergedPRs` 30-min ticker re-promotes `failed` rows; startup 72h sweep), but outside the 30-min window the row stays `failed` until the next restart — a transient reverse-direction honesty gap: `HasCompletedExecution` reports false for shipped work and HISTORY shows a pipeline ✗ for a merged PR.

## Fix

Guard the reclassify to pre-merge stages only: in `recordExecutionEvent`'s StageFailed branch, skip `ReclassifyCompletionAsFailed` when the PR's previous stage was `StageMerged`/`StagePostMergeCI`/`StageReleasing` (the work shipped; post-merge pipeline failure is a different fact than delivery failure, and is already alerted on its own paths). The CAS finalize (:2270, GH-4620) keeps its current behavior — state explicitly in the PR that only the reclassify is being narrowed.

## Acceptance Criteria

- [ ] Test: `StagePostMergeCI → StageFailed` transition does NOT reclassify (real store; row stays `completed`; `HasCompletedExecution` stays true).
- [ ] Test: pre-merge `StageWaitingCI → StageFailed` still reclassifies (existing GH-5067 tests untouched and green).
- [ ] The previous-stage source is the transition detector's `previousStage` (controller.go:2687-2704), not a re-read.
- [ ] `go test ./internal/autopilot/... ./internal/memory/...` green.

## Refs

PR#5070 review follow-up 1 · controller.go:2269 (chokepoint), :5488/:5306/:5510/:6074 (post-merge failed exits) · store.go:2398 (self-heal) · GH-5067