### PR TITLE
GH-5155: feat(telegram): add pre-mutation authorization guard to HandleCallback

### DIFF
--- a/.agent/tasks/gh-5155.md
+++ b/.agent/tasks/gh-5155.md
@@ -1,0 +1,10 @@
+# GH-5155
+
+**Created:** 2026-08-24
+
+## Problem
+
+In internal/approval/telegram.go HandleCallback (~:471), add identity checks before any state mutation, mirroring the existing not-found/expired early-return shape. Two-step guard: (1) if pending.Request.Approvers is non-empty, require plain string equality of userID against an entry; (2) otherwise fall back to a handler-scoped allowlist. Empty approvers + empty fallback = unrestricted.
+
+## Acceptance Criteria
+

--- a/internal/approval/telegram.go
+++ b/internal/approval/telegram.go
@@ -69,6 +69,12 @@ type TelegramHandler struct {
 	// destination" warning per bad value (GH-4380), so a persistently
 	// misconfigured Approvers entry logs once instead of once per tick.
 	warnedInvalidDest map[string]bool
+
+	// allowedUsers is a handler-scoped fallback allowlist consulted by
+	// isAuthorizedApprover when a request's own Request.Approvers is empty
+	// (GH-5155). Set via WithAllowedUsers. Nil/empty means unrestricted —
+	// any tapper may decide a request that carries no configured approvers.
+	allowedUsers []string
 }
 
 // telegramPending tracks a pending Telegram approval request
@@ -191,6 +197,47 @@ func (h *TelegramHandler) WithStore(store PendingApprovalStore) *TelegramHandler
 func (h *TelegramHandler) WithDecisionRecorder(recorder DecisionRecorder) *TelegramHandler {
 	h.recorder = recorder
 	return h
+}
+
+// WithAllowedUsers attaches a handler-scoped allowlist of user IDs permitted
+// to decide approval requests whose own Request.Approvers is empty
+// (GH-5155). Requests that do carry Approvers are gated by that list
+// instead — this fallback only applies when Approvers is unset. Returns h
+// to allow builder-style chaining.
+func (h *TelegramHandler) WithAllowedUsers(users []string) *TelegramHandler {
+	h.allowedUsers = users
+	return h
+}
+
+// isAuthorizedApprover reports whether userID may decide a request via this
+// handler (GH-5155). When approvers (the request's own Request.Approvers)
+// is non-empty it is the authoritative allowlist — userID must exactly
+// match one of its entries via plain string equality, since Approvers
+// already carries whatever identity format the operator configured for
+// this channel (e.g. Telegram numeric user ids). When approvers is empty,
+// control falls back to the handler-scoped allowedUsers set (see
+// WithAllowedUsers) so a channel can still restrict who may decide requests
+// that didn't specify their own approver list. Both empty means
+// unrestricted — any user may decide, preserving behavior for callers that
+// never configured either.
+func (h *TelegramHandler) isAuthorizedApprover(userID string, approvers []string) bool {
+	if len(approvers) > 0 {
+		for _, a := range approvers {
+			if a == userID {
+				return true
+			}
+		}
+		return false
+	}
+	if len(h.allowedUsers) == 0 {
+		return true
+	}
+	for _, u := range h.allowedUsers {
+		if u == userID {
+			return true
+		}
+	}
+	return false
 }
 
 // Rehydrate loads persisted pending approvals from the store and re-inserts them
