### PR TITLE
feat(comms): thread SendText so every reply returns to the originating topic

### DIFF
--- a/cmd/pilot/adapters.go
+++ b/cmd/pilot/adapters.go
@@ -25,11 +25,12 @@ import (
 
 // telegramBriefAdapter wraps telegram.Client to satisfy briefs.TelegramSender interface
 type telegramBriefAdapter struct {
-	client *telegram.Client
+	client          *telegram.Client
+	messageThreadID int64
 }
 
 func (a *telegramBriefAdapter) SendBriefMessage(ctx context.Context, chatID, text, parseMode string) (*briefs.TelegramMessageResponse, error) {
-	resp, err := a.client.SendMessage(ctx, chatID, text, parseMode, 0)
+	resp, err := a.client.SendMessage(ctx, chatID, text, parseMode, a.messageThreadID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -1764,7 +1764,7 @@ Examples:
 						// Add Telegram sender if configured
 						if cfg.Adapters.Telegram != nil && cfg.Adapters.Telegram.Enabled {
 							tgClient := telegram.NewClient(cfg.Adapters.Telegram.BotToken)
-							deliveryOpts = append(deliveryOpts, briefs.WithTelegramSender(&telegramBriefAdapter{client: tgClient}))
+							deliveryOpts = append(deliveryOpts, briefs.WithTelegramSender(&telegramBriefAdapter{client: tgClient, messageThreadID: cfg.Adapters.Telegram.MessageThreadID}))
 						}
 
 						deliveryOpts = append(deliveryOpts, briefs.WithLogger(slog.Default()))

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -3765,7 +3765,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			}
 			if cfg.Adapters.Telegram != nil && cfg.Adapters.Telegram.Enabled {
 				tgClient := telegram.NewClient(cfg.Adapters.Telegram.BotToken)
-				deliveryOpts = append(deliveryOpts, briefs.WithTelegramSender(&telegramBriefAdapter{client: tgClient}))
+				deliveryOpts = append(deliveryOpts, briefs.WithTelegramSender(&telegramBriefAdapter{client: tgClient, messageThreadID: cfg.Adapters.Telegram.MessageThreadID}))
 			}
 			deliveryOpts = append(deliveryOpts, briefs.WithLogger(slog.Default()))
 

--- a/internal/adapters/discord/handler_test.go
+++ b/internal/adapters/discord/handler_test.go
@@ -49,7 +49,7 @@ type sentResult struct {
 }
 type sentChunk struct{ contextID, threadID, content, prefix string }
 
-func (n *noopMessenger) SendText(_ context.Context, contextID, text string) error {
+func (n *noopMessenger) SendText(_ context.Context, contextID, threadID, text string) error {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	n.texts = append(n.texts, sentText{contextID, text})
@@ -664,7 +664,7 @@ func TestMessengerImplementation(t *testing.T) {
 	ctx := context.Background()
 
 	// Test: SendText
-	err := messenger.SendText(ctx, "chan123", "Hello")
+	err := messenger.SendText(ctx, "chan123", "", "Hello")
 	if err != nil {
 		t.Fatalf("SendText failed: %v", err)
 	}

--- a/internal/adapters/discord/messenger.go
+++ b/internal/adapters/discord/messenger.go
@@ -21,7 +21,7 @@ func NewMessenger(client *Client) *DiscordMessenger {
 }
 
 // SendText sends a plain text message to the given channel.
-func (m *DiscordMessenger) SendText(ctx context.Context, contextID, text string) error {
+func (m *DiscordMessenger) SendText(ctx context.Context, contextID, threadID, text string) error {
 	msg, err := m.client.SendMessage(ctx, contextID, text)
 	if err != nil {
 		return fmt.Errorf("send text: %w", err)

--- a/internal/adapters/sdkshim/bridge_messenger.go
+++ b/internal/adapters/sdkshim/bridge_messenger.go
@@ -23,7 +23,7 @@ func MessengerToBridge(b core.ChatBridge) comms.Messenger {
 	return &bridgeMessenger{bridge: b}
 }
 
-func (m *bridgeMessenger) SendText(ctx context.Context, contextID, text string) error {
+func (m *bridgeMessenger) SendText(ctx context.Context, contextID, threadID, text string) error {
 	_, err := m.bridge.Send(ctx, core.OutboundMessage{
 		ChannelID: contextID,
 		Text:      text,

--- a/internal/adapters/sdkshim/bridge_messenger.go
+++ b/internal/adapters/sdkshim/bridge_messenger.go
@@ -26,6 +26,7 @@ func MessengerToBridge(b core.ChatBridge) comms.Messenger {
 func (m *bridgeMessenger) SendText(ctx context.Context, contextID, threadID, text string) error {
 	_, err := m.bridge.Send(ctx, core.OutboundMessage{
 		ChannelID: contextID,
+		ThreadID:  threadID,
 		Text:      text,
 	})
 	return err

--- a/internal/adapters/sdkshim/bridge_messenger_test.go
+++ b/internal/adapters/sdkshim/bridge_messenger_test.go
@@ -1,0 +1,101 @@
+package sdkshim
+
+import (
+	"context"
+	"testing"
+
+	"github.com/qf-studio/studio-sdk/sdk/core"
+)
+
+// recordingBridge captures every OutboundMessage handed to Send so tests can
+// assert the exact wire shape the SDK bridge receives.
+type recordingBridge struct {
+	sent []core.OutboundMessage
+}
+
+func (b *recordingBridge) Start(ctx context.Context) error { return nil }
+func (b *recordingBridge) Send(_ context.Context, m core.OutboundMessage) (core.MessageRef, error) {
+	b.sent = append(b.sent, m)
+	return core.MessageRef{ChannelID: m.ChannelID, MessageID: "msg-1", ThreadID: m.ThreadID}, nil
+}
+func (b *recordingBridge) Edit(ctx context.Context, ref core.MessageRef, text string) error {
+	return nil
+}
+func (b *recordingBridge) Ack(ctx context.Context, callbackID string) error { return nil }
+
+// TestBridgeMessengerThreadIDPropagation guards the accept-and-discard gap
+// PR#5121 closes: every comms.Messenger method that takes a threadID must set
+// it on the core.OutboundMessage it hands to the bridge. SendText was the one
+// implementation that silently dropped it (compiles clean, so only a wire-
+// level assertion catches a regression).
+func TestBridgeMessengerThreadIDPropagation(t *testing.T) {
+	const threadID = "42"
+
+	tests := []struct {
+		name string
+		send func(m *bridgeMessenger) error
+	}{
+		{
+			name: "SendText",
+			send: func(m *bridgeMessenger) error {
+				return m.SendText(context.Background(), "C1", threadID, "hello")
+			},
+		},
+		{
+			name: "SendConfirmation",
+			send: func(m *bridgeMessenger) error {
+				_, err := m.SendConfirmation(context.Background(), "C1", threadID, "TG-1", "desc", "proj")
+				return err
+			},
+		},
+		{
+			name: "SendResult",
+			send: func(m *bridgeMessenger) error {
+				return m.SendResult(context.Background(), "C1", threadID, "TG-1", true, "out", "")
+			},
+		},
+		{
+			name: "SendChunked",
+			send: func(m *bridgeMessenger) error {
+				return m.SendChunked(context.Background(), "C1", threadID, "content", "prefix")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bridge := &recordingBridge{}
+			m := &bridgeMessenger{bridge: bridge}
+
+			if err := tt.send(m); err != nil {
+				t.Fatalf("%s: %v", tt.name, err)
+			}
+			if len(bridge.sent) == 0 {
+				t.Fatalf("%s: no outbound message reached the bridge", tt.name)
+			}
+			for i, sent := range bridge.sent {
+				if sent.ThreadID != threadID {
+					t.Errorf("%s: outbound message %d ThreadID = %q, want %q", tt.name, i, sent.ThreadID, threadID)
+				}
+			}
+		})
+	}
+}
+
+// TestBridgeMessengerSendTextEmptyThreadID asserts the zero-value fallback:
+// an empty threadID must reach the bridge as an empty ThreadID (adapters
+// treat empty as "no thread" — never a fabricated value).
+func TestBridgeMessengerSendTextEmptyThreadID(t *testing.T) {
+	bridge := &recordingBridge{}
+	m := &bridgeMessenger{bridge: bridge}
+
+	if err := m.SendText(context.Background(), "C1", "", "hello"); err != nil {
+		t.Fatalf("SendText: %v", err)
+	}
+	if len(bridge.sent) != 1 {
+		t.Fatalf("sent %d messages, want 1", len(bridge.sent))
+	}
+	if got := bridge.sent[0].ThreadID; got != "" {
+		t.Errorf("ThreadID = %q, want empty", got)
+	}
+}

--- a/internal/adapters/slack/messenger.go
+++ b/internal/adapters/slack/messenger.go
@@ -21,10 +21,11 @@ func NewMessenger(client *Client) *SlackMessenger {
 }
 
 // SendText sends a plain text message to the given channel.
-func (m *SlackMessenger) SendText(ctx context.Context, contextID, text string) error {
+func (m *SlackMessenger) SendText(ctx context.Context, contextID, threadID, text string) error {
 	msg := &Message{
-		Channel: contextID,
-		Text:    text,
+		Channel:  contextID,
+		Text:     text,
+		ThreadTS: threadID,
 	}
 	_, err := m.client.PostMessage(ctx, msg)
 	return err

--- a/internal/adapters/slack/messenger_test.go
+++ b/internal/adapters/slack/messenger_test.go
@@ -51,6 +51,44 @@ func TestSlackMessenger_SendText(t *testing.T) {
 	}
 }
 
+// TestSlackMessenger_SendTextThreadTS asserts the wire payload: a threaded
+// SendText must put the thread id in the raw JSON `thread_ts` field (the
+// entire Slack leg of GH-4888 is this one field), and an unthreaded send
+// must omit the key entirely (`omitempty` — Slack rejects an empty string).
+func TestSlackMessenger_SendTextThreadTS(t *testing.T) {
+	tests := []struct {
+		name         string
+		threadID     string
+		wantKey      bool
+		wantThreadTS string
+	}{
+		{name: "threaded send carries thread_ts on the wire", threadID: "1111.2222", wantKey: true, wantThreadTS: "1111.2222"},
+		{name: "unthreaded send omits thread_ts", threadID: "", wantKey: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var raw map[string]interface{}
+			m := newTestSlackMessenger(t, func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewDecoder(r.Body).Decode(&raw)
+				_ = json.NewEncoder(w).Encode(PostMessageResponse{OK: true, TS: "1234.5678", Channel: "C123"})
+			})
+
+			if err := m.SendText(context.Background(), "C123", tt.threadID, "hello slack"); err != nil {
+				t.Fatalf("SendText returned error: %v", err)
+			}
+
+			got, ok := raw["thread_ts"]
+			if ok != tt.wantKey {
+				t.Fatalf("thread_ts present = %v, want %v (value: %v)", ok, tt.wantKey, got)
+			}
+			if tt.wantKey && got != tt.wantThreadTS {
+				t.Errorf("thread_ts = %v, want %q", got, tt.wantThreadTS)
+			}
+		})
+	}
+}
+
 func TestSlackMessenger_SendConfirmation(t *testing.T) {
 	m := newTestSlackMessenger(t, func(w http.ResponseWriter, r *http.Request) {
 		var raw map[string]interface{}

--- a/internal/adapters/slack/messenger_test.go
+++ b/internal/adapters/slack/messenger_test.go
@@ -42,7 +42,7 @@ func TestSlackMessenger_SendText(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(PostMessageResponse{OK: true, TS: "1234.5678", Channel: msg.Channel})
 	})
 
-	err := m.SendText(context.Background(), "C123", "hello slack")
+	err := m.SendText(context.Background(), "C123", "", "hello slack")
 	if err != nil {
 		t.Fatalf("SendText returned error: %v", err)
 	}

--- a/internal/adapters/telegram/client.go
+++ b/internal/adapters/telegram/client.go
@@ -538,8 +538,8 @@ type BriefMessageResponse struct {
 
 // SendBriefMessage sends a message and returns a simplified response for brief delivery.
 // This method satisfies the briefs.TelegramSender interface.
-func (c *Client) SendBriefMessage(ctx context.Context, chatID, text, parseMode string) (*BriefMessageResponse, error) {
-	resp, err := c.SendMessage(ctx, chatID, text, parseMode, 0)
+func (c *Client) SendBriefMessage(ctx context.Context, chatID, text, parseMode string, messageThreadID int64) (*BriefMessageResponse, error) {
+	resp, err := c.SendMessage(ctx, chatID, text, parseMode, messageThreadID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapters/telegram/client_test.go
+++ b/internal/adapters/telegram/client_test.go
@@ -791,3 +791,58 @@ func TestMessageUnmarshalsTopicFields(t *testing.T) {
 		t.Errorf("topicThreadID() = %q, want %q", got, "42")
 	}
 }
+
+func TestSendBriefMessagePassesMessageThreadID(t *testing.T) {
+	tests := []struct {
+		name            string
+		messageThreadID int64
+		apiOK           bool
+		wantErr         bool
+	}{
+		{name: "topic message", messageThreadID: 42, apiOK: true},
+		{name: "no topic", messageThreadID: 0, apiOK: true},
+		{name: "api error", messageThreadID: 42, apiOK: false, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var raw map[string]interface{}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewDecoder(r.Body).Decode(&raw)
+				if !tt.apiOK {
+					_ = json.NewEncoder(w).Encode(SendMessageResponse{OK: false, Description: "topic closed", ErrorCode: 400})
+					return
+				}
+				_ = json.NewEncoder(w).Encode(SendMessageResponse{OK: true, Result: &Result{MessageID: 9}})
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeTelegramBotToken, server.URL)
+			resp, err := client.SendBriefMessage(context.Background(), "123456", "daily brief", "", tt.messageThreadID)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error from a failed send")
+				}
+				if resp != nil {
+					t.Errorf("resp = %v, want nil on error", resp)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("SendBriefMessage: %v", err)
+			}
+			if resp == nil || resp.MessageID != 9 {
+				t.Fatalf("resp = %v, want MessageID 9", resp)
+			}
+
+			got, ok := raw["message_thread_id"]
+			if ok != (tt.messageThreadID != 0) {
+				t.Fatalf("message_thread_id present = %v, want %v", ok, tt.messageThreadID != 0)
+			}
+			if tt.messageThreadID != 0 && got != float64(tt.messageThreadID) {
+				t.Errorf("message_thread_id = %v, want %d", got, tt.messageThreadID)
+			}
+		})
+	}
+}

--- a/internal/adapters/telegram/commands.go
+++ b/internal/adapters/telegram/commands.go
@@ -27,7 +27,7 @@ func NewCommandHandler(h *Handler, store *memory.Store) *CommandHandler {
 }
 
 // HandleCommand routes commands to their handlers
-func (c *CommandHandler) HandleCommand(ctx context.Context, chatID, text string) {
+func (c *CommandHandler) HandleCommand(ctx context.Context, chatID, threadID, text string) {
 	parts := strings.Fields(text)
 	if len(parts) == 0 {
 		return
@@ -41,58 +41,58 @@ func (c *CommandHandler) HandleCommand(ctx context.Context, chatID, text string)
 
 	switch cmd {
 	case "/start", "/help":
-		c.handleHelp(ctx, chatID)
+		c.handleHelp(ctx, chatID, threadID)
 	case "/status":
-		c.handleStatus(ctx, chatID)
+		c.handleStatus(ctx, chatID, threadID)
 	case "/cancel":
-		c.handleCancel(ctx, chatID)
+		c.handleCancel(ctx, chatID, threadID)
 	case "/queue":
-		c.handleQueue(ctx, chatID)
+		c.handleQueue(ctx, chatID, threadID)
 	case "/projects":
-		c.handleProjects(ctx, chatID)
+		c.handleProjects(ctx, chatID, threadID)
 	case "/project", "/switch":
 		if len(args) > 0 {
-			c.handleSwitch(ctx, chatID, args[0])
+			c.handleSwitch(ctx, chatID, threadID, args[0])
 		} else {
-			c.handleCurrentProject(ctx, chatID)
+			c.handleCurrentProject(ctx, chatID, threadID)
 		}
 	case "/history":
-		c.handleHistory(ctx, chatID)
+		c.handleHistory(ctx, chatID, threadID)
 	case "/budget":
-		c.handleBudget(ctx, chatID)
+		c.handleBudget(ctx, chatID, threadID)
 	case "/tasks", "/list":
-		c.handleTasks(ctx, chatID)
+		c.handleTasks(ctx, chatID, threadID)
 	case "/run":
 		if len(args) > 0 {
 			c.handler.handleRunCommand(ctx, chatID, args[0])
 		} else {
-			_, _ = c.handler.client.SendMessage(ctx, chatID, "Usage: /run <task-id>\nExample: /run 07", "", 0)
+			_, _ = c.handler.client.SendMessage(ctx, chatID, "Usage: /run <task-id>\nExample: /run 07", "", parseThreadID(threadID))
 		}
 	case "/stop":
-		c.handleStop(ctx, chatID)
+		c.handleStop(ctx, chatID, threadID)
 	case "/voice":
 		c.handler.sendVoiceSetupPrompt(ctx, chatID)
 	case "/brief":
-		c.handleBrief(ctx, chatID)
+		c.handleBrief(ctx, chatID, threadID)
 	case "/nopr":
 		if len(args) > 0 {
-			c.handleNoPR(ctx, chatID, strings.Join(args, " "))
+			c.handleNoPR(ctx, chatID, threadID, strings.Join(args, " "))
 		} else {
-			_, _ = c.handler.client.SendMessage(ctx, chatID, "Usage: /nopr <task description>\nExecutes task without creating a PR.", "", 0)
+			_, _ = c.handler.client.SendMessage(ctx, chatID, "Usage: /nopr <task description>\nExecutes task without creating a PR.", "", parseThreadID(threadID))
 		}
 	case "/pr":
 		if len(args) > 0 {
-			c.handleForcePR(ctx, chatID, strings.Join(args, " "))
+			c.handleForcePR(ctx, chatID, threadID, strings.Join(args, " "))
 		} else {
-			_, _ = c.handler.client.SendMessage(ctx, chatID, "Usage: /pr <task description>\nForces PR creation even for ephemeral-looking tasks.", "", 0)
+			_, _ = c.handler.client.SendMessage(ctx, chatID, "Usage: /pr <task description>\nForces PR creation even for ephemeral-looking tasks.", "", parseThreadID(threadID))
 		}
 	default:
-		_, _ = c.handler.client.SendMessage(ctx, chatID, "Unknown command. Use /help for available commands.", "", 0)
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "Unknown command. Use /help for available commands.", "", parseThreadID(threadID))
 	}
 }
 
 // handleHelp shows comprehensive help with all commands
-func (c *CommandHandler) handleHelp(ctx context.Context, chatID string) {
+func (c *CommandHandler) handleHelp(ctx context.Context, chatID, threadID string) {
 	var helpText string
 	if c.handler.plainTextMode {
 		helpText = `🤖 Pilot Bot
@@ -164,11 +164,11 @@ I execute tasks and answer questions about your codebase.
 _Note: Ephemeral commands (serve, run, etc.) auto-skip PR creation._`
 	}
 
-	_, _ = c.handler.client.SendMessage(ctx, chatID, helpText, c.handler.getParseMode(), 0)
+	_, _ = c.handler.client.SendMessage(ctx, chatID, helpText, c.handler.getParseMode(), parseThreadID(threadID))
 }
 
 // handleStatus shows current status with running/pending/queue info
-func (c *CommandHandler) handleStatus(ctx context.Context, chatID string) {
+func (c *CommandHandler) handleStatus(ctx context.Context, chatID, threadID string) {
 	var pending *comms.PendingTask
 	var running *comms.RunningTask
 	if c.handler.commsHandler != nil {
@@ -232,39 +232,39 @@ func (c *CommandHandler) handleStatus(ctx context.Context, chatID string) {
 		sb.WriteString("\n✅ Ready for tasks")
 	}
 
-	_, _ = c.handler.client.SendMessage(ctx, chatID, sb.String(), c.handler.getParseMode(), 0)
+	_, _ = c.handler.client.SendMessage(ctx, chatID, sb.String(), c.handler.getParseMode(), parseThreadID(threadID))
 }
 
 // handleCancel cancels pending or running task
-func (c *CommandHandler) handleCancel(ctx context.Context, chatID string) {
+func (c *CommandHandler) handleCancel(ctx context.Context, chatID, threadID string) {
 	if c.handler.commsHandler != nil {
 		if err := c.handler.commsHandler.CancelTask(ctx, chatID); err != nil {
-			_, _ = c.handler.client.SendMessage(ctx, chatID, "No task to cancel.", "", 0)
+			_, _ = c.handler.client.SendMessage(ctx, chatID, "No task to cancel.", "", parseThreadID(threadID))
 		}
 		return
 	}
-	_, _ = c.handler.client.SendMessage(ctx, chatID, "No task to cancel.", "", 0)
+	_, _ = c.handler.client.SendMessage(ctx, chatID, "No task to cancel.", "", parseThreadID(threadID))
 }
 
 // handleQueue shows queued tasks
-func (c *CommandHandler) handleQueue(ctx context.Context, chatID string) {
+func (c *CommandHandler) handleQueue(ctx context.Context, chatID, threadID string) {
 	if c.store == nil {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, "📋 Queue not available (no memory store)", "", 0)
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "📋 Queue not available (no memory store)", "", parseThreadID(threadID))
 		return
 	}
 
 	queued, err := c.store.GetQueuedTasks(10)
 	if err != nil {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, "❌ Failed to fetch queue", "", 0)
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "❌ Failed to fetch queue", "", parseThreadID(threadID))
 		return
 	}
 
 	if len(queued) == 0 {
 		// Show pending task as fallback
 		if c.handler.commsHandler != nil && c.handler.commsHandler.GetPendingTask(chatID) != nil {
-			_, _ = c.handler.client.SendMessage(ctx, chatID, "📋 No queued tasks\n⏳ 1 pending confirmation", "", 0)
+			_, _ = c.handler.client.SendMessage(ctx, chatID, "📋 No queued tasks\n⏳ 1 pending confirmation", "", parseThreadID(threadID))
 		} else {
-			_, _ = c.handler.client.SendMessage(ctx, chatID, "📋 Queue is empty", "", 0)
+			_, _ = c.handler.client.SendMessage(ctx, chatID, "📋 Queue is empty", "", parseThreadID(threadID))
 		}
 		return
 	}
@@ -288,19 +288,19 @@ func (c *CommandHandler) handleQueue(ctx context.Context, chatID string) {
 		sb.WriteString(fmt.Sprintf("   📁 %s • ⏱ %s ago\n\n", filepath.Base(task.ProjectPath), age))
 	}
 
-	_, _ = c.handler.client.SendMessage(ctx, chatID, sb.String(), c.handler.getParseMode(), 0)
+	_, _ = c.handler.client.SendMessage(ctx, chatID, sb.String(), c.handler.getParseMode(), parseThreadID(threadID))
 }
 
 // handleProjects lists configured projects
-func (c *CommandHandler) handleProjects(ctx context.Context, chatID string) {
+func (c *CommandHandler) handleProjects(ctx context.Context, chatID, threadID string) {
 	if c.handler.projects == nil {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, "📁 No projects configured.\n\nAdd projects to ~/.pilot/config.yaml", "", 0)
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "📁 No projects configured.\n\nAdd projects to ~/.pilot/config.yaml", "", parseThreadID(threadID))
 		return
 	}
 
 	projects := c.handler.projects.ListProjects()
 	if len(projects) == 0 {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, "📁 No projects configured.\n\nAdd projects to ~/.pilot/config.yaml", "", 0)
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "📁 No projects configured.\n\nAdd projects to ~/.pilot/config.yaml", "", parseThreadID(threadID))
 		return
 	}
 
@@ -343,14 +343,14 @@ func (c *CommandHandler) handleProjects(ctx context.Context, chatID string) {
 	}
 
 	if len(keyboard) > 0 {
-		_, _ = c.handler.client.SendMessageWithKeyboard(ctx, chatID, sb.String(), c.handler.getParseMode(), keyboard, 0)
+		_, _ = c.handler.client.SendMessageWithKeyboard(ctx, chatID, sb.String(), c.handler.getParseMode(), keyboard, parseThreadID(threadID))
 	} else {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, sb.String(), c.handler.getParseMode(), 0)
+		_, _ = c.handler.client.SendMessage(ctx, chatID, sb.String(), c.handler.getParseMode(), parseThreadID(threadID))
 	}
 }
 
 // handleSwitch switches to a different project
-func (c *CommandHandler) handleSwitch(ctx context.Context, chatID, projectName string) {
+func (c *CommandHandler) handleSwitch(ctx context.Context, chatID, threadID, projectName string) {
 	proj, err := c.handler.setActiveProject(chatID, projectName)
 	if err != nil {
 		// Try fuzzy match
@@ -364,7 +364,7 @@ func (c *CommandHandler) handleSwitch(ctx context.Context, chatID, projectName s
 		}
 
 		if err != nil {
-			_, _ = c.handler.client.SendMessage(ctx, chatID, fmt.Sprintf("❌ Project '%s' not found\n\nUse /projects to see available projects", projectName), "", 0)
+			_, _ = c.handler.client.SendMessage(ctx, chatID, fmt.Sprintf("❌ Project '%s' not found\n\nUse /projects to see available projects", projectName), "", parseThreadID(threadID))
 			return
 		}
 	}
@@ -379,11 +379,11 @@ func (c *CommandHandler) handleSwitch(ctx context.Context, chatID, projectName s
 	} else {
 		text = fmt.Sprintf("✅ Switched to *%s*%s\n`%s`", escapeMarkdown(proj.Name), nav, proj.Path)
 	}
-	_, _ = c.handler.client.SendMessage(ctx, chatID, text, c.handler.getParseMode(), 0)
+	_, _ = c.handler.client.SendMessage(ctx, chatID, text, c.handler.getParseMode(), parseThreadID(threadID))
 }
 
 // handleCurrentProject shows current active project
-func (c *CommandHandler) handleCurrentProject(ctx context.Context, chatID string) {
+func (c *CommandHandler) handleCurrentProject(ctx context.Context, chatID, threadID string) {
 	activeProjectPath := c.handler.getActiveProjectPath(chatID)
 	projInfo := c.handler.getActiveProjectInfo(chatID)
 
@@ -404,24 +404,24 @@ func (c *CommandHandler) handleCurrentProject(ctx context.Context, chatID string
 	} else {
 		text = fmt.Sprintf("📁 Active: *%s*%s\n`%s`\n\nUse /projects to see all", escapeMarkdown(projName), nav, activeProjectPath)
 	}
-	_, _ = c.handler.client.SendMessage(ctx, chatID, text, c.handler.getParseMode(), 0)
+	_, _ = c.handler.client.SendMessage(ctx, chatID, text, c.handler.getParseMode(), parseThreadID(threadID))
 }
 
 // handleHistory shows recent task history
-func (c *CommandHandler) handleHistory(ctx context.Context, chatID string) {
+func (c *CommandHandler) handleHistory(ctx context.Context, chatID, threadID string) {
 	if c.store == nil {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, "📜 History not available (no memory store)", "", 0)
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "📜 History not available (no memory store)", "", parseThreadID(threadID))
 		return
 	}
 
 	executions, err := c.store.GetRecentExecutions(10, "")
 	if err != nil {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, "❌ Failed to fetch history", "", 0)
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "❌ Failed to fetch history", "", parseThreadID(threadID))
 		return
 	}
 
 	if len(executions) == 0 {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, "📜 No task history yet", "", 0)
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "📜 No task history yet", "", parseThreadID(threadID))
 		return
 	}
 
@@ -474,13 +474,13 @@ func (c *CommandHandler) handleHistory(ctx context.Context, chatID string) {
 		sb.WriteString("\n")
 	}
 
-	_, _ = c.handler.client.SendMessage(ctx, chatID, sb.String(), c.handler.getParseMode(), 0)
+	_, _ = c.handler.client.SendMessage(ctx, chatID, sb.String(), c.handler.getParseMode(), parseThreadID(threadID))
 }
 
 // handleBudget shows usage and costs
-func (c *CommandHandler) handleBudget(ctx context.Context, chatID string) {
+func (c *CommandHandler) handleBudget(ctx context.Context, chatID, threadID string) {
 	if c.store == nil {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, "💰 Budget not available (no memory store)", "", 0)
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "💰 Budget not available (no memory store)", "", parseThreadID(threadID))
 		return
 	}
 
@@ -493,7 +493,7 @@ func (c *CommandHandler) handleBudget(ctx context.Context, chatID string) {
 		End:   now,
 	})
 	if err != nil {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, "❌ Failed to fetch usage data", "", 0)
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "❌ Failed to fetch usage data", "", parseThreadID(threadID))
 		return
 	}
 
@@ -550,14 +550,14 @@ func (c *CommandHandler) handleBudget(ctx context.Context, chatID string) {
 		sb.WriteString(fmt.Sprintf("\n_Period: %s - %s_", monthStart.Format("Jan 2"), now.Format("Jan 2")))
 	}
 
-	_, _ = c.handler.client.SendMessage(ctx, chatID, sb.String(), c.handler.getParseMode(), 0)
+	_, _ = c.handler.client.SendMessage(ctx, chatID, sb.String(), c.handler.getParseMode(), parseThreadID(threadID))
 }
 
 // handleTasks shows task backlog
-func (c *CommandHandler) handleTasks(ctx context.Context, chatID string) {
+func (c *CommandHandler) handleTasks(ctx context.Context, chatID, threadID string) {
 	taskList := c.handler.fastListTasks()
 	if taskList == "" {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, "📋 No tasks found in .agent/tasks/", "", 0)
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "📋 No tasks found in .agent/tasks/", "", parseThreadID(threadID))
 		return
 	}
 	var text string
@@ -566,15 +566,15 @@ func (c *CommandHandler) handleTasks(ctx context.Context, chatID string) {
 	} else {
 		text = "📋 *Task Backlog*\n\n" + taskList
 	}
-	_, _ = c.handler.client.SendMessage(ctx, chatID, text, c.handler.getParseMode(), 0)
+	_, _ = c.handler.client.SendMessage(ctx, chatID, text, c.handler.getParseMode(), parseThreadID(threadID))
 }
 
 // handleStop stops a running task
-func (c *CommandHandler) handleStop(ctx context.Context, chatID string) {
+func (c *CommandHandler) handleStop(ctx context.Context, chatID, threadID string) {
 	if c.handler.commsHandler != nil {
 		running := c.handler.commsHandler.GetRunningTask(chatID)
 		if running == nil {
-			_, _ = c.handler.client.SendMessage(ctx, chatID, "No task is currently running.", "", 0)
+			_, _ = c.handler.client.SendMessage(ctx, chatID, "No task is currently running.", "", parseThreadID(threadID))
 			return
 		}
 		_ = c.handler.commsHandler.CancelTask(ctx, chatID)
@@ -584,25 +584,25 @@ func (c *CommandHandler) handleStop(ctx context.Context, chatID string) {
 		} else {
 			text = fmt.Sprintf("🛑 Stopped task `%s`", running.TaskID)
 		}
-		_, _ = c.handler.client.SendMessage(ctx, chatID, text, c.handler.getParseMode(), 0)
+		_, _ = c.handler.client.SendMessage(ctx, chatID, text, c.handler.getParseMode(), parseThreadID(threadID))
 		return
 	}
-	_, _ = c.handler.client.SendMessage(ctx, chatID, "No task is currently running.", "", 0)
+	_, _ = c.handler.client.SendMessage(ctx, chatID, "No task is currently running.", "", parseThreadID(threadID))
 }
 
 // handleBrief generates and sends a daily brief on demand
-func (c *CommandHandler) handleBrief(ctx context.Context, chatID string) {
+func (c *CommandHandler) handleBrief(ctx context.Context, chatID, threadID string) {
 	if c.store == nil {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, "📋 Brief not available (no memory store)", "", 0)
+		_, _ = c.handler.client.SendMessage(ctx, chatID, "📋 Brief not available (no memory store)", "", parseThreadID(threadID))
 		return
 	}
 
-	_, _ = c.handler.client.SendMessage(ctx, chatID, "📊 Generating brief...", "", 0)
+	_, _ = c.handler.client.SendMessage(ctx, chatID, "📊 Generating brief...", "", parseThreadID(threadID))
 
 	generator := briefs.NewGenerator(c.store, nil)
 	brief, err := generator.GenerateDaily()
 	if err != nil {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, fmt.Sprintf("❌ Failed to generate brief: %s", err.Error()), "", 0)
+		_, _ = c.handler.client.SendMessage(ctx, chatID, fmt.Sprintf("❌ Failed to generate brief: %s", err.Error()), "", parseThreadID(threadID))
 		return
 	}
 
@@ -610,11 +610,11 @@ func (c *CommandHandler) handleBrief(ctx context.Context, chatID string) {
 	formatter := briefs.NewPlainTextFormatter()
 	text, err := formatter.Format(brief)
 	if err != nil {
-		_, _ = c.handler.client.SendMessage(ctx, chatID, fmt.Sprintf("❌ Failed to format brief: %s", err.Error()), "", 0)
+		_, _ = c.handler.client.SendMessage(ctx, chatID, fmt.Sprintf("❌ Failed to format brief: %s", err.Error()), "", parseThreadID(threadID))
 		return
 	}
 
-	_, _ = c.handler.client.SendMessage(ctx, chatID, text, "", 0)
+	_, _ = c.handler.client.SendMessage(ctx, chatID, text, "", parseThreadID(threadID))
 }
 
 // formatTimeAgo formats a time as relative (e.g., "2h ago", "3d ago")
@@ -636,14 +636,14 @@ func formatTimeAgo(t time.Time) string {
 }
 
 // HandleCallbackSwitch handles project switch callbacks
-func (c *CommandHandler) HandleCallbackSwitch(ctx context.Context, chatID, projectName string) {
-	c.handleSwitch(ctx, chatID, projectName)
+func (c *CommandHandler) HandleCallbackSwitch(ctx context.Context, chatID, threadID, projectName string) {
+	c.handleSwitch(ctx, chatID, threadID, projectName)
 }
 
 // handleNoPR executes a task without creating a PR
-func (c *CommandHandler) handleNoPR(ctx context.Context, chatID, description string) {
+func (c *CommandHandler) handleNoPR(ctx context.Context, chatID, threadID, description string) {
 	taskID := fmt.Sprintf("TG-%d", time.Now().Unix())
-	_, _ = c.handler.client.SendMessage(ctx, chatID, fmt.Sprintf("🚀 Executing without PR: %s", truncateForDisplay(description, 50)), "", 0)
+	_, _ = c.handler.client.SendMessage(ctx, chatID, fmt.Sprintf("🚀 Executing without PR: %s", truncateForDisplay(description, 50)), "", parseThreadID(threadID))
 	if c.handler.commsHandler != nil {
 		forcePR := false
 		c.handler.commsHandler.ExecuteDirectTask(ctx, chatID, "", taskID, description, &comms.DirectTaskOpts{
@@ -653,9 +653,9 @@ func (c *CommandHandler) handleNoPR(ctx context.Context, chatID, description str
 }
 
 // handleForcePR executes a task and forces PR creation
-func (c *CommandHandler) handleForcePR(ctx context.Context, chatID, description string) {
+func (c *CommandHandler) handleForcePR(ctx context.Context, chatID, threadID, description string) {
 	taskID := fmt.Sprintf("TG-%d", time.Now().Unix())
-	_, _ = c.handler.client.SendMessage(ctx, chatID, fmt.Sprintf("🚀 Executing with PR: %s", truncateForDisplay(description, 50)), "", 0)
+	_, _ = c.handler.client.SendMessage(ctx, chatID, fmt.Sprintf("🚀 Executing with PR: %s", truncateForDisplay(description, 50)), "", parseThreadID(threadID))
 	if c.handler.commsHandler != nil {
 		forcePR := true
 		c.handler.commsHandler.ExecuteDirectTask(ctx, chatID, "", taskID, description, &comms.DirectTaskOpts{

--- a/internal/adapters/telegram/commands_test.go
+++ b/internal/adapters/telegram/commands_test.go
@@ -5,11 +5,16 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/qf-studio/pilot/internal/comms"
+	"github.com/qf-studio/pilot/internal/executor"
+	"github.com/qf-studio/pilot/internal/memory"
 	"github.com/qf-studio/pilot/internal/testutil"
 )
 
@@ -501,4 +506,292 @@ func TestSplitCommandMention(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Forum-topic threading: every command reply must carry message_thread_id.
+// ---------------------------------------------------------------------------
+
+// threadIDUnderTest is a non-empty forum topic ID: asserting on it (rather than
+// the empty string) proves the thread is actually threaded through, not merely
+// defaulted away.
+const threadIDUnderTest = "42"
+
+type capturedSend struct {
+	text     string
+	threadID int64
+}
+
+// threadCapturingServer records the text and message_thread_id of every
+// sendMessage call.
+type threadCapturingServer struct {
+	server *httptest.Server
+	mu     sync.Mutex
+	sends  []capturedSend
+}
+
+func newThreadCapturingServer(t *testing.T) *threadCapturingServer {
+	t.Helper()
+	s := &threadCapturingServer{}
+	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/sendMessage") {
+			var req SendMessageRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
+				s.mu.Lock()
+				s.sends = append(s.sends, capturedSend{text: req.Text, threadID: req.MessageThreadID})
+				s.mu.Unlock()
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(SendMessageResponse{OK: true, Result: &Result{MessageID: 123, ChatID: 456}})
+	}))
+	t.Cleanup(s.server.Close)
+	return s
+}
+
+func (s *threadCapturingServer) captured() []capturedSend {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]capturedSend, len(s.sends))
+	copy(out, s.sends)
+	return out
+}
+
+func (s *threadCapturingServer) assertAllSentToThread(t *testing.T, wantText string) {
+	t.Helper()
+	sends := s.captured()
+	if len(sends) == 0 {
+		t.Fatal("no messages sent")
+	}
+	found := false
+	for _, send := range sends {
+		if strings.Contains(send.text, wantText) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("no message contains %q: %v", wantText, sends)
+	}
+	want := parseThreadID(threadIDUnderTest)
+	for i, send := range sends {
+		if send.threadID != want {
+			t.Errorf("message %d sent with message_thread_id %d, want %d", i, send.threadID, want)
+		}
+	}
+}
+
+// mustCreateTelegramStore builds a per-test store on disk; ":memory:" is a
+// shared-cache handle here, so seeded rows leak between subtests.
+func mustCreateTelegramStore(t *testing.T) *memory.Store {
+	t.Helper()
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to create memory store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func mustCreateClosedTelegramStore(t *testing.T) *memory.Store {
+	t.Helper()
+	store := mustCreateTelegramStore(t)
+	if err := store.Close(); err != nil {
+		t.Fatalf("failed to close memory store: %v", err)
+	}
+	return store
+}
+
+func mustCreateQueuedTelegramStore(t *testing.T) *memory.Store {
+	t.Helper()
+	store := mustCreateTelegramStore(t)
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-queued",
+		TaskID:      "GH-1",
+		ProjectPath: "/tmp/project",
+		Status:      "queued",
+		CreatedAt:   time.Now(),
+	}); err != nil {
+		t.Fatalf("failed to seed queued execution: %v", err)
+	}
+	return store
+}
+
+func mustCreateHistoryTelegramStore(t *testing.T) *memory.Store {
+	t.Helper()
+	store := mustCreateTelegramStore(t)
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-done",
+		TaskID:      "GH-2",
+		ProjectPath: "/tmp/project",
+		Status:      "completed",
+		PRUrl:       "https://example.test/pr/2",
+		DurationMs:  1500,
+		CreatedAt:   time.Now(),
+	}); err != nil {
+		t.Fatalf("failed to seed completed execution: %v", err)
+	}
+	return store
+}
+
+func mustCreateTasksDir(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	tasksDir := filepath.Join(root, ".agent", "tasks")
+	if err := os.MkdirAll(tasksDir, 0o755); err != nil {
+		t.Fatalf("mkdir tasks: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tasksDir, "TASK-01-demo.md"), []byte("# TASK-01: Demo task\n"), 0o644); err != nil {
+		t.Fatalf("write task file: %v", err)
+	}
+	return root
+}
+
+// TestCommandHandler_SendsToOriginatingTopic asserts every Telegram command
+// reply carries the forum topic the command arrived in.
+func TestCommandHandler_SendsToOriginatingTopic(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		store       func(t *testing.T) *memory.Store
+		projectPath func(t *testing.T) string
+		noComms     bool
+		seedPending bool
+		wantText    string
+	}{
+		{name: "run without args", input: "/run", wantText: "Usage: /run"},
+		{name: "nopr without args", input: "/nopr", wantText: "Usage: /nopr"},
+		{name: "pr without args", input: "/pr", wantText: "Usage: /pr"},
+		{name: "unknown command", input: "/frobnicate", wantText: "Unknown command"},
+		{name: "nopr with description", input: "/nopr add response caching", noComms: true, wantText: "Executing without PR"},
+		{name: "pr with description", input: "/pr add response caching", noComms: true, wantText: "Executing with PR"},
+		{name: "cancel with nothing pending", input: "/cancel", wantText: "No task to cancel."},
+		{name: "cancel without comms handler", input: "/cancel", noComms: true, wantText: "No task to cancel."},
+		{name: "stop with nothing running", input: "/stop", wantText: "No task is currently running."},
+		{name: "stop without comms handler", input: "/stop", noComms: true, wantText: "No task is currently running."},
+		{name: "status", input: "/status", wantText: "Status"},
+		{name: "brief without store", input: "/brief", wantText: "Brief not available"},
+		{name: "brief generated", input: "/brief", store: mustCreateTelegramStore, wantText: "Generating brief"},
+		{name: "queue fetch error", input: "/queue", store: mustCreateClosedTelegramStore, wantText: "Failed to fetch queue"},
+		{name: "queue empty", input: "/queue", store: mustCreateTelegramStore, wantText: "Queue is empty"},
+		{name: "queue empty with pending confirmation", input: "/queue", store: mustCreateTelegramStore, seedPending: true, wantText: "pending confirmation"},
+		{name: "queue listed", input: "/queue", store: mustCreateQueuedTelegramStore, wantText: "Task Queue"},
+		{name: "history fetch error", input: "/history", store: mustCreateClosedTelegramStore, wantText: "Failed to fetch history"},
+		{name: "history empty", input: "/history", store: mustCreateTelegramStore, wantText: "No task history yet"},
+		{name: "history listed", input: "/history", store: mustCreateHistoryTelegramStore, wantText: "Recent Tasks"},
+		{name: "budget fetch error", input: "/budget", store: mustCreateClosedTelegramStore, wantText: "Failed to fetch usage data"},
+		{name: "budget summary", input: "/budget", store: mustCreateTelegramStore, wantText: "Usage This Month"},
+		{name: "tasks none", input: "/tasks", wantText: "No tasks found"},
+		{name: "tasks listed", input: "/tasks", projectPath: mustCreateTasksDir, wantText: "Task Backlog"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newThreadCapturingServer(t)
+
+			projectPath := "/test/path"
+			if tt.projectPath != nil {
+				projectPath = tt.projectPath(t)
+			}
+
+			h := &Handler{
+				client:      NewClientWithBaseURL(testutil.FakeTelegramBotToken, srv.server.URL),
+				projectPath: projectPath,
+			}
+			if !tt.noComms {
+				h.commsHandler = comms.NewHandler(&comms.HandlerConfig{
+					Messenger:    &noopMessenger{},
+					ProjectPath:  projectPath,
+					TaskIDPrefix: "TG",
+				})
+			}
+
+			var store *memory.Store
+			if tt.store != nil {
+				store = tt.store(t)
+			}
+			cmd := NewCommandHandler(h, store)
+
+			ctx := context.Background()
+			if tt.seedPending {
+				h.commsHandler.HandleMessage(ctx, &comms.IncomingMessage{
+					ContextID: "123",
+					SenderID:  "u1",
+					Text:      "Add a rate limiter to the gateway",
+				})
+				if h.commsHandler.GetPendingTask("123") == nil {
+					t.Fatal("failed to seed a pending task")
+				}
+			}
+
+			cmd.HandleCommand(ctx, "123", threadIDUnderTest, tt.input)
+
+			srv.assertAllSentToThread(t, tt.wantText)
+		})
+	}
+}
+
+// blockingBackend parks until the execution context is cancelled, so a test can
+// observe a genuinely in-flight task.
+type blockingBackend struct {
+	started chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingBackend) Name() string      { return "blocking" }
+func (b *blockingBackend) IsAvailable() bool { return true }
+
+func (b *blockingBackend) Execute(ctx context.Context, _ executor.ExecuteOptions) (*executor.BackendResult, error) {
+	b.once.Do(func() { close(b.started) })
+	<-ctx.Done()
+	return &executor.BackendResult{Success: false, Error: "cancelled"}, ctx.Err()
+}
+
+// TestCommandHandler_StopRunningTaskSendsToOriginatingTopic covers the /stop
+// branch that reports a task it actually stopped.
+func TestCommandHandler_StopRunningTaskSendsToOriginatingTopic(t *testing.T) {
+	srv := newThreadCapturingServer(t)
+
+	backend := &blockingBackend{started: make(chan struct{})}
+	runner := executor.NewRunnerWithBackend(backend)
+	runner.SetSkipPreflightChecks(true)
+	runner.SetRecordingEnabled(false)
+
+	projectPath := t.TempDir()
+	h := &Handler{
+		client:      NewClientWithBaseURL(testutil.FakeTelegramBotToken, srv.server.URL),
+		projectPath: projectPath,
+		commsHandler: comms.NewHandler(&comms.HandlerConfig{
+			Messenger:    &noopMessenger{},
+			Runner:       runner,
+			ProjectPath:  projectPath,
+			TaskIDPrefix: "TG",
+		}),
+	}
+	cmd := NewCommandHandler(h, nil)
+
+	ctx := context.Background()
+	forcePR := false
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.commsHandler.ExecuteDirectTask(ctx, "123", threadIDUnderTest, "TG-stop-me", "serve the docs site",
+			&comms.DirectTaskOpts{ForcePR: &forcePR})
+	}()
+
+	select {
+	case <-backend.started:
+	case <-time.After(30 * time.Second):
+		t.Fatal("backend never started")
+	}
+
+	cmd.HandleCommand(ctx, "123", threadIDUnderTest, "/stop")
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("task did not stop")
+	}
+
+	srv.assertAllSentToThread(t, "Stopped task")
 }

--- a/internal/adapters/telegram/commands_test.go
+++ b/internal/adapters/telegram/commands_test.go
@@ -82,7 +82,7 @@ func TestCommandHandler_HandleHelp(t *testing.T) {
 	cmd := NewCommandHandler(h, nil)
 
 	ctx := context.Background()
-	cmd.HandleCommand(ctx, "123", "/help")
+	cmd.HandleCommand(ctx, "123", "", "/help")
 
 	// Check that message was formatted (we can't check exact content due to mock server)
 	// The handler will try to send but the mock server won't match URLs
@@ -112,7 +112,7 @@ func TestCommandHandler_HandleStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// This will fail to send (no real Telegram) but should not panic
-			cmd.HandleCommand(ctx, tt.chatID, "/status")
+			cmd.HandleCommand(ctx, tt.chatID, "", "/status")
 		})
 	}
 }
@@ -139,7 +139,7 @@ func TestCommandHandler_HandleCancel(t *testing.T) {
 	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd.HandleCommand(ctx, tt.chatID, "/cancel")
+			cmd.HandleCommand(ctx, tt.chatID, "", "/cancel")
 			// Verify no panic; cancel state managed by commsHandler
 		})
 	}
@@ -173,7 +173,7 @@ func TestCommandHandler_HandleQueue(t *testing.T) {
 				cmd = NewCommandHandler(h, nil)
 			}
 
-			cmd.HandleCommand(ctx, "chat1", "/queue")
+			cmd.HandleCommand(ctx, "chat1", "", "/queue")
 			// Just verify no panic
 		})
 	}
