### PR TITLE
GH-5133: fix(dispatch): base-presence false-hold on glob paths wedges queue head — extractor accepts globs, held head never re-evaluates in quiet queue, breaker alert loops (3h incident)

### DIFF
--- a/internal/executor/dependency_detector.go
+++ b/internal/executor/dependency_detector.go
@@ -139,20 +139,33 @@ var pathLineRefSuffixRe = regexp.MustCompile(`:\d+(?:-\d+)?$`)
 // contain slashes and a dot.
 var referencedPathIgnorePrefixes = []string{"http://", "https://"}
 
+// globMetacharacters is every character that turns a backtick-quoted span
+// from a checkable file path into a *description of files* — a glob pattern
+// (GH-5133): asterisk/question-mark wildcards, character classes (`[...]`),
+// and brace sets (`{...}`). A glob is never itself a file on disk, so
+// probing it via FileExistsOnDefaultBranch (base_presence.go) always 404s
+// and always produces a false-positive hold — the GH-5133 incident's root
+// cause, where a perfectly natural citation like `cmd/pilot/*.go` wedged the
+// dispatch queue for 3 hours on a phantom "prerequisite not on main".
+const globMetacharacters = "*?[]{}"
+
 // ExtractReferencedPaths returns every backtick-quoted repo-relative file
 // path mentioned in body, in first-seen order with duplicates removed
 // (GH-5045/GH-5052).
 //
 // Heuristic, validated by hand against real issue bodies (GH-5021, ui
 // GH-120/124/139): backtick content counts as a path when it (1) is not a
-// URL, (2) contains a "/", (3) contains no whitespace, and (4) ends in a
+// URL, (2) contains a "/", (3) contains no whitespace, (4) contains no glob
+// metacharacter (GH-5133: `*`, `?`, `[`, `]`, `{`, `}` — a glob names a set
+// of files, not one checkable prerequisite), and (5) ends in a
 // dot-extension once an optional trailing ":<line>" or ":<start>-<end>"
 // line-ref suffix is stripped. This is intentionally conservative — it
 // catches genuine file citations (`internal/boardapi/dto.go`,
 // `internal/fleet/tenantres.go:42`) while excluding shell commands
 // (`aws s3 cp`, `make test`), bare API routes with no extension
