### PR TITLE
GH-5101: fix(cmd/pilot): advance retry ladder in one-shot execute failure path

### DIFF
--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -35,6 +35,7 @@ import (
 	"github.com/qf-studio/pilot/internal/memory"
 	"github.com/qf-studio/pilot/internal/pilot"
 	"github.com/qf-studio/pilot/internal/replay"
+	"github.com/qf-studio/pilot/internal/retryladder"
 	"github.com/qf-studio/pilot/internal/singleton"
 	"github.com/qf-studio/pilot/internal/upgrade"
 	githubSDK "github.com/qf-studio/studio-sdk/sdk/integrations/github"
@@ -1281,6 +1282,49 @@ func parseInt64(s string) (int64, error) {
 	return id, err
 }
 
+// stampPilotFailedWithLadder applies the pilot-failed label to issueNum and
+// advances the pilot-failed-retry-N ladder in the same mutation (GH-5101),
+// mirroring postTitleRejectionEscalation's GH-5077/GH-5098 pattern for the
+// `pilot github run` one-shot execute path's two failure sites in
+// newGitHubRunCmd (runner.Execute error, and the no-commit/no-PR outcome).
+// Without this, both sites stamped a bare pilot-failed with no rung
+// advance, so the ladder never progressed for issues driven through this
+// CLI path — only issues failed via the poller/executor's own retry loop
+// ever reached pilot-failed-retry-2/exhausted.
+//
+// Fetches the issue's live labels immediately before mutating: the `issue`
+// read at the top of newGitHubRunCmd is stale by the time execution
+// finishes, potentially long after that read. Best-effort throughout —
+// failures are logged via logGitHubAPIError, never returned, matching every
+// other label call at these two sites.
+func stampPilotFailedWithLadder(ctx context.Context, client *github.Client, owner, repoName string, issueNum int) {
+	addLabels := []string{github.LabelFailed}
+	var removeLabel string
+
+	issue, err := client.GetIssue(ctx, owner, repoName, issueNum)
+	if err != nil {
+		// Fail open on the ladder computation (mirrors
+		// postTitleRejectionEscalation's fetchIssueState fail-open stance) —
+		// still stamp pilot-failed itself, just without advancing the rung.
+		logGitHubAPIError("GetIssue", owner, repoName, issueNum, err)
+	} else {
+		hasFailed := github.HasLabel(issue, github.LabelFailed)
+		if add, remove, _ := retryladder.Advance(extractGitHubLabelNames(issue), hasFailed); add != "" {
+			addLabels = append(addLabels, add)
+			removeLabel = remove
+		}
+	}
+
+	if err := client.AddLabels(ctx, owner, repoName, issueNum, addLabels); err != nil {
+		logGitHubAPIError("AddLabels", owner, repoName, issueNum, err)
+	}
+	if removeLabel != "" {
+		if err := client.RemoveLabel(ctx, owner, repoName, issueNum, removeLabel); err != nil {
+			logGitHubAPIError("RemoveLabel", owner, repoName, issueNum, err)
+		}
+	}
+}
+
 func newGitHubCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "github",
@@ -1503,10 +1547,9 @@ Examples:
 
 			result, err := runner.Execute(ctx, task)
 			if err != nil {
-				// Add failed label
-				if labelErr := client.AddLabels(ctx, owner, repoName, int(issueNum), []string{"pilot-failed"}); labelErr != nil {
-					logGitHubAPIError("AddLabels", owner, repoName, int(issueNum), labelErr)
-				}
+				// Add failed label, advancing the pilot-failed-retry-N ladder
+				// in the same mutation (GH-5101).
+				stampPilotFailedWithLadder(ctx, client, owner, repoName, int(issueNum))
 				if labelErr := client.RemoveLabel(ctx, owner, repoName, int(issueNum), "pilot-in-progress"); labelErr != nil {
 					logGitHubAPIError("RemoveLabel", owner, repoName, int(issueNum), labelErr)
 				}
@@ -1533,10 +1576,9 @@ Examples:
 			// — inferring failure from artifact absence alone here ignores the
 			// classification runner.Execute already computed.
 			if !result.IsEpic && result.CommitSHA == "" && result.PRUrl == "" && !executor.IsNoArtifactExplainedOutcome(result.Outcome) {
-				// No commits and no PR - mark as failed
-				if err := client.AddLabels(ctx, owner, repoName, int(issueNum), []string{"pilot-failed"}); err != nil {
-					logGitHubAPIError("AddLabels", owner, repoName, int(issueNum), err)
-				}
+				// No commits and no PR - mark as failed, advancing the
+				// pilot-failed-retry-N ladder in the same mutation (GH-5101).
+				stampPilotFailedWithLadder(ctx, client, owner, repoName, int(issueNum))
 
 				comment := fmt.Sprintf("⚠️ Pilot execution completed but no changes were made.\n\n**Duration:** %s\n**Branch:** `%s`\n\nNo commits or PR were created. The task may need clarification or manual intervention.",
 					result.Duration, branchName)

--- a/cmd/pilot/gh5101_ladder_wiring_test.go
+++ b/cmd/pilot/gh5101_ladder_wiring_test.go
@@ -1,0 +1,133 @@
+// GH-5101: stampPilotFailedWithLadder wires the `pilot github run` one-shot
+// execute failure sites (newGitHubRunCmd, runner.Execute error and the
+// no-commit/no-PR outcome) into the shared retryladder.Advance helper, so
+// stamping pilot-failed also advances the pilot-failed-retry-N rung in the
+// same mutation — mirroring postTitleRejectionEscalation's GH-5077/GH-5098
+// pattern. Before this, both sites called client.AddLabels with a bare
+// "pilot-failed" and never touched the ladder, so issues driven through
+// this CLI path never advanced past pilot-failed-retry-1 no matter how many
+// times they failed here.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// gh5101FakeIssueServer stands in for the GitHub REST API, using the
+// argv-log idiom this package already uses for recording ordered call
+// sequences (writeFakeGh's recorded argv in ghguard_test.go; the recorded
+// DELETE sequence in TestUnwindGithubStartedLabel_GH5028) — here the "log"
+// is the ordered sequence of label mutations the server observes, since
+// stampPilotFailedWithLadder talks to the GitHub REST client rather than a
+// gh subprocess.
+func gh5101FakeIssueServer(t *testing.T, issueNumber int, initialLabels []string) (*httptest.Server, *[]string) {
+	t.Helper()
+	var mu sync.Mutex
+	var log []string
+
+	labels := make([]github.Label, len(initialLabels))
+	for i, l := range initialLabels {
+		labels[i] = github.Label{Name: l}
+	}
+	issue := &github.Issue{Number: issueNumber, Title: "test issue", Labels: labels}
+
+	issuePath := fmt.Sprintf("/repos/owner/repo/issues/%d", issueNumber)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == issuePath:
+			_ = json.NewEncoder(w).Encode(issue)
+		case r.Method == http.MethodPost && r.URL.Path == issuePath+"/labels":
+			var body struct {
+				Labels []string `json:"labels"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			for _, l := range body.Labels {
+				log = append(log, "add:"+l)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, issuePath+"/labels/"):
+			removed := strings.TrimPrefix(r.URL.Path, issuePath+"/labels/")
+			log = append(log, "remove:"+removed)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	return server, &log
+}
+
+// TestStampPilotFailedWithLadder_RungAdvanceAndExhaustedTerminal covers the
+// GH-5101 wiring end to end: the rung-advance path (fresh failure at each
+// ladder position) and the exhausted-terminal case (once at the top rung, a
+// further failure must stamp pilot-failed alone, without regressing off
+// pilot-failed-retry-exhausted or re-advancing past it).
+func TestStampPilotFailedWithLadder_RungAdvanceAndExhaustedTerminal(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialLabels []string
+		wantLog       []string
+	}{
+		{
+			name:          "no ladder label yet -> stamps pilot-failed and retry-1",
+			initialLabels: nil,
+			wantLog:       []string{"add:pilot-failed", "add:pilot-failed-retry-1"},
+		},
+		{
+			name:          "retry-1 present -> advances to retry-2",
+			initialLabels: []string{"pilot-failed-retry-1"},
+			wantLog:       []string{"add:pilot-failed", "add:pilot-failed-retry-2", "remove:pilot-failed-retry-1"},
+		},
+		{
+			name:          "retry-2 present -> exhausts the ladder",
+			initialLabels: []string{"pilot-failed-retry-2"},
+			wantLog:       []string{"add:pilot-failed", "add:pilot-failed-retry-exhausted", "remove:pilot-failed-retry-2"},
+		},
+		{
+			name:          "exhausted-terminal: already at top rung -> no further advancement, no regression",
+			initialLabels: []string{"pilot-failed-retry-exhausted"},
+			wantLog:       []string{"add:pilot-failed"},
+		},
+		{
+			name:          "duplicate fail event: issue already carries pilot-failed -> ladder does not re-advance",
+			initialLabels: []string{"pilot-failed", "pilot-failed-retry-1"},
+			wantLog:       []string{"add:pilot-failed"},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issueNumber := 5101000 + i
+			server, log := gh5101FakeIssueServer(t, issueNumber, tt.initialLabels)
+			defer server.Close()
+
+			client := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			stampPilotFailedWithLadder(context.Background(), client, "owner", "repo", issueNumber)
+
+			if len(*log) != len(tt.wantLog) {
+				t.Fatalf("call log = %v, want %v", *log, tt.wantLog)
+			}
+			for i, want := range tt.wantLog {
+				if (*log)[i] != want {
+					t.Errorf("call log[%d] = %q, want %q (full log: %v)", i, (*log)[i], want, *log)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5101.

Closes #5101

## Changes

In cmd/pilot/commands.go around lines 1507 and 1537, wire the one-shot execute failure sites into the shared ladder helper so stamping pilot-failed also advances the rung in the same mutation. Add a table-driven test using the argv-log idiom already used in cmd/pilot covering rung advance and the exhausted-terminal case (once at the top rung, next failure stamps pilot-failed-retry-exhausted without regression).