### PR TITLE
GH-5132: ci(docs-deploy): stop unbounded image/tag growth — prune images post-deploy, registry cleanup job, prod-* tag pruning in sync-docs (3rd space incident; SOP step 3)

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -69,7 +69,11 @@ jobs:
 
             # Prune old prod-* tags on GitLab, keeping the newest 10 (SOP
             # gitlab-space-reclaim.md Step 3) — never the tag just pushed.
-            # `|| true` per-tag so one failure doesn't kill the sync.
+            # The trailing `|| true` covers the whole pipeline, not just the
+            # push: GitHub Actions runs steps with `set -eo pipefail`, and
+            # `grep -v` exits 1 whenever it filters out every line (e.g. the
+            # very first sync, before 10 old tags exist) — without this the
+            # step would abort before the loop even runs.
             git ls-remote --tags origin 'refs/tags/prod-*' \
               | awk -F/ '{print $3}' \
               | grep -v "^${DEPLOY_TAG}\$" \
@@ -77,5 +81,5 @@ jobs:
               | while read -r t; do
                   echo "Pruning stale GitLab tag: ${t}"
                   git push origin ":refs/tags/${t}" || true
-                done
+                done || true
           fi

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -66,4 +66,16 @@ jobs:
             git tag "$DEPLOY_TAG"
             git push origin "$DEPLOY_TAG"
             echo "Tagged ${DEPLOY_TAG} to trigger deploy"
+
+            # Prune old prod-* tags on GitLab, keeping the newest 10 (SOP
+            # gitlab-space-reclaim.md Step 3) — never the tag just pushed.
+            # `|| true` per-tag so one failure doesn't kill the sync.
+            git ls-remote --tags origin 'refs/tags/prod-*' \
+              | awk -F/ '{print $3}' \
+              | grep -v "^${DEPLOY_TAG}\$" \
+              | sort -V | head -n -10 \
+              | while read -r t; do
+                  echo "Pruning stale GitLab tag: ${t}"
+                  git push origin ":refs/tags/${t}" || true
+                done
           fi

--- a/docs/.gitlab-ci.yml
+++ b/docs/.gitlab-ci.yml
@@ -18,6 +18,7 @@ build:
         -f docker/Dockerfile \
         .
     - docker push "${CI_REGISTRY_IMAGE}:${CI_COMMIT_REF_NAME}"
+    - docker image prune -af --filter "until=168h" || true
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
       when: never
@@ -31,6 +32,7 @@ build:
     - docker rm -f pilot-docs || true
     - docker compose -f docker-compose.prod.yml pull
     - docker compose -f docker-compose.prod.yml up -d --force-recreate
+    - docker image prune -af --filter "until=168h" || true
 
 deploy-prod:
   stage: deploy-prod
@@ -44,3 +46,30 @@ deploy-prod:
     - if: '$CI_COMMIT_TAG =~ /^prod-[0-9]+\.[0-9]+\.[0-9]+/'
       when: on_success
   <<: *deployment
+
+# Registry cleanup: bulk-deletes old prod-* image tags via the GitLab API,
+# keeping the newest 5 and anything pushed in the last 7 days. Requires a
+# CI/CD variable CLEANUP_TOKEN (maintainer-scope project access token, `api`
+# scope) — see .agent/sops/integrations/gitlab-space-reclaim.md Step 3.
+# Degrades gracefully (allow_failure) if CLEANUP_TOKEN is unset.
+#
+# Uses curlimages/curl instead of the top-level docker:latest image: verified
+# docker:latest's busybox wget (v1.37.0) has no --method flag at all (GET/POST
+# only), so it cannot issue the DELETE this job needs.
+cleanup-registry:
+  stage: deploy-prod
+  image: curlimages/curl:latest
+  needs: ["deploy-prod"]
+  tags:
+    - devops
+  allow_failure: true
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^prod-[0-9]+\.[0-9]+\.[0-9]+/'
+  script:
+    - |
+      if [ -z "${CLEANUP_TOKEN}" ]; then
+        echo "WARN: CLEANUP_TOKEN not set — skipping registry tag cleanup. See .agent/sops/integrations/gitlab-space-reclaim.md Step 3."
+        exit 0
+      fi
+    - REPO_ID=$(curl -sS --header "PRIVATE-TOKEN: ${CLEANUP_TOKEN}" "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/registry/repositories" | sed -n 's/.*"id":\([0-9]*\).*/\1/p' | head -1)
+    - curl -sS -X DELETE --header "PRIVATE-TOKEN: ${CLEANUP_TOKEN}" "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/registry/repositories/${REPO_ID}/tags?name_regex_delete=.*&keep_n=5&older_than=7d" || true


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5132.

Closes #5132

## Changes

GitHub Issue GH-5132: ci(docs-deploy): stop unbounded image/tag growth — prune images post-deploy, registry cleanup job, prod-* tag pruning in sync-docs (3rd space incident; SOP step 3)