@@ -485,8 +532,16 @@ func (h *TelegramHandler) HandleCallback(ctx context.Context, callbackID, data, 
 
 	h.mu.Lock()
 	pending, exists := h.pending[requestID]
+	// GH-5155: decide authorization inside the same critical section as the
+	// lookup, and only delete from h.pending when authorized — an
+	// unauthorized tap must not mutate any state (pending map, store,
+	// resolved decision), just like the not-found/expired paths below.
+	authorized := true
 	if exists {
-		delete(h.pending, requestID)
+		authorized = h.isAuthorizedApprover(userID, pending.Request.Approvers)
+		if authorized {
+			delete(h.pending, requestID)
+		}
 	}
 	h.mu.Unlock()
 
@@ -500,6 +555,19 @@ func (h *TelegramHandler) HandleCallback(ctx context.Context, callbackID, data, 
 			slog.String("user", username))
 		if err := h.client.AnswerCallback(ctx, callbackID, "Request expired or already processed"); err != nil {
 			h.log.Warn("failed to answer unknown-request approval callback",
+				slog.String("request_id", requestID), slog.Any("error", err))
+		}
+		return true
+	}
+
+	if !authorized {
+		h.log.Info("Approval callback from unauthorized user",
+			slog.String("request_id", requestID),
+			slog.String("decision", string(decision)),
+			slog.String("user", username),
+			slog.String("user_id", userID))
+		if err := h.client.AnswerCallback(ctx, callbackID, "You are not authorized to decide this request"); err != nil {
+			h.log.Warn("failed to answer unauthorized approval callback",
 				slog.String("request_id", requestID), slog.Any("error", err))
 		}
 		return true

--- a/internal/approval/telegram_test.go
+++ b/internal/approval/telegram_test.go
@@ -1113,7 +1113,10 @@ func TestTelegramHandler_ApproverRouting(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		handler.HandleCallback(context.Background(), "cb1", "approve:req-edit-routing", "user", "tester")
+		// userID must match the configured Approvers entry (GH-5155) for the
+		// callback to be authorized — this test exercises routing, not
+		// authorization, so it uses the approver identity itself.
+		handler.HandleCallback(context.Background(), "cb1", "approve:req-edit-routing", "99999", "tester")
 
 		edited := client.getEditedMessages()
 		if len(edited) != 1 {
@@ -1729,6 +1732,143 @@ func TestTelegramHandler_HandleCallback_ExpiredButPending_AnswerCallbackError_Lo
 	}
 }
 
+// TestTelegramHandler_HandleCallback_ApproversGate covers the GH-5155
+// identity check: when Request.Approvers is non-empty, only a userID that
+// exactly matches one of its entries may decide the request. A rejected tap
+// must not mutate any state — the request stays pending so the real
+// approver can still act.
+func TestTelegramHandler_HandleCallback_ApproversGate(t *testing.T) {
+	client := &mockTelegramClient{}
+	handler := NewTelegramHandler(client, "chat123", 0)
+
+	req := &Request{
+		ID:        "req-approvers-gate",
+		TaskID:    "TASK-01",
+		Stage:     StagePreExecution,
+		Title:     "Test task",
+		Approvers: []string{"12345", "67890"},
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	respCh, err := handler.SendApprovalRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// A user not in Approvers must be rejected without consuming the request.
+	handled := handler.HandleCallback(context.Background(), "cb1", "approve:req-approvers-gate", "intruder", "intruder")
+	if !handled {
+		t.Error("expected callback to be handled (even when unauthorized)")
+	}
+
+	cbs := client.getAnsweredCallbacks()
+	if len(cbs) != 1 || cbs[0].Text != "You are not authorized to decide this request" {
+		t.Fatalf("expected unauthorized answer text, got: %+v", cbs)
+	}
+	select {
+	case resp := <-respCh:
+		t.Fatalf("expected no response for unauthorized tap, got: %+v", resp)
+	default:
+	}
+
+	handler.mu.RLock()
+	_, stillPending := handler.pending["req-approvers-gate"]
+	handler.mu.RUnlock()
+	if !stillPending {
+		t.Fatal("expected request to remain pending after an unauthorized tap")
+	}
+
+	// The listed approver can still decide it afterwards.
+	handled = handler.HandleCallback(context.Background(), "cb2", "approve:req-approvers-gate", "67890", "approver")
+	if !handled {
+		t.Error("expected callback to be handled")
+	}
+	select {
+	case resp := <-respCh:
+		if resp.Decision != DecisionApproved {
+			t.Errorf("expected approved, got %s", resp.Decision)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for response")
+	}
+}
+
+// TestTelegramHandler_HandleCallback_AllowlistFallback covers the GH-5155
+// fallback path: when Request.Approvers is empty, authorization falls back
+// to the handler-scoped allowlist set via WithAllowedUsers.
+func TestTelegramHandler_HandleCallback_AllowlistFallback(t *testing.T) {
+	client := &mockTelegramClient{}
+	handler := NewTelegramHandler(client, "chat123", 0).WithAllowedUsers([]string{"allowed-1"})
+
+	req := &Request{
+		ID:        "req-allowlist-fallback",
+		TaskID:    "TASK-01",
+		Stage:     StagePreExecution,
+		Title:     "Test task",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	respCh, err := handler.SendApprovalRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Not in the handler allowlist -> rejected.
+	handled := handler.HandleCallback(context.Background(), "cb1", "approve:req-allowlist-fallback", "not-allowed", "someone")
+	if !handled {
+		t.Error("expected callback to be handled (even when unauthorized)")
+	}
+	cbs := client.getAnsweredCallbacks()
+	if len(cbs) != 1 || cbs[0].Text != "You are not authorized to decide this request" {
+		t.Fatalf("expected unauthorized answer text, got: %+v", cbs)
+	}
+
+	// In the handler allowlist -> authorized.
+	handled = handler.HandleCallback(context.Background(), "cb2", "approve:req-allowlist-fallback", "allowed-1", "someone-else")
+	if !handled {
+		t.Error("expected callback to be handled")
+	}
+	select {
+	case resp := <-respCh:
+		if resp.Decision != DecisionApproved {
+			t.Errorf("expected approved, got %s", resp.Decision)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for response")
+	}
+}
+
+// TestTelegramHandler_HandleCallback_UnrestrictedWhenNoApproversOrAllowlist
+// covers the GH-5155 default: empty Approvers and no handler allowlist means
+// any user may decide the request (preserves prior behavior).
+func TestTelegramHandler_HandleCallback_UnrestrictedWhenNoApproversOrAllowlist(t *testing.T) {
+	client := &mockTelegramClient{}
+	handler := NewTelegramHandler(client, "chat123", 0)
+
+	req := &Request{
+		ID:        "req-unrestricted",
+		TaskID:    "TASK-01",
+		Stage:     StagePreExecution,
+		Title:     "Test task",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	respCh, err := handler.SendApprovalRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	handled := handler.HandleCallback(context.Background(), "cb1", "approve:req-unrestricted", "anyone", "anyone")
+	if !handled {
+		t.Error("expected callback to be handled")
+	}
+	select {
+	case resp := <-respCh:
+		if resp.Decision != DecisionApproved {
+			t.Errorf("expected approved, got %s", resp.Decision)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for response")
+	}
+}
+
 // TestTelegramHandler_Rehydrate_ResendsFreshPromptPerPendingRequest is the
 // GH-4159 regression test: after a restart, Rehydrate must send a fresh,
 // actionable prompt for each restored request (same request_id/buttons) so
@@ -2101,7 +2241,9 @@ func TestTelegramHandler_NotifyMerged_SendsFollowUpInSameChat(t *testing.T) {
 	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	handler.HandleCallback(context.Background(), "cb1", "approve:req-merged", "u1", "tester")
+	// userID must match the configured Approvers entry (GH-5155) for the
+	// callback to be authorized.
+	handler.HandleCallback(context.Background(), "cb1", "approve:req-merged", "99999", "tester")
 
 	sentBefore := len(client.getSentMessages())
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5155.

Closes #5155

## Changes

In internal/approval/telegram.go HandleCallback (~:471), add identity checks before any state mutation, mirroring the existing not-found/expired early-return shape. Two-step guard: (1) if pending.Request.Approvers is non-empty, require plain string equality of userID against an entry; (2) otherwise fall back to a handler-scoped allowlist. Empty approvers + empty fallback = unrestricted.