### PR TITLE
GH-5099: fix(autopilot): advance retry ladder on TerminalLabel + preserve park on exha...

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -18,6 +18,7 @@ import (
 	"github.com/qf-studio/pilot/internal/ghbudget"
 	"github.com/qf-studio/pilot/internal/logging"
 	"github.com/qf-studio/pilot/internal/memory"
+	"github.com/qf-studio/pilot/internal/retryladder"
 	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 )
 
@@ -9264,8 +9265,26 @@ func (c *Controller) notifyExternalClose(ctx context.Context, prState *PRState) 
 		// GitHub call. err != nil there already fails open (issue is nil), so
 		// only a clean read with State == closed counts as positive evidence.
 		issueAlreadyClosed := err == nil && issue != nil && issue.State == github.StateClosed
+		// GH-5099: exhaustion outranks close-supersedes-hold. GH-5042 above
+		// made "this close always supersedes an escalation hold" the default
+		// rule (needs-human/needs-manual-rebase stripped unconditionally),
+		// but an issue already parked at pilot-failed-retry-exhausted
+		// (bda03368/GH-5079) is a stronger signal than an ordinary hold: its
+		// retry budget is spent, not merely paused. A stale PR — opened
+		// before that parking — closing without merge must not silently
+		// strip pilot-needs-human and re-arm pilot-retry-ready on it; that
+		// would resurrect an issue Pilot has already given up on. Only the
+		// default retry-ready resolution is gated: a TerminalLabel-driven
+		// close (pilot-failed/-superseded/etc., handled below) still
+		// proceeds normally since it isn't re-arming anything.
+		exhaustedParked := err == nil && issue != nil && issueLabel == github.LabelRetryReady &&
+			github.HasLabel(issue, github.LabelFailedRetryExhausted)
 		if issueAlreadyClosed {
 			c.log.Info("skipping issue label correction: issue already closed", "issue", prState.IssueNumber, "pr", prState.PRNumber)
+		} else if exhaustedParked {
+			c.log.Info("skipping issue label correction: pilot-failed-retry ladder already exhausted, issue stays parked under pilot-needs-human",
+				"issue", prState.IssueNumber, "pr", prState.PRNumber)
+			nextSteps = "The issue has already exhausted its pilot-failed-retry ladder and stays parked under pilot-needs-human, so its labels were left unchanged."
 		} else {
 			addLabels := []string{issueLabel}
 			// GH-5042/GH-5032: pilot-retry-ready must always imply pollable —
@@ -9290,6 +9309,30 @@ func (c *Controller) notifyExternalClose(ctx context.Context, prState *PRState) 
 				// Remove stale pilot-failed label (GH-1302 gap) — only when we're not
 				// the ones setting it above.
 				removeLabels = append(removeLabels, github.LabelFailed)
+			} else if issue != nil {
+				// GH-5099: this close resolves to pilot-failed (a
+				// TerminalLabel set above — e.g. the dead-fix-issue
+				// re-strand case) — fold the shared pilot-failed-retry-N
+				// ladder advance (internal/retryladder, GH-5098) into the
+				// very same label mutation instead of leaving it a
+				// follow-up call, matching postTitleRejectionEscalation
+				// (title_rejection.go, GH-5077) and NotifyTaskFailed
+				// (adapters/github/notifier.go, GH-5100). `issue` was
+				// fetched above and nothing has written to it since, so its
+				// Labels are still the correct pre-mutation snapshot
+				// retryladder.Advance needs to tell a fresh pilot-failed
+				// application from a duplicate one (which must not advance
+				// the rung again).
+				currentLabels := make([]string, len(issue.Labels))
+				for i, l := range issue.Labels {
+					currentLabels[i] = l.Name
+				}
+				if add, remove, _ := retryladder.Advance(currentLabels, github.HasLabel(issue, github.LabelFailed)); add != "" {
+					addLabels = append(addLabels, add)
+					if remove != "" {
+						removeLabels = append(removeLabels, remove)
+					}
+				}
 			}
 			c.mutateIssueLabels(ctx, prState.IssueNumber, addLabels, removeLabels)
 		}