@@ -212,7 +212,7 @@ func TestCommandHandler_HandleProjects(t *testing.T) {
 			h := newTestHandlerForCommands(tt.projects, "/default/path")
 			cmd := NewCommandHandler(h, nil)
 
-			cmd.HandleCommand(ctx, "chat1", "/projects")
+			cmd.HandleCommand(ctx, "chat1", "", "/projects")
 			// Just verify no panic
 		})
 	}
@@ -255,7 +255,7 @@ func TestCommandHandler_HandleSwitch(t *testing.T) {
 	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd.HandleCommand(ctx, "chat1", tt.command)
+			cmd.HandleCommand(ctx, "chat1", "", tt.command)
 
 			path := h.getActiveProjectPath("chat1")
 			if path != tt.wantPath {
@@ -289,7 +289,7 @@ func TestCommandHandler_HandleHistory(t *testing.T) {
 				cmd = NewCommandHandler(h, nil)
 			}
 
-			cmd.HandleCommand(ctx, "chat1", "/history")
+			cmd.HandleCommand(ctx, "chat1", "", "/history")
 			// Just verify no panic
 		})
 	}
@@ -301,7 +301,7 @@ func TestCommandHandler_HandleBudget(t *testing.T) {
 	cmd := NewCommandHandler(h, nil)
 
 	ctx := context.Background()
-	cmd.HandleCommand(ctx, "chat1", "/budget")
+	cmd.HandleCommand(ctx, "chat1", "", "/budget")
 	// Just verify no panic
 }
 
