### PR TITLE
GH-5147: fix(navigator): q-prefixed query scratch dirties repo root, trips finish_tripwire_root_clean (refile of #5145)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,8 @@ pilot-bench/jobs/
 .agent/.nav-runtime-state.lock
 .agent/.nav-v6-state.bak/
 deploy/grafana/*.bak
+
+# Navigator "ask a question" scratch docs (leaked into .agent/tasks, dirty
+# the shared repo root and trip finish_tripwire_root_clean — GH-5147).
+# Anchored to .agent/tasks only so .agent/tasks/archive/q-*.md stays tracked.
+/.agent/tasks/q-*.md

--- a/internal/executor/finish_tripwires_test.go
+++ b/internal/executor/finish_tripwires_test.go
@@ -128,6 +128,56 @@ func TestCheckRootClean(t *testing.T) {
 			t.Error("expected violation for a repo with an unstaged diff")
 		}
 	})
+
+	// GH-5147 regression: a leftover Navigator "ask a question" scratch doc
+	// (q-<epoch>.md) in .agent/tasks used to leave the shared root
+	// perpetually dirty and spam finish_tripwire_root_clean. The durable fix
+	// is a repo-root .gitignore rule (/.agent/tasks/q-*.md); this test
+	// mirrors that rule in a synthetic repo and asserts the ignored scratch
+	// file no longer trips the tripwire, while a genuine tracked-file diff
+	// still does.
+	t.Run("gitignored query-scratch doc passes, genuine diff still fails", func(t *testing.T) {
+		dir := t.TempDir()
+		initGitRepo(t, dir)
+
+		gitignorePath := filepath.Join(dir, ".gitignore")
+		if err := os.WriteFile(gitignorePath, []byte("/.agent/tasks/q-*.md\n"), 0o644); err != nil {
+			t.Fatalf("write .gitignore: %v", err)
+		}
+		cmd := exec.Command("git", "add", ".gitignore")
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git add .gitignore failed: %v\n%s", err, out)
+		}
+		cmd = exec.Command("git", "commit", "-q", "-m", "add gitignore")
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git commit .gitignore failed: %v\n%s", err, out)
+		}
+
+		tasksDir := filepath.Join(dir, ".agent", "tasks")
+		if err := os.MkdirAll(tasksDir, 0o755); err != nil {
+			t.Fatalf("mkdir .agent/tasks: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tasksDir, "q-1787504539.md"), []byte("scratch\n"), 0o644); err != nil {
+			t.Fatalf("write query-scratch doc: %v", err)
+		}
+
+		result := checkRootClean(&memory.Execution{ID: "exec-5", ProjectPath: dir})
+		if result.violated {
+			t.Errorf("expected no violation with only a gitignored query-scratch doc present, got %+v", result)
+		}
+
+		// A genuine diff to a tracked file must still trip the tripwire —
+		// the gitignore rule must not blind checkRootClean to real dirt.
+		if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello\nmodified\n"), 0o644); err != nil {
+			t.Fatalf("modify README: %v", err)
+		}
+		result = checkRootClean(&memory.Execution{ID: "exec-6", ProjectPath: dir})
+		if !result.violated {
+			t.Error("expected violation for a repo with a genuine tracked-file diff alongside the ignored scratch doc")
+		}
+	})
 }
 
 func TestCheckLabelLifecycle(t *testing.T) {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5147.

Closes #5147

## Changes

GitHub Issue GH-5147: fix(navigator): q-prefixed query scratch dirties repo root, trips finish_tripwire_root_clean (refile of #5145)

## Problem

The finish tripwire checkRootClean (tracker finish_tripwire_root_clean, in internal/executor/finish_tripwires.go) fires on **every** execution finish whenever the shared project root has a non-empty git status. On the founder box this fired continuously 2026-08-17 through 2026-08-23, driving recurring circuit_breaker_trip and finish_tripwire_failure_streak **critical** alerts to slack-engineering.

Root cause was **not** the self-review-in-root pitfall the tripwire guards — the root was correctly on the default branch and backends ran in their own worktrees. The dirt was a single stale, untracked query scratch file (379B, a read-only "ask a question" task doc) sitting in the tracked tasks directory, with a name of the form q-EPOCH-dot-md.

The read-only "ask a question" path writes its scratch doc (name pattern: the letter q, a dash, an epoch timestamp, then a .md extension) into the tracked tasks directory (.agent/tasks) and never cleans it up. One leaked file is enough to make git status non-empty forever, so the tripwire treats a harmless artifact as the root-dirty pitfall and spams critical alerts.

The specific stray file was already removed on the box; this issue is the durable fix so it cannot recur.

## Proposed fix

Stop query scratch docs from dirtying the tracked tree. Preferred: gitignore them.

- Add an anchored ignore rule to the repo-root .gitignore that matches the q-prefixed markdown scratch docs in the .agent/tasks directory ONLY (anchored with a leading slash so it does NOT affect the archive subdirectory). The rule is: a leading slash, then the tasks directory path, then the letter q, a dash, an asterisk wildcard, and a .md extension.

- The archive subdirectory (.agent/tasks/archive) holds intentionally-committed query docs. Confirm those remain tracked and committed after adding the ignore rule (gitignore does not untrack already-committed files, but verify git status stays clean with an archived copy present).

Alternative, if you prefer to fix the writer instead of ignoring output: have the "ask a question" path write its scratch doc to an already-ignored location, or delete the doc after the question is answered. Pick whichever is lower-risk; the gitignore is the minimal change.

## Acceptance criteria

- A leftover q-prefixed markdown scratch doc left in the tasks directory no longer makes git status non-empty — the new ignore rule covers it.
- Archived query docs under the archive subdirectory remain tracked and committed.
- checkRootClean still fires for a genuine root diff (e.g. a stray modification to a tracked file) — the guard is preserved; only the query-scratch false positive is removed. Add or extend a test if the writer path is changed.

## Refs

- Tripwire: internal/executor/finish_tripwires.go (checkRootClean, tracker finish_tripwire_root_clean)
- Incident: continuous critical alerts 2026-08-17 through 2026-08-23, founder box