### PR TITLE
GH-5115: fix(autopilot): preserve pilot-needs-human on exhausted-parked issue across ALL terminal close resolutions

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -9304,7 +9304,23 @@ func (c *Controller) notifyExternalClose(ctx context.Context, prState *PRState) 
 			// for it to hold). Strip pilot-needs-human/needs-manual-rebase
 			// here unconditionally, mirroring escalateAndHold's reverse
 			// direction (needs-human supersedes retry-ready).
-			removeLabels := []string{github.LabelInProgress, labelNeedsHuman, labelNeedsManualRebase}
+			removeLabels := []string{github.LabelInProgress, labelNeedsManualRebase}
+			// GH-5115: broaden GH-5099's exhaustion-outranks-close-supersedes-hold
+			// rule (see exhaustedParked above, which only covers the
+			// issueLabel == LabelRetryReady resolution and fully skips this
+			// whole block) to every close resolution that still reaches here,
+			// including a TerminalLabel-driven close (pilot-failed/
+			// pilot-superseded/etc). An issue already parked at
+			// pilot-failed-retry-exhausted is a stronger signal than an
+			// ordinary hold no matter what this particular stale PR's close
+			// resolves to: pilot-needs-human must stay standing so the issue
+			// doesn't silently un-park. pilot-in-progress still clears
+			// unconditionally above so the issue doesn't render as stuck
+			// mid-execution.
+			exhaustedLabelPresent := err == nil && issue != nil && github.HasLabel(issue, github.LabelFailedRetryExhausted)
+			if !exhaustedLabelPresent {
+				removeLabels = append(removeLabels, labelNeedsHuman)
+			}
 			if issueLabel != github.LabelFailed {
 				// Remove stale pilot-failed label (GH-1302 gap) — only when we're not
 				// the ones setting it above.

--- a/internal/autopilot/gh5115_test.go
+++ b/internal/autopilot/gh5115_test.go
@@ -1,0 +1,58 @@
+package autopilot
+
+import (
+	"context"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GH-5115: broadens GH-5099's "exhaustion outranks close-supersedes-hold"
+// rule (gh5099_test.go's TestNotifyExternalClose_ExhaustionOutranksCloseSupersedesHold)
+// from the default pilot-retry-ready resolution to every close resolution
+// notifyExternalClose can reach, including a TerminalLabel-driven close
+// (pilot-failed/pilot-superseded/etc). An issue already parked at
+// pilot-failed-retry-exhausted must keep pilot-needs-human standing no
+// matter which resolution this particular stale PR's close maps to — only
+// pilot-in-progress still clears, so the issue doesn't render as stuck
+// mid-execution. Reuses the gh5042LabelServer httptest idiom (gh5042_test.go).
+func TestNotifyExternalClose_ExhaustionOutranksTerminalLabelClose(t *testing.T) {
+	tests := []struct {
+		name          string
+		terminalLabel string
+	}{
+		{name: "failed resolution", terminalLabel: github.LabelFailed},
+		{name: "superseded resolution", terminalLabel: github.LabelSuperseded},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initial := []string{labelNeedsHuman, github.LabelFailedRetryExhausted, github.LabelInProgress}
+			server, snapshot := gh5042LabelServer(t, 10, initial, "open")
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+			prState := &PRState{
+				PRNumber:      42,
+				IssueNumber:   10,
+				TerminalLabel: tt.terminalLabel,
+			}
+			c.notifyExternalClose(context.Background(), prState)
+
+			got := snapshot()
+			if !got[labelNeedsHuman] {
+				t.Errorf("expected %s to remain (exhaustion outranks close-supersedes-hold), got=%v", labelNeedsHuman, got)
+			}
+			if got[github.LabelInProgress] {
+				t.Errorf("expected %s cleared even though %s was suppressed, got=%v", github.LabelInProgress, labelNeedsHuman, got)
+			}
+			if !got[github.LabelFailedRetryExhausted] {
+				t.Errorf("expected %s rung label to remain untouched, got=%v", github.LabelFailedRetryExhausted, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5115.

Closes #5115

## Changes

In `internal/autopilot/controller.go` `notifyExternalClose` (~line 9280), broaden the existing narrow gate to adopt the stricter form from closed PR#5103: when `pilot-failed-retry-exhausted` is present on the issue, suppress the `pilot-needs-human` strip for every close resolution (not just retry-ready), while still clearing `pilot-in-progress`. Leave the existing `exhaustedParked` full-skip path for the retry-ready case unchanged. Add table-driven tests in the autopilot `_test` package covering TerminalLabel-driven close for both `failed` and `superseded` resolutions on an exhausted+parked issue: assert `pilot-needs-human` retained, `pilot-in-progress` cleared, rung labels intact. Confirm existing `gh5099` tests remain green. Run `go test ./internal/autopilot/...` to verify.