### PR TITLE
GH-5104: chore(deps): bump studio-sdk pin v0.35.2 → v0.36.0 — workspace-label fallback, team-UUID CreateLabel, multi-workspace polling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/qf-studio/grom v0.2.0
-	github.com/qf-studio/studio-sdk v0.35.2
+	github.com/qf-studio/studio-sdk v0.36.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2
 	github.com/wailsapp/wails/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/qf-studio/grom v0.2.0 h1:EefLLr794KGk8ihdpKBgJnmSyUc//b/n8zZ77VbeuXY=
 github.com/qf-studio/grom v0.2.0/go.mod h1:YVihqE0treA2091TLNhGWvGi5+vMYv/ZBlAlX7Mr/JI=
-github.com/qf-studio/studio-sdk v0.35.2 h1:ela9pIg9oV3QQywwBhDD9+x1zE+miBqcDg/8wwV6PXc=
-github.com/qf-studio/studio-sdk v0.35.2/go.mod h1:M/uFBeXsPAtsrO7wiIgE/GgWzfw80ftW6BrQUIOwxUM=
+github.com/qf-studio/studio-sdk v0.36.0 h1:1AVe+SSZjEPXzmBuVfK8+sVpD9Txyi71ESHkNU3dnF4=
+github.com/qf-studio/studio-sdk v0.36.0/go.mod h1:M/uFBeXsPAtsrO7wiIgE/GgWzfw80ftW6BrQUIOwxUM=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5104.

Closes #5104

## Changes

GitHub Issue GH-5104: chore(deps): bump studio-sdk pin v0.35.2 → v0.36.0 — workspace-label fallback, team-UUID CreateLabel, multi-workspace polling

## Task

Bump `github.com/qf-studio/studio-sdk` from **v0.35.2 → v0.36.0** in go.mod/go.sum.

## What v0.36.0 carries (all external-contributor linear fixes, reviewed + merged 2026-08-21)

- sdk PR#115 — `GetLabelByName` falls back to workspace-scoped labels (fixes the poller startup death on Linear's default label scope; sdk#114).
- sdk PR#116 — `CreateLabel` resolves team key → UUID before `issueLabelCreate` (fixes label auto-creation failing everywhere; sdk#113).
- sdk PR#129 — every configured Linear workspace gets its own poller (multi-workspace configs previously silently polled only the first; sdk#128).

## Acceptance Criteria

- [ ] Pin exactly v0.36.0 (the tag), not a pseudo-version.
- [ ] `go build ./... && go test ./...` green — pay attention to `cmd/pilot/poller_linear.go` and any linear-adapter seams (the two-parallel-clients pitfall: the production poller runs the SDK client).
- [ ] No code changes beyond go.mod/go.sum unless a compile break forces one; if forced, state it in the PR body.

## Refs

sdk v0.36.0 tag · pilot#4889 (future preflight work builds on these helpers) · pitfall `jira-two-parallel-clients-poller-is-sdk`