### PR TITLE
GH-5099: fix(autopilot): advance retry ladder on TerminalLabel + preserve park on exhausted+close

### DIFF
--- a/.agent/tasks/gh-5098.md
+++ b/.agent/tasks/gh-5098.md
@@ -1,0 +1,10 @@
+# GH-5098
+
+**Created:** 2026-08-21
+
+## Problem
+
+Pull the rung-advance logic out of postTitleRejectionEscalation (internal/executor/title_rejection.go) into a reusable helper that stamps pilot-failed and advances the retry rung in a single label mutation. Place it where all four caller packages (executor, autopilot, adapters/github, cmd/pilot) can reach it — either as an exported helper in a shared package or, if that would create an import cycle, follow the documented label-constant duplication idiom and colocate a thin wrapper per package that delegates to a common rung-computation routine. Keep title-rejection callsite behavior byte-identical (gh5077/gh5079/gh5080 tests remain untouched and green). Add a focused unit test covering rung progression and the single-mutation invariant.
+
+## Acceptance Criteria
+

--- a/.agent/tasks/gh-5099.md
+++ b/.agent/tasks/gh-5099.md
@@ -1,0 +1,10 @@
+# GH-5099
+
+**Created:** 2026-08-21
+
+## Problem
+
+Two changes in internal/autopilot/controller.go. (a) At the close path where TerminalLabel = github.LabelFailed is applied via mutateIssueLabels (~:9105), call the shared helper from subtask 1 so pilot-failed and the rung advance happen in the same mutation. (b) In the PR-close handler that currently strips pilot-needs-human and can add pilot-retry-ready + pilot, gate those mutations on the absence of pilot-failed-retry-exhausted: when the exhausted label is present, do not strip pilot-needs-human and do not add pilot-retry-ready. Document the precedence rule inline ("exhaustion outranks close-supersedes-hold"). Add tests: ladder advances on autopilot terminal close; exhausted+parked issue whose stale PR closes has labels unchanged (needs-human present, retry-ready absent). Use the existing autopilot httptest/argv-log idiom.
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -18,6 +18,7 @@ import (
 	"github.com/qf-studio/pilot/internal/ghbudget"
 	"github.com/qf-studio/pilot/internal/logging"
 	"github.com/qf-studio/pilot/internal/memory"
+	"github.com/qf-studio/pilot/internal/retryladder"
 	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 )
 
