### PR TITLE
GH-5114: test(retryladder): pin label constants across packages via external equality test

### DIFF
--- a/internal/adapters/github/labelfailed_constants_test.go
+++ b/internal/adapters/github/labelfailed_constants_test.go
@@ -1,0 +1,38 @@
+package github_test
+
+// GH-5114 (GH-5100 addendum item 3): internal/retryladder intentionally
+// duplicates the pilot-failed-retry-N label constants from
+// internal/adapters/github/types.go:140,159-161 (see retryladder.go's
+// package doc for why — it's a leaf package importable from
+// internal/executor without an import cycle). This test guards that
+// duplication: if either copy drifts, retry-ladder label mutations and the
+// GitHub adapter's own label set would silently diverge.
+
+import (
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/retryladder"
+)
+
+func TestRetryLadderLabelConstants_MatchGitHubAdapter(t *testing.T) {
+	cases := []struct {
+		name        string
+		ladderValue string
+		githubValue string
+	}{
+		{"LabelFailed", retryladder.LabelFailed, github.LabelFailed},
+		{"LabelFailedRetry1", retryladder.LabelFailedRetry1, github.LabelFailedRetry1},
+		{"LabelFailedRetry2", retryladder.LabelFailedRetry2, github.LabelFailedRetry2},
+		{"LabelFailedRetryExhausted", retryladder.LabelFailedRetryExhausted, github.LabelFailedRetryExhausted},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.ladderValue != tc.githubValue {
+				t.Errorf("retryladder.%s = %q, github.%s = %q; duplicated constants have drifted",
+					tc.name, tc.ladderValue, tc.name, tc.githubValue)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5114.

Closes #5114

## Changes

Add a `_test` package test (e.g. under `internal/adapters/github/` or a neutral consumer package that already imports both) that imports both `internal/retryladder` and the second package holding the duplicated `LabelFailed*` constants (types.go:159-161). Assert `retryladder.LabelFailed == LabelFailed`, `retryladder.LabelFailedRetry1 == LabelFailedRetry1`, `retryladder.LabelFailedRetry2 == LabelFailedRetry2`, and `retryladder.LabelFailedRetryExhausted == LabelFailedRetryExhausted`. Verify by locally mutating one constant that the test fails, then revert. Delivers GH-5100 addendum item 3. Scope is one new test file; no production code changes.