### PR TITLE
feat(telegram): reply in the forum topic a message arrived from

### DIFF
--- a/docs/content/integrations/telegram.mdx
+++ b/docs/content/integrations/telegram.mdx
@@ -92,6 +92,18 @@ Approval prompts addressed to an individual approver (where `approvers[0]` is a
 chat ID) go to that chat directly and ignore this setting. Alert channels take
 their own `message_thread_id` — see [Alerts](/features/alerts).
 
+### Replies follow the conversation
+
+Replies to a message you sent — answers, plans, task confirmations, results —
+go back to the topic that message came from, whichever topic that is.
+`message_thread_id` is the default for messages Pilot starts on its own (task
+lifecycle notifications and alerts), not a ceiling on where replies can go.
+
+Messages sent in a forum's General thread are answered in General. In a
+supergroup *without* Topics enabled, replies are unaffected — the Bot API only
+accepts a topic for forum supergroups, so Pilot deliberately ignores the thread
+id of an ordinary reply chain rather than sending one that would be rejected.
+
 ## Chat Modes
 
 Pilot automatically detects your intent and responds in one of five modes:

--- a/internal/adapters/telegram/client.go
+++ b/internal/adapters/telegram/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 )
 
@@ -95,14 +96,23 @@ type InlineKeyboardButton struct {
 
 // Message represents a Telegram message
 type Message struct {
-	MessageID int64        `json:"message_id"`
-	From      *User        `json:"from,omitempty"`
-	Chat      *Chat        `json:"chat"`
-	Date      int64        `json:"date"`
-	Text      string       `json:"text,omitempty"`
-	Photo     []*PhotoSize `json:"photo,omitempty"`
-	Voice     *Voice       `json:"voice,omitempty"`
-	Caption   string       `json:"caption,omitempty"`
+	MessageID       int64        `json:"message_id"`
+	MessageThreadID int64        `json:"message_thread_id,omitempty"`
+	IsTopicMessage  bool         `json:"is_topic_message,omitempty"`
+	From            *User        `json:"from,omitempty"`
+	Chat            *Chat        `json:"chat"`
+	Date            int64        `json:"date"`
+	Text            string       `json:"text,omitempty"`
+	Photo           []*PhotoSize `json:"photo,omitempty"`
+	Voice           *Voice       `json:"voice,omitempty"`
+	Caption         string       `json:"caption,omitempty"`
+}
+
+func (m *Message) topicThreadID() string {
+	if m == nil || !m.IsTopicMessage || m.MessageThreadID == 0 {
+		return ""
+	}
+	return strconv.FormatInt(m.MessageThreadID, 10)
 }
 
 // Voice represents a voice message

--- a/internal/adapters/telegram/client_test.go
+++ b/internal/adapters/telegram/client_test.go
@@ -730,3 +730,64 @@ func TestClientSendsMessageThreadID(t *testing.T) {
 		})
 	}
 }