@@ -9267,29 +9268,77 @@ func (c *Controller) notifyExternalClose(ctx context.Context, prState *PRState) 
 		if issueAlreadyClosed {
 			c.log.Info("skipping issue label correction: issue already closed", "issue", prState.IssueNumber, "pr", prState.PRNumber)
 		} else {
-			addLabels := []string{issueLabel}
-			// GH-5042/GH-5032: pilot-retry-ready must always imply pollable —
-			// ensure the pilot label is present in the very same mutation
-			// instead of trusting it survived whatever state the issue was
-			// already in. GH-5032's live incident: an escalateAndHold hold
-			// had left `pilot` absent, so setting pilot-retry-ready alone
-			// stranded a "ready to retry" issue the poller could never see
-			// for 2+ hours.
-			if issueLabel == github.LabelRetryReady {
-				addLabels = append(addLabels, github.LabelPilot)
+			// GH-5099 precedence rule: exhaustion outranks close-supersedes-hold.
+			// GH-5079 parks an issue under pilot-needs-human once its
+			// pilot-failed-retry ladder reaches the terminal
+			// pilot-failed-retry-exhausted rung. A second/stale PR for the same
+			// issue closing later must not silently un-park it — without this
+			// check, the "close always supersedes hold" rule below would strip
+			// pilot-needs-human and re-arm pilot-retry-ready (+ pilot) the
+			// moment any PR for the issue closes, undoing GH-5079's terminal
+			// park. issue/err are the pilot-done-guard fetch above (line
+			// ~9162); err != nil there already fails open, so only a clean
+			// read counts as positive evidence of exhaustion.
+			issueExhausted := err == nil && issue != nil && github.HasLabel(issue, github.LabelFailedRetryExhausted)
+
+			var addLabels []string
+			if issueLabel == github.LabelRetryReady && issueExhausted {
+				// Exhaustion wins: do not re-arm retry-ready or its implied
+				// pilot label on an exhausted+parked issue.
+			} else {
+				addLabels = []string{issueLabel}
+				// GH-5042/GH-5032: pilot-retry-ready must always imply pollable —
+				// ensure the pilot label is present in the very same mutation
+				// instead of trusting it survived whatever state the issue was
+				// already in. GH-5032's live incident: an escalateAndHold hold
+				// had left `pilot` absent, so setting pilot-retry-ready alone
+				// stranded a "ready to retry" issue the poller could never see
+				// for 2+ hours.
+				if issueLabel == github.LabelRetryReady {
+					addLabels = append(addLabels, github.LabelPilot)
+				}
 			}
 			// GH-5042: whatever this close resolves to — retry-ready,
-			// superseded, or failed-owned-elsewhere — it always supersedes
+			// superseded, or failed-owned-elsewhere — it normally supersedes
 			// any escalation hold still standing on the issue (the hold
 			// existed for a PR that is now closed; there is nothing left
 			// for it to hold). Strip pilot-needs-human/needs-manual-rebase
-			// here unconditionally, mirroring escalateAndHold's reverse
-			// direction (needs-human supersedes retry-ready).
-			removeLabels := []string{github.LabelInProgress, labelNeedsHuman, labelNeedsManualRebase}
+			// here, mirroring escalateAndHold's reverse direction
+			// (needs-human supersedes retry-ready) — except pilot-needs-human
+			// is left standing when issueExhausted (GH-5099: exhaustion
+			// outranks close-supersedes-hold, see above).
+			removeLabels := []string{github.LabelInProgress, labelNeedsManualRebase}
+			if !issueExhausted {
+				removeLabels = append(removeLabels, labelNeedsHuman)
+			}
 			if issueLabel != github.LabelFailed {
 				// Remove stale pilot-failed label (GH-1302 gap) — only when we're not
 				// the ones setting it above.
 				removeLabels = append(removeLabels, github.LabelFailed)
+			}
+			// GH-5099: when this close resolves to pilot-failed, fold the
+			// pilot-failed-retry-N ladder advance into this same mutation
+			// (subtask GH-5098's shared internal/retryladder helper) instead
+			// of a separate label write — mirrors the executor's
+			// title-rejection escalation call site
+			// (internal/executor/title_rejection.go, GH-5077/GH-5098).
+			// currentLabels reflects the issue's state immediately before
+			// this mutation (the same pilot-done-guard fetch above), so a
+			// fresh pilot-failed application here advances the rung exactly
+			// once, and a repeat application (issue already carries
+			// pilot-failed) is a no-op per retryladder.Advance.
+			if issueLabel == github.LabelFailed && err == nil && issue != nil {
+				currentLabels := make([]string, len(issue.Labels))
+				for i, l := range issue.Labels {
+					currentLabels[i] = l.Name
+				}
+				hasFailed := github.HasLabel(issue, github.LabelFailed)
+				if add, remove, _ := retryladder.Advance(currentLabels, hasFailed); add != "" {
+					addLabels = append(addLabels, add)
+					if remove != "" {
+						removeLabels = append(removeLabels, remove)
+					}
+				}
 			}
 			c.mutateIssueLabels(ctx, prState.IssueNumber, addLabels, removeLabels)
 		}

--- a/internal/autopilot/gh5099_test.go
+++ b/internal/autopilot/gh5099_test.go
@@ -1,0 +1,110 @@
+package autopilot
+
+import (
+	"context"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestNotifyExternalClose_LadderAdvancesOnTerminalClose is the GH-5099
+// subtask (a) acceptance test: when notifyExternalClose resolves a close to
+// pilot-failed (prState.TerminalLabel already says so — the "autopilot
+// terminal close" path, e.g. handleCIFailed), the pilot-failed-retry-N
+// ladder rung (internal/retryladder's shared Advance helper, GH-5098) must
+// advance in the very same mutateIssueLabels call instead of a separate
+// label write. Table-driven across every rung, reusing the gh5042LabelServer
+// converged-label-set fixture (gh5042_test.go) so each case only has to
+// state the issue's live labels before the close and assert the converged
+// set after it.
+func TestNotifyExternalClose_LadderAdvancesOnTerminalClose(t *testing.T) {
+	tests := []struct {
+		name    string
+		initial []string
+		want    []string
+	}{
+		{
+			name:    "fresh failure - advances to retry-1",
+			initial: []string{github.LabelInProgress},
+			want:    []string{github.LabelFailed, github.LabelFailedRetry1},
+		},
+		{
+			// GH-5078: the stale-label janitor clears pilot-failed (but not
+			// the rung label) after its 24h threshold to re-admit the issue
+			// for another attempt, so a second real failure sees pilot-failed
+			// absent (a fresh application) with retry-1 still standing from
+			// the first attempt.
+			name:    "rung standing, pilot-failed cleared by janitor - advances to retry-2",
+			initial: []string{github.LabelFailedRetry1},
+			want:    []string{github.LabelFailed, github.LabelFailedRetry2},
+		},
+		{
+			name:    "rung standing, pilot-failed cleared by janitor - advances to exhausted",
+			initial: []string{github.LabelFailedRetry2},
+			want:    []string{github.LabelFailed, github.LabelFailedRetryExhausted},
+		},
+		{
+			name:    "already exhausted - stays exhausted, no further advance",
+			initial: []string{github.LabelFailed, github.LabelFailedRetryExhausted},
+			want:    []string{github.LabelFailed, github.LabelFailedRetryExhausted},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, snapshot := gh5042LabelServer(t, 10, tt.initial, "open")
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+			prState := &PRState{
+				PRNumber:      42,
+				IssueNumber:   10,
+				Stage:         StageFailed,
+				Error:         "CI checks failed",
+				TerminalLabel: github.LabelFailed,
+			}
+			c.notifyExternalClose(context.Background(), prState)
+
+			assertLabelSet(t, snapshot(), tt.want)
+		})
+	}
+}
+
+// TestNotifyExternalClose_ExhaustionOutranksCloseSupersedesHold is the
+// GH-5099 subtask (b) acceptance test: an issue already parked under
+// pilot-needs-human because its pilot-failed-retry ladder reached
+// pilot-failed-retry-exhausted (GH-5079) must stay parked when some other,
+// stale PR for the same issue closes later. Before this fix, notifyExternalClose's
+// "close always supersedes hold" rule (GH-5042) unconditionally stripped
+// pilot-needs-human and re-armed pilot-retry-ready (+ pilot) on every close —
+// which would silently un-park an exhausted, already-terminal issue.
+func TestNotifyExternalClose_ExhaustionOutranksCloseSupersedesHold(t *testing.T) {
+	initial := []string{labelNeedsHuman, github.LabelFailed, github.LabelFailedRetryExhausted}
+	server, snapshot := gh5042LabelServer(t, 10, initial, "open")
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	// No TerminalLabel set and no durable spawned-fix claim (stateStore is
+	// nil) — this is a stale/unrelated PR closing, so notifyExternalClose
+	// would otherwise resolve to the default pilot-retry-ready outcome.
+	prState := &PRState{PRNumber: 99, IssueNumber: 10, Error: "closed without merging"}
+	c.notifyExternalClose(context.Background(), prState)
+
+	labels := snapshot()
+	if !labels[labelNeedsHuman] {
+		t.Errorf("expected pilot-needs-human to remain on an exhausted+parked issue, got labels=%v", labels)
+	}
+	if labels[github.LabelRetryReady] {
+		t.Errorf("expected pilot-retry-ready NOT to be added to an exhausted+parked issue, got labels=%v", labels)
+	}
+	if labels[github.LabelPilot] {
+		t.Errorf("expected pilot NOT to be added alongside the suppressed pilot-retry-ready, got labels=%v", labels)
+	}
+}

--- a/internal/executor/title_rejection.go
+++ b/internal/executor/title_rejection.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 	"unicode"
+
+	"github.com/qf-studio/pilot/internal/retryladder"
 )
 
 // GH-2363: After the 2nd consecutive rejection for the same title, stop