--- a/internal/autopilot/gh5099_test.go
+++ b/internal/autopilot/gh5099_test.go
@@ -1,0 +1,114 @@
+package autopilot
+
+import (
+	"context"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GH-5099 (GH-5088 subtask): notifyExternalClose's TerminalLabel-driven
+// pilot-failed close must advance the shared pilot-failed-retry-N ladder
+// (internal/retryladder, GH-5098) in the same label mutation, matching
+// postTitleRejectionEscalation (title_rejection.go, GH-5077) and
+// NotifyTaskFailed (adapters/github/notifier.go, GH-5100). Reuses the
+// gh5042LabelServer httptest idiom (gh5042_test.go) that tracks an issue's
+// live label set across GET/POST-labels/DELETE-labels calls.
+
+// TestNotifyExternalClose_LadderAdvancesOnTerminalFailedClose covers the
+// fresh-failure case: an issue with no prior ladder rung whose PR closes
+// with TerminalLabel=pilot-failed must come out of notifyExternalClose
+// carrying pilot-failed + pilot-failed-retry-1, applied in the very same
+// mutation as the pilot-failed stamp.
+func TestNotifyExternalClose_LadderAdvancesOnTerminalFailedClose(t *testing.T) {
+	server, snapshot := gh5042LabelServer(t, 10, nil, "open")
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:      42,
+		IssueNumber:   10,
+		TerminalLabel: github.LabelFailed,
+	}
+	c.notifyExternalClose(context.Background(), prState)
+
+	got := snapshot()
+	if !got[github.LabelFailed] {
+		t.Errorf("expected %s applied, got=%v", github.LabelFailed, got)
+	}
+	if !got[github.LabelFailedRetry1] {
+		t.Errorf("expected ladder to advance to %s in the same mutation, got=%v", github.LabelFailedRetry1, got)
+	}
+}
+
+// TestNotifyExternalClose_LadderAdvancesPastExistingRung covers the
+// repeated-failure case: an issue already sitting at pilot-failed-retry-1
+// (from an earlier failure cycle, pilot-failed since cleared for the
+// retry) whose PR closes again with TerminalLabel=pilot-failed must
+// advance the rung to pilot-failed-retry-2 and shed retry-1, in the same
+// mutation as the pilot-failed stamp.
+func TestNotifyExternalClose_LadderAdvancesPastExistingRung(t *testing.T) {
+	server, snapshot := gh5042LabelServer(t, 10, []string{github.LabelFailedRetry1}, "open")
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:      42,
+		IssueNumber:   10,
+		TerminalLabel: github.LabelFailed,
+	}
+	c.notifyExternalClose(context.Background(), prState)
+
+	got := snapshot()
+	if !got[github.LabelFailed] {
+		t.Errorf("expected %s applied, got=%v", github.LabelFailed, got)
+	}
+	if !got[github.LabelFailedRetry2] {
+		t.Errorf("expected ladder to advance to %s, got=%v", github.LabelFailedRetry2, got)
+	}
+	if got[github.LabelFailedRetry1] {
+		t.Errorf("expected superseded rung %s removed, got=%v", github.LabelFailedRetry1, got)
+	}
+}
+
+// TestNotifyExternalClose_ExhaustionOutranksCloseSupersedesHold covers the
+// GH-5099 precedence rule: "exhaustion outranks close-supersedes-hold".
+// GH-5042 made notifyExternalClose's default retry-ready resolution strip
+// pilot-needs-human unconditionally (a close always supersedes a hold) —
+// but an issue already parked at pilot-failed-retry-exhausted
+// (bda03368/GH-5079) has a spent retry budget, not merely a paused one. A
+// stale PR (opened before that parking) closing without merge must leave
+// the issue's labels untouched: pilot-needs-human stays, pilot-retry-ready
+// is never added.
+func TestNotifyExternalClose_ExhaustionOutranksCloseSupersedesHold(t *testing.T) {
+	initial := []string{labelNeedsHuman, github.LabelFailedRetryExhausted}
+	server, snapshot := gh5042LabelServer(t, 10, initial, "open")
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	// No TerminalLabel set: this is the stale-PR-close path resolving to
+	// the default pilot-retry-ready outcome, not a fresh terminal failure.
+	prState := &PRState{PRNumber: 42, IssueNumber: 10, Error: "stale PR closed without merging"}
+	c.notifyExternalClose(context.Background(), prState)
+
+	got := snapshot()
+	if !got[labelNeedsHuman] {
+		t.Errorf("expected %s to remain (exhaustion outranks close-supersedes-hold), got=%v", labelNeedsHuman, got)
+	}
+	if got[github.LabelRetryReady] {
+		t.Errorf("expected %s NOT added on an exhausted+parked issue, got=%v", github.LabelRetryReady, got)
+	}
+	if !got[github.LabelFailedRetryExhausted] {
+		t.Errorf("expected %s to remain untouched, got=%v", github.LabelFailedRetryExhausted, got)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5099.

Closes #5099

## Changes

GitHub Issue GH-5099: fix(autopilot): advance retry ladder on TerminalLabel + preserve park on exha...

<!--autopilot-meta
parent: GH-5088
inherited-spec: true
-->

Parent: GH-5088

Two changes in internal/autopilot/controller.go. (a) At the close path where TerminalLabel = github.LabelFailed is applied via mutateIssueLabels (~:9105), call the shared helper from subtask 1 so pilot-failed and the rung advance happen in the same mutation. (b) In the PR-close handler that currently strips pilot-needs-human and can add pilot-retry-ready + pilot, gate those mutations on the absence of pilot-failed-retry-exhausted: when the exhausted label is present, do not strip pilot-needs-human and do not add pilot-retry-ready. Document the precedence rule inline ("exhaustion outranks close-supersedes-hold"). Add tests: ladder advances on autopilot terminal close; exhausted+parked issue whose stale PR closes has labels unchanged (needs-human present, retry-ready absent). Use the existing autopilot httptest/argv-log idiom.

## Scope fence

Implement ONLY the slice described above. The parent issue GH-5088 is decomposed
into sibling sub-issues that cover the rest of its spec — consult the parent
for context, but do NOT implement parts of it that fall outside this subtask.