### PR TITLE
GH-5136: ci(docs-deploy): add docker builder prune to both cleanup sites — image prune misses BuildKit cache, the 224GB incident vector (PR#5134 review)

### DIFF
--- a/docs/.gitlab-ci.yml
+++ b/docs/.gitlab-ci.yml
@@ -19,6 +19,7 @@ build:
         .
     - docker push "${CI_REGISTRY_IMAGE}:${CI_COMMIT_REF_NAME}"
     - docker image prune -af --filter "until=168h" || true
+    - docker builder prune -af --filter "until=168h" || true
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
       when: never
@@ -33,6 +34,7 @@ build:
     - docker compose -f docker-compose.prod.yml pull
     - docker compose -f docker-compose.prod.yml up -d --force-recreate
     - docker image prune -af --filter "until=168h" || true
+    - docker builder prune -af --filter "until=168h" || true
 
 deploy-prod:
   stage: deploy-prod


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5136.

Closes #5136

## Changes

GitHub Issue GH-5136: ci(docs-deploy): add docker builder prune to both cleanup sites — image prune misses BuildKit cache, the 224GB incident vector (PR#5134 review)

## Problem

PR#5134 (GH-5132) added docker IMAGE pruning to the docs deploy pipeline, but the 2026-08-22 incident's dominant disk consumer was BuildKit BUILD CACHE: 224 GB / 1417 entries vs only 16 GB of images on the prod server. The build job runs docker build with the no-cache flag, which never READS the cache but still WRITES fresh layers to it on every deploy — and docker image prune does not touch BuildKit cache at all. Without this, the primary vector regrows unbounded and the server wedges again in a few months.

(The requirement was posted as an issue comment on GH-5132 after dispatch — invisible to the executor, whose prompt is issue title+body only. This re-files it as a proper body.)

## Fix

In `docs/.gitlab-ci.yml`, add ONE line immediately after each of the two existing image-prune lines (build job script end, and the .deployment anchor script end):

```yaml
- docker builder prune -af --filter "until=168h" || true
```

Non-fatal (or-true), same 7-day filter as the image prune. No other changes; do not touch the cleanup-registry job or sync-docs.yml.

## Acceptance

1. Both prune sites in `docs/.gitlab-ci.yml` run image prune AND builder prune, each `|| true`.
2. Deploy happy path unchanged (cleanup strictly appended).
3. yamllint-clean.