@@ -311,7 +311,7 @@ func TestCommandHandler_HandleTasks(t *testing.T) {
 	cmd := NewCommandHandler(h, nil)
 
 	ctx := context.Background()
-	cmd.HandleCommand(ctx, "chat1", "/tasks")
+	cmd.HandleCommand(ctx, "chat1", "", "/tasks")
 	// Just verify no panic
 }
 
@@ -321,7 +321,7 @@ func TestCommandHandler_UnknownCommand(t *testing.T) {
 	cmd := NewCommandHandler(h, nil)
 
 	ctx := context.Background()
-	cmd.HandleCommand(ctx, "chat1", "/unknown_command")
+	cmd.HandleCommand(ctx, "chat1", "", "/unknown_command")
 	// Just verify no panic
 }
 
@@ -428,7 +428,7 @@ func TestCommandHandler_HandleCallbackSwitch(t *testing.T) {
 	// Set initial project
 	_ = h.commsHandler.SetActiveProject("chat1", "project-a")
 
-	cmd.HandleCallbackSwitch(ctx, "chat1", "project-b")
+	cmd.HandleCallbackSwitch(ctx, "chat1", "", "project-b")
 
 	path := h.getActiveProjectPath("chat1")
 	if path != "/path/b" {
@@ -468,7 +468,7 @@ func TestCommandRouting(t *testing.T) {
 	for _, command := range commands {
 		t.Run(command, func(t *testing.T) {
 			// Should not panic
-			cmd.HandleCommand(ctx, "chat1", command)
+			cmd.HandleCommand(ctx, "chat1", "", command)
 		})
 	}
 }

--- a/internal/adapters/telegram/handler.go
+++ b/internal/adapters/telegram/handler.go
@@ -374,7 +374,7 @@ func (h *Handler) processUpdate(ctx context.Context, update *Update) {
 
 	// Commands stay local
 	if strings.HasPrefix(text, "/") {
-		h.handleCommand(ctx, chatID, text)
+		h.handleCommand(ctx, chatID, msg.topicThreadID(), text)
 		return
 	}
 
@@ -447,7 +447,7 @@ func (h *Handler) handleCallback(ctx context.Context, callback *CallbackQuery) {
 		}
 	case strings.HasPrefix(data, "switch_"):
 		projectName := strings.TrimPrefix(data, "switch_")
-		h.cmdHandler.HandleCallbackSwitch(ctx, chatID, projectName)
+		h.cmdHandler.HandleCallbackSwitch(ctx, chatID, callback.Message.topicThreadID(), projectName)
 	case data == "voice_check_status":
 		h.sendVoiceSetupPrompt(ctx, chatID)
 	case strings.HasPrefix(data, "approve:") || strings.HasPrefix(data, "reject:"):
@@ -467,9 +467,9 @@ func (h *Handler) handleCallback(ctx context.Context, callback *CallbackQuery) {
 }
 
 // handleCommand processes bot commands
-func (h *Handler) handleCommand(ctx context.Context, chatID, text string) {
+func (h *Handler) handleCommand(ctx context.Context, chatID, threadID, text string) {
 	// Delegate to command handler
-	h.cmdHandler.HandleCommand(ctx, chatID, text)
+	h.cmdHandler.HandleCommand(ctx, chatID, threadID, text)
 }
 
 // handleRunCommand executes a task directly without confirmation

--- a/internal/adapters/telegram/handler_test.go
+++ b/internal/adapters/telegram/handler_test.go
@@ -24,7 +24,7 @@ import (
 // noopMessenger is a no-op implementation of comms.Messenger for tests.
 type noopMessenger struct{}
 
-func (n *noopMessenger) SendText(context.Context, string, string) error { return nil }
+func (n *noopMessenger) SendText(context.Context, string, string, string) error { return nil }
 func (n *noopMessenger) SendConfirmation(context.Context, string, string, string, string, string) (string, error) {
 	return "", nil
 }

--- a/internal/adapters/telegram/handler_test.go
+++ b/internal/adapters/telegram/handler_test.go
@@ -2025,3 +2025,61 @@ func TestDispatchImageTaskPropagatesThreadID(t *testing.T) {
 		})
 	}
 }
+
+// TestForumTopicRepliesReturnToTopic asserts an incoming forum-topic message and
+// a topic-scoped callback both route their replies back into that topic.
+func TestForumTopicRepliesReturnToTopic(t *testing.T) {
+	topicMessage := func() *Message {
+		return &Message{
+			MessageID:       7,
+			MessageThreadID: 42,
+			IsTopicMessage:  true,
+			Chat:            &Chat{ID: -100123, Type: "supergroup"},
+			From:            &User{ID: 55},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		invoke   func(h *Handler, ctx context.Context)
+		wantText string
+	}{
+		{
+			name: "slash command from a topic",
+			invoke: func(h *Handler, ctx context.Context) {
+				msg := topicMessage()
+				msg.Text = "/help"
+				h.processUpdate(ctx, &Update{UpdateID: 1, Message: msg})
+			},
+			wantText: "Pilot Bot",
+		},
+		{
+			name: "project switch callback from a topic",
+			invoke: func(h *Handler, ctx context.Context) {
+				h.handleCallback(ctx, &CallbackQuery{
+					ID:      "cb-1",
+					From:    &User{ID: 55},
+					Data:    "switch_ghost",
+					Message: topicMessage(),
+				})
+			},
+			wantText: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newThreadCapturingServer(t)
+
+			h := &Handler{
+				client:       NewClientWithBaseURL(testutil.FakeTelegramBotToken, srv.server.URL),
+				commsHandler: newTestCommsHandler(),
+			}
+			h.cmdHandler = NewCommandHandler(h, nil)
+
+			tt.invoke(h, context.Background())
+
+			srv.assertAllSentToThread(t, tt.wantText)
+		})
+	}
+}

--- a/internal/adapters/telegram/messenger.go
+++ b/internal/adapters/telegram/messenger.go
@@ -42,8 +42,8 @@ func parseThreadID(threadID string) int64 {
 }
 
 // SendText sends a plain text message to the given chat.
-func (m *TelegramMessenger) SendText(ctx context.Context, contextID, text string) error {
-	_, err := m.client.SendMessage(ctx, contextID, text, m.parseMode(), 0)
+func (m *TelegramMessenger) SendText(ctx context.Context, contextID, threadID, text string) error {
+	_, err := m.client.SendMessage(ctx, contextID, text, m.parseMode(), parseThreadID(threadID))
 	return err
 }
 

--- a/internal/adapters/telegram/messenger_test.go
+++ b/internal/adapters/telegram/messenger_test.go
@@ -41,7 +41,7 @@ func TestTelegramMessenger_SendText(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(SendMessageResponse{OK: true, Result: &Result{MessageID: 1}})
 	})
 
-	err := m.SendText(context.Background(), "123", "hello world")
+	err := m.SendText(context.Background(), "123", "", "hello world")
 	if err != nil {
 		t.Fatalf("SendText returned error: %v", err)
 	}

--- a/internal/adapters/web/api_test.go
+++ b/internal/adapters/web/api_test.go
@@ -65,7 +65,7 @@ func TestAPI_Dispatch_ValidTextMessage_ReturnsAcceptTimeSeq(t *testing.T) {
 	ctx := context.Background()
 
 	// Seed one prior event so the accept-time seq is non-zero.
-	if err := m.SendText(ctx, "web:c1", "prior"); err != nil {
+	if err := m.SendText(ctx, "web:c1", "", "prior"); err != nil {
 		t.Fatalf("seed SendText error: %v", err)
 	}
 
@@ -155,7 +155,7 @@ func TestAPI_Events_UsesConversationIDPrefix(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_ = m.SendText(ctx, "web:c1", "hi")
+		_ = m.SendText(ctx, "web:c1", "", "hi")
 	}()
 	wg.Wait()
 

--- a/internal/adapters/web/messenger.go
+++ b/internal/adapters/web/messenger.go
@@ -135,7 +135,7 @@ func (m *WebMessenger) pruneLocked() {
 }
 
 // SendText appends a plain text event.
-func (m *WebMessenger) SendText(_ context.Context, contextID, text string) error {
+func (m *WebMessenger) SendText(_ context.Context, contextID, _threadID, text string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.pruneLocked()
@@ -213,7 +213,7 @@ func (m *WebMessenger) SendChunked(ctx context.Context, contextID, _threadID, co
 	if prefix != "" {
 		text = prefix + content
 	}
-	return m.SendText(ctx, contextID, text)
+	return m.SendText(ctx, contextID, _threadID, text)
 }
 
 // AcknowledgeCallback is a no-op: there is no platform-level callback

--- a/internal/adapters/web/messenger_test.go
+++ b/internal/adapters/web/messenger_test.go
@@ -11,7 +11,7 @@ func TestWebMessenger_SendText_SeqOrdering(t *testing.T) {
 	ctx := context.Background()
 
 	for i, text := range []string{"one", "two", "three"} {
-		if err := m.SendText(ctx, "web:c1", text); err != nil {
+		if err := m.SendText(ctx, "web:c1", "", text); err != nil {
 			t.Fatalf("SendText[%d] error: %v", i, err)
 		}
 	}
@@ -140,7 +140,7 @@ func TestWebMessenger_BufferCap_DropsOldest(t *testing.T) {
 
 	total := maxEventsPerConversation + 10
 	for i := 0; i < total; i++ {
-		if err := m.SendText(ctx, "web:c1", "msg"); err != nil {
+		if err := m.SendText(ctx, "web:c1", "", "msg"); err != nil {
 			t.Fatalf("SendText error: %v", err)
 		}
 	}
@@ -166,7 +166,7 @@ func TestWebMessenger_ConversationExpiry(t *testing.T) {
 	m.now = func() time.Time { return fakeNow }
 	ctx := context.Background()
 
-	if err := m.SendText(ctx, "web:c1", "hello"); err != nil {
+	if err := m.SendText(ctx, "web:c1", "", "hello"); err != nil {
 		t.Fatalf("SendText error: %v", err)
 	}
 

--- a/internal/autopilot/telegram_notifier.go
+++ b/internal/autopilot/telegram_notifier.go
@@ -10,15 +10,17 @@ import (
 
 // TelegramNotifier sends autopilot notifications to Telegram.
 type TelegramNotifier struct {
-	client *telegram.Client
-	chatID string
+	client          *telegram.Client
+	chatID          string
+	messageThreadID int64
 }
 
 // NewTelegramNotifier creates a Telegram notifier for autopilot events.
-func NewTelegramNotifier(client *telegram.Client, chatID string) *TelegramNotifier {
+func NewTelegramNotifier(client *telegram.Client, chatID string, messageThreadID int64) *TelegramNotifier {
 	return &TelegramNotifier{
-		client: client,
-		chatID: chatID,
+		client:          client,
+		chatID:          chatID,
+		messageThreadID: messageThreadID,
 	}
 }
 
@@ -52,7 +54,7 @@ func (n *TelegramNotifier) NotifyMerged(ctx context.Context, prState *PRState) e
 		"Method: squash",
 		envPrefix(prState), prState.PRNumber, prDetail(prState))
 
-	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown", 0)
+	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown", n.messageThreadID)
 	return err
 }
 
@@ -71,7 +73,7 @@ func (n *TelegramNotifier) NotifyCIFailed(ctx context.Context, prState *PRState,
 	msg := fmt.Sprintf("%s❌ *CI Failed* for PR #%d%s\n\n%s",
 		envPrefix(prState), prState.PRNumber, prDetail(prState), checks)
 
-	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown", 0)
+	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown", n.messageThreadID)
 	return err
 }
 
@@ -83,7 +85,7 @@ func (n *TelegramNotifier) NotifyApprovalRequired(ctx context.Context, prState *
 		envPrefix(prState), prState.PRNumber, prDetail(prState),
 		prState.PRNumber, prState.PRNumber)
 
-	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown", 0)
+	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown", n.messageThreadID)
 	return err
 }
 
@@ -94,7 +96,7 @@ func (n *TelegramNotifier) NotifyFixIssueCreated(ctx context.Context, prState *P
 		"Pilot will pick this up automatically.",
 		envPrefix(prState), issueNumber, prState.PRNumber)
 
-	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown", 0)
+	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown", n.messageThreadID)
 	return err
 }
 
@@ -103,7 +105,7 @@ func (n *TelegramNotifier) NotifyPipelineComplete(ctx context.Context, prState *
 	msg := fmt.Sprintf("%s🏁 *Pipeline complete* for GH-%d — PR #%d merged%s",
 		envPrefix(prState), prState.IssueNumber, prState.PRNumber, prDetail(prState))
 
-	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown", 0)
+	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown", n.messageThreadID)
 	return err
 }
 
@@ -140,7 +142,7 @@ func (n *TelegramNotifier) NotifyReleased(ctx context.Context, prState *PRState,
 		releaseURL,
 	)
 
-	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown", 0)
+	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown", n.messageThreadID)
 	return err
 }
 

--- a/internal/autopilot/telegram_notifier_test.go
+++ b/internal/autopilot/telegram_notifier_test.go
@@ -26,7 +26,7 @@ func newTestNotifier(t *testing.T, captureText *string) (*TelegramNotifier, *htt
 	}))
 
 	client := telegram.NewClientWithBaseURL("test-token", server.URL)
-	notifier := NewTelegramNotifier(client, "123456")
+	notifier := NewTelegramNotifier(client, "123456", 0)
 	return notifier, server
 }
 
@@ -338,7 +338,7 @@ func TestTelegramNotifier_NotifyReleased_ScopeCarrier(t *testing.T) {
 
 func TestNewTelegramNotifier(t *testing.T) {
 	client := telegram.NewClient("test-token")
-	notifier := NewTelegramNotifier(client, "123456")
+	notifier := NewTelegramNotifier(client, "123456", 0)
 
 	if notifier == nil {
 		t.Fatal("NewTelegramNotifier returned nil")

--- a/internal/comms/commands.go
+++ b/internal/comms/commands.go
@@ -86,7 +86,7 @@ func (c *CommandHandler) SetIssueIntakeFunc(f func(ctx context.Context, contextI
 }
 
 // HandleCommand routes slash commands to their handlers.
-func (c *CommandHandler) HandleCommand(ctx context.Context, contextID, text string) {
+func (c *CommandHandler) HandleCommand(ctx context.Context, contextID, threadID, text string) {
 	parts := strings.Fields(text)
 	if len(parts) == 0 {
 		return
@@ -97,66 +97,66 @@ func (c *CommandHandler) HandleCommand(ctx context.Context, contextID, text stri
 
 	switch cmd {
 	case "/start", "/help":
-		c.handleHelp(ctx, contextID)
+		c.handleHelp(ctx, contextID, threadID)
 	case "/status":
-		c.handleStatus(ctx, contextID)
+		c.handleStatus(ctx, contextID, threadID)
 	case "/cancel":
-		c.handleCancel(ctx, contextID)
+		c.handleCancel(ctx, contextID, threadID)
 	case "/queue":
-		c.handleQueue(ctx, contextID)
+		c.handleQueue(ctx, contextID, threadID)
 	case "/projects":
-		c.handleProjects(ctx, contextID)
+		c.handleProjects(ctx, contextID, threadID)
 	case "/project", "/switch":
 		if len(args) > 0 {
-			c.handleSwitch(ctx, contextID, args[0])
+			c.handleSwitch(ctx, contextID, threadID, args[0])
 		} else {
-			c.handleCurrentProject(ctx, contextID)
+			c.handleCurrentProject(ctx, contextID, threadID)
 		}
 	case "/history":
-		c.handleHistory(ctx, contextID)
+		c.handleHistory(ctx, contextID, threadID)
 	case "/budget":
-		c.handleBudget(ctx, contextID)
+		c.handleBudget(ctx, contextID, threadID)
 	case "/tasks", "/list":
-		c.handleTasks(ctx, contextID)
+		c.handleTasks(ctx, contextID, threadID)
 	case "/run":
 		if len(args) > 0 {
 			if c.runCommandFunc != nil {
 				c.runCommandFunc(ctx, contextID, args[0])
 			} else {
-				_ = c.messenger.SendText(ctx, contextID, "Usage: /run <task-id>\nExample: /run 07")
+				_ = c.messenger.SendText(ctx, contextID, threadID, "Usage: /run <task-id>\nExample: /run 07")
 			}
 		} else {
-			_ = c.messenger.SendText(ctx, contextID, "Usage: /run <task-id>\nExample: /run 07")
+			_ = c.messenger.SendText(ctx, contextID, threadID, "Usage: /run <task-id>\nExample: /run 07")
 		}
 	case "/stop":
-		c.handleStop(ctx, contextID)
+		c.handleStop(ctx, contextID, threadID)
 	case "/brief":
-		c.handleBrief(ctx, contextID)
+		c.handleBrief(ctx, contextID, threadID)
 	case "/nopr":
 		if len(args) > 0 {
-			c.handleNoPR(ctx, contextID, strings.Join(args, " "))
+			c.handleNoPR(ctx, contextID, threadID, strings.Join(args, " "))
 		} else {
-			_ = c.messenger.SendText(ctx, contextID, "Usage: /nopr <task description>\nExecutes task without creating a PR.")
+			_ = c.messenger.SendText(ctx, contextID, threadID, "Usage: /nopr <task description>\nExecutes task without creating a PR.")
 		}
 	case "/pr":
 		if len(args) > 0 {
-			c.handleForcePR(ctx, contextID, strings.Join(args, " "))
+			c.handleForcePR(ctx, contextID, threadID, strings.Join(args, " "))
 		} else {
-			_ = c.messenger.SendText(ctx, contextID, "Usage: /pr <task description>\nForces PR creation even for ephemeral-looking tasks.")
+			_ = c.messenger.SendText(ctx, contextID, threadID, "Usage: /pr <task description>\nForces PR creation even for ephemeral-looking tasks.")
 		}
 	case "/draft-issue":
 		if len(args) > 0 {
-			c.handleDraftIssue(ctx, contextID, strings.Join(args, " "))
+			c.handleDraftIssue(ctx, contextID, threadID, strings.Join(args, " "))
 		} else {
-			_ = c.messenger.SendText(ctx, contextID, "Usage: /draft-issue <description>\nDrafts and creates a pilot-labeled GitHub issue.")
+			_ = c.messenger.SendText(ctx, contextID, threadID, "Usage: /draft-issue <description>\nDrafts and creates a pilot-labeled GitHub issue.")
 		}
 	default:
-		_ = c.messenger.SendText(ctx, contextID, "Unknown command. Use /help for available commands.")
+		_ = c.messenger.SendText(ctx, contextID, threadID, "Unknown command. Use /help for available commands.")
 	}
 }
 
 // handleHelp shows comprehensive help with all commands.
-func (c *CommandHandler) handleHelp(ctx context.Context, contextID string) {
+func (c *CommandHandler) handleHelp(ctx context.Context, contextID, threadID string) {
 	helpText := `🤖 Pilot Bot
 
 I execute tasks and answer questions about your codebase.
@@ -192,7 +192,7 @@ What I Understand
 
 Note: Ephemeral commands (serve, run, etc.) auto-skip PR creation.`
 
-	_ = c.messenger.SendText(ctx, contextID, helpText)
+	_ = c.messenger.SendText(ctx, contextID, threadID, helpText)
 }
 
 // formatQueueSummary formats active and queued executions into a concise status string.
@@ -254,7 +254,7 @@ func formatQueueSummary(running, queued []*memory.Execution) string {
 }
 
 // handleStatus shows current status with running/pending/queue info.
-func (c *CommandHandler) handleStatus(ctx context.Context, contextID string) {
+func (c *CommandHandler) handleStatus(ctx context.Context, contextID, threadID string) {
 	var sb strings.Builder
 	sb.WriteString("📊 Status\n\n")
 
@@ -311,46 +311,46 @@ func (c *CommandHandler) handleStatus(ctx context.Context, contextID string) {
 		sb.WriteString("\n✅ Ready for tasks")
 	}
 
-	_ = c.messenger.SendText(ctx, contextID, sb.String())
+	_ = c.messenger.SendText(ctx, contextID, threadID, sb.String())
 }
 
 // handleCancel cancels pending or running task.
-func (c *CommandHandler) handleCancel(ctx context.Context, contextID string) {
+func (c *CommandHandler) handleCancel(ctx context.Context, contextID, threadID string) {
 	if c.cancelTaskFunc != nil {
 		if err := c.cancelTaskFunc(ctx, contextID); err == nil {
 			return
 		}
 	}
-	_ = c.messenger.SendText(ctx, contextID, "No task to cancel.")
+	_ = c.messenger.SendText(ctx, contextID, threadID, "No task to cancel.")
 }
 
 // handleQueue shows queued tasks.
-func (c *CommandHandler) handleQueue(ctx context.Context, contextID string) {
+func (c *CommandHandler) handleQueue(ctx context.Context, contextID, threadID string) {
 	if c.store == nil {
-		_ = c.messenger.SendText(ctx, contextID, "📋 Queue not available (no memory store)")
+		_ = c.messenger.SendText(ctx, contextID, threadID, "📋 Queue not available (no memory store)")
 		return
 	}
 
 	queued, err := c.store.GetQueuedTasks(10)
 	if err != nil {
-		_ = c.messenger.SendText(ctx, contextID, "❌ Failed to fetch queue")
+		_ = c.messenger.SendText(ctx, contextID, threadID, "❌ Failed to fetch queue")
 		return
 	}
 
-	_ = c.messenger.SendText(ctx, contextID, formatQueueSummary(nil, queued))
+	_ = c.messenger.SendText(ctx, contextID, threadID, formatQueueSummary(nil, queued))
 }
 
 // handleProjects lists configured projects.
-func (c *CommandHandler) handleProjects(ctx context.Context, contextID string) {
+func (c *CommandHandler) handleProjects(ctx context.Context, contextID, threadID string) {
 	if c.projectListFunc == nil {
-		_ = c.messenger.SendText(ctx, contextID,
+		_ = c.messenger.SendText(ctx, contextID, threadID,
 			"📁 No projects configured.\n\nAdd projects to ~/.pilot/config.yaml")
 		return
 	}
 
 	projects := c.projectListFunc()
 	if len(projects) == 0 {
-		_ = c.messenger.SendText(ctx, contextID,
+		_ = c.messenger.SendText(ctx, contextID, threadID,
 			"📁 No projects configured.\n\nAdd projects to ~/.pilot/config.yaml")
 		return
 	}
@@ -388,18 +388,18 @@ func (c *CommandHandler) handleProjects(ctx context.Context, contextID string) {
 		}
 	}
 
-	_ = c.messenger.SendText(ctx, contextID, sb.String())
+	_ = c.messenger.SendText(ctx, contextID, threadID, sb.String())
 }
 
 // handleSwitch switches to a different project.
-func (c *CommandHandler) handleSwitch(ctx context.Context, contextID, projectName string) {
+func (c *CommandHandler) handleSwitch(ctx context.Context, contextID, threadID, projectName string) {
 	if c.setProjectFunc == nil {
-		_ = c.messenger.SendText(ctx, contextID, "Project switching not configured")
+		_ = c.messenger.SendText(ctx, contextID, threadID, "Project switching not configured")
 		return
 	}
 
 	if err := c.setProjectFunc(contextID, projectName); err != nil {
-		_ = c.messenger.SendText(ctx, contextID,
+		_ = c.messenger.SendText(ctx, contextID, threadID,
 			fmt.Sprintf("❌ Project '%s' not found\n\nUse /projects to see available projects", projectName))
 		return
 	}
@@ -412,13 +412,13 @@ func (c *CommandHandler) handleSwitch(ctx context.Context, contextID, projectNam
 		}
 	}
 
-	_ = c.messenger.SendText(ctx, contextID, fmt.Sprintf("✅ Switched to %s", name))
+	_ = c.messenger.SendText(ctx, contextID, threadID, fmt.Sprintf("✅ Switched to %s", name))
 }
 
 // handleCurrentProject shows current active project.
-func (c *CommandHandler) handleCurrentProject(ctx context.Context, contextID string) {
+func (c *CommandHandler) handleCurrentProject(ctx context.Context, contextID, threadID string) {
 	if c.activeProjectFunc == nil {
-		_ = c.messenger.SendText(ctx, contextID, "Active project: unknown\n\nUse /projects to see all")
+		_ = c.messenger.SendText(ctx, contextID, threadID, "Active project: unknown\n\nUse /projects to see all")
 		return
 	}
 
@@ -428,24 +428,24 @@ func (c *CommandHandler) handleCurrentProject(ctx context.Context, contextID str
 	}
 
 	text := fmt.Sprintf("📁 Active: %s\n%s\n\nUse /projects to see all", projName, projPath)
-	_ = c.messenger.SendText(ctx, contextID, text)
+	_ = c.messenger.SendText(ctx, contextID, threadID, text)
 }
 
 // handleHistory shows recent task history.
-func (c *CommandHandler) handleHistory(ctx context.Context, contextID string) {
+func (c *CommandHandler) handleHistory(ctx context.Context, contextID, threadID string) {
 	if c.store == nil {
-		_ = c.messenger.SendText(ctx, contextID, "📜 History not available (no memory store)")
+		_ = c.messenger.SendText(ctx, contextID, threadID, "📜 History not available (no memory store)")
 		return
 	}
 
 	executions, err := c.store.GetRecentExecutions(10, "")
 	if err != nil {
-		_ = c.messenger.SendText(ctx, contextID, "❌ Failed to fetch history")
+		_ = c.messenger.SendText(ctx, contextID, threadID, "❌ Failed to fetch history")
 		return
 	}
 
 	if len(executions) == 0 {
-		_ = c.messenger.SendText(ctx, contextID, "📜 No task history yet")
+		_ = c.messenger.SendText(ctx, contextID, threadID, "📜 No task history yet")
 		return
 	}
 
@@ -484,13 +484,13 @@ func (c *CommandHandler) handleHistory(ctx context.Context, contextID string) {
 		sb.WriteString("\n")
 	}
 
-	_ = c.messenger.SendText(ctx, contextID, sb.String())
+	_ = c.messenger.SendText(ctx, contextID, threadID, sb.String())
 }
 
 // handleBudget shows usage and costs.
-func (c *CommandHandler) handleBudget(ctx context.Context, contextID string) {
+func (c *CommandHandler) handleBudget(ctx context.Context, contextID, threadID string) {
 	if c.store == nil {
-		_ = c.messenger.SendText(ctx, contextID, "💰 Budget not available (no memory store)")
+		_ = c.messenger.SendText(ctx, contextID, threadID, "💰 Budget not available (no memory store)")
 		return
 	}
 
@@ -503,7 +503,7 @@ func (c *CommandHandler) handleBudget(ctx context.Context, contextID string) {
 		End:   now,
 	})
 	if err != nil {
-		_ = c.messenger.SendText(ctx, contextID, "❌ Failed to fetch usage data")
+		_ = c.messenger.SendText(ctx, contextID, threadID, "❌ Failed to fetch usage data")
 		return
 	}
 
@@ -542,38 +542,38 @@ func (c *CommandHandler) handleBudget(ctx context.Context, contextID string) {
 	// Period info
 	sb.WriteString(fmt.Sprintf("Period: %s - %s", monthStart.Format("Jan 2"), now.Format("Jan 2")))
 
-	_ = c.messenger.SendText(ctx, contextID, sb.String())
+	_ = c.messenger.SendText(ctx, contextID, threadID, sb.String())
 }
 
 // handleTasks shows task backlog.
-func (c *CommandHandler) handleTasks(ctx context.Context, contextID string) {
+func (c *CommandHandler) handleTasks(ctx context.Context, contextID, threadID string) {
 	if c.listTasksFunc == nil {
-		_ = c.messenger.SendText(ctx, contextID, "📋 No tasks found in .agent/tasks/")
+		_ = c.messenger.SendText(ctx, contextID, threadID, "📋 No tasks found in .agent/tasks/")
 		return
 	}
 
 	taskList := c.listTasksFunc()
 	if taskList == "" {
-		_ = c.messenger.SendText(ctx, contextID, "📋 No tasks found in .agent/tasks/")
+		_ = c.messenger.SendText(ctx, contextID, threadID, "📋 No tasks found in .agent/tasks/")
 		return
 	}
 
 	text := "📋 Task Backlog\n\n" + taskList
-	_ = c.messenger.SendText(ctx, contextID, text)
+	_ = c.messenger.SendText(ctx, contextID, threadID, text)
 }
 
 // handleStop stops a running task.
-func (c *CommandHandler) handleStop(ctx context.Context, contextID string) {
+func (c *CommandHandler) handleStop(ctx context.Context, contextID, threadID string) {
 	if c.stopTaskFunc != nil {
 		if err := c.stopTaskFunc(ctx, contextID); err == nil {
 			return
 		}
 	}
-	_ = c.messenger.SendText(ctx, contextID, "No task is currently running.")
+	_ = c.messenger.SendText(ctx, contextID, threadID, "No task is currently running.")
 }
 
 // handleBrief generates and sends a daily brief on demand.
-func (c *CommandHandler) handleBrief(ctx context.Context, contextID string) {
+func (c *CommandHandler) handleBrief(ctx context.Context, contextID, threadID string) {
 	if c.briefGeneratorFunc != nil {
 		// Use the platform-specific brief generator (e.g., from Telegram adapter)
 		_ = c.briefGeneratorFunc(ctx, contextID)
@@ -581,49 +581,49 @@ func (c *CommandHandler) handleBrief(ctx context.Context, contextID string) {
 	}
 
 	if c.store == nil {
-		_ = c.messenger.SendText(ctx, contextID, "📋 Brief not available (no memory store)")
+		_ = c.messenger.SendText(ctx, contextID, threadID, "📋 Brief not available (no memory store)")
 		return
 	}
 
-	_ = c.messenger.SendText(ctx, contextID, "📊 Brief generation not configured")
+	_ = c.messenger.SendText(ctx, contextID, threadID, "📊 Brief generation not configured")
 }
 
 // handleNoPR executes a task without creating a PR.
-func (c *CommandHandler) handleNoPR(ctx context.Context, contextID, description string) {
+func (c *CommandHandler) handleNoPR(ctx context.Context, contextID, threadID, description string) {
 	if c.runCommandFunc != nil {
 		taskID := fmt.Sprintf("CMD-%d", time.Now().Unix())
-		_ = c.messenger.SendText(ctx, contextID,
+		_ = c.messenger.SendText(ctx, contextID, threadID,
 			fmt.Sprintf("🚀 Executing without PR: %s", TruncateText(description, 50)))
 		// Note: In Telegram, this calls executeTaskWithOptions with forcePR=false
 		// For shared handler, we just invoke the run command and let the adapter handle noPR semantics
 		c.runCommandFunc(ctx, contextID, taskID)
 	} else {
-		_ = c.messenger.SendText(ctx, contextID,
+		_ = c.messenger.SendText(ctx, contextID, threadID,
 			fmt.Sprintf("🚀 Executing without PR: %s", TruncateText(description, 50)))
 	}
 }
 
 // handleForcePR executes a task and forces PR creation.
-func (c *CommandHandler) handleForcePR(ctx context.Context, contextID, description string) {
+func (c *CommandHandler) handleForcePR(ctx context.Context, contextID, threadID, description string) {
 	if c.runCommandFunc != nil {
 		taskID := fmt.Sprintf("CMD-%d", time.Now().Unix())
-		_ = c.messenger.SendText(ctx, contextID,
+		_ = c.messenger.SendText(ctx, contextID, threadID,
 			fmt.Sprintf("🚀 Executing with PR: %s", TruncateText(description, 50)))
 		// Note: In Telegram, this calls executeTaskWithOptions with forcePR=true
 		// For shared handler, we just invoke the run command and let the adapter handle forcePR semantics
 		c.runCommandFunc(ctx, contextID, taskID)
 	} else {
-		_ = c.messenger.SendText(ctx, contextID,
+		_ = c.messenger.SendText(ctx, contextID, threadID,
 			fmt.Sprintf("🚀 Executing with PR: %s", TruncateText(description, 50)))
 	}
 }
 
 // handleDraftIssue creates a pilot-labeled GitHub issue from a freeform description.
-func (c *CommandHandler) handleDraftIssue(ctx context.Context, contextID, description string) {
+func (c *CommandHandler) handleDraftIssue(ctx context.Context, contextID, threadID, description string) {
 	if c.issueIntakeFunc != nil {
 		c.issueIntakeFunc(ctx, contextID, description)
 	} else {
-		_ = c.messenger.SendText(ctx, contextID,
+		_ = c.messenger.SendText(ctx, contextID, threadID,
 			"Issue intake is not available. Ensure bot and GitHub adapter are configured.")
 	}
 }

--- a/internal/comms/commands_test.go
+++ b/internal/comms/commands_test.go
@@ -2,6 +2,7 @@ package comms
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -9,13 +10,17 @@ import (
 	"github.com/qf-studio/pilot/internal/memory"
 )
 
+var errNoSuchProject = errors.New("no such project")
+
 // mockMessenger captures messages sent by the command handler.
 type mockMessenger struct {
-	messages []string
+	messages  []string
+	threadIDs []string
 }
 
 func (m *mockMessenger) SendText(ctx context.Context, contextID, threadID, text string) error {
 	m.messages = append(m.messages, text)
+	m.threadIDs = append(m.threadIDs, threadID)
 	return nil
 }
 
@@ -33,6 +38,7 @@ func (m *mockMessenger) SendResult(ctx context.Context, contextID, threadID, tas
 
 func (m *mockMessenger) SendChunked(ctx context.Context, contextID, threadID, content, prefix string) error {
 	m.messages = append(m.messages, content)
+	m.threadIDs = append(m.threadIDs, threadID)
 	return nil
 }
 
@@ -643,4 +649,256 @@ func mustCreateMemoryStore(t *testing.T) *memory.Store {
 		t.Fatalf("failed to create memory store: %v", err)
 	}
 	return store
+}
+
+// threadIDUnderTest is a non-empty forum topic ID: asserting on it (rather than
+// the empty string) proves the thread is actually threaded through, not merely
+// defaulted away.
+const threadIDUnderTest = "42"
+
+type stubProject struct {
+	name string
+	path string
+}
+
+func (p stubProject) GetName() string   { return p.name }
+func (p stubProject) GetPath() string   { return p.path }
+func (p stubProject) IsNavigator() bool { return true }
+
+// mustCreateTempMemoryStore builds a per-test store on disk; ":memory:" is a
+// shared-cache handle here, so seeded rows leak between subtests.
+func mustCreateTempMemoryStore(t *testing.T) *memory.Store {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to create memory store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func mustCreateClosedMemoryStore(t *testing.T) *memory.Store {
+	store := mustCreateTempMemoryStore(t)
+	if err := store.Close(); err != nil {
+		t.Fatalf("failed to close memory store: %v", err)
+	}
+	return store
+}
+
+func mustCreateSeededMemoryStore(t *testing.T) *memory.Store {
+	store := mustCreateTempMemoryStore(t)
+	err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-1",
+		TaskID:      "GH-1",
+		ProjectPath: "/tmp/project",
+		Status:      "completed",
+		PRUrl:       "https://example.test/pr/1",
+		DurationMs:  1500,
+		CreatedAt:   time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("failed to seed execution: %v", err)
+	}
+	return store
+}
+
+// TestCommandHandler_SendsToOriginatingThread asserts every command reply
+// carries the caller's threadID down to the messenger.
+func TestCommandHandler_SendsToOriginatingThread(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		store    func(t *testing.T) *memory.Store
+		setup    func(cmd *CommandHandler)
+		wantText string
+	}{
+		{
+			name:     "nopr without args",
+			input:    "/nopr",
+			wantText: "Usage: /nopr",
+		},
+		{
+			name:     "pr without args",
+			input:    "/pr",
+			wantText: "Usage: /pr",
+		},
+		{
+			name:     "draft-issue without args",
+			input:    "/draft-issue",
+			wantText: "Usage: /draft-issue",
+		},
+		{
+			name:     "draft-issue without intake func",
+			input:    "/draft-issue add response caching",
+			wantText: "Issue intake is not available",
+		},
+		{
+			name:     "queue fetch error",
+			input:    "/queue",
+			store:    mustCreateClosedMemoryStore,
+			wantText: "Failed to fetch queue",
+		},
+		{
+			name:  "projects configured but empty",
+			input: "/projects",
+			setup: func(cmd *CommandHandler) {
+				cmd.SetProjectListFunc(func() []interface{} { return nil })
+			},
+			wantText: "No projects configured",
+		},
+		{
+			name:  "projects listed",
+			input: "/projects",
+			setup: func(cmd *CommandHandler) {
+				cmd.SetProjectListFunc(func() []interface{} {
+					return []interface{}{stubProject{name: "alpha", path: "/tmp/alpha"}}
+				})
+				cmd.SetActiveProjectFunc(func(string) (string, string) { return "alpha", "/tmp/alpha" })
+			},
+			wantText: "alpha",
+		},
+		{
+			name:  "switch to unknown project",
+			input: "/switch ghost",
+			setup: func(cmd *CommandHandler) {
+				cmd.SetSetProjectFunc(func(string, string) error { return errNoSuchProject })
+			},
+			wantText: "not found",
+		},
+		{
+			name:  "current project",
+			input: "/project",
+			setup: func(cmd *CommandHandler) {
+				cmd.SetActiveProjectFunc(func(string) (string, string) { return "alpha", "/tmp/alpha" })
+			},
+			wantText: "Active",
+		},
+		{
+			name:     "history fetch error",
+			input:    "/history",
+			store:    mustCreateClosedMemoryStore,
+			wantText: "Failed to fetch history",
+		},
+		{
+			name:     "history empty",
+			input:    "/history",
+			store:    mustCreateTempMemoryStore,
+			wantText: "No task history yet",
+		},
+		{
+			name:     "history listed",
+			input:    "/history",
+			store:    mustCreateSeededMemoryStore,
+			wantText: "Recent Tasks",
+		},
+		{
+			name:     "budget fetch error",
+			input:    "/budget",
+			store:    mustCreateClosedMemoryStore,
+			wantText: "Failed to fetch usage data",
+		},
+		{
+			name:     "budget summary",
+			input:    "/budget",
+			store:    mustCreateTempMemoryStore,
+			wantText: "Usage This Month",
+		},
+		{
+			name:  "tasks none",
+			input: "/tasks",
+			setup: func(cmd *CommandHandler) {
+				cmd.SetListTasksFunc(func() string { return "" })
+			},
+			wantText: "No tasks found",
+		},
+		{
+			name:  "tasks listed",
+			input: "/tasks",
+			setup: func(cmd *CommandHandler) {
+				cmd.SetListTasksFunc(func() string { return "• TASK-01" })
+			},
+			wantText: "Task Backlog",
+		},
+		{
+			name:     "brief without generator",
+			input:    "/brief",
+			store:    mustCreateTempMemoryStore,
+			wantText: "Brief generation not configured",
+		},
+		{
+			name:  "nopr with description",
+			input: "/nopr add response caching",
+			setup: func(cmd *CommandHandler) {
+				cmd.SetRunCommandFunc(func(context.Context, string, string) {})
+			},
+			wantText: "Executing without PR",
+		},
+		{
+			name:  "pr with description",
+			input: "/pr add response caching",
+			setup: func(cmd *CommandHandler) {
+				cmd.SetRunCommandFunc(func(context.Context, string, string) {})
+			},
+			wantText: "Executing with PR",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			messenger := &mockMessenger{}
+			var store *memory.Store
+			if tt.store != nil {
+				store = tt.store(t)
+			}
+			cmd := NewCommandHandler(messenger, store)
+			if tt.setup != nil {
+				tt.setup(cmd)
+			}
+
+			cmd.HandleCommand(context.Background(), "chat1", threadIDUnderTest, tt.input)
+
+			if len(messenger.messages) == 0 {
+				t.Fatal("no messages sent")
+			}
+			found := false
+			for _, msg := range messenger.messages {
+				if strings.Contains(msg, tt.wantText) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("no message contains %q: %v", tt.wantText, messenger.messages)
+			}
+			for i, got := range messenger.threadIDs {
+				if got != threadIDUnderTest {
+					t.Errorf("message %d sent with threadID %q, want %q", i, got, threadIDUnderTest)
+				}
+			}
+		})
+	}
+}
+
+// TestCommandHandler_DraftIssueRoutesToIntake covers the /draft-issue branch
+// that delegates to the issue intake func instead of replying itself.
+func TestCommandHandler_DraftIssueRoutesToIntake(t *testing.T) {
+	messenger := &mockMessenger{}
+	cmd := NewCommandHandler(messenger, nil)
+
+	var gotContextID, gotText string
+	cmd.SetIssueIntakeFunc(func(_ context.Context, contextID, text string) {
+		gotContextID = contextID
+		gotText = text
+	})
+
+	cmd.HandleCommand(context.Background(), "chat1", threadIDUnderTest, "/draft-issue add response caching")
+
+	if gotContextID != "chat1" {
+		t.Errorf("intake contextID = %q, want %q", gotContextID, "chat1")
+	}
+	if gotText != "add response caching" {
+		t.Errorf("intake text = %q, want %q", gotText, "add response caching")
+	}
+	if len(messenger.messages) != 0 {
+		t.Errorf("expected no direct reply when intake is wired, got %v", messenger.messages)
+	}
 }

--- a/internal/comms/commands_test.go
+++ b/internal/comms/commands_test.go
@@ -14,7 +14,7 @@ type mockMessenger struct {
 	messages []string
 }
 
-func (m *mockMessenger) SendText(ctx context.Context, contextID, text string) error {
+func (m *mockMessenger) SendText(ctx context.Context, contextID, threadID, text string) error {
 	m.messages = append(m.messages, text)
 	return nil
 }
@@ -50,7 +50,7 @@ func TestCommandHandler_HandleHelp(t *testing.T) {
 	cmd := NewCommandHandler(messenger, nil)
 
 	ctx := context.Background()
-	cmd.HandleCommand(ctx, "chat1", "/help")
+	cmd.HandleCommand(ctx, "chat1", "", "/help")
 
 	if len(messenger.messages) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(messenger.messages))
@@ -79,7 +79,7 @@ func TestCommandHandler_HandleStart(t *testing.T) {
 	cmd := NewCommandHandler(messenger, nil)
 
 	ctx := context.Background()
-	cmd.HandleCommand(ctx, "chat1", "/start")
+	cmd.HandleCommand(ctx, "chat1", "", "/start")
 
 	if len(messenger.messages) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(messenger.messages))
@@ -122,7 +122,7 @@ func TestCommandHandler_HandleStatus(t *testing.T) {
 			tt.setupFunc(cmd)
 
 			ctx := context.Background()
-			cmd.HandleCommand(ctx, "chat1", "/status")
+			cmd.HandleCommand(ctx, "chat1", "", "/status")
 
 			if len(tt.messenger.messages) == 0 {
 				t.Fatal("no messages sent")
@@ -162,7 +162,7 @@ func TestCommandHandler_HandleQueue(t *testing.T) {
 			cmd := NewCommandHandler(tt.messenger, tt.store)
 
 			ctx := context.Background()
-			cmd.HandleCommand(ctx, "chat1", "/queue")
+			cmd.HandleCommand(ctx, "chat1", "", "/queue")
 
 			if len(tt.messenger.messages) == 0 {
 				t.Fatal("no messages sent")
@@ -182,7 +182,7 @@ func TestCommandHandler_HandleProjects(t *testing.T) {
 
 	// No projects function configured
 	ctx := context.Background()
-	cmd.HandleCommand(ctx, "chat1", "/projects")
+	cmd.HandleCommand(ctx, "chat1", "", "/projects")
 
 	if len(messenger.messages) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(messenger.messages))
@@ -200,7 +200,7 @@ func TestCommandHandler_HandleTasks(t *testing.T) {
 
 	// No list function configured
 	ctx := context.Background()
-	cmd.HandleCommand(ctx, "chat1", "/tasks")
+	cmd.HandleCommand(ctx, "chat1", "", "/tasks")
 
 	if len(messenger.messages) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(messenger.messages))
@@ -217,7 +217,7 @@ func TestCommandHandler_HandleCancel(t *testing.T) {
 	cmd := NewCommandHandler(messenger, nil)
 
 	ctx := context.Background()
-	cmd.HandleCommand(ctx, "chat1", "/cancel")
+	cmd.HandleCommand(ctx, "chat1", "", "/cancel")
 
 	if len(messenger.messages) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(messenger.messages))
@@ -234,7 +234,7 @@ func TestCommandHandler_HandleStop(t *testing.T) {
 	cmd := NewCommandHandler(messenger, nil)
 
 	ctx := context.Background()
-	cmd.HandleCommand(ctx, "chat1", "/stop")
+	cmd.HandleCommand(ctx, "chat1", "", "/stop")
 
 	if len(messenger.messages) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(messenger.messages))
@@ -251,7 +251,7 @@ func TestCommandHandler_HandleBudget(t *testing.T) {
 	cmd := NewCommandHandler(messenger, nil)
 
 	ctx := context.Background()
-	cmd.HandleCommand(ctx, "chat1", "/budget")
+	cmd.HandleCommand(ctx, "chat1", "", "/budget")
 
 	if len(messenger.messages) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(messenger.messages))
@@ -268,7 +268,7 @@ func TestCommandHandler_HandleHistory(t *testing.T) {
 	cmd := NewCommandHandler(messenger, nil)
 
 	ctx := context.Background()
-	cmd.HandleCommand(ctx, "chat1", "/history")
+	cmd.HandleCommand(ctx, "chat1", "", "/history")
 
 	if len(messenger.messages) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(messenger.messages))
@@ -285,7 +285,7 @@ func TestCommandHandler_HandleBrief(t *testing.T) {
 	cmd := NewCommandHandler(messenger, nil)
 
 	ctx := context.Background()
-	cmd.HandleCommand(ctx, "chat1", "/brief")
+	cmd.HandleCommand(ctx, "chat1", "", "/brief")
 
 	if len(messenger.messages) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(messenger.messages))
@@ -332,12 +332,12 @@ func TestCommandHandler_HandleRun(t *testing.T) {
 			if tt.hasHandler {
 				cmd.SetRunCommandFunc(func(ctx context.Context, contextID, taskID string) {
 					// Just mark that handler was called
-					_ = messenger.SendText(ctx, contextID, "Handler called with "+taskID)
+					_ = messenger.SendText(ctx, contextID, "", "Handler called with "+taskID)
 				})
 			}
 
 			ctx := context.Background()
-			cmd.HandleCommand(ctx, "chat1", tt.input)
+			cmd.HandleCommand(ctx, "chat1", "", tt.input)
 
 			if len(messenger.messages) == 0 {
 				t.Fatal("no messages sent")
@@ -386,7 +386,7 @@ func TestCommandHandler_HandleSwitch(t *testing.T) {
 			tt.setupFunc(cmd)
 
 			ctx := context.Background()
-			cmd.HandleCommand(ctx, "chat1", tt.input)
+			cmd.HandleCommand(ctx, "chat1", "", tt.input)
 
 			if len(messenger.messages) == 0 {
 				t.Fatal("no messages sent")
@@ -405,7 +405,7 @@ func TestCommandHandler_HandleUnknown(t *testing.T) {
 	cmd := NewCommandHandler(messenger, nil)
 
 	ctx := context.Background()
-	cmd.HandleCommand(ctx, "chat1", "/unknown")
+	cmd.HandleCommand(ctx, "chat1", "", "/unknown")
 
 	if len(messenger.messages) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(messenger.messages))
@@ -426,7 +426,7 @@ func TestCommandHandler_HandleNoPR(t *testing.T) {
 	cmd := NewCommandHandler(messenger, nil)
 
 	ctx := context.Background()
-	cmd.HandleCommand(ctx, "chat1", "/nopr create a new feature")
+	cmd.HandleCommand(ctx, "chat1", "", "/nopr create a new feature")
 
 	if len(messenger.messages) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(messenger.messages))
@@ -443,7 +443,7 @@ func TestCommandHandler_HandlePR(t *testing.T) {
 	cmd := NewCommandHandler(messenger, nil)
 
 	ctx := context.Background()
-	cmd.HandleCommand(ctx, "chat1", "/pr create a new feature")
+	cmd.HandleCommand(ctx, "chat1", "", "/pr create a new feature")
 
 	if len(messenger.messages) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(messenger.messages))
@@ -487,7 +487,7 @@ func TestCommandHandler_CommandParsing(t *testing.T) {
 			cmd := NewCommandHandler(messenger, nil)
 
 			ctx := context.Background()
-			cmd.HandleCommand(ctx, "chat1", tt.input)
+			cmd.HandleCommand(ctx, "chat1", "", tt.input)
 
 			tt.verify(t, messenger.messages)
 		})
@@ -500,7 +500,7 @@ func TestCommandHandler_ListAlias(t *testing.T) {
 	cmd := NewCommandHandler(messenger, nil)
 
 	ctx := context.Background()
-	cmd.HandleCommand(ctx, "chat1", "/list")
+	cmd.HandleCommand(ctx, "chat1", "", "/list")
 
 	if len(messenger.messages) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(messenger.messages))
@@ -518,7 +518,7 @@ func TestCommandHandler_ProjectAlias(t *testing.T) {
 
 	ctx := context.Background()
 	// /project without args should show current project
-	cmd.HandleCommand(ctx, "chat1", "/project")
+	cmd.HandleCommand(ctx, "chat1", "", "/project")
 
 	if len(messenger.messages) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(messenger.messages))

--- a/internal/comms/factory_test.go
+++ b/internal/comms/factory_test.go
@@ -150,8 +150,8 @@ func TestBuildHandler_NilClassifierConfig(t *testing.T) {
 // are exercised via BuildHandler and produce consistent fields.
 func TestBuildHandler_AdapterParity(t *testing.T) {
 	cases := []struct {
-		name         string
-		prefix       string
+		name          string
+		prefix        string
 		hasClassifier bool
 	}{
 		{"telegram-main", "TG", true},

--- a/internal/comms/handler.go
+++ b/internal/comms/handler.go
@@ -195,7 +195,7 @@ func (h *Handler) HandleMessage(ctx context.Context, msg *IncomingMessage) {
 	// Rate limit check
 	if !h.rateLimit.AllowMessage(contextID) {
 		h.log.Warn("Message rate limit exceeded", slog.String("context_id", contextID))
-		_ = h.messenger.SendText(ctx, contextID, "⚠️ Rate limit exceeded. Please wait before sending more messages.")
+		_ = h.messenger.SendText(ctx, contextID, msg.ThreadID, "⚠️ Rate limit exceeded. Please wait before sending more messages.")
 		return
 	}
 
@@ -218,7 +218,7 @@ func (h *Handler) HandleMessage(ctx context.Context, msg *IncomingMessage) {
 			h.log.Warn("unknown callback action_id reached comms",
 				slog.String("context_id", contextID),
 				slog.String("action_id", msg.ActionID))
-			_ = h.messenger.SendText(ctx, contextID, fmt.Sprintf("Unknown action: %s", msg.ActionID))
+			_ = h.messenger.SendText(ctx, contextID, msg.ThreadID, fmt.Sprintf("Unknown action: %s", msg.ActionID))
 		}
 		return
 	}
@@ -245,9 +245,9 @@ func (h *Handler) HandleMessage(ctx context.Context, msg *IncomingMessage) {
 	// Dispatch
 	switch detected {
 	case intent.IntentGreeting:
-		h.handleGreeting(ctx, contextID)
+		h.handleGreeting(ctx, contextID, msg.ThreadID)
 	case intent.IntentCommand:
-		h.handleCommand(ctx, contextID, text)
+		h.handleCommand(ctx, contextID, msg.ThreadID, text)
 	case intent.IntentOperational:
 		h.handleOperational(ctx, contextID, msg.ThreadID, text)
 	case intent.IntentQuestion:
@@ -264,7 +264,7 @@ func (h *Handler) HandleMessage(ctx context.Context, msg *IncomingMessage) {
 		h.handleIssueIntake(ctx, contextID, msg.ThreadID, text)
 	default:
 		// Unknown intent — clarify rather than auto-creating a task.
-		_ = h.messenger.SendText(ctx, contextID, "I didn't quite catch that — try /help, or rephrase your request.")
+		_ = h.messenger.SendText(ctx, contextID, msg.ThreadID, "I didn't quite catch that — try /help, or rephrase your request.")
 	}
 }
 
@@ -330,20 +330,20 @@ func (h *Handler) detectIntent(ctx context.Context, contextID, text string) inte
 
 // ---------- intent handlers ----------
 
-func (h *Handler) handleGreeting(ctx context.Context, contextID string) {
+func (h *Handler) handleGreeting(ctx context.Context, contextID, threadID string) {
 	if h.responder != nil {
-		_ = h.messenger.SendText(ctx, contextID, h.responder.Greeting())
+		_ = h.messenger.SendText(ctx, contextID, threadID, h.responder.Greeting())
 		return
 	}
-	_ = h.messenger.SendText(ctx, contextID, "👋 Hello! I'm Pilot — send me a task, question, or say /help.")
+	_ = h.messenger.SendText(ctx, contextID, threadID, "👋 Hello! I'm Pilot — send me a task, question, or say /help.")
 }
 
-func (h *Handler) handleCommand(ctx context.Context, contextID, text string) {
+func (h *Handler) handleCommand(ctx context.Context, contextID, threadID, text string) {
 	if h.cmdHandler == nil {
-		_ = h.messenger.SendText(ctx, contextID, "I didn't quite catch that — try /help, or rephrase your request.")
+		_ = h.messenger.SendText(ctx, contextID, threadID, "I didn't quite catch that — try /help, or rephrase your request.")
 		return
 	}
-	h.cmdHandler.HandleCommand(ctx, contextID, text)
+	h.cmdHandler.HandleCommand(ctx, contextID, threadID, text)
 }
 
 func (h *Handler) handleOperational(ctx context.Context, contextID, threadID, text string) {
@@ -354,21 +354,21 @@ func (h *Handler) handleOperational(ctx context.Context, contextID, threadID, te
 
 	running, err := h.store.GetActiveExecutions()
 	if err != nil {
-		_ = h.messenger.SendText(ctx, contextID, "❌ Failed to fetch queue status")
+		_ = h.messenger.SendText(ctx, contextID, threadID, "❌ Failed to fetch queue status")
 		return
 	}
 
 	queued, err := h.store.GetQueuedTasks(10)
 	if err != nil {
-		_ = h.messenger.SendText(ctx, contextID, "❌ Failed to fetch queue status")
+		_ = h.messenger.SendText(ctx, contextID, threadID, "❌ Failed to fetch queue status")
 		return
 	}
 
-	_ = h.messenger.SendText(ctx, contextID, formatQueueSummary(running, queued))
+	_ = h.messenger.SendText(ctx, contextID, threadID, formatQueueSummary(running, queued))
 }
 
 func (h *Handler) handleQuestion(ctx context.Context, contextID, threadID, question string) {
-	_ = h.messenger.SendText(ctx, contextID, "🔍 Looking into that...")
+	_ = h.messenger.SendText(ctx, contextID, threadID, "🔍 Looking into that...")
 
 	// Fast path: retrieval-grounded LLM answer (~2-4s, cites real file paths).
 	if h.responder != nil {
@@ -394,7 +394,7 @@ func (h *Handler) handleQuestion(ctx context.Context, contextID, threadID, quest
 	}
 
 	if h.runner == nil {
-		_ = h.messenger.SendText(ctx, contextID, "I couldn't answer that question.")
+		_ = h.messenger.SendText(ctx, contextID, threadID, "I couldn't answer that question.")
 		return
 	}
 
@@ -427,9 +427,9 @@ If the question is too broad, ask for clarification instead of exploring everyth
 
 	if err != nil {
 		if questionCtx.Err() == context.DeadlineExceeded {
-			_ = h.messenger.SendText(ctx, contextID, "⏱ Question timed out. Try asking something more specific.")
+			_ = h.messenger.SendText(ctx, contextID, threadID, "⏱ Question timed out. Try asking something more specific.")
 		} else {
-			_ = h.messenger.SendText(ctx, contextID, "❌ Sorry, I couldn't answer that question. Try rephrasing it.")
+			_ = h.messenger.SendText(ctx, contextID, threadID, "❌ Sorry, I couldn't answer that question. Try rephrasing it.")
 		}
 		return
 	}
@@ -443,7 +443,7 @@ If the question is too broad, ask for clarification instead of exploring everyth
 }
 
 func (h *Handler) handleResearch(ctx context.Context, contextID, threadID, query string) {
-	_ = h.messenger.SendText(ctx, contextID, "🔬 Researching...")
+	_ = h.messenger.SendText(ctx, contextID, threadID, "🔬 Researching...")
 
 	taskID := fmt.Sprintf("RES-%d", time.Now().Unix())
 	researchProjectPath := h.getActiveProjectPath(contextID)
@@ -474,16 +474,16 @@ DO NOT make any code changes. This is a read-only research task.`, query),
 
 	if err != nil {
 		if researchCtx.Err() == context.DeadlineExceeded {
-			_ = h.messenger.SendText(ctx, contextID, "⏱ Research timed out. Try a more specific query.")
+			_ = h.messenger.SendText(ctx, contextID, threadID, "⏱ Research timed out. Try a more specific query.")
 		} else {
-			_ = h.messenger.SendText(ctx, contextID, fmt.Sprintf("❌ Research failed: %s", err.Error()))
+			_ = h.messenger.SendText(ctx, contextID, threadID, fmt.Sprintf("❌ Research failed: %s", err.Error()))
 		}
 		return
 	}
 
 	content := CleanInternalSignals(result.Output)
 	if content == "" {
-		_ = h.messenger.SendText(ctx, contextID, "Research completed but produced no output.")
+		_ = h.messenger.SendText(ctx, contextID, threadID, "Research completed but produced no output.")
 		return
 	}
 
@@ -491,7 +491,7 @@ DO NOT make any code changes. This is a read-only research task.`, query),
 }
 
 func (h *Handler) handlePlanning(ctx context.Context, contextID, threadID, request string) {
-	_ = h.messenger.SendText(ctx, contextID, "📐 Drafting plan...")
+	_ = h.messenger.SendText(ctx, contextID, threadID, "📐 Drafting plan...")
 
 	taskID := fmt.Sprintf("PLAN-%d", time.Now().Unix())
 	planProjectPath := h.getActiveProjectPath(contextID)
@@ -525,16 +525,16 @@ DO NOT make any code changes. Only explore and plan.`, request),
 
 	if err != nil {
 		if planCtx.Err() == context.DeadlineExceeded {
-			_ = h.messenger.SendText(ctx, contextID, "⏱ Planning timed out. Try a simpler request.")
+			_ = h.messenger.SendText(ctx, contextID, threadID, "⏱ Planning timed out. Try a simpler request.")
 		} else {
-			_ = h.messenger.SendText(ctx, contextID, fmt.Sprintf("❌ Planning failed: %s", err.Error()))
+			_ = h.messenger.SendText(ctx, contextID, threadID, fmt.Sprintf("❌ Planning failed: %s", err.Error()))
 		}
 		return
 	}
 
 	planContent := CleanInternalSignals(result.Output)
 	if planContent == "" {
-		_ = h.messenger.SendText(ctx, contextID, "Planning completed but produced no output.")
+		_ = h.messenger.SendText(ctx, contextID, threadID, "Planning completed but produced no output.")
 		return
 	}
 
@@ -556,7 +556,7 @@ DO NOT make any code changes. Only explore and plan.`, request),
 	if err != nil {
 		h.log.Warn("Failed to send plan confirmation, falling back to text", slog.Any("error", err))
 		_ = h.messenger.SendChunked(ctx, contextID, threadID, planContent, "📋 Implementation Plan")
-		_ = h.messenger.SendText(ctx, contextID, "Reply yes to execute or no to cancel.")
+		_ = h.messenger.SendText(ctx, contextID, threadID, "Reply yes to execute or no to cancel.")
 	}
 }
 
@@ -570,7 +570,7 @@ func (h *Handler) handleChat(ctx context.Context, contextID, threadID, message s
 		response, err := h.responder.Chat(ctx, history, message)
 		if err != nil {
 			h.log.Warn("responder.Chat failed", slog.Any("error", err))
-			_ = h.messenger.SendText(ctx, contextID, "Sorry, I couldn't process that. Try rephrasing?")
+			_ = h.messenger.SendText(ctx, contextID, threadID, "Sorry, I couldn't process that. Try rephrasing?")
 			return
 		}
 		if response == "" {
@@ -580,7 +580,7 @@ func (h *Handler) handleChat(ctx context.Context, contextID, threadID, message s
 		if maxLen > 0 && len(response) > maxLen {
 			response = response[:maxLen-3] + "..."
 		}
-		_ = h.messenger.SendText(ctx, contextID, response)
+		_ = h.messenger.SendText(ctx, contextID, threadID, response)
 		if h.convStore != nil {
 			h.convStore.Add(contextID, "assistant", TruncateText(response, 500))
 		}
@@ -588,7 +588,7 @@ func (h *Handler) handleChat(ctx context.Context, contextID, threadID, message s
 	}
 
 	// Fallback: executor path (unchanged behavior when bot is disabled).
-	_ = h.messenger.SendText(ctx, contextID, "💬 Thinking...")
+	_ = h.messenger.SendText(ctx, contextID, threadID, "💬 Thinking...")
 
 	taskID := fmt.Sprintf("CHAT-%d", time.Now().Unix())
 	chatProjectPath := h.getActiveProjectPath(contextID)
@@ -618,9 +618,9 @@ User message: %s`, chatProjectPath, message),
 
 	if err != nil {
 		if chatCtx.Err() == context.DeadlineExceeded {
-			_ = h.messenger.SendText(ctx, contextID, "⏱ Took too long to respond. Try a simpler question.")
+			_ = h.messenger.SendText(ctx, contextID, threadID, "⏱ Took too long to respond. Try a simpler question.")
 		} else {
-			_ = h.messenger.SendText(ctx, contextID, "Sorry, I couldn't process that. Try rephrasing?")
+			_ = h.messenger.SendText(ctx, contextID, threadID, "Sorry, I couldn't process that. Try rephrasing?")
 		}
 		return
 	}
@@ -636,7 +636,7 @@ User message: %s`, chatProjectPath, message),
 		response = response[:maxLen-3] + "..."
 	}
 
-	_ = h.messenger.SendText(ctx, contextID, response)
+	_ = h.messenger.SendText(ctx, contextID, threadID, response)
 
 	// Record in conversation history
 	if h.convStore != nil {
@@ -648,7 +648,7 @@ func (h *Handler) handleTask(ctx context.Context, contextID, threadID, descripti
 	// Task rate limit
 	if !h.rateLimit.AllowTask(contextID) {
 		h.log.Warn("Task rate limit exceeded", slog.String("context_id", contextID))
-		_ = h.messenger.SendText(ctx, contextID,
+		_ = h.messenger.SendText(ctx, contextID, threadID,
 			"⚠️ Task rate limit exceeded. You've submitted too many tasks recently. Please wait before submitting more.")
 		return
 	}
@@ -657,7 +657,7 @@ func (h *Handler) handleTask(ctx context.Context, contextID, threadID, descripti
 	h.mu.Lock()
 	if existing, exists := h.pendingTasks[contextID]; exists {
 		h.mu.Unlock()
-		_ = h.messenger.SendText(ctx, contextID,
+		_ = h.messenger.SendText(ctx, contextID, threadID,
 			fmt.Sprintf("⚠️ You already have a pending task: %s\n\nReply yes to execute or no to cancel.", existing.TaskID))
 		return
 	}
@@ -679,7 +679,7 @@ func (h *Handler) handleTask(ctx context.Context, contextID, threadID, descripti
 	_, err := h.messenger.SendConfirmation(ctx, contextID, threadID, taskID, description, h.getActiveProjectPath(contextID))
 	if err != nil {
 		h.log.Warn("Failed to send task confirmation", slog.Any("error", err))
-		_ = h.messenger.SendText(ctx, contextID,
+		_ = h.messenger.SendText(ctx, contextID, threadID,
 			fmt.Sprintf("📋 Task %s\n\n%s\n\nReply yes to execute or no to cancel.",
 				taskID, TruncateText(description, 500)))
 	}
@@ -731,12 +731,12 @@ func (h *Handler) handleConfirmation(ctx context.Context, contextID, threadID st
 	h.mu.Unlock()
 
 	if !exists {
-		_ = h.messenger.SendText(ctx, contextID, "No pending task to confirm.")
+		_ = h.messenger.SendText(ctx, contextID, threadID, "No pending task to confirm.")
 		return
 	}
 
 	if !confirmed {
-		_ = h.messenger.SendText(ctx, contextID, fmt.Sprintf("❌ Task %s cancelled.", pending.TaskID))
+		_ = h.messenger.SendText(ctx, contextID, threadID, fmt.Sprintf("❌ Task %s cancelled.", pending.TaskID))
 		return
 	}
 
@@ -758,7 +758,7 @@ func (h *Handler) executeTaskCore(ctx context.Context, contextID, threadID, task
 	msgRef, err := h.messenger.SendProgress(ctx, contextID, "", taskID, "Starting"+prNote, 0, "Initializing...")
 	if err != nil {
 		h.log.Warn("Failed to send progress start", slog.Any("error", err))
-		_ = h.messenger.SendText(ctx, contextID, detail)
+		_ = h.messenger.SendText(ctx, contextID, threadID, detail)
 	}
 
 	// Track running task
@@ -767,6 +767,7 @@ func (h *Handler) executeTaskCore(ctx context.Context, contextID, threadID, task
 	h.runningTasks[contextID] = &RunningTask{
 		TaskID:    taskID,
 		ContextID: contextID,
+		ThreadID:  threadID,
 		StartedAt: time.Now(),
 		Cancel:    taskCancel,
 	}
@@ -838,7 +839,7 @@ func (h *Handler) executeTaskCore(ctx context.Context, contextID, threadID, task
 	execID, lifeErr := lifecycle.Begin(task, executor.ExecStatusRunning)
 	if lifeErr != nil {
 		if errors.Is(lifeErr, executor.ErrClaimLost) {
-			_ = h.messenger.SendText(ctx, contextID, fmt.Sprintf("⚠️ %s is already being executed by another Pilot process.", taskID))
+			_ = h.messenger.SendText(ctx, contextID, threadID, fmt.Sprintf("⚠️ %s is already being executed by another Pilot process.", taskID))
 			if h.runner != nil {
 				h.runner.RemoveProgressCallback(callbackName)
 			}
@@ -1001,11 +1002,11 @@ func (h *Handler) CancelTask(ctx context.Context, contextID string) error {
 	h.mu.Unlock()
 
 	if hasPending {
-		_ = h.messenger.SendText(ctx, contextID, fmt.Sprintf("❌ Cancelled pending task %s", pending.TaskID))
+		_ = h.messenger.SendText(ctx, contextID, pending.ThreadID, fmt.Sprintf("❌ Cancelled pending task %s", pending.TaskID))
 		return nil
 	}
 	if hasRunning {
-		_ = h.messenger.SendText(ctx, contextID, fmt.Sprintf("🛑 Stopping task %s", running.TaskID))
+		_ = h.messenger.SendText(ctx, contextID, running.ThreadID, fmt.Sprintf("🛑 Stopping task %s", running.TaskID))
 		return nil
 	}
 	return fmt.Errorf("no task to cancel")
@@ -1031,18 +1032,19 @@ func (h *Handler) CleanupLoop(ctx context.Context) {
 
 func (h *Handler) cleanupExpiredTasks(ctx context.Context) {
 	h.mu.Lock()
-	var expired []string
+	type expiredTask struct{ contextID, threadID string }
+	var expired []expiredTask
 	for id, task := range h.pendingTasks {
 		if time.Since(task.CreatedAt) > 5*time.Minute {
-			expired = append(expired, id)
+			expired = append(expired, expiredTask{contextID: id, threadID: task.ThreadID})
 		}
 	}
-	for _, id := range expired {
-		delete(h.pendingTasks, id)
+	for _, e := range expired {
+		delete(h.pendingTasks, e.contextID)
 	}
 	h.mu.Unlock()
 
-	for _, id := range expired {
-		_ = h.messenger.SendText(ctx, id, "⏰ Pending task expired (5 min timeout). Send a new request.")
+	for _, e := range expired {
+		_ = h.messenger.SendText(ctx, e.contextID, e.threadID, "⏰ Pending task expired (5 min timeout). Send a new request.")
 	}
 }

--- a/internal/comms/handler_chat_test.go
+++ b/internal/comms/handler_chat_test.go
@@ -147,7 +147,7 @@ func TestHandleGreeting_ResponderPath_UsesPersona(t *testing.T) {
 	m := &handlerMock{}
 	h, _ := newHandlerWithResponder(m, "", "I am your Go assistant.")
 
-	h.handleGreeting(context.Background(), "ch1")
+	h.handleGreeting(context.Background(), "ch1", "")
 
 	texts := m.getTexts()
 	if len(texts) == 0 {
@@ -163,7 +163,7 @@ func TestHandleGreeting_NilResponder_StaticText(t *testing.T) {
 	m := &handlerMock{}
 	h := newTestHandler(m)
 
-	h.handleGreeting(context.Background(), "ch1")
+	h.handleGreeting(context.Background(), "ch1", "")
 
 	texts := m.getTexts()
 	if len(texts) == 0 {

--- a/internal/comms/handler_test.go
+++ b/internal/comms/handler_test.go
@@ -44,7 +44,7 @@ type hSentProgress struct {
 	progress                                 int
 }
 
-func (m *handlerMock) SendText(_ context.Context, contextID, text string) error {
+func (m *handlerMock) SendText(_ context.Context, contextID, threadID, text string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.texts = append(m.texts, hSentText{contextID, text})
@@ -1279,5 +1279,69 @@ func TestSendTaskResult_NotDeclined(t *testing.T) {
 	res := m.results[0]
 	if !res.success || res.prURL != "https://github.com/qf-studio/pilot/pull/123" || res.output != "done" {
 		t.Errorf("unexpected SendResult contents: %+v", res)
+	}
+}
+
+type threadCapturingMessenger struct {
+	mockMessenger
+	mu      sync.Mutex
+	threads []string
+}
+
+func (m *threadCapturingMessenger) SendText(_ context.Context, _, threadID, _ string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.threads = append(m.threads, threadID)
+	return nil
+}
+
+func (m *threadCapturingMessenger) SendConfirmation(_ context.Context, _, threadID, _, _, _ string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.threads = append(m.threads, threadID)
+	return "1", nil
+}
+
+func (m *threadCapturingMessenger) seen() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.threads...)
+}
+
+func TestRepliesReturnToOriginatingThread(t *testing.T) {
+	tests := []struct {
+		name     string
+		threadID string
+		text     string
+	}{
+		{name: "task intent from a topic", threadID: "42", text: "implement rate limiting for the API"},
+		{name: "greeting from a topic", threadID: "42", text: "hi"},
+		{name: "command from a topic", threadID: "42", text: "/status"},
+		{name: "general thread carries no topic", threadID: "", text: "implement rate limiting for the API"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msgr := &threadCapturingMessenger{}
+			h := NewHandler(&HandlerConfig{Messenger: msgr, TaskIDPrefix: "TG"})
+
+			h.HandleMessage(context.Background(), &IncomingMessage{
+				ContextID: "chat-1",
+				SenderID:  "user-1",
+				Text:      tt.text,
+				ThreadID:  tt.threadID,
+				Platform:  "telegram",
+			})
+
+			got := msgr.seen()
+			if len(got) == 0 {
+				t.Fatal("expected at least one outbound message")
+			}
+			for i, threadID := range got {
+				if threadID != tt.threadID {
+					t.Errorf("outbound %d threadID = %q, want %q", i, threadID, tt.threadID)
+				}
+			}
+		})
 	}
 }

--- a/internal/comms/handler_test.go
+++ b/internal/comms/handler_test.go
@@ -2,6 +2,7 @@ package comms
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -17,17 +18,19 @@ import (
 
 // handlerMock records all Messenger calls for assertion in handler tests.
 type handlerMock struct {
-	mu       sync.Mutex
-	texts    []hSentText
-	confirms []hSentConfirm
-	results  []hSentResult
-	chunks   []hSentChunk
-	progress []hSentProgress
-	acks     []string
+	mu          sync.Mutex
+	texts       []hSentText
+	confirms    []hSentConfirm
+	results     []hSentResult
+	chunks      []hSentChunk
+	progress    []hSentProgress
+	acks        []string
+	confirmErr  error
+	progressErr error
 }
 
 type hSentText struct {
-	contextID, text string
+	contextID, threadID, text string
 }
 type hSentConfirm struct {
 	contextID, threadID, taskID, desc, project string
@@ -47,7 +50,7 @@ type hSentProgress struct {
 func (m *handlerMock) SendText(_ context.Context, contextID, threadID, text string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.texts = append(m.texts, hSentText{contextID, text})
+	m.texts = append(m.texts, hSentText{contextID, threadID, text})
 	return nil
 }
 
@@ -55,6 +58,9 @@ func (m *handlerMock) SendConfirmation(_ context.Context, contextID, threadID, t
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.confirms = append(m.confirms, hSentConfirm{contextID, threadID, taskID, desc, project})
+	if m.confirmErr != nil {
+		return "", m.confirmErr
+	}
 	return "msg-ref-1", nil
 }
 
@@ -62,6 +68,9 @@ func (m *handlerMock) SendProgress(_ context.Context, contextID, msgRef, taskID,
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.progress = append(m.progress, hSentProgress{contextID, msgRef, taskID, phase, detail, progress})
+	if m.progressErr != nil {
+		return "", m.progressErr
+	}
 	return msgRef, nil
 }
 
@@ -1342,6 +1351,291 @@ func TestRepliesReturnToOriginatingThread(t *testing.T) {
 					t.Errorf("outbound %d threadID = %q, want %q", i, threadID, tt.threadID)
 				}
 			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Forum-topic threading: every reply must land in the thread it came from.
+// ---------------------------------------------------------------------------
+
+// scriptedBackend returns a canned backend result so executor-backed intent
+// handlers can be driven through their success, empty and error branches.
+type scriptedBackend struct {
+	output string
+	err    error
+}
+
+func (b *scriptedBackend) Name() string      { return "scripted" }
+func (b *scriptedBackend) IsAvailable() bool { return true }
+
+func (b *scriptedBackend) Execute(_ context.Context, _ executor.ExecuteOptions) (*executor.BackendResult, error) {
+	if b.err != nil {
+		return nil, b.err
+	}
+	return &executor.BackendResult{Success: true, Output: b.output}, nil
+}
+
+func newScriptedRunner(backend executor.Backend) *executor.Runner {
+	runner := executor.NewRunnerWithBackend(backend)
+	runner.SetSkipPreflightChecks(true)
+	runner.SetRecordingEnabled(false)
+	return runner
+}
+
+func (m *handlerMock) allSends() (bodies []string, threadIDs []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, s := range m.texts {
+		bodies = append(bodies, s.text)
+		threadIDs = append(threadIDs, s.threadID)
+	}
+	for _, s := range m.chunks {
+		bodies = append(bodies, s.content)
+		threadIDs = append(threadIDs, s.threadID)
+	}
+	for _, s := range m.confirms {
+		bodies = append(bodies, s.desc)
+		threadIDs = append(threadIDs, s.threadID)
+	}
+	for _, s := range m.results {
+		bodies = append(bodies, s.output)
+		threadIDs = append(threadIDs, s.threadID)
+	}
+	return bodies, threadIDs
+}
+
+func assertAllSentToThread(t *testing.T, m *handlerMock, wantText string) {
+	t.Helper()
+	bodies, threadIDs := m.allSends()
+	if len(bodies) == 0 {
+		t.Fatal("no messages sent")
+	}
+	found := false
+	for _, body := range bodies {
+		if strings.Contains(body, wantText) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("no message contains %q: %v", wantText, bodies)
+	}
+	for i, got := range threadIDs {
+		if got != threadIDUnderTest {
+			t.Errorf("message %d sent with threadID %q, want %q", i, got, threadIDUnderTest)
+		}
+	}
+}
+
+// TestHandler_OperationalQueueError_UsesThread covers the queue-status fetch
+// failure reply in handleOperational.
+func TestHandler_OperationalQueueError_UsesThread(t *testing.T) {
+	m := &handlerMock{}
+	h := NewHandler(&HandlerConfig{
+		Messenger:    m,
+		Store:        mustCreateClosedMemoryStore(t),
+		TaskIDPrefix: "TEST",
+	})
+
+	h.handleOperational(context.Background(), "ch1", threadIDUnderTest, "what's queued?")
+
+	assertAllSentToThread(t, m, "Failed to fetch queue status")
+}
+
+// TestHandler_ExecutorIntents_UseThread drives the question / research /
+// planning / chat handlers through their empty-output and success branches and
+// asserts every reply carries the originating thread.
+func TestHandler_ExecutorIntents_UseThread(t *testing.T) {
+	tests := []struct {
+		name       string
+		backend    *scriptedBackend
+		confirmErr error
+		invoke     func(h *Handler, ctx context.Context)
+		wantText   string
+	}{
+		{
+			name:    "question answered",
+			backend: &scriptedBackend{output: "auth lives in internal/auth"},
+			invoke: func(h *Handler, ctx context.Context) {
+				h.handleQuestion(ctx, "ch1", threadIDUnderTest, "where is auth?")
+			},
+			wantText: "auth lives in internal/auth",
+		},
+		{
+			name:     "research produces no output",
+			backend:  &scriptedBackend{output: ""},
+			invoke:   func(h *Handler, ctx context.Context) { h.handleResearch(ctx, "ch1", threadIDUnderTest, "caching") },
+			wantText: "no output",
+		},
+		{
+			name:     "research succeeds",
+			backend:  &scriptedBackend{output: "findings: use an LRU"},
+			invoke:   func(h *Handler, ctx context.Context) { h.handleResearch(ctx, "ch1", threadIDUnderTest, "caching") },
+			wantText: "findings: use an LRU",
+		},
+		{
+			name:     "planning produces no output",
+			backend:  &scriptedBackend{output: ""},
+			invoke:   func(h *Handler, ctx context.Context) { h.handlePlanning(ctx, "ch1", threadIDUnderTest, "add caching") },
+			wantText: "no output",
+		},
+		{
+			name:     "planning sends confirmation",
+			backend:  &scriptedBackend{output: "step 1: add an LRU"},
+			invoke:   func(h *Handler, ctx context.Context) { h.handlePlanning(ctx, "ch1", threadIDUnderTest, "add caching") },
+			wantText: "step 1: add an LRU",
+		},
+		{
+			name:       "planning falls back to a confirm prompt",
+			backend:    &scriptedBackend{output: "step 1: add an LRU"},
+			confirmErr: errors.New("no inline keyboards here"),
+			invoke:     func(h *Handler, ctx context.Context) { h.handlePlanning(ctx, "ch1", threadIDUnderTest, "add caching") },
+			wantText:   "Reply yes to execute",
+		},
+		{
+			name:     "chat responds",
+			backend:  &scriptedBackend{output: "doing fine"},
+			invoke:   func(h *Handler, ctx context.Context) { h.handleChat(ctx, "ch1", threadIDUnderTest, "how are you?") },
+			wantText: "doing fine",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &handlerMock{confirmErr: tt.confirmErr}
+			h := NewHandler(&HandlerConfig{
+				Messenger:    m,
+				Runner:       newScriptedRunner(tt.backend),
+				ProjectPath:  t.TempDir(),
+				TaskIDPrefix: "TEST",
+			})
+
+			tt.invoke(h, context.Background())
+
+			assertAllSentToThread(t, m, tt.wantText)
+		})
+	}
+}
+
+// TestHandler_ChatResponderError_UsesThread covers the responder failure reply.
+func TestHandler_ChatResponderError_UsesThread(t *testing.T) {
+	m := &handlerMock{}
+	a := &mockAnswerer{err: errors.New("llm down")}
+	h := NewHandler(&HandlerConfig{
+		Messenger:    m,
+		Responder:    &Responder{client: a, answerModel: "claude-haiku-4-5-20251001"},
+		TaskIDPrefix: "TEST",
+	})
+
+	h.handleChat(context.Background(), "ch1", threadIDUnderTest, "hey")
+
+	assertAllSentToThread(t, m, "couldn't process that")
+}
+
+// TestHandler_TaskConfirmationFallback_UsesThread covers the text fallback when
+// the platform cannot render a confirmation control.
+func TestHandler_TaskConfirmationFallback_UsesThread(t *testing.T) {
+	m := &handlerMock{confirmErr: errors.New("no inline keyboards here")}
+	h := newTestHandler(m)
+
+	h.handleTask(context.Background(), "ch1", threadIDUnderTest, "add response caching", "u1")
+
+	assertAllSentToThread(t, m, "Reply yes to execute")
+}
+
+// TestHandler_ProgressStartFallback_UsesThread covers the text fallback when the
+// progress control cannot be created.
+func TestHandler_ProgressStartFallback_UsesThread(t *testing.T) {
+	m := &handlerMock{progressErr: errors.New("no progress messages here")}
+	h := NewHandler(&HandlerConfig{
+		Messenger:    m,
+		Runner:       newScriptedRunner(&scriptedBackend{output: "done"}),
+		ProjectPath:  t.TempDir(),
+		TaskIDPrefix: "TEST",
+	})
+
+	h.executeTask(context.Background(), "ch1", threadIDUnderTest, "TEST-1", "add response caching")
+
+	assertAllSentToThread(t, m, "Starting TEST-1")
+}
+
+// TestHandler_ClaimLost_UsesThread covers the "already executing" reply when
+// another process holds the execution claim.
+func TestHandler_ClaimLost_UsesThread(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	projectPath := t.TempDir()
+	taskID := "TEST-claimed"
+	if _, err := executor.NewExecutionLifecycle(store).Begin(
+		&executor.Task{ID: taskID, ProjectPath: projectPath}, executor.ExecStatusRunning); err != nil {
+		t.Fatalf("pre-claim Begin: %v", err)
+	}
+
+	m := &handlerMock{}
+	h := NewHandler(&HandlerConfig{
+		Messenger:    m,
+		Runner:       newScriptedRunner(&scriptedBackend{output: "done"}),
+		Store:        store,
+		ProjectPath:  projectPath,
+		TaskIDPrefix: "TEST",
+	})
+
+	h.executeTask(context.Background(), "ch1", threadIDUnderTest, taskID, "add response caching")
+
+	assertAllSentToThread(t, m, "already being executed")
+}
+
+// TestHandler_CancelTaskUsesStoredThread asserts cancellation replies go to the
+// thread the task was started from — CancelTask has no caller thread to use.
+func TestHandler_CancelTaskUsesStoredThread(t *testing.T) {
+	tests := []struct {
+		name     string
+		seed     func(h *Handler)
+		wantText string
+	}{
+		{
+			name: "pending task",
+			seed: func(h *Handler) {
+				h.pendingTasks["ch1"] = &PendingTask{
+					TaskID:    "TEST-1",
+					ContextID: "ch1",
+					ThreadID:  threadIDUnderTest,
+					CreatedAt: time.Now(),
+				}
+			},
+			wantText: "Cancelled pending task TEST-1",
+		},
+		{
+			name: "running task",
+			seed: func(h *Handler) {
+				h.runningTasks["ch1"] = &RunningTask{
+					TaskID:    "TEST-2",
+					ContextID: "ch1",
+					ThreadID:  threadIDUnderTest,
+					StartedAt: time.Now(),
+					Cancel:    func() {},
+				}
+			},
+			wantText: "Stopping task TEST-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &handlerMock{}
+			h := newTestHandler(m)
+			tt.seed(h)
+
+			if err := h.CancelTask(context.Background(), "ch1"); err != nil {
+				t.Fatalf("CancelTask: %v", err)
+			}
+
+			assertAllSentToThread(t, m, tt.wantText)
 		})
 	}
 }

--- a/internal/comms/issue_intake.go
+++ b/internal/comms/issue_intake.go
@@ -102,11 +102,11 @@ func (r *Responder) DraftIssue(ctx context.Context, history []intent.Conversatio
 // handleIssueIntake drafts a GitHub issue from the user's freeform message and creates it directly.
 func (h *Handler) handleIssueIntake(ctx context.Context, contextID, threadID, text string) {
 	if h.responder == nil {
-		_ = h.messenger.SendText(ctx, contextID, "Issue intake requires the bot module to be enabled (bot.enabled: true).")
+		_ = h.messenger.SendText(ctx, contextID, threadID, "Issue intake requires the bot module to be enabled (bot.enabled: true).")
 		return
 	}
 	if h.issueCreator == nil {
-		_ = h.messenger.SendText(ctx, contextID, "Issue creation requires GitHub to be configured (adapters.github).")
+		_ = h.messenger.SendText(ctx, contextID, threadID, "Issue creation requires GitHub to be configured (adapters.github).")
 		return
 	}
 
@@ -114,7 +114,7 @@ func (h *Handler) handleIssueIntake(ctx context.Context, contextID, threadID, te
 	h.mu.Lock()
 	if _, inFlight := h.pendingIssues[contextID]; inFlight {
 		h.mu.Unlock()
-		_ = h.messenger.SendText(ctx, contextID, "⚠️ An issue is already being drafted for this context. Please wait.")
+		_ = h.messenger.SendText(ctx, contextID, threadID, "⚠️ An issue is already being drafted for this context. Please wait.")
 		return
 	}
 	placeholder := &IssueDraft{}
@@ -126,7 +126,7 @@ func (h *Handler) handleIssueIntake(ctx context.Context, contextID, threadID, te
 		h.mu.Unlock()
 	}()
 
-	_ = h.messenger.SendText(ctx, contextID, "🎫 Drafting issue...")
+	_ = h.messenger.SendText(ctx, contextID, threadID, "🎫 Drafting issue...")
 
 	var history []intent.ConversationMessage
 	if h.convStore != nil {
@@ -136,7 +136,7 @@ func (h *Handler) handleIssueIntake(ctx context.Context, contextID, threadID, te
 	draft, err := h.responder.DraftIssue(ctx, history, text)
 	if err != nil {
 		h.log.Warn("DraftIssue failed", slog.Any("error", err))
-		_ = h.messenger.SendText(ctx, contextID, "❌ Failed to draft issue. Try being more specific about what you'd like to track.")
+		_ = h.messenger.SendText(ctx, contextID, threadID, "❌ Failed to draft issue. Try being more specific about what you'd like to track.")
 		return
 	}
 
@@ -144,7 +144,7 @@ func (h *Handler) handleIssueIntake(ctx context.Context, contextID, threadID, te
 	url, err := h.issueCreator.CreateIssue(ctx, projectPath, draft)
 	if err != nil {
 		h.log.Warn("CreateIssue failed", slog.Any("error", err), slog.String("title", draft.Title))
-		_ = h.messenger.SendText(ctx, contextID, fmt.Sprintf("❌ Failed to create issue: %s", err.Error()))
+		_ = h.messenger.SendText(ctx, contextID, threadID, fmt.Sprintf("❌ Failed to create issue: %s", err.Error()))
 		return
 	}
 

--- a/internal/comms/issue_intake_test.go
+++ b/internal/comms/issue_intake_test.go
@@ -283,3 +283,59 @@ func TestIsIssueIntakeRequest(t *testing.T) {
 		}
 	}
 }
+
+// TestHandleIssueIntake_AlreadyDrafting covers the in-flight guard and asserts
+// the warning goes back to the originating thread.
+func TestHandleIssueIntake_AlreadyDrafting(t *testing.T) {
+	responder, _ := newMockResponder(`{"title":"feat(x): y","body":"b","labels":["pilot"]}`, "")
+	messenger := &mockMessenger{}
+	h := &Handler{
+		messenger:     messenger,
+		responder:     responder,
+		issueCreator:  &mockIssueCreator{url: "https://example.test/issues/1"},
+		pendingIssues: map[string]*IssueDraft{"ctx1": {}},
+		log:           slog.Default(),
+	}
+
+	h.handleIssueIntake(context.Background(), "ctx1", threadIDUnderTest, "file a ticket")
+
+	if len(messenger.messages) != 1 {
+		t.Fatalf("expected 1 message, got %v", messenger.messages)
+	}
+	if !strings.Contains(messenger.messages[0], "already being drafted") {
+		t.Errorf("expected in-flight warning, got %q", messenger.messages[0])
+	}
+	if messenger.threadIDs[0] != threadIDUnderTest {
+		t.Errorf("threadID = %q, want %q", messenger.threadIDs[0], threadIDUnderTest)
+	}
+}
+
+// TestHandleIssueIntake_DraftFailure covers the LLM draft failure reply.
+func TestHandleIssueIntake_DraftFailure(t *testing.T) {
+	a := &mockAnswerer{err: errors.New("llm down")}
+	messenger := &mockMessenger{}
+	h := &Handler{
+		messenger:     messenger,
+		responder:     &Responder{client: a, answerModel: "claude-haiku-4-5-20251001"},
+		issueCreator:  &mockIssueCreator{url: "https://example.test/issues/1"},
+		pendingIssues: make(map[string]*IssueDraft),
+		log:           slog.Default(),
+	}
+
+	h.handleIssueIntake(context.Background(), "ctx1", threadIDUnderTest, "file a ticket")
+
+	found := false
+	for _, msg := range messenger.messages {
+		if strings.Contains(msg, "Failed to draft issue") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected draft failure message, got %v", messenger.messages)
+	}
+	for i, got := range messenger.threadIDs {
+		if got != threadIDUnderTest {
+			t.Errorf("message %d sent with threadID %q, want %q", i, got, threadIDUnderTest)
+		}
+	}
+}

--- a/internal/comms/types.go
+++ b/internal/comms/types.go
@@ -27,7 +27,7 @@ type IncomingMessage struct {
 // Messenger is the interface every chat adapter must implement for outbound messaging.
 type Messenger interface {
 	// SendText sends a plain text message to the given context (channel/chat).
-	SendText(ctx context.Context, contextID, text string) error
+	SendText(ctx context.Context, contextID, threadID, text string) error
 
 	// SendConfirmation sends a task confirmation prompt with approve/reject buttons.
 	// Returns a messageRef that can be used to update the message later.
@@ -71,6 +71,7 @@ func (p *PendingTask) GetCreatedAt() time.Time { return p.CreatedAt }
 type RunningTask struct {
 	TaskID    string
 	ContextID string
+	ThreadID  string
 	StartedAt time.Time
 	Cancel    context.CancelFunc
 }


### PR DESCRIPTION
Final leg of the forum-topic chain. **Stacked on https://github.com/qf-studio/pilot/pull/5120** — contains that commit too; after it merges this diff reduces to the single `SendText` commit (happy to rebase on request).

`comms.Messenger.SendText` had no `threadID` parameter while `SendConfirmation`/`SendResult`/`SendChunked` did, so progress chatter, greetings, command replies, question answers and error notices escaped the thread on Slack and the topic on Telegram. This adds the parameter, threads it through all comms call sites, and updates every messenger implementation (Telegram, Slack, Discord, sdkshim bridge) plus test doubles.

Fixes #4888

Verified: `go build/vet/test ./...` clean, `golangci-lint run --new-from-rev=main` 0 issues. Rebase onto current main also threaded the new `ErrClaimLost` SendText call in `comms/handler.go`.