### PR TITLE
GH-5130: feat(telegram): voice and photo replies still escape the forum topic — thread ThreadID through handleVoice/handlePhoto (PR#5120 review follow-up)

### DIFF
--- a/internal/adapters/telegram/handler.go
+++ b/internal/adapters/telegram/handler.go
@@ -526,14 +526,20 @@ func (h *Handler) handlePhoto(ctx context.Context, chatID string, msg *Message) 
 	logging.WithComponent("telegram").Debug("Received photo",
 		slog.String("chat_id", chatID), slog.Int("width", photo.Width), slog.Int("height", photo.Height))
 
+	// GH-5130: carry the originating topic's thread through the ack, the
+	// download-failure message, and the eventual task dispatch so photo
+	// replies land back in the topic the message came from.
+	threadID := msg.topicThreadID()
+	threadIDInt := parseThreadID(threadID)
+
 	// Send acknowledgment
-	_, _ = h.client.SendMessage(ctx, chatID, "📷 Processing image...", "", 0)
+	_, _ = h.client.SendMessage(ctx, chatID, "📷 Processing image...", "", threadIDInt)
 
 	// Download the image
 	imagePath, err := h.downloadImage(ctx, photo.FileID)
 	if err != nil {
 		logging.WithComponent("telegram").Warn("Failed to download image", slog.Any("error", err))
-		_, _ = h.client.SendMessage(ctx, chatID, "❌ Failed to download image. Please try again.", "", 0)
+		_, _ = h.client.SendMessage(ctx, chatID, "❌ Failed to download image. Please try again.", "", threadIDInt)
 		return
 	}
 	defer func() {
@@ -541,6 +547,13 @@ func (h *Handler) handlePhoto(ctx context.Context, chatID string, msg *Message) 
 		_ = os.Remove(imagePath)
 	}()
 
+	h.dispatchImageTask(ctx, chatID, threadID, msg, imagePath)
+}
+
+// dispatchImageTask sends a downloaded image to commsHandler as a direct
+// task, carrying ThreadID so the task dispatch and its replies land back in
+// the topic the photo came from (GH-5130).
+func (h *Handler) dispatchImageTask(ctx context.Context, chatID, threadID string, msg *Message, imagePath string) {
 	// Build prompt with image context
 	prompt := msg.Caption
 	if prompt == "" {
@@ -550,7 +563,7 @@ func (h *Handler) handlePhoto(ctx context.Context, chatID string, msg *Message) 
 	// Execute with image via commsHandler
 	taskID := fmt.Sprintf("IMG-%d", time.Now().Unix())
 	if h.commsHandler != nil {
-		h.commsHandler.ExecuteDirectTask(ctx, chatID, "", taskID, prompt, &comms.DirectTaskOpts{
+		h.commsHandler.ExecuteDirectTask(ctx, chatID, threadID, taskID, prompt, &comms.DirectTaskOpts{
 			ImagePath: imagePath,
 		})
 	}
@@ -571,11 +584,17 @@ func (h *Handler) handleVoice(ctx context.Context, chatID string, msg *Message) 
 		}
 	}
 
+	// GH-5130: carry the originating topic's thread through every ack/error
+	// reply and the eventual transcript delivery so voice replies land back
+	// in the topic the message came from.
+	threadID := msg.topicThreadID()
+	threadIDInt := parseThreadID(threadID)
+
 	// Check if transcription is available
 	if h.transcriber == nil {
 		logging.WithComponent("telegram").Debug("Voice message received but transcription not configured")
-		msg := h.voiceNotAvailableMessage()
-		_, _ = h.client.SendMessage(ctx, chatID, msg, "", 0)
+		notAvailable := h.voiceNotAvailableMessage()
+		_, _ = h.client.SendMessage(ctx, chatID, notAvailable, "", threadIDInt)
 		return
 	}
 
@@ -584,13 +603,13 @@ func (h *Handler) handleVoice(ctx context.Context, chatID string, msg *Message) 
 		slog.String("chat_id", chatID), slog.Int("duration", voice.Duration))
 
 	// Send acknowledgment
-	_, _ = h.client.SendMessage(ctx, chatID, "🎤 Transcribing voice message...", "", 0)
+	_, _ = h.client.SendMessage(ctx, chatID, "🎤 Transcribing voice message...", "", threadIDInt)
 
 	// Download the voice file
 	audioPath, err := h.downloadAudio(ctx, voice.FileID)
 	if err != nil {
 		logging.WithComponent("telegram").Warn("Failed to download voice", slog.Any("error", err))
-		_, _ = h.client.SendMessage(ctx, chatID, "❌ Failed to download voice message. Please try again.", "", 0)
+		_, _ = h.client.SendMessage(ctx, chatID, "❌ Failed to download voice message. Please try again.", "", threadIDInt)
 		return
 	}
 	defer func() {
@@ -604,15 +623,22 @@ func (h *Handler) handleVoice(ctx context.Context, chatID string, msg *Message) 
 	result, err := h.transcriber.Transcribe(transcribeCtx, audioPath)
 	if err != nil {
 		logging.WithComponent("telegram").Warn("Transcription failed", slog.Any("error", err))
-		_, _ = h.client.SendMessage(ctx, chatID, "❌ Failed to transcribe voice message. Please try again or send as text.", "", 0)
+		_, _ = h.client.SendMessage(ctx, chatID, "❌ Failed to transcribe voice message. Please try again or send as text.", "", threadIDInt)
 		return
 	}
 
 	if result.Text == "" {
-		_, _ = h.client.SendMessage(ctx, chatID, "🤷 Couldn't understand the voice message. Please try again or send as text.", "", 0)
+		_, _ = h.client.SendMessage(ctx, chatID, "🤷 Couldn't understand the voice message. Please try again or send as text.", "", threadIDInt)
 		return
 	}
 
+	h.deliverVoiceTranscript(ctx, chatID, msg, threadID, threadIDInt, result)
+}
+
+// deliverVoiceTranscript echoes the transcript back to the chat and
+// delegates the transcribed text to commsHandler, both carrying ThreadID so
+// voice replies land back in the topic the message came from (GH-5130).
+func (h *Handler) deliverVoiceTranscript(ctx context.Context, chatID string, msg *Message, threadID string, threadIDInt int64, result *transcription.Result) {
 	// Show the transcription to the user
 	langInfo := ""
 	if result.Language != "" && result.Language != "unknown" {
@@ -620,7 +646,7 @@ func (h *Handler) handleVoice(ctx context.Context, chatID string, msg *Message) 
 	}
 
 	transcriptMsg := fmt.Sprintf("🎤 Transcribed%s:\n%s", langInfo, result.Text)
-	_, _ = h.client.SendMessage(ctx, chatID, transcriptMsg, "", 0)
+	_, _ = h.client.SendMessage(ctx, chatID, transcriptMsg, "", threadIDInt)
 
 	// Delegate transcribed text to commsHandler
 	text := strings.TrimSpace(result.Text)
@@ -636,6 +662,7 @@ func (h *Handler) handleVoice(ctx context.Context, chatID string, msg *Message) 
 			SenderID:  senderID,
 			Text:      text,
 			VoiceText: text,
+			ThreadID:  threadID,
 			Platform:  "telegram",
 			Timestamp: time.Now(),
 		})

