### PR TITLE
GH-5118: fix(pilot-poller): preflight messages narrate pre-v0.36.0 failure modes — condition severity/remedy on classification (PR#5113 residual)

### DIFF
--- a/cmd/pilot/poller_linear.go
+++ b/cmd/pilot/poller_linear.go
@@ -28,12 +28,27 @@ type linearLabelClassifier interface {
 // status label for one workspace, once at poller startup, and logs a line
 // for any label that isn't cleanly team-scoped (GH-5092).
 //
-// The trigger label is logged at Error, immediately above the existing
-// startup-death log that fires when the SDK poller's own GetLabelByName
-// check fails inside Start() — this preflight does not change that failure
-// path, it only names the remedy ahead of it. Status labels are logged at
-// Warn, since they already degrade to Warn-and-continue mid-poll; the
-// startup line just explains why before the poll loop begins.
+// Message/severity matrix — pinned to studio-sdk v0.36.0's label-lookup
+// behavior (sdk/integrations/linear/client.go: GetLabelByName's workspace
+// fallback via getWorkspaceLabelByName, and GetOrCreateLabel's auto-create).
+// Re-derive this matrix against the new lookup code whenever the studio-sdk
+// pin moves — v0.35.2 and earlier had neither the workspace fallback nor
+// the auto-create, so a workspace-scoped trigger label was ERROR and a
+// missing status label was WARN under that version (GH-5118 follow-up to
+// PR#5113).
+//
+//	classification    | trigger label                    | status label
+//	------------------|-----------------------------------|------------------------------------
+//	team_scoped       | OK, silent                        | OK, silent
+//	workspace_scoped  | WARN — GetLabelByName's workspace  | WARN — GetOrCreateLabel resolves
+//	                  | fallback resolves it; still no     | it via the same fallback; still
+//	                  | team-scope precedence              | no team-scope precedence
+//	another_team      | ERROR — the fallback only matches  | WARN — GetLabelByName fails the
+//	                  | a label with a nil team, so this   | same way, so GetOrCreateLabel
+//	                  | never resolves; startup will fail  | falls through to CreateLabel and
+//	                  |                                     | mints a duplicate under this team
+//	missing           | ERROR — no label anywhere;         | INFO — GetOrCreateLabel
+//	                  | startup will fail                  | auto-creates it on first use
 //
 // If the classification call itself errors (network/API failure), that is
 // logged at Warn and the label is skipped — the preflight must never block
@@ -53,20 +68,29 @@ func preflightLinearLabels(ctx context.Context, log *slog.Logger, classifier lin
 			return
 		}
 
-		if isTrigger {
-			log.Error("Linear trigger label is not team-scoped; poller startup will fail",
-				slog.String("label", label),
-				slog.String("classification", string(result.Classification)),
-				slog.String("remedy", result.Remedy),
-			)
-			return
-		}
-
-		log.Warn("Linear status label is not team-scoped; label will fail mid-poll",
+		fields := []any{
 			slog.String("label", label),
 			slog.String("classification", string(result.Classification)),
 			slog.String("remedy", result.Remedy),
-		)
+		}
+
+		if isTrigger {
+			if result.Classification == linearSDK.LabelWorkspaceScoped {
+				log.Warn("Linear trigger label is workspace-scoped; resolves via workspace fallback but has no team-scope precedence", fields...)
+				return
+			}
+			log.Error("Linear trigger label is not team-scoped; poller startup will fail", fields...)
+			return
+		}
+
+		switch result.Classification {
+		case linearSDK.LabelMissing:
+			log.Info("Linear status label does not exist yet; will be auto-created on first use", fields...)
+		case linearSDK.LabelWorkspaceScoped:
+			log.Warn("Linear status label is workspace-scoped; resolves via workspace fallback but has no team-scope precedence", fields...)
+		default: // LabelAnotherTeam
+			log.Warn("Linear status label belongs to another team; a duplicate will be created under this team instead of reusing it", fields...)
+		}
 	}
 
 	classify(triggerLabel, true)

--- a/cmd/pilot/poller_linear_preflight_gh5092_test.go
+++ b/cmd/pilot/poller_linear_preflight_gh5092_test.go
@@ -32,11 +32,12 @@ func newTestLogger(buf *strings.Builder) *slog.Logger {
 	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
 }
 
-// TestPreflightLinearLabels_TriggerMisconfigured verifies a misconfigured
-// trigger label produces the classified startup ERROR line — the trigger
-// label still fails closed, but the remedy is now logged immediately above
-// that failure (GH-5092).
-func TestPreflightLinearLabels_TriggerMisconfigured(t *testing.T) {
+// TestPreflightLinearLabels_TriggerWorkspaceScoped verifies a
+// workspace-scoped trigger label logs a WARN, not an ERROR: v0.36.0's
+// GetLabelByName falls back to a workspace-scoped lookup
+// (getWorkspaceLabelByName), so this classification no longer fails
+// startup — it only loses team-scope precedence (GH-5118).
+func TestPreflightLinearLabels_TriggerWorkspaceScoped(t *testing.T) {
 	var buf strings.Builder
 	classifier := &stubLinearClassifier{
 		results: map[string]*linearSDK.LabelClassificationResult{
@@ -50,8 +51,11 @@ func TestPreflightLinearLabels_TriggerMisconfigured(t *testing.T) {
 	preflightLinearLabels(context.Background(), newTestLogger(&buf), classifier, "ENG", "pilot", nil)
 
 	logged := buf.String()
-	if !strings.Contains(logged, "level=ERROR") {
-		t.Errorf("expected an ERROR line for the misconfigured trigger label, got: %s", logged)
+	if strings.Contains(logged, "level=ERROR") {
+		t.Errorf("workspace-scoped trigger label must not be logged at ERROR (resolves via workspace fallback), got: %s", logged)
+	}
+	if !strings.Contains(logged, "level=WARN") {
+		t.Errorf("expected a WARN line for the workspace-scoped trigger label, got: %s", logged)
 	}
 	if !strings.Contains(logged, "label=pilot") {
 		t.Errorf("expected the log line to name the label, got: %s", logged)
@@ -64,38 +68,131 @@ func TestPreflightLinearLabels_TriggerMisconfigured(t *testing.T) {
 	}
 }
 
-// TestPreflightLinearLabels_StatusLabelMisconfigured verifies a
-// misconfigured status label produces a startup WARN line naming the
-// remedy, ahead of the mid-poll Warn-and-continue degradation it already
-// has (GH-5092).
-func TestPreflightLinearLabels_StatusLabelMisconfigured(t *testing.T) {
-	var buf strings.Builder
-	classifier := &stubLinearClassifier{
-		results: map[string]*linearSDK.LabelClassificationResult{
-			"pilot-failed": {
-				Classification: linearSDK.LabelAnotherTeam,
-				Remedy:         `label "pilot-failed" belongs to team Engineering — move or rename it, or create a separate label under ENG`,
-			},
+// TestPreflightLinearLabels_TriggerMisconfigured verifies a trigger label
+// owned by another team or missing entirely still produces the classified
+// startup ERROR line — those classifications still fail closed under
+// v0.36.0, since GetLabelByName's workspace fallback only matches a label
+// with a nil team (GH-5092, GH-5118).
+func TestPreflightLinearLabels_TriggerMisconfigured(t *testing.T) {
+	tests := []struct {
+		name           string
+		classification linearSDK.LabelClassification
+		remedy         string
+		wantSubstr     string
+	}{
+		{
+			name:           "another_team",
+			classification: linearSDK.LabelAnotherTeam,
+			remedy:         `label "pilot" belongs to team Engineering — move or rename it, or create a separate label under ENG`,
+			wantSubstr:     "belongs to team Engineering",
+		},
+		{
+			name:           "missing",
+			classification: linearSDK.LabelMissing,
+			remedy:         `label "pilot" does not exist — create it under team ENG`,
+			wantSubstr:     "does not exist",
 		},
 	}
 
-	preflightLinearLabels(context.Background(), newTestLogger(&buf), classifier, "ENG", "pilot", []string{"pilot-in-progress", "pilot-done", "pilot-failed"})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf strings.Builder
+			classifier := &stubLinearClassifier{
+				results: map[string]*linearSDK.LabelClassificationResult{
+					"pilot": {
+						Classification: tt.classification,
+						Remedy:         tt.remedy,
+					},
+				},
+			}
 
-	logged := buf.String()
-	if strings.Contains(logged, "level=ERROR") {
-		t.Errorf("status label misconfiguration must not be logged at ERROR (only the trigger label fails closed), got: %s", logged)
+			preflightLinearLabels(context.Background(), newTestLogger(&buf), classifier, "ENG", "pilot", nil)
+
+			logged := buf.String()
+			if !strings.Contains(logged, "level=ERROR") {
+				t.Errorf("expected an ERROR line for the misconfigured trigger label, got: %s", logged)
+			}
+			if !strings.Contains(logged, "label=pilot") {
+				t.Errorf("expected the log line to name the label, got: %s", logged)
+			}
+			if !strings.Contains(logged, string(tt.classification)) {
+				t.Errorf("expected the log line to name the classification, got: %s", logged)
+			}
+			if !strings.Contains(logged, tt.wantSubstr) {
+				t.Errorf("expected the log line to carry the SDK remedy, got: %s", logged)
+			}
+		})
 	}
-	if !strings.Contains(logged, "level=WARN") {
-		t.Errorf("expected a WARN line for the misconfigured status label, got: %s", logged)
+}
+
+// TestPreflightLinearLabels_StatusLabelMisconfigured verifies status label
+// classifications produce the right severity/message under v0.36.0's
+// GetOrCreateLabel: a missing label is auto-created (INFO), while
+// workspace-scoped or another-team labels still warrant a WARN — but with
+// text describing what GetOrCreateLabel actually does, not the pre-v0.36.0
+// "will fail mid-poll" claim (GH-5092, GH-5118).
+func TestPreflightLinearLabels_StatusLabelMisconfigured(t *testing.T) {
+	tests := []struct {
+		name           string
+		classification linearSDK.LabelClassification
+		remedy         string
+		wantLevel      string
+		wantSubstr     string
+	}{
+		{
+			name:           "another_team",
+			classification: linearSDK.LabelAnotherTeam,
+			remedy:         `label "pilot-failed" belongs to team Engineering — move or rename it, or create a separate label under ENG`,
+			wantLevel:      "level=WARN",
+			wantSubstr:     "belongs to team Engineering",
+		},
+		{
+			name:           "workspace_scoped",
+			classification: linearSDK.LabelWorkspaceScoped,
+			remedy:         `label "pilot-failed" is workspace-scoped (scope is immutable in Linear) — delete & recreate team-scoped under ENG`,
+			wantLevel:      "level=WARN",
+			wantSubstr:     "delete & recreate team-scoped",
+		},
+		{
+			name:           "missing",
+			classification: linearSDK.LabelMissing,
+			remedy:         `label "pilot-failed" does not exist — create it under team ENG`,
+			wantLevel:      "level=INFO",
+			wantSubstr:     "does not exist",
+		},
 	}
-	if !strings.Contains(logged, "label=pilot-failed") {
-		t.Errorf("expected the log line to name the label, got: %s", logged)
-	}
-	if !strings.Contains(logged, "another_team") {
-		t.Errorf("expected the log line to name the classification, got: %s", logged)
-	}
-	if !strings.Contains(logged, "belongs to team Engineering") {
-		t.Errorf("expected the log line to carry the SDK remedy, got: %s", logged)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf strings.Builder
+			classifier := &stubLinearClassifier{
+				results: map[string]*linearSDK.LabelClassificationResult{
+					"pilot-failed": {
+						Classification: tt.classification,
+						Remedy:         tt.remedy,
+					},
+				},
+			}
+
+			preflightLinearLabels(context.Background(), newTestLogger(&buf), classifier, "ENG", "pilot", []string{"pilot-in-progress", "pilot-done", "pilot-failed"})
+
+			logged := buf.String()
+			if strings.Contains(logged, "level=ERROR") {
+				t.Errorf("status label misconfiguration must not be logged at ERROR (only the trigger label fails closed), got: %s", logged)
+			}
+			if !strings.Contains(logged, tt.wantLevel) {
+				t.Errorf("expected a %s line for the %s status label, got: %s", tt.wantLevel, tt.name, logged)
+			}
+			if !strings.Contains(logged, "label=pilot-failed") {
+				t.Errorf("expected the log line to name the label, got: %s", logged)
+			}
+			if !strings.Contains(logged, string(tt.classification)) {
+				t.Errorf("expected the log line to name the classification, got: %s", logged)
+			}
+			if !strings.Contains(logged, tt.wantSubstr) {
+				t.Errorf("expected the log line to carry the SDK remedy, got: %s", logged)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5118.

Closes #5118

## Changes

GitHub Issue GH-5118: fix(pilot-poller): preflight messages narrate pre-v0.36.0 failure modes — condition severity/remedy on classification (PR#5113 residual)

## Summary

PR#5113's preflight messages narrate v0.35.2-era failure modes, but the v0.36.0 pin (merged the same day) changed them: `GetLabelByName` now falls back to workspace-scoped labels, so a **workspace-scoped trigger label no longer kills startup** — yet the preflight logs ERROR "poller startup will fail" for exactly that classification. And `missing` status labels are **auto-created** by `GetOrCreateLabel`, yet the WARN says "label will fail mid-poll".

## Fix

In `cmd/pilot/poller_linear.go` (~:57-69), condition message text and severity on classification against v0.36.0 semantics:
- Trigger label: `workspace_scoped` → INFO/WARN "works via workspace fallback; consider a team-scoped label for precedence clarity" (not ERROR); `another_team`/`missing` → keep ERROR "startup will fail" (still true).
- Status labels: `missing` → INFO "will be auto-created on first use"; `workspace_scoped`/`another_team` → keep WARN with accurate consequence.
State the message matrix in a comment tied to the sdk version so the next pin bump revisits it.

## Acceptance Criteria

- [ ] Message/severity matrix matches v0.36.0 behavior for all 4 classifications × (trigger|status); tests updated per case (stub-classifier idiom).
- [ ] No control-flow change — preflight stays log-only.
- [ ] `go test ./cmd/pilot/...` green.

## Refs

PR#5113 review comment (follow-up 1) · sdk v0.36.0 fallback (`getWorkspaceLabelByName`) + `GetOrCreateLabel`