### PR TITLE
GH-5122: feat(cli): add --gitlab flag to pilot start — docs promise it, flag never existed (user report)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -113,7 +113,7 @@
 | GitHub polling | ✅ | adapters/github | `pilot start --github` | `adapters.github.polling` | 30s interval |
 | GitHub run issue | ✅ | adapters/github | `pilot github run` | `adapters.github` | Manual trigger |
 | GitLab polling | ✅ | adapters/gitlab | `pilot start --gitlab` | `adapters.gitlab` | Full adapter with webhook support |
-| Azure DevOps | ✅ | adapters/azuredevops | `pilot start --azuredevops` | `adapters.azuredevops` | Full adapter with webhook support |
+| Azure DevOps | ✅ | adapters/azuredevops | `-` | `adapters.azure_devops` | Config-only (no CLI flag); full adapter with webhook support |
 | Linear webhooks | ✅ | adapters/linear | - | `adapters.linear` | Wired in pilot.go, gateway route + handler registered |
 | Linear sub-issue creation | ✅ | adapters/linear | - | `adapters.linear` | CreateIssue GraphQL mutation for epic decomposition (v1.27.0) |
 | Jira webhooks | ✅ | adapters/jira | - | `adapters.jira` | Wired in pilot.go, gateway route + handler + orchestrator |

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/qf-studio/pilot/internal/adapterhealth"
 	"github.com/qf-studio/pilot/internal/adapters/discord"
 	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/adapters/gitlab"
 	"github.com/qf-studio/pilot/internal/adapters/linear"
 	"github.com/qf-studio/pilot/internal/adapters/plane"
 	"github.com/qf-studio/pilot/internal/adapters/sdkshim"
@@ -416,6 +417,7 @@ func newStartCmd() *cobra.Command {
 		enableSlack    bool
 		enablePlane    bool
 		enableDiscord  bool
+		enableGitlab   bool
 		// Mode flags
 		noGateway      bool   // Lightweight mode: polling only, no HTTP gateway
 		sequential     bool   // Sequential execution mode (one issue at a time)
@@ -465,7 +467,7 @@ Examples:
 			}
 
 			// Apply flag overrides to config
-			applyInputOverrides(cfg, cmd, enableTelegram, enableGithub, enableLinear, enableSlack, enableTunnel, enablePlane, enableDiscord)
+			applyInputOverrides(cfg, cmd, enableTelegram, enableGithub, enableLinear, enableSlack, enableTunnel, enablePlane, enableDiscord, enableGitlab)
 
 			// GH-3826: warn loudly when Telegram will send approval requests
 			// but has no inbound polling to receive the approve/reject tap —
@@ -1560,6 +1562,7 @@ Examples:
 	cmd.Flags().BoolVar(&enableSlack, "slack", false, "Enable Slack Socket Mode (overrides config)")
 	cmd.Flags().BoolVar(&enablePlane, "plane", false, "Enable Plane.so polling (overrides config)")
 	cmd.Flags().BoolVar(&enableDiscord, "discord", false, "Enable Discord bot (overrides config)")
+	cmd.Flags().BoolVar(&enableGitlab, "gitlab", false, "Enable GitLab polling (overrides config)")
 	cmd.Flags().BoolVar(&enableTunnel, "tunnel", false, "Enable public tunnel for webhook ingress (Cloudflare/ngrok)")
 	cmd.Flags().StringVar(&teamID, "team", "", "Team ID or name for project access scoping (overrides config)")
 	cmd.Flags().StringVar(&teamMember, "team-member", "", "Member email for team access scoping (overrides config)")