-// (`/api/v1/orgs`), and extensionless filenames with no path separator
-// (`0008_board.up.sql`).
+// (`/api/v1/orgs`), extensionless filenames with no path separator
+// (`0008_board.up.sql`), and glob patterns (`cmd/pilot/*.go`,
+// `internal/**/*_test.go`, `pkg/{a,b}/main.go`, `file[0-9].go`).
 func ExtractReferencedPaths(body string) []string {
 	if body == "" {
 		return nil
@@ -173,6 +186,10 @@ func ExtractReferencedPaths(body string) []string {
 			}
 		}
 		if isURL || !strings.Contains(candidate, "/") {
+			continue
+		}
+
+		if strings.ContainsAny(candidate, globMetacharacters) {
 			continue
 		}
 

--- a/internal/executor/dependency_detector_gh5052_test.go
+++ b/internal/executor/dependency_detector_gh5052_test.go
@@ -137,6 +137,35 @@ func TestExtractReferencedPaths(t *testing.T) {
 			body: "See `internal/foo.go` and again `internal/foo.go`.",
 			want: []string{"internal/foo.go"},
 		},
+		{
+			// GH-5133: the incident body citing `cmd/pilot/*.go` — a plain
+			// single-star glob — as a natural way to reference "the Go
+			// files under cmd/pilot". Must never be treated as a
+			// checkable prerequisite path.
+			name: "excludes a plain single-star glob (GH-5133 incident shape)",
+			body: "See the Go files under `cmd/pilot/*.go` for context.",
+			want: nil,
+		},
+		{
+			name: "excludes a recursive double-star glob",
+			body: "Touches everything under `internal/**/*_test.go`.",
+			want: nil,
+		},
+		{
+			name: "excludes a brace-set glob",
+			body: "Update both `pkg/{a,b}/main.go` files.",
+			want: nil,
+		},
+		{
+			name: "excludes a character-class glob",
+			body: "Applies to `file[0-9].go` variants.",
+			want: nil,
+		},
+		{
+			name: "glob and real path together: only the real path is extracted",
+			body: "Fix `cmd/pilot/*.go` callers of `internal/executor/runner.go`.",
+			want: []string{"internal/executor/runner.go"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -501,7 +501,9 @@ func (d *Dispatcher) checkTelemetryGap() {
 }
 
 // runStaleRecoveryLoop ticks every StaleRecoveryInterval and calls
-// recoverStaleTasks. It stops when ctx is cancelled or the dispatcher stops.
+// recoverStaleTasks, then wakes every live project worker (wakeHeldWorkers)
+// so a held queue head gets re-evaluated even when nothing new is ever
+// dispatched. It stops when ctx is cancelled or the dispatcher stops.
 func (d *Dispatcher) runStaleRecoveryLoop(ctx context.Context) {
 	defer d.wg.Done()
 
@@ -521,7 +523,45 @@ func (d *Dispatcher) runStaleRecoveryLoop(ctx context.Context) {
 			return
 		case <-ticker.C:
 			d.recoverStaleTasks()
+			d.wakeHeldWorkers()
 		}
+	}
+}
+
+// wakeHeldWorkers signals every currently-live project worker (GH-5133).
+//
+// Before this, ProjectWorker.processQueue only ever ran in response to a
+// fresh QueueTask/ensureWorker call (see Signal's call sites) — a
+// base-presence-held queue head (base_presence.go /
+// DispatcherConfig.BasePresenceHoldMaxCycles) is only re-evaluated, and its
+// hold_count only advances, on the next such wake. Once an executions row
+// already exists for the held task, every subsequent poller re-pickup drops
+// pre-dispatch as "dispatch claim lost" (cmd/pilot/handler_common.go)
+// WITHOUT ever reaching QueueTask/ensureWorker — so in an otherwise quiet
+// project queue, a held head could sit forever: the escalation path
+// (pilot-needs-human + park, GH-5052 F2) was unreachable, and every
+// genuinely innocent task queued behind it starved right along with it
+// (the GH-5133 incident: a 3-hour wedge from a false hold that could never
+// unstick itself).
+//
+// Reusing the existing StaleRecoveryInterval tick (rather than adding a
+// second ticker) is deliberate: Signal is a cheap, idempotent, non-blocking
+// buffered-channel send (a no-op if a signal is already pending), so waking
+// every worker on every stale-recovery tick costs nothing extra for the
+// overwhelming majority of ticks where nothing is held, and bounds a
+// genuine hold to at most BasePresenceHoldMaxCycles * StaleRecoveryInterval
+// before it escalates and parks — mirroring ResumeAdmissionFor's identical
+// signal-every-worker pattern below.
+func (d *Dispatcher) wakeHeldWorkers() {
+	d.mu.RLock()
+	workers := make([]*ProjectWorker, 0, len(d.workers))
+	for _, w := range d.workers {
+		workers = append(workers, w)
+	}
+	d.mu.RUnlock()
+
+	for _, w := range workers {
+		w.Signal()
 	}
 }
 
@@ -3190,6 +3230,21 @@ func (w *ProjectWorker) recordExecutionEvent(executionID string, stage memory.St
 // operator visibility into a base-presence escalation rested entirely on
 // label-watching (EmitProgress's "NeedsHuman" phase is dashboard-only, not
 // alerts-engine-routed).
+//
+// GH-5133 (Defect 3) NO-OP RATIONALE: the incident's dispatch-loop breaker
+// (cmd/pilot/handler_common.go fireLoopBreakerAlert, driven by
+// repickBackoff.recordClaimLostDrop) fired a content-free critical alert
+// every ~30min for 3+ hours because the held row kept getting re-picked and
+// dropped as "dispatch claim lost" with no terminal state ever reached. That
+// loop needs no additional plumbing here: once this function's label lands
+// and the caller parks the row (ExecStatusSkipped, below), the next GitHub
+// poll admits the issue through cmd/pilot/handlers.go's
+// githubEventHasNeedsHumanLabel backstop, which skips pilot-needs-human-
+// labeled issues before they ever reach the claim-lost/breaker path again —
+// so fixing Defect 2 (wakeHeldWorkers, this file) already ends the breaker
+// loop at exactly one content-bearing alert (this escalation's own
+// AlertEventTypeTaskFailed, reason-populated) with no separate Defect 3 code
+// change required.
 func (w *ProjectWorker) escalateBasePresenceHold(ctx context.Context, task *Task, reason string) {
 	if task.SourceAdapter != "" && task.SourceAdapter != "github" {
 		return

--- a/internal/executor/gh5133_held_head_wake_test.go
+++ b/internal/executor/gh5133_held_head_wake_test.go
@@ -1,0 +1,184 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// GH-5133 (Defect 2): before wakeHeldWorkers existed, ProjectWorker.processQueue
+// only ever ran again in response to a NEW dispatch (QueueTask/ensureWorker's
+// own Signal call) — a base-presence-held queue head that never received
+// another fresh dispatch could sit forever: its hold_count never advanced,
+// the escalation/park path (BasePresenceHoldMaxCycles -> pilot-needs-human +
+// ExecStatusSkipped) was unreachable, and every genuinely innocent task
+// queued behind it starved right along with it. This is the exact 3-hour
+// incident wedge: two held docs issues in front of a clean third one, no
+// further dispatches for hours.
+//
+// This test drives a REAL *Dispatcher (not a bare ProjectWorker driven by
+// manual processQueue() calls, as the pre-existing GH-5052 suite does) so
+// the periodic runStaleRecoveryLoop -> wakeHeldWorkers path introduced by
+// this fix is what actually re-evaluates the held head — the test only
+// dispatches once, at Start (queue adoption), then goes quiet, exactly
+// mirroring the incident's "no new dispatches" condition.
+func TestDispatcher_HeldHeadInQuietQueue_EscalatesAndQueueAdvancesViaPeriodicWake(t *testing.T) {
+	logFile := setupFakeGhCLI(t)
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	// escalateBasePresenceHold shells out with cmd.Dir = task.ProjectPath, and
+	// the second (unheld) task actually executes and needs a real git repo
+	// checked out on its branch to create commits/PRs against.
+	const secondBranch = "pilot/GH-9402"
+	projectPath := setupPRGuardRepo(t, secondBranch, false)
+
+	held := &memory.Execution{
+		ID:           "exec-gh5133-held",
+		TaskID:       "GH-9401",
+		ProjectPath:  projectPath,
+		Status:       "queued",
+		TaskBranch:   "pilot/GH-9401",
+		TaskCreatePR: true,
+		// A real (non-glob) path reference, so ExtractReferencedPaths (fixed by
+		// Defect 1 to exclude globs) still yields a non-empty path and the
+		// dispatcher's `len(refs) > 0 || len(paths) > 0` gate is entered,
+		// letting the stubbed checkBasePresence below actually run. This test
+		// pins the QUEUE mechanics of a genuine hold (Defect 2); the glob
+		// exclusion itself is pinned separately by TestExtractReferencedPaths.
+		TaskDescription: "See `internal/executor/definitely_missing_file.go` for the affected files.",
+	}
+	if err := store.SaveExecution(held); err != nil {
+		t.Fatalf("SaveExecution(held): %v", err)
+	}
+	// A second, genuinely clean task queued behind the held one for the SAME
+	// project — must remain starved until the head is parked, then execute.
+	second := &memory.Execution{
+		ID:              "exec-gh5133-second",
+		TaskID:          "GH-9402",
+		ProjectPath:     projectPath,
+		Status:          "queued",
+		TaskBranch:      secondBranch,
+		TaskCreatePR:    true,
+		TaskDescription: "No dependency markers here.",
+	}
+	if err := store.SaveExecution(second); err != nil {
+		t.Fatalf("SaveExecution(second): %v", err)
+	}
+
+	stubFetchIssueState(t, func(_ context.Context, _ *Runner, _ *Task, _ string) (IssueState, error) {
+		return IssueState{Closed: false}, nil
+	})
+	origMergedPR := mergedPRPreflightCheck
+	mergedPRPreflightCheck = func(_ context.Context, _, _ string) (string, error) { return "", nil }
+	t.Cleanup(func() { mergedPRPreflightCheck = origMergedPR })
+
+	// The stubbed probe forces the hold deterministically (rather than relying
+	// on a real GitHub lookup) — this test pins the QUEUE mechanics (Defect 2),
+	// not the extractor itself (Defect 1, covered by TestExtractReferencedPaths).
+	// Force a hold for the first task only, as if a genuinely-missing path
+	// were cited.
+	stubCheckBasePresence(t, func(_ context.Context, _ *Runner, task *Task, _ string, _ []int, _ []string) (BasePresenceHold, error) {
+		if task.ID != "GH-9401" {
+			t.Fatalf("checkBasePresence unexpectedly called for task %q", task.ID)
+		}
+		return BasePresenceHold{Held: true, Reason: `referenced path "internal/executor/definitely_missing_file.go" not found on default branch`}, nil
+	})
+
+	backend := &mockFixedBackend{result: &BackendResult{Success: true, Output: "should only run for the second task"}}
+	runner := NewRunnerWithBackend(backend)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+
+	config := &DispatcherConfig{
+		// Long enough that neither stale-recovery pass ever reaps these rows
+		// by age, short enough the test doesn't wait long in wall-clock time.
+		StaleRunningThreshold:     time.Hour,
+		StaleQueuedThreshold:      time.Hour,
+		StaleRecoveryInterval:     20 * time.Millisecond,
+		BasePresenceHoldMaxCycles: 3,
+	}
+	dispatcher := NewDispatcher(store, runner, config)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start's own queue adoption is the ONLY fresh dispatch this test ever
+	// produces — after this, nothing calls QueueTask/ensureWorker/Signal
+	// again. Every further re-evaluation of the held head must come from
+	// the periodic wakeHeldWorkers path alone.
+	if err := dispatcher.Start(ctx); err != nil {
+		t.Fatalf("dispatcher.Start: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	deadline := time.Now().Add(5 * time.Second)
+	var heldExec *memory.Execution
+	for time.Now().Before(deadline) {
+		var err error
+		heldExec, err = store.GetExecution(held.ID)
+		if err != nil {
+			t.Fatalf("GetExecution(held): %v", err)
+		}
+		if heldExec.Status == string(ExecStatusSkipped) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if heldExec.Status != string(ExecStatusSkipped) {
+		t.Fatalf("expected the held task to escalate and park as %q via periodic wakes alone, got %q", ExecStatusSkipped, heldExec.Status)
+	}
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read gh CLI log: %v", err)
+	}
+	log := string(data)
+	if got := strings.Count(log, "issue edit 9401"); got != 1 {
+		t.Errorf("expected exactly one `gh issue edit 9401` escalation call, got %d (log: %q)", got, log)
+	}
+	if !strings.Contains(log, "--add-label pilot-needs-human") {
+		t.Errorf("expected the escalation call to add the pilot-needs-human label, got log: %q", log)
+	}
+
+	// The second, innocent task must have been unblocked and executed —
+	// this is the "starved tasks behind it then execute" half of the
+	// acceptance criterion. Poll backend.execCount (not the execution's
+	// status) since Dispatcher.Start runs the worker in its own goroutine:
+	// the row flips out of "queued" the instant it's picked up, well before
+	// the async backend invocation (branch checkout, commit, etc.) actually
+	// completes — waiting on status alone raced the still-in-flight
+	// execution against this test's deadline/cancel, canceling it mid-run.
+	deadline = time.Now().Add(5 * time.Second)
+	var count int
+	var gotProjectPath string
+	for time.Now().Before(deadline) {
+		backend.mu.Lock()
+		count = backend.execCount
+		gotProjectPath = backend.gotProjectPath
+		backend.mu.Unlock()
+		if count > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if count == 0 {
+		t.Error("expected the queue head to advance to the second task and execute it once the first was parked")
+	}
+	if gotProjectPath != projectPath {
+		t.Errorf("expected the second task's execution to use project path %q, got %q", projectPath, gotProjectPath)
+	}
+
+	secondExec, err := store.GetExecution(second.ID)
+	if err != nil {
+		t.Fatalf("GetExecution(second): %v", err)
+	}
+	if secondExec.Status == "queued" {
+		t.Errorf("expected the second task to have been picked up off the queue once the head was parked, got status %q", secondExec.Status)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5133.

Closes #5133

## Changes

GitHub Issue GH-5133: fix(dispatch): base-presence false-hold on glob paths wedges queue head — extractor accepts globs, held head never re-evaluates in quiet queue, breaker alert loops (3h incident)

## Incident (2026-08-22 evening)

Three freshly dispatched docs issues (#5127/#5129/#5132) wedged the pilot-repo queue for ~3 hours with critical circuit_breaker_trip alerts firing to Slack every 30 minutes. Full chain below; each link is its own defect.

### Defect 1 — ExtractReferencedPaths treats backtick-quoted glob patterns as literal paths

`internal/executor/dependency_detector.go` (ExtractReferencedPaths, ~line 156): the path heuristic accepts any backtick span with no whitespace, a slash, and a dot-extension. A glob reference like cmd/pilot/*.go (backtick-quoted in the issue body, a completely natural way to cite "the Go files under cmd/pilot") passes all four filters. The base-presence probe (`internal/executor/base_presence.go`, FileExistsOnDefaultBranch) then queries the GitHub contents API for a file literally named *.go, gets 404, and holds the task:

```
Task held: prerequisite not on main — referenced path "cmd/pilot/*.go" not found on default branch
```

**Fix**: skip any candidate containing glob metacharacters — asterisk, question mark, square brackets, curly braces — before the extension check. A glob is a *description of files*, never a checkable prerequisite path; holding on it is always a false positive. Table-driven tests: plain glob, recursive double-star glob, brace set, char class → all excluded; the existing positive cases unchanged.

### Defect 2 — held queue head starves the project queue and escalation is unreachable

`internal/executor/dispatcher.go` (~2904, base-presence hold in processQueue): a held task stays at the queue head and is only re-evaluated when a NEW dispatch wakes the worker. But once an execution row exists, every poller re-pickup drops pre-dispatch with "dispatch claim lost" — which does NOT wake the queue. Observed: hold_count reached 3 in 40 minutes (each increment coinciding with an unrelated fresh dispatch), then froze for 3 hours because nothing else was dispatched. Consequences:

- The escalation/park path (BasePresenceHoldMaxCycles → pilot-needs-human + ExecStatusSkipped, the GH-5052 F2 design) is effectively unreachable in a quiet queue — it needs N wake-ups that never come.
- Innocent tasks behind the head (#5129, #5132 — #5132's body was fully clean) starve indefinitely: zero hold events of their own, just queued forever.

**Fix direction** (implementer judgment): re-evaluate held heads on a timer (e.g. per poll interval) OR count claim-lost re-pickups of a held task as a wake signal. Either makes hold_count actually advance to escalation in bounded time. Pin with a test: held head + no new dispatches → escalates and parks within max-cycles ticks, queue advances to the next task.

### Defect 3 — the breaker alert loop carries no actionable context and never resolves

The dispatch-loop breaker ("task rejected 10+ consecutive times") plus rule circuit_breaker_trip fired critical alerts every ~30 minutes for 3+ hours, with no hold reason, no task body pointer, and no terminal state ever reached — pure pager noise for a wedge that needed exactly one fact surfaced (the hold reason from defect 1). When defect 2's escalation fires properly, this loop should end at pilot-needs-human + one content-bearing alert (the PR#5069 rendering path). Verify that interaction; add the hold reason to the breaker alert payload if it survives at all.

## Incident recovery (already done, for the record)

Operator-canceled GH-5127/GH-5129 (pilot task cancel), de-globbed both bodies on GitHub, cycled the pilot label to re-arm (fresh executions read the corrected bodies); #5132 left queued — it unwedges when the re-armed dispatches wake the queue.

## Acceptance

1. A backtick-quoted glob in an issue body produces zero extracted paths (unit-pinned for all four metacharacter classes).
2. A genuinely-held task in an otherwise quiet queue reaches escalation/park within BasePresenceHoldMaxCycles bounded ticks; tasks behind it then execute.
3. No behavior change for real missing-file holds (the GH-5045/GH-5052 cases stay pinned green).