@@ -26,17 +28,21 @@ const titleRejectionMaxCount = 2
 // labelPilotFailed mirrors adapters/github.LabelFailed, defined locally for
 // the same import-cycle reason as labelPilotSuperseded (issue_state.go):
 // adapters/github imports internal/comms, which imports internal/executor.
-const labelPilotFailed = "pilot-failed"
+// Aliased to retryladder.LabelFailed (GH-5098) rather than a separate string
+// literal so the value has a single source of truth despite the local name
+// duplication.
+const labelPilotFailed = retryladder.LabelFailed
 
 // GH-5077: pilot-failed-retry-N ladder labels mirror
 // adapters/github.LabelFailedRetry1/2/Exhausted (types.go:159-161), defined
 // locally for the same import-cycle reason as labelPilotSuperseded
 // (issue_state.go). Escalation order matches
-// adapters/github.FailedRetryStateLabels (types.go:169).
+// adapters/github.FailedRetryStateLabels (types.go:169). Aliased to
+// retryladder's constants (GH-5098) rather than separate string literals.
 const (
-	labelPilotFailedRetry1         = "pilot-failed-retry-1"
-	labelPilotFailedRetry2         = "pilot-failed-retry-2"
-	labelPilotFailedRetryExhausted = "pilot-failed-retry-exhausted"
+	labelPilotFailedRetry1         = retryladder.LabelFailedRetry1
+	labelPilotFailedRetry2         = retryladder.LabelFailedRetry2
+	labelPilotFailedRetryExhausted = retryladder.LabelFailedRetryExhausted
 )
 
 // nextFailedRetryLabel computes the pilot-failed-retry-N ladder mutation
