### PR TITLE
GH-5092: feat(pilot-poller): wire Linear label preflight at startup with per-label rem...

### DIFF
--- a/cmd/pilot/poller_linear.go
+++ b/cmd/pilot/poller_linear.go
@@ -13,6 +13,68 @@ import (
 	"github.com/qf-studio/pilot/internal/logging"
 )
 
+// linearStatusLabels are the pilot-* labels the SDK poller creates/uses for
+// lifecycle tracking (see studio-sdk's Poller.cacheLabelIDs). They degrade to
+// Warn-and-continue mid-poll if misconfigured, unlike the trigger label.
+var linearStatusLabels = []string{"pilot-in-progress", "pilot-done", "pilot-failed"}
+
+// linearLabelClassifier abstracts studio-sdk's *linear.Client.ClassifyLabel
+// so the preflight can be exercised with a stub in tests.
+type linearLabelClassifier interface {
+	ClassifyLabel(ctx context.Context, teamRef, labelName string) (*linearSDK.LabelClassificationResult, error)
+}
+
+// preflightLinearLabels classifies the trigger label and every pilot-*
+// status label for one workspace, once at poller startup, and logs a line
+// for any label that isn't cleanly team-scoped (GH-5092).
+//
+// The trigger label is logged at Error, immediately above the existing
+// startup-death log that fires when the SDK poller's own GetLabelByName
+// check fails inside Start() — this preflight does not change that failure
+// path, it only names the remedy ahead of it. Status labels are logged at
+// Warn, since they already degrade to Warn-and-continue mid-poll; the
+// startup line just explains why before the poll loop begins.
+//
+// If the classification call itself errors (network/API failure), that is
+// logged at Warn and the label is skipped — the preflight must never block
+// startup on its own failure.
+func preflightLinearLabels(ctx context.Context, log *slog.Logger, classifier linearLabelClassifier, teamRef, triggerLabel string, statusLabels []string) {
+	classify := func(label string, isTrigger bool) {
+		result, err := classifier.ClassifyLabel(ctx, teamRef, label)
+		if err != nil {
+			log.Warn("Linear label preflight: classification call failed, skipping",
+				slog.String("label", label),
+				slog.Any("error", err),
+			)
+			return
+		}
+
+		if result.Classification == linearSDK.LabelTeamScoped {
+			return
+		}
+
+		if isTrigger {
+			log.Error("Linear trigger label is not team-scoped; poller startup will fail",
+				slog.String("label", label),
+				slog.String("classification", string(result.Classification)),
+				slog.String("remedy", result.Remedy),
+			)
+			return
+		}
+
+		log.Warn("Linear status label is not team-scoped; label will fail mid-poll",
+			slog.String("label", label),
+			slog.String("classification", string(result.Classification)),
+			slog.String("remedy", result.Remedy),
+		)
+	}
+
+	classify(triggerLabel, true)
+	for _, label := range statusLabels {
+		classify(label, false)
+	}
+}
+
 func newSDKLinearWorkspace(name, apiKey, teamID, triggerLabel string, projectIDs, projects []string, interval time.Duration) *linearSDK.WorkspaceConfig {
 	return &linearSDK.WorkspaceConfig{
 		Name:         name,
@@ -59,6 +121,12 @@ func linearPollerRegistration() PollerRegistration {
 				if ws.Polling != nil && ws.Polling.Interval > 0 {
 					wsInterval = ws.Polling.Interval
 				}
+
+				// GH-5092: classify the trigger label and every pilot-*
+				// status label once at startup, before the SDK poller's
+				// own (opaque) label lookups run.
+				preflightLinearLabels(ctx, logging.WithComponent("linear"), linearSDK.NewClient(ws.APIKey), ws.TeamID, triggerLabel, linearStatusLabels)
+
 				sdkWorkspaces = append(sdkWorkspaces, newSDKLinearWorkspace(ws.Name, ws.APIKey, ws.TeamID, triggerLabel, ws.ProjectIDs, ws.Projects, wsInterval))
 				notifiersByTeamID[ws.TeamID] = linearSDK.NewNotifier(linearSDK.NewClient(ws.APIKey))
 			}

--- a/cmd/pilot/poller_linear_preflight_gh5092_test.go
+++ b/cmd/pilot/poller_linear_preflight_gh5092_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	linearSDK "github.com/qf-studio/studio-sdk/sdk/integrations/linear"
+)
+
+// stubLinearClassifier is a fake linearLabelClassifier that returns
+// per-label results (or an error) from a caller-supplied map, so tests can
+// drive preflightLinearLabels without a live Linear API.
+type stubLinearClassifier struct {
+	results map[string]*linearSDK.LabelClassificationResult
+	errs    map[string]error
+}
+
+func (s *stubLinearClassifier) ClassifyLabel(_ context.Context, _, labelName string) (*linearSDK.LabelClassificationResult, error) {
+	if err, ok := s.errs[labelName]; ok {
+		return nil, err
+	}
+	if result, ok := s.results[labelName]; ok {
+		return result, nil
+	}
+	return &linearSDK.LabelClassificationResult{Classification: linearSDK.LabelTeamScoped}, nil
+}
+
+func newTestLogger(buf *strings.Builder) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+}
+
+// TestPreflightLinearLabels_TriggerMisconfigured verifies a misconfigured
+// trigger label produces the classified startup ERROR line — the trigger
+// label still fails closed, but the remedy is now logged immediately above
+// that failure (GH-5092).
+func TestPreflightLinearLabels_TriggerMisconfigured(t *testing.T) {
+	var buf strings.Builder
+	classifier := &stubLinearClassifier{
+		results: map[string]*linearSDK.LabelClassificationResult{
+			"pilot": {
+				Classification: linearSDK.LabelWorkspaceScoped,
+				Remedy:         `label "pilot" is workspace-scoped (scope is immutable in Linear) — delete & recreate team-scoped under ENG`,
+			},
+		},
+	}
+
+	preflightLinearLabels(context.Background(), newTestLogger(&buf), classifier, "ENG", "pilot", nil)
+
+	logged := buf.String()
+	if !strings.Contains(logged, "level=ERROR") {
+		t.Errorf("expected an ERROR line for the misconfigured trigger label, got: %s", logged)
+	}
+	if !strings.Contains(logged, "label=pilot") {
+		t.Errorf("expected the log line to name the label, got: %s", logged)
+	}
+	if !strings.Contains(logged, "workspace_scoped") {
+		t.Errorf("expected the log line to name the classification, got: %s", logged)
+	}
+	if !strings.Contains(logged, "delete & recreate team-scoped") {
+		t.Errorf("expected the log line to carry the SDK remedy, got: %s", logged)
+	}
+}
+
+// TestPreflightLinearLabels_StatusLabelMisconfigured verifies a
+// misconfigured status label produces a startup WARN line naming the
+// remedy, ahead of the mid-poll Warn-and-continue degradation it already
+// has (GH-5092).
+func TestPreflightLinearLabels_StatusLabelMisconfigured(t *testing.T) {
+	var buf strings.Builder
+	classifier := &stubLinearClassifier{
+		results: map[string]*linearSDK.LabelClassificationResult{
+			"pilot-failed": {
+				Classification: linearSDK.LabelAnotherTeam,
+				Remedy:         `label "pilot-failed" belongs to team Engineering — move or rename it, or create a separate label under ENG`,
+			},
+		},
+	}
+
+	preflightLinearLabels(context.Background(), newTestLogger(&buf), classifier, "ENG", "pilot", []string{"pilot-in-progress", "pilot-done", "pilot-failed"})
+
+	logged := buf.String()
+	if strings.Contains(logged, "level=ERROR") {
+		t.Errorf("status label misconfiguration must not be logged at ERROR (only the trigger label fails closed), got: %s", logged)
+	}
+	if !strings.Contains(logged, "level=WARN") {
+		t.Errorf("expected a WARN line for the misconfigured status label, got: %s", logged)
+	}
+	if !strings.Contains(logged, "label=pilot-failed") {
+		t.Errorf("expected the log line to name the label, got: %s", logged)
+	}
+	if !strings.Contains(logged, "another_team") {
+		t.Errorf("expected the log line to name the classification, got: %s", logged)
+	}
+	if !strings.Contains(logged, "belongs to team Engineering") {
+		t.Errorf("expected the log line to carry the SDK remedy, got: %s", logged)
+	}
+}
+
+// TestPreflightLinearLabels_ClassifierErrorLogsWarnAndContinues verifies
+// that a classification-call failure (network/API error) is logged at WARN
+// and does not block the remaining labels or panic — the preflight must
+// never block startup on its own failure (GH-5092).
+func TestPreflightLinearLabels_ClassifierErrorLogsWarnAndContinues(t *testing.T) {
+	var buf strings.Builder
+	classifier := &stubLinearClassifier{
+		errs: map[string]error{
+			"pilot": errors.New("linear API: 500 internal server error"),
+		},
+		results: map[string]*linearSDK.LabelClassificationResult{
+			"pilot-done": {
+				Classification: linearSDK.LabelMissing,
+				Remedy:         `label "pilot-done" does not exist — create it under team ENG`,
+			},
+		},
+	}
+
+	preflightLinearLabels(context.Background(), newTestLogger(&buf), classifier, "ENG", "pilot", []string{"pilot-done"})
+
+	logged := buf.String()
+	if strings.Contains(logged, "level=ERROR") {
+		t.Errorf("a classifier error must never escalate to ERROR/fail closed, got: %s", logged)
+	}
+	if !strings.Contains(logged, "level=WARN") {
+		t.Errorf("expected a WARN line for the classifier error, got: %s", logged)
+	}
+	if !strings.Contains(logged, "label=pilot") {
+		t.Errorf("expected the error WARN line to name the label, got: %s", logged)
+	}
+	// The remaining status label must still be classified — one label's
+	// classifier error must not abort the rest of the preflight.
+	if !strings.Contains(logged, "label=pilot-done") {
+		t.Errorf("expected classification to continue for subsequent labels after an error, got: %s", logged)
+	}
+	if !strings.Contains(logged, "does not exist") {
+		t.Errorf("expected the subsequent label's remedy to still be logged, got: %s", logged)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5092.

Closes #5092

## Changes

GitHub Issue GH-5092: feat(pilot-poller): wire Linear label preflight at startup with per-label rem...

<!--autopilot-meta
parent: GH-4889
inherited-spec: true
-->

Parent: GH-4889

In cmd/pilot/poller_linear.go, call the new SDK classifier once at poller startup for each configured workspace, iterating the trigger label and every pilot-* status label. For each label that isn't cleanly team-scoped, log one line at the appropriate level naming the label, the classification, and the specific remedy from the SDK result. Preserve existing runtime behavior: the trigger label still fails closed (startup dies if the trigger label is unusable, but now with the classified remedy in the log immediately above), status labels still degrade to Warn-and-continue mid-poll (but the startup line now names why each one will fail before the poll loop begins). If the classification call itself errors (network/API failure), log WARN and continue — the preflight must never block startup on its own failure. Add a focused test in cmd/pilot/ that stubs the SDK classifier and asserts: (a) misconfigured trigger label produces the classified startup error, (b) misconfigured status label produces a startup WARN line naming the remedy, (c) SDK error path logs WARN and startup continues. Run make lint && make test to close.

## Scope fence

Implement ONLY the slice described above. The parent issue GH-4889 is decomposed
into sibling sub-issues that cover the rest of its spec — consult the parent
for context, but do NOT implement parts of it that fall outside this subtask.