@@ -1583,6 +1586,7 @@ func validateAdapterFlags(cfg *config.Config, cmd *cobra.Command) error {
 		{"linear", cfg.Adapters != nil && cfg.Adapters.Linear != nil && cfg.Adapters.Linear.Enabled, cfg.Adapters != nil && cfg.Adapters.Linear != nil},
 		{"plane", cfg.Adapters != nil && cfg.Adapters.Plane != nil && cfg.Adapters.Plane.Enabled, cfg.Adapters != nil && cfg.Adapters.Plane != nil},
 		{"discord", cfg.Adapters != nil && cfg.Adapters.Discord != nil && cfg.Adapters.Discord.Enabled, cfg.Adapters != nil && cfg.Adapters.Discord != nil},
+		{"gitlab", cfg.Adapters != nil && cfg.Adapters.GitLab != nil && cfg.Adapters.GitLab.Enabled, cfg.Adapters != nil && cfg.Adapters.GitLab != nil},
 	}
 	for _, a := range adapters {
 		if !cmd.Flags().Changed(a.flag) {
@@ -1603,7 +1607,7 @@ func validateAdapterFlags(cfg *config.Config, cmd *cobra.Command) error {
 
 // applyInputOverrides applies CLI flag overrides to config
 // Uses cmd.Flags().Changed() to only apply flags that were explicitly set
-func applyInputOverrides(cfg *config.Config, cmd *cobra.Command, telegramFlag, githubFlag, linearFlag, slackFlag, tunnelFlag, planeFlag, discordFlag bool) {
+func applyInputOverrides(cfg *config.Config, cmd *cobra.Command, telegramFlag, githubFlag, linearFlag, slackFlag, tunnelFlag, planeFlag, discordFlag, gitlabFlag bool) {
 	if cmd.Flags().Changed("telegram") {
 		if cfg.Adapters.Telegram == nil {
 			cfg.Adapters.Telegram = telegram.DefaultConfig()
@@ -1655,6 +1659,16 @@ func applyInputOverrides(cfg *config.Config, cmd *cobra.Command, telegramFlag, g
 			cfg.Adapters.Discord = discord.DefaultConfig()
 		}
 		cfg.Adapters.Discord.Enabled = discordFlag
+	}
+	if cmd.Flags().Changed("gitlab") {
+		if cfg.Adapters.GitLab == nil {
+			cfg.Adapters.GitLab = gitlab.DefaultConfig()
+		}
+		cfg.Adapters.GitLab.Enabled = gitlabFlag
+		if cfg.Adapters.GitLab.Polling == nil {
+			cfg.Adapters.GitLab.Polling = &gitlab.PollingConfig{}
+		}
+		cfg.Adapters.GitLab.Polling.Enabled = gitlabFlag
 	}
 }
 

--- a/cmd/pilot/main_test.go
+++ b/cmd/pilot/main_test.go
@@ -866,19 +866,22 @@ func TestApplyTeamOverrides_OverridesExistingConfig(t *testing.T) {
 
 func TestApplyInputOverrides(t *testing.T) {
 	tests := []struct {
-		name          string
-		setFlags      map[string]string // flags to mark as "changed"
-		telegram      bool
-		github        bool
-		linear        bool
-		slack         bool
-		tunnel        bool
-		checkTelegram *bool // expected Telegram.Enabled (nil = skip check)
-		checkGitHub   *bool
-		checkLinear   *bool
-		checkSlack    *bool
-		checkSocket   *bool // expected Slack.SocketMode
-		checkTunnel   *bool
+		name               string
+		setFlags           map[string]string // flags to mark as "changed"
+		telegram           bool
+		github             bool
+		linear             bool
+		slack              bool
+		tunnel             bool
+		gitlab             bool
+		checkTelegram      *bool // expected Telegram.Enabled (nil = skip check)
+		checkGitHub        *bool
+		checkLinear        *bool
+		checkSlack         *bool
+		checkSocket        *bool // expected Slack.SocketMode
+		checkTunnel        *bool
+		checkGitLab        *bool // expected GitLab.Enabled
+		checkGitLabPolling *bool // expected GitLab.Polling.Enabled
 	}{
 		{
 			name:     "no flags changed — config untouched",
@@ -938,6 +941,22 @@ func TestApplyInputOverrides(t *testing.T) {
 			checkSlack:  boolPtr(true),
 			checkSocket: boolPtr(true),
 		},
+		{
+			// GH-5122: --gitlab must set BOTH Enabled and Polling.Enabled —
+			// the poller's Enabled predicate (poller_gitlab.go) requires both.
+			name:               "gitlab flag enables gitlab and polling",
+			setFlags:           map[string]string{"gitlab": "true"},
+			gitlab:             true,
+			checkGitLab:        boolPtr(true),
+			checkGitLabPolling: boolPtr(true),
+		},
+		{
+			name:               "gitlab flag false disables gitlab and polling",
+			setFlags:           map[string]string{"gitlab": "false"},
+			gitlab:             false,
+			checkGitLab:        boolPtr(false),
+			checkGitLabPolling: boolPtr(false),
+		},
 	}
 
 	for _, tt := range tests {
@@ -950,12 +969,13 @@ func TestApplyInputOverrides(t *testing.T) {
 			cmd.Flags().Bool("linear", false, "")
 			cmd.Flags().Bool("slack", false, "")
 			cmd.Flags().Bool("tunnel", false, "")
+			cmd.Flags().Bool("gitlab", false, "")
 
 			for k, v := range tt.setFlags {
 				_ = cmd.Flags().Set(k, v)
 			}
 
-			applyInputOverrides(cfg, cmd, tt.telegram, tt.github, tt.linear, tt.slack, tt.tunnel, false, false)
+			applyInputOverrides(cfg, cmd, tt.telegram, tt.github, tt.linear, tt.slack, tt.tunnel, false, false, tt.gitlab)
 
 			if tt.checkTelegram != nil {
 				if cfg.Adapters.Telegram == nil {
@@ -1003,6 +1023,22 @@ func TestApplyInputOverrides(t *testing.T) {
 				}
 				if cfg.Tunnel.Enabled != *tt.checkTunnel {
 					t.Errorf("Tunnel.Enabled = %v, want %v", cfg.Tunnel.Enabled, *tt.checkTunnel)
+				}
+			}
+			if tt.checkGitLab != nil {
+				if cfg.Adapters.GitLab == nil {
+					t.Fatal("expected GitLab config to be created")
+				}
+				if cfg.Adapters.GitLab.Enabled != *tt.checkGitLab {
+					t.Errorf("GitLab.Enabled = %v, want %v", cfg.Adapters.GitLab.Enabled, *tt.checkGitLab)
+				}
+			}
+			if tt.checkGitLabPolling != nil {
+				if cfg.Adapters.GitLab == nil || cfg.Adapters.GitLab.Polling == nil {
+					t.Fatal("expected GitLab.Polling config to be created")
+				}
+				if cfg.Adapters.GitLab.Polling.Enabled != *tt.checkGitLabPolling {
+					t.Errorf("GitLab.Polling.Enabled = %v, want %v", cfg.Adapters.GitLab.Polling.Enabled, *tt.checkGitLabPolling)
 				}
 			}
 		})

--- a/cmd/pilot/validate_flags_test.go
+++ b/cmd/pilot/validate_flags_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/adapters/gitlab"
 	"github.com/qf-studio/pilot/internal/adapters/linear"
 	"github.com/qf-studio/pilot/internal/config"
 )
@@ -100,5 +101,55 @@ func TestValidateAdapterFlags_LinearDisabled(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "adapters.linear.enabled is false") {
 		t.Errorf("error = %q, want mention of 'adapters.linear.enabled is false'", err.Error())
+	}
+}
+
+// GH-5122: --gitlab with no adapter block must fail loudly (docs promised
+// this flag since dd9a2086 but it was never registered).
+func TestValidateAdapterFlags_GitlabMissingBlock(t *testing.T) {
+	cfg := &config.Config{
+		Adapters: &config.AdaptersConfig{},
+	}
+	cmd := newTestStartCmd(t, "gitlab")
+
+	err := validateAdapterFlags(cfg, cmd)
+	if err == nil {
+		t.Fatal("expected error when --gitlab set and adapter block missing")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "--gitlab") || !strings.Contains(msg, "missing") {
+		t.Errorf("error = %q, want mention of --gitlab and 'missing'", msg)
+	}
+}
+
+// GH-5122: --gitlab with adapter block disabled must fail loudly.
+func TestValidateAdapterFlags_GitlabDisabled(t *testing.T) {
+	cfg := &config.Config{
+		Adapters: &config.AdaptersConfig{
+			GitLab: &gitlab.Config{Enabled: false},
+		},
+	}
+	cmd := newTestStartCmd(t, "gitlab")
+
+	err := validateAdapterFlags(cfg, cmd)
+	if err == nil {
+		t.Fatal("expected error when --gitlab set and adapter disabled")
+	}
+	if !strings.Contains(err.Error(), "adapters.gitlab.enabled is false") {
+		t.Errorf("error = %q, want mention of 'adapters.gitlab.enabled is false'", err.Error())
+	}
+}
+
+// GH-5122: --gitlab with adapter enabled passes validation.
+func TestValidateAdapterFlags_GitlabEnabled(t *testing.T) {
+	cfg := &config.Config{
+		Adapters: &config.AdaptersConfig{
+			GitLab: &gitlab.Config{Enabled: true},
+		},
+	}
+	cmd := newTestStartCmd(t, "gitlab")
+
+	if err := validateAdapterFlags(cfg, cmd); err != nil {
+		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/docs/content/cli/commands.mdx
+++ b/docs/content/cli/commands.mdx
@@ -20,7 +20,6 @@ pilot start [flags]
 | `--discord` | Enable Discord bot (overrides config) |
 | `--plane` | Enable Plane polling (overrides config) |
 | `--env=ENV` | Enable autopilot: `dev`, `stage`, `prod` |
-| `--auto-release` | Enable tag-based release automation (requires `--env=prod`) |
 | `--dashboard` | Show TUI dashboard for real-time task monitoring |
 | `-p`, `--project` | Project path (default: config default or cwd) |
 | `--replace` | Kill existing bot instance before starting |
@@ -46,8 +45,8 @@ pilot start --telegram --github --dashboard
 # Sequential execution (wait for merge before next)
 pilot start --github --sequential
 
-# Production with auto-release
-pilot start --github --env=prod --auto-release
+# Production (release automation is config-only: autopilot.release.auto_release)
+pilot start --github --env=prod
 
 # With JSON logging for aggregation systems
 pilot start --github --log-format=json


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5122.

Closes #5122

## Changes

GitHub Issue GH-5122: feat(cli): add --gitlab flag to pilot start — docs promise it, flag never existed (user report)

## Problem

An external user followed the docs and ran `pilot start --gitlab` — the flag does not exist and never has (verified via git pickaxe: no `--gitlab` registration in any commit). The GitLab adapter itself is fully wired (`cmd/pilot/poller_gitlab.go`, SDK poller, registry-tested) but is reachable only via config (`adapters.gitlab.enabled` + `adapters.gitlab.polling.enabled`).

The docs have promised the flag since docs-sync commit `dd9a2086` (2026-07-03, #3793) in three places:

- `docs/content/cli/commands.mdx:17` — flag table row
- `docs/content/getting-started/quickstart.mdx:117` — `pilot start --gitlab --dashboard` (GitLab quickstart tab is a dead end)
- `docs/content/index.mdx:46` — `# or --gitlab`

Additional phantoms found in the same sweep:

- `--auto-release` in the `docs/content/cli/commands.mdx` flag table — no such flag exists anywhere in `cmd/pilot`.
- `.agent/system/FEATURE-MATRIX.md:115-116` — claims `pilot start --gitlab` AND `pilot start --azuredevops`; neither flag exists.

## Fix: make the docs true — add `--gitlab` to `pilot start`

Mirror the `--plane` pattern exactly (all in `cmd/pilot/main.go`):

1. **Flag registration** (~line 1557, alongside the other adapter flags):
   `cmd.Flags().BoolVar(&enableGitlab, "gitlab", false, "Enable GitLab polling (overrides config)")`
   plus the matching `enableGitlab` var and threading it through the `applyInputOverrides` call site (~line 674 collects `Changed(...)` per flag — follow the existing plumbing for `plane`).

2. **`applyInputOverrides`** (main.go:1602): add a `gitlab` branch modeled on the `plane` branch (main.go:1639-1648): if `Changed("gitlab")`, ensure `cfg.Adapters.GitLab` exists (use the gitlab package's `DefaultConfig()` if one exists; if not, construct the zero-value config struct the same way other adapters without a DefaultConfig are handled), set `.Enabled = gitlabFlag`, ensure `.Polling` non-nil, set `.Polling.Enabled = gitlabFlag`. The poller's `Enabled` predicate (`cmd/pilot/poller_gitlab.go:19-22`) requires BOTH bits — set both.

3. **`validateAdapterFlags`** (main.go:1571): add a `gitlab` row to the `adapterCheck` table so `--gitlab` with a missing/disabled config block fails loud with the standard "flag set but adapters.gitlab.enabled is false / block is missing" error (GH-2361 guard) instead of silently launching a blank poller. NOTE the ordering subtlety: `validateAdapterFlags` must see the config BEFORE `applyInputOverrides` force-enables it — follow whatever call order `plane`/`discord` use today (they are in both lists; match their behavior exactly).

## Docs corrections (same PR)

- `docs/content/cli/commands.mdx`: REMOVE the `--auto-release` row (phantom). Keep the `--gitlab` row (now true).
- `docs/content/getting-started/quickstart.mdx:117` + `docs/content/index.mdx:46`: no change needed once the flag ships — verify they match the final flag name.
- `.agent/system/FEATURE-MATRIX.md:116` (Azure DevOps row): change CLI column from `pilot start --azuredevops` to `-` with config path `adapters.azure_devops` — do NOT add an `--azuredevops` flag in this issue (out of scope; config-only is the documented path for ADO/Jira/Asana).
- `.agent/system/FEATURE-MATRIX.md:115` (GitLab row): keep `pilot start --gitlab` (now true).

## Tests

- Extend the existing flag-validation coverage (`cmd/pilot/validate_flags_test.go`) with table rows for `--gitlab`: missing block → error, disabled block → error, enabled block → ok.
- Extend override coverage (wherever `applyInputOverrides` is pinned — see `cmd/pilot/wiring_test.go` / `adapter_wiring_test.go` patterns) asserting `--gitlab` sets BOTH `Adapters.GitLab.Enabled` and `Adapters.GitLab.Polling.Enabled`, and constructs the blocks when nil.
- Do not touch `cmd/pilot/poller_gitlab.go` or its tests — the poller side is correct.

## Acceptance criteria

1. `pilot start --gitlab` with a valid `adapters.gitlab` config block starts the GitLab poller (log line `GitLab polling enabled`).
2. `pilot start --gitlab` with no gitlab block exits with the GH-2361-style actionable error, not a silent no-op.
3. `--gitlab` appears in `pilot start --help`.
4. `--auto-release` row gone from commands.mdx; FEATURE-MATRIX ADO row no longer claims a nonexistent flag.
5. All existing adapter-flag tests still green.