@@ -56,25 +62,14 @@ const (
 // issue that's already failed is a duplicate fail-label event and must not
 // advance the ladder again. See postTitleRejectionEscalation's
 // already-failed guard.
+//
+// GH-5098: thin wrapper over retryladder.NextRung, the package-independent
+// rung-computation routine every pilot-failed call site (executor,
+// autopilot, adapters/github, cmd/pilot) can reach without an import cycle.
+// Kept here under its original name/signature so this package's own tests
+// (gh5077/gh5079/gh5080) stay byte-identical.
 func nextFailedRetryLabel(currentLabels []string) (add, remove string) {
-	has := func(name string) bool {
-		for _, l := range currentLabels {
-			if strings.EqualFold(l, name) {
-				return true
-			}
-		}
-		return false
-	}
-	switch {
-	case has(labelPilotFailedRetryExhausted):
-		return "", ""
-	case has(labelPilotFailedRetry2):
-		return labelPilotFailedRetryExhausted, labelPilotFailedRetry2
-	case has(labelPilotFailedRetry1):
-		return labelPilotFailedRetry2, labelPilotFailedRetry1
-	default:
-		return labelPilotFailedRetry1, ""
-	}
+	return retryladder.NextRung(currentLabels)
 }
 
 // titleRejection tracks consecutive rejections for a single issue.
@@ -297,14 +292,19 @@ func (r *Runner) postTitleRejectionEscalation(ctx context.Context, task *Task) e
 	// pilot-failed: a repeat escalation for an already-failed issue (e.g. the
 	// same non-conventional title rejected a 3rd, 4th... time) is a duplicate
 	// fail-label event and must not advance the ladder again.
+	// GH-5098: retryladder.Advance is the reusable stamp+advance-in-one-
+	// mutation helper — it folds the already-failed guard in above (returns
+	// "","",false when hasFailed) so this callsite only needs to gate on the
+	// state read having succeeded, matching the original inline behavior
+	// byte-for-byte.
 	var exhausted bool
-	if stateErr == nil && !state.HasLabel(labelPilotFailed) {
-		if add, remove := nextFailedRetryLabel(state.Labels); add != "" {
+	if stateErr == nil {
+		if add, remove, exh := retryladder.Advance(state.Labels, state.HasLabel(labelPilotFailed)); add != "" {
 			addLabels = append(addLabels, add)
 			if remove != "" {
 				removeLabels = append(removeLabels, remove)
 			}
-			exhausted = add == labelPilotFailedRetryExhausted
+			exhausted = exh
 		}
 	}
 	// GH-5079: the ladder reaching its terminal rung means the retry budget

--- a/internal/retryladder/retryladder.go
+++ b/internal/retryladder/retryladder.go
@@ -1,0 +1,83 @@
+// Package retryladder computes the pilot-failed-retry-N label ladder
+// mutation shared by every Pilot call site that stamps pilot-failed onto a
+// GitHub issue: internal/executor (postTitleRejectionEscalation, GH-5077),
+// internal/autopilot, internal/adapters/github, and cmd/pilot.
+//
+// GH-5098: extracted from internal/executor/title_rejection.go's
+// nextFailedRetryLabel so the rung-computation isn't re-implemented at each
+// call site. This package intentionally has zero internal/... dependencies
+// of its own — a leaf package — so every caller can import it directly
+// without risking an import cycle. In particular internal/executor cannot
+// import internal/adapters/github (adapters/github imports internal/comms,
+// which imports internal/executor — see title_rejection.go's
+// labelPilotFailed comment), so the canonical label values from
+// internal/adapters/github/types.go are duplicated here as plain string
+// constants rather than imported, per Pilot's documented
+// label-constant-duplication idiom.
+package retryladder
+
+import "strings"
+
+// Label name constants for the pilot-failed-retry-N ladder. Mirror
+// adapters/github.LabelFailed / LabelFailedRetry1/2/Exhausted
+// (internal/adapters/github/types.go:140,159-161).
+const (
+	LabelFailed               = "pilot-failed"
+	LabelFailedRetry1         = "pilot-failed-retry-1"
+	LabelFailedRetry2         = "pilot-failed-retry-2"
+	LabelFailedRetryExhausted = "pilot-failed-retry-exhausted"
+)
+
+// NextRung computes the pilot-failed-retry-N ladder mutation (none ->
+// pilot-failed-retry-1 -> pilot-failed-retry-2 ->
+// pilot-failed-retry-exhausted) for a single, fresh pilot-failed
+// application. currentLabels is the issue's live label set read immediately
+// before this event's mutation. Returns the label to add and (if any) the
+// label to remove — the ladder holds exactly one rung label at a time, so
+// advancing always removes the previous rung.
+//
+// Both return values are empty once the issue has already reached the
+// terminal pilot-failed-retry-exhausted rung: GH-5077 requires no further
+// advancement past exhaustion.
+func NextRung(currentLabels []string) (add, remove string) {
+	has := func(name string) bool {
+		for _, l := range currentLabels {
+			if strings.EqualFold(l, name) {
+				return true
+			}
+		}
+		return false
+	}
+	switch {
+	case has(LabelFailedRetryExhausted):
+		return "", ""
+	case has(LabelFailedRetry2):
+		return LabelFailedRetryExhausted, LabelFailedRetry2
+	case has(LabelFailedRetry1):
+		return LabelFailedRetry2, LabelFailedRetry1
+	default:
+		return LabelFailedRetry1, ""
+	}
+}
+
+// Advance is the reusable "stamp pilot-failed + advance the retry rung in a
+// single label mutation" helper (GH-5098). Given an issue's current label
+// set (read immediately before the mutation) and whether the issue already
+// carries pilot-failed, it returns the ladder label to add and (if any)
+// remove for that one mutation, plus whether the ladder just reached its
+// terminal rung — all inputs a caller needs to fold into a single
+// add/remove label-edit call alongside its own pilot-failed application.
+//
+// Ladder advancement only happens for a fresh pilot-failed application
+// (hasFailed == false): a repeat pilot-failed application on an issue that
+// already carries the label is a duplicate fail-label event and must not
+// advance the ladder again — see
+// internal/executor/title_rejection.go's postTitleRejectionEscalation,
+// the original call site this was extracted from.
+func Advance(currentLabels []string, hasFailed bool) (add, remove string, exhausted bool) {
+	if hasFailed {
+		return "", "", false
+	}
+	add, remove = NextRung(currentLabels)
+	return add, remove, add == LabelFailedRetryExhausted
+}

--- a/internal/retryladder/retryladder_test.go
+++ b/internal/retryladder/retryladder_test.go
@@ -1,0 +1,131 @@
+package retryladder
+
+import "testing"
+
+// TestNextRung_RungTransitions mirrors
+// internal/executor's TestNextFailedRetryLabel_RungTransitions (the
+// pre-extraction test) — this is the canonical rung-computation routine
+// both that test and this package's callers now delegate to (GH-5098).
+func TestNextRung_RungTransitions(t *testing.T) {
+	tests := []struct {
+		name       string
+		labels     []string
+		wantAdd    string
+		wantRemove string
+	}{
+		{
+			name:       "no ladder label yet -> retry-1",
+			labels:     nil,
+			wantAdd:    LabelFailedRetry1,
+			wantRemove: "",
+		},
+		{
+			name:       "unrelated labels only -> retry-1",
+			labels:     []string{"bug", "pilot"},
+			wantAdd:    LabelFailedRetry1,
+			wantRemove: "",
+		},
+		{
+			name:       "retry-1 present -> retry-2, removes retry-1",
+			labels:     []string{LabelFailedRetry1},
+			wantAdd:    LabelFailedRetry2,
+			wantRemove: LabelFailedRetry1,
+		},
+		{
+			name:       "retry-2 present -> exhausted, removes retry-2",
+			labels:     []string{LabelFailedRetry2},
+			wantAdd:    LabelFailedRetryExhausted,
+			wantRemove: LabelFailedRetry2,
+		},
+		{
+			name:       "exhausted present -> no further advancement",
+			labels:     []string{LabelFailedRetryExhausted},
+			wantAdd:    "",
+			wantRemove: "",
+		},
+		{
+			name:       "case-insensitive match on existing rung",
+			labels:     []string{"PILOT-FAILED-RETRY-1"},
+			wantAdd:    LabelFailedRetry2,
+			wantRemove: LabelFailedRetry1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAdd, gotRemove := NextRung(tt.labels)
+			if gotAdd != tt.wantAdd || gotRemove != tt.wantRemove {
+				t.Errorf("NextRung(%v) = (%q, %q), want (%q, %q)",
+					tt.labels, gotAdd, gotRemove, tt.wantAdd, tt.wantRemove)
+			}
+		})
+	}
+}
+
+// TestAdvance_SingleMutationInvariant asserts Advance folds the
+// already-failed guard and the rung computation into one decision, so a
+// caller gets everything needed for a single label-edit call without a
+// separate follow-up mutation. GH-5077's core invariant: a repeat
+// pilot-failed application (hasFailed == true) must never advance the
+// ladder again, regardless of what rung the current labels show.
+func TestAdvance_SingleMutationInvariant(t *testing.T) {
+	tests := []struct {
+		name          string
+		labels        []string
+		hasFailed     bool
+		wantAdd       string
+		wantRemove    string
+		wantExhausted bool
+	}{
+		{
+			name:      "fresh failure, no rung yet -> stamps retry-1",
+			labels:    nil,
+			hasFailed: false,
+			wantAdd:   LabelFailedRetry1,
+		},
+		{
+			name:       "fresh failure, retry-1 present -> advances to retry-2",
+			labels:     []string{LabelFailedRetry1},
+			hasFailed:  false,
+			wantAdd:    LabelFailedRetry2,
+			wantRemove: LabelFailedRetry1,
+		},
+		{
+			name:          "fresh failure, retry-2 present -> exhausts the ladder",
+			labels:        []string{LabelFailedRetry2},
+			hasFailed:     false,
+			wantAdd:       LabelFailedRetryExhausted,
+			wantRemove:    LabelFailedRetry2,
+			wantExhausted: true,
+		},
+		{
+			name:      "fresh failure, already exhausted -> no further advancement",
+			labels:    []string{LabelFailedRetryExhausted},
+			hasFailed: false,
+			wantAdd:   "",
+		},
+		{
+			name:      "duplicate fail event (hasFailed=true) -> never advances, even mid-ladder",
+			labels:    []string{LabelFailedRetry1},
+			hasFailed: true,
+			wantAdd:   "",
+		},
+		{
+			name:      "duplicate fail event at exhausted rung -> still no-op",
+			labels:    []string{LabelFailedRetryExhausted},
+			hasFailed: true,
+			wantAdd:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAdd, gotRemove, gotExhausted := Advance(tt.labels, tt.hasFailed)
+			if gotAdd != tt.wantAdd || gotRemove != tt.wantRemove || gotExhausted != tt.wantExhausted {
+				t.Errorf("Advance(%v, %v) = (%q, %q, %v), want (%q, %q, %v)",
+					tt.labels, tt.hasFailed, gotAdd, gotRemove, gotExhausted,
+					tt.wantAdd, tt.wantRemove, tt.wantExhausted)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5099.

Closes #5099

## Changes

Two changes in internal/autopilot/controller.go. (a) At the close path where TerminalLabel = github.LabelFailed is applied via mutateIssueLabels (~:9105), call the shared helper from subtask 1 so pilot-failed and the rung advance happen in the same mutation. (b) In the PR-close handler that currently strips pilot-needs-human and can add pilot-retry-ready + pilot, gate those mutations on the absence of pilot-failed-retry-exhausted: when the exhausted label is present, do not strip pilot-needs-human and do not add pilot-retry-ready. Document the precedence rule inline ("exhaustion outranks close-supersedes-hold"). Add tests: ladder advances on autopilot terminal close; exhausted+parked issue whose stale PR closes has labels unchanged (needs-human present, retry-ready absent). Use the existing autopilot httptest/argv-log idiom.