## Problem

Third recurrence (2026-07 ×2, 2026-08-22) of GitLab `quant-flow` namespace storage exhaustion breaking docs-deploy pipelines. SOP `.agent/sops/integrations/gitlab-space-reclaim.md` § Step 3 prescribed these prevention changes on 2026-07-06 ("file as a pilot issue when picked up") — never filed. This issue is that filing. Root cause is fully mechanical, all in-tree:

1. `docs/.gitlab-ci.yml` build job tags every image with the UNIQUE deploy ref (`${CI_REGISTRY_IMAGE}:${CI_COMMIT_REF_NAME}` where the ref is `prod-X.Y.Z-<unix-ts>`) and pushes it — one immortal registry image per release, several/day, no cleanup policy.
2. The deploy job's `docker rm -f pilot-docs` removes the container only; each `compose pull` of a new unique tag strands the previous image on the prod-server (`devops` runner) disk forever.
3. `.github/workflows/sync-docs.yml` pushes a unique `prod-*` git tag per release to `quant-flow/pilot-docs` and never deletes old ones — unbounded tag/object growth.
4. `docker build --no-cache` maximizes local layer churn on the runner.

## Fixes (all in this repo; docs/ content syncs to GitLab automatically)

### A. `docs/.gitlab-ci.yml` — runner/prod-server disk

Append to the `.deployment` anchor's script, after `up -d --force-recreate`:

```yaml
- docker image prune -af --filter "until=168h" || true
```

Rationale: removes stranded images older than 7 days; `-a` is safe because the running container's image is always in use and recent rollback candidates (<7d) survive. `|| true` so cleanup failure never fails a successful deploy. Also add the same prune at the END of the build job's script (after push) to clear `--no-cache` layer churn.

Do NOT remove `--no-cache` in this issue (build correctness call, out of scope).

### B. `docs/.gitlab-ci.yml` — registry growth

Add a `cleanup-registry` job (stage `deploy-prod`, `when: on_success`, same `prod-*` tag rule, `allow_failure: true`) that calls the GitLab API to bulk-delete old registry tags:

```yaml
cleanup-registry:
  stage: deploy-prod
  needs: ["deploy-prod"]
  tags: [devops]
  allow_failure: true
  rules:
    - if: '$CI_COMMIT_TAG =~ /^prod-[0-9]+\.[0-9]+\.[0-9]+/'
  script:
    - REPO_ID=$(wget -qO- --header "PRIVATE-TOKEN: ${CLEANUP_TOKEN}" "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/registry/repositories" | sed -n 's/.*"id":\([0-9]*\).*/\1/p' | head -1)
    - wget -qO- --method=DELETE --header "PRIVATE-TOKEN: ${CLEANUP_TOKEN}" "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/registry/repositories/${REPO_ID}/tags?name_regex_delete=.*&keep_n=5&older_than=7d" || true
```

NOTE for implementer: the exact HTTP tool available in `docker:latest` is busybox wget — verify the DELETE-with-body form works or switch the job image to `curlimages/curl` and use curl. `CLEANUP_TOKEN` is a CI/CD variable the operator must set (maintainer-scope project access token); the job must degrade gracefully (allow_failure) when unset, with a clear echo warning. Document the variable in a comment at the top of the job.

### C. `.github/workflows/sync-docs.yml` — git tag pruning (SOP step 3 verbatim)

After pushing the new `prod-*` tag, list remote `prod-*` tags, keep the newest 10 by version-sort, delete the rest on the GitLab remote:

```bash
git ls-remote --tags gitlab 'refs/tags/prod-*' | awk -F/ '{print $3}' | sort -V | head -n -10 | while read t; do git push gitlab ":refs/tags/$t" || true; done
```

Adapt to the workflow's actual remote name/auth (it already has push credentials to the GitLab repo — reuse them). Never delete the tag just pushed. `|| true` per-tag so one failure doesn't kill the sync.

## Constraints

- Files: `docs/.gitlab-ci.yml`, `.github/workflows/sync-docs.yml` only.
- Deploy behavior must be unchanged on the happy path — cleanup strictly additive and non-fatal (`allow_failure`/`|| true` everywhere).
- No secrets in code; `CLEANUP_TOKEN` referenced as CI variable only.

## Acceptance

1. Deploy job's script ends with the image prune; build job prunes after push.
2. `cleanup-registry` job present, allow_failure, gated on the same `prod-*` rule, warns-and-passes when `CLEANUP_TOKEN` unset.
3. sync-docs.yml deletes all but the newest 10 remote `prod-*` tags after a successful push, never the current one.
4. yamllint/actionlint clean (CI covers the workflow file).

## Out of scope (operator, per SOP)

Immediate space reclaim on the namespace (needs glab re-auth, SOP steps 1-2) · GitLab UI registry cleanup policy (Settings-level) · deleting the dead `gitlab:` token block from box config.