+
+func TestMessageTopicThreadID(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  *Message
+		want string
+	}{
+		{
+			name: "forum topic message",
+			msg:  &Message{MessageThreadID: 42, IsTopicMessage: true},
+			want: "42",
+		},
+		{
+			name: "General thread in a forum carries no topic",
+			msg:  &Message{},
+			want: "",
+		},
+		{
+			name: "supergroup reply chain is not a forum topic",
+			msg:  &Message{MessageThreadID: 42},
+			want: "",
+		},
+		{
+			name: "flagged topic without an id",
+			msg:  &Message{IsTopicMessage: true},
+			want: "",
+		},
+		{
+			name: "nil message",
+			msg:  nil,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.msg.topicThreadID(); got != tt.want {
+				t.Errorf("topicThreadID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMessageUnmarshalsTopicFields(t *testing.T) {
+	raw := `{"message_id":7,"message_thread_id":42,"is_topic_message":true,"chat":{"id":-100123,"type":"supergroup"},"text":"hi"}`
+
+	var msg Message
+	if err := json.Unmarshal([]byte(raw), &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if msg.MessageThreadID != 42 {
+		t.Errorf("MessageThreadID = %d, want 42", msg.MessageThreadID)
+	}
+	if !msg.IsTopicMessage {
+		t.Error("IsTopicMessage = false, want true")
+	}
+	if got := msg.topicThreadID(); got != "42" {
+		t.Errorf("topicThreadID() = %q, want %q", got, "42")
+	}
+}

--- a/internal/adapters/telegram/handler.go
+++ b/internal/adapters/telegram/handler.go
@@ -393,6 +393,7 @@ func (h *Handler) processUpdate(ctx context.Context, update *Update) {
 			SenderID:   senderID,
 			SenderName: senderName,
 			Text:       text,
+			ThreadID:   msg.topicThreadID(),
 			Platform:   "telegram",
 			Timestamp:  time.Now(),
 		})
@@ -421,6 +422,7 @@ func (h *Handler) handleCallback(ctx context.Context, callback *CallbackQuery) {
 			h.commsHandler.HandleMessage(ctx, &comms.IncomingMessage{
 				ContextID:  chatID,
 				SenderID:   senderID,
+				ThreadID:   callback.Message.topicThreadID(),
 				Platform:   "telegram",
 				IsCallback: true,
 				CallbackID: callback.ID,
@@ -436,6 +438,7 @@ func (h *Handler) handleCallback(ctx context.Context, callback *CallbackQuery) {
 			h.commsHandler.HandleMessage(ctx, &comms.IncomingMessage{
 				ContextID:  chatID,
 				SenderID:   senderID,
+				ThreadID:   callback.Message.topicThreadID(),
 				Platform:   "telegram",
 				IsCallback: true,
 				CallbackID: callback.ID,

--- a/internal/adapters/telegram/handler_test.go
+++ b/internal/adapters/telegram/handler_test.go
@@ -1771,3 +1771,94 @@ func TestWarnDroppedOnceDedupes(t *testing.T) {
 		t.Errorf("unexpected keys: %v", h.warnedDropped)
 	}
 }
+
+type threadRecordingMessenger struct {
+	noopMessenger
+	mu       sync.Mutex
+	called   bool
+	threadID string
+}
+
+func (m *threadRecordingMessenger) record(threadID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.called = true
+	m.threadID = threadID
+}
+
+func (m *threadRecordingMessenger) seen() (bool, string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.called, m.threadID
+}
+
+func (m *threadRecordingMessenger) SendConfirmation(_ context.Context, _, threadID, _, _, _ string) (string, error) {
+	m.record(threadID)
+	return "1", nil
+}
+
+func (m *threadRecordingMessenger) SendResult(_ context.Context, _, threadID, _ string, _ bool, _, _ string) error {
+	m.record(threadID)
+	return nil
+}
+
+func (m *threadRecordingMessenger) SendChunked(_ context.Context, _, threadID, _, _ string) error {
+	m.record(threadID)
+	return nil
+}
+
+func TestProcessUpdatePropagatesTopicThreadID(t *testing.T) {
+	tests := []struct {
+		name            string
+		messageThreadID int64
+		isTopicMessage  bool
+		wantThreadID    string
+	}{
+		{
+			name:            "reply goes back to the originating topic",
+			messageThreadID: 42,
+			isTopicMessage:  true,
+			wantThreadID:    "42",
+		},
+		{
+			name:         "General thread reply carries no topic",
+			wantThreadID: "",
+		},
+		{
+			name:            "supergroup reply chain is not treated as a topic",
+			messageThreadID: 42,
+			wantThreadID:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msgr := &threadRecordingMessenger{}
+			h := &Handler{
+				commsHandler: comms.NewHandler(&comms.HandlerConfig{
+					Messenger:    msgr,
+					TaskIDPrefix: "TG",
+				}),
+			}
+
+			h.processUpdate(context.Background(), &Update{
+				Message: &Message{
+					MessageID:       7,
+					MessageThreadID: tt.messageThreadID,
+					IsTopicMessage:  tt.isTopicMessage,
+					Chat:            &Chat{ID: -100123, Type: "supergroup"},
+					From:            &User{ID: 55, FirstName: "Ada"},
+					Text:            "implement rate limiting for the API",
+				},
+			})
+
+			called, got := msgr.seen()
+			if !called {
+				t.Fatal("expected an outbound messenger call carrying a thread id")
+			}
+			if got != tt.wantThreadID {
+				t.Errorf("threadID = %q, want %q", got, tt.wantThreadID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Inbound leg of the forum-topic chain (#4871 outbound merged via #4891).

Captures `message_thread_id` from incoming long-poll updates, gated on `is_topic_message` so supergroup reply chains are not mistaken for topics, and forwards it as `ThreadID` on the `IncomingMessage` so `comms.Handler` threads confirmations, results and chunked output back to the originating topic. General-thread messages carry no topic and keep the configured default.

Fixes #4887

Rebased onto current main (the old copy of the #4891 commit dropped). Single commit; full rationale in the commit message. Verified: `go build/vet/test ./...` clean, `golangci-lint run --new-from-rev=main` 0 issues.

Stacked follow-up for #4888 (SendText threading) comes next; it includes this commit.