--- a/internal/adapters/telegram/handler_test.go
+++ b/internal/adapters/telegram/handler_test.go
@@ -8,14 +8,17 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/qf-studio/pilot/internal/comms"
+	"github.com/qf-studio/pilot/internal/executor"
 	"github.com/qf-studio/pilot/internal/logging"
 	"github.com/qf-studio/pilot/internal/testutil"
+	"github.com/qf-studio/pilot/internal/transcription"
 )
 
 // noopMessenger is a no-op implementation of comms.Messenger for tests.
@@ -1855,6 +1858,166 @@ func TestProcessUpdatePropagatesTopicThreadID(t *testing.T) {
 			called, got := msgr.seen()
 			if !called {
 				t.Fatal("expected an outbound messenger call carrying a thread id")
+			}
+			if got != tt.wantThreadID {
+				t.Errorf("threadID = %q, want %q", got, tt.wantThreadID)
+			}
+		})
+	}
+}
+
+// TestDeliverVoiceTranscriptPropagatesThreadID covers GH-5130: handleVoice's
+// interim replies and its delegated IncomingMessage must carry the
+// originating topic's thread, mirroring TestProcessUpdatePropagatesTopicThreadID
+// (PR#5120) for the voice path.
+func TestDeliverVoiceTranscriptPropagatesThreadID(t *testing.T) {
+	tests := []struct {
+		name            string
+		messageThreadID int64
+		isTopicMessage  bool
+		wantThreadID    string
+	}{
+		{
+			name:            "topic voice message threads transcript and reply back to the topic",
+			messageThreadID: 42,
+			isTopicMessage:  true,
+			wantThreadID:    "42",
+		},
+		{
+			name:         "general thread voice message carries no topic",
+			wantThreadID: "",
+		},
+		{
+			name:            "supergroup reply chain is not treated as a topic",
+			messageThreadID: 42,
+			wantThreadID:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sentThreadID interface{}
+			var sawKey bool
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var raw map[string]interface{}
+				_ = json.NewDecoder(r.Body).Decode(&raw)
+				sentThreadID, sawKey = raw["message_thread_id"]
+				_ = json.NewEncoder(w).Encode(SendMessageResponse{OK: true, Result: &Result{MessageID: 1}})
+			}))
+			defer server.Close()
+
+			msgr := &threadRecordingMessenger{}
+			h := &Handler{
+				client: NewClientWithBaseURL(testutil.FakeTelegramBotToken, server.URL),
+				commsHandler: comms.NewHandler(&comms.HandlerConfig{
+					Messenger:    msgr,
+					TaskIDPrefix: "TG",
+				}),
+			}
+
+			msg := &Message{
+				MessageID:       7,
+				MessageThreadID: tt.messageThreadID,
+				IsTopicMessage:  tt.isTopicMessage,
+				Chat:            &Chat{ID: -100123, Type: "supergroup"},
+				From:            &User{ID: 55, FirstName: "Ada"},
+			}
+			threadID := msg.topicThreadID()
+
+			h.deliverVoiceTranscript(context.Background(), "-100123", msg, threadID, parseThreadID(threadID), &transcription.Result{
+				Text: "implement rate limiting for the API",
+			})
+
+			wantKey := tt.wantThreadID != ""
+			if sawKey != wantKey {
+				t.Fatalf("transcript echo message_thread_id present = %v, want %v (value: %v)", sawKey, wantKey, sentThreadID)
+			}
+			if wantKey {
+				want, _ := strconv.ParseInt(tt.wantThreadID, 10, 64)
+				if sentThreadID != float64(want) {
+					t.Errorf("transcript echo message_thread_id = %v, want %d", sentThreadID, want)
+				}
+			}
+
+			called, got := msgr.seen()
+			if !called {
+				t.Fatal("expected the delegated IncomingMessage to trigger an outbound messenger call")
+			}
+			if got != tt.wantThreadID {
+				t.Errorf("delegated threadID = %q, want %q", got, tt.wantThreadID)
+			}
+		})
+	}
+}
+
+// noopImageBackend is a fast, no-op executor.Backend for exercising
+// dispatchImageTask's ExecuteDirectTask call without spawning a real
+// process, mirroring noopChatBackend in internal/comms/handler_lifecycle_test.go.
+type noopImageBackend struct{}
+
+func (b *noopImageBackend) Name() string      { return "noop-image-backend" }
+func (b *noopImageBackend) IsAvailable() bool { return true }
+func (b *noopImageBackend) Execute(_ context.Context, _ executor.ExecuteOptions) (*executor.BackendResult, error) {
+	return &executor.BackendResult{Success: true, Output: "a photo"}, nil
+}
+
+// TestDispatchImageTaskPropagatesThreadID covers GH-5130: handlePhoto's
+// ExecuteDirectTask call must carry the originating topic's thread so the
+// task dispatch and its replies (rendered via comms.Handler's
+// executeTaskCore -> SendResult) land back in that topic.
+func TestDispatchImageTaskPropagatesThreadID(t *testing.T) {
+	tests := []struct {
+		name            string
+		messageThreadID int64
+		isTopicMessage  bool
+		wantThreadID    string
+	}{
+		{
+			name:            "topic photo threads task dispatch back to the topic",
+			messageThreadID: 42,
+			isTopicMessage:  true,
+			wantThreadID:    "42",
+		},
+		{
+			name:         "non-topic photo carries no thread",
+			wantThreadID: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := executor.NewRunnerWithBackend(&noopImageBackend{})
+			runner.SetSkipPreflightChecks(true)
+			runner.SetRecordingEnabled(false)
+
+			msgr := &threadRecordingMessenger{}
+			h := &Handler{
+				commsHandler: comms.NewHandler(&comms.HandlerConfig{
+					Messenger:    msgr,
+					Runner:       runner,
+					ProjectPath:  t.TempDir(),
+					TaskIDPrefix: "TG",
+				}),
+			}
+
+			msg := &Message{
+				MessageThreadID: tt.messageThreadID,
+				IsTopicMessage:  tt.isTopicMessage,
+				Chat:            &Chat{ID: -100123, Type: "supergroup"},
+				Caption:         "describe this screenshot",
+			}
+			threadID := msg.topicThreadID()
+
+			imagePath := filepath.Join(t.TempDir(), "photo.jpg")
+			if err := os.WriteFile(imagePath, []byte("fake-image-bytes"), 0o600); err != nil {
+				t.Fatalf("write temp image: %v", err)
+			}
+
+			h.dispatchImageTask(context.Background(), "-100123", threadID, msg, imagePath)
+
+			called, got := msgr.seen()
+			if !called {
+				t.Fatal("expected ExecuteDirectTask to trigger an outbound messenger call carrying a thread id")
 			}
 			if got != tt.wantThreadID {
 				t.Errorf("threadID = %q, want %q", got, tt.wantThreadID)


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5130.

Closes #5130

## Changes

GitHub Issue GH-5130: feat(telegram): voice and photo replies still escape the forum topic — thread ThreadID through handleVoice/handlePhoto (PR#5120 review follow-up)

## Problem

PR#5120 (GH-4887) made text and callback replies return to the originating Telegram forum topic, but two `IncomingMessage`/dispatch construction sites still drop the topic (found in PR#5120 review):

1. **Voice**: `handleVoice` builds its `IncomingMessage` without `ThreadID` (`internal/adapters/telegram/handler.go:631` at time of filing), and its interim sends ("Processing…", transcript echo) pass thread `0` — a voice message sent in a topic gets its transcript and all replies OUTSIDE the topic.
2. **Photo**: `handlePhoto` calls `ExecuteDirectTask(ctx, chatID, "", ...)` with a hardcoded empty threadID (`handler.go:550`).

The telegram integration docs (updated by PR#5120) promise replies go "back to the topic that message came from, whichever topic that is" — voice/photo currently break that promise.

## Fix

Mirror PR#5120's pattern at both sites: populate `ThreadID` from `message.topicThreadID()` (the existing `is_topic_message`-gated helper) in `handleVoice`'s IncomingMessage and thread it through `handlePhoto`'s `ExecuteDirectTask` call + any interim `SendMessage` calls in those paths.

## Tests

Extend the existing table-driven handler tests (see `TestProcessUpdatePropagatesTopicThreadID`, `threadRecordingMessenger` pattern from PR#5120) with voice and photo cases: topic message → threadID propagates to outbound; non-topic → zero/omitted. Mocks must record and assert the threadID (argument-discarding-mock gate).

## Acceptance

1. Voice message in a topic: transcript echo + reply land in that topic.
2. Photo in a topic: task dispatch + replies land in that topic.
3. Non-topic voice/photo behavior unchanged.

Credit: gap identified during PR#5120 review; left unlabeled briefly in case @lkshrk wants to complete the chain (24h, per the standing handover rule) — label `pilot` after that to dispatch.