### PR TITLE
GH-5156: feat(slack): add pre-mutation authorization guard to HandleInteraction

### DIFF
--- a/internal/approval/slack.go
+++ b/internal/approval/slack.go
@@ -72,6 +72,13 @@ type SlackHandler struct {
 	log      *slog.Logger
 	store    PendingApprovalStore // optional; enables restart persistence (GH-4411)
 	recorder DecisionRecorder     // optional; persists decisions directly (restart-safe, GH-4411)
+
+	// allowedUsers is a handler-scoped fallback allowlist consulted by
+	// isAuthorizedApprover when a request's own Request.Approvers is empty
+	// (GH-5156, mirrors Telegram's GH-5155). Set via WithAllowedUsers.
+	// Nil/empty means unrestricted — any clicker may decide a request that
+	// carries no configured approvers.
+	allowedUsers []string
 }
 
 // slackPending tracks a pending Slack approval request
@@ -177,6 +184,47 @@ func (h *SlackHandler) WithStore(store PendingApprovalStore) *SlackHandler {
 func (h *SlackHandler) WithDecisionRecorder(recorder DecisionRecorder) *SlackHandler {
 	h.recorder = recorder
 	return h
+}
+
+// WithAllowedUsers attaches a handler-scoped allowlist of user IDs permitted
+// to decide approval requests whose own Request.Approvers is empty
+// (GH-5156, mirrors Telegram's GH-5155). Requests that do carry Approvers
+// are gated by that list instead — this fallback only applies when
+// Approvers is unset. Returns h to allow builder-style chaining.
+func (h *SlackHandler) WithAllowedUsers(users []string) *SlackHandler {
+	h.allowedUsers = users
+	return h
+}
+
+// isAuthorizedApprover reports whether userID may decide a request via this
+// handler (GH-5156, mirrors Telegram's GH-5155). When approvers (the
+// request's own Request.Approvers) is non-empty it is the authoritative
+// allowlist — userID must exactly match one of its entries via plain string
+// equality, since Approvers already carries whatever identity format the
+// operator configured for this channel (e.g. Slack user ids). When
+// approvers is empty, control falls back to the handler-scoped allowedUsers
+// set (see WithAllowedUsers) so a channel can still restrict who may decide
+// requests that didn't specify their own approver list. Both empty means
+// unrestricted — any user may decide, preserving behavior for callers that
+// never configured either.
+func (h *SlackHandler) isAuthorizedApprover(userID string, approvers []string) bool {
+	if len(approvers) > 0 {
+		for _, a := range approvers {
+			if a == userID {
+				return true
+			}
+		}
+		return false
+	}
+	if len(h.allowedUsers) == 0 {
+		return true
+	}
+	for _, u := range h.allowedUsers {
+		if u == userID {
+			return true
+		}
+	}
+	return false
 }
 
 // Rehydrate loads persisted pending approvals from the store and re-inserts them
@@ -413,8 +461,16 @@ func (h *SlackHandler) HandleInteraction(ctx context.Context, actionID, value, u
 
 	h.mu.Lock()
 	pending, exists := h.pending[requestID]
+	// GH-5156: decide authorization inside the same critical section as the
+	// lookup, and only delete from h.pending when authorized — an
+	// unauthorized click must not mutate any state (pending map, store,
+	// resolved decision), just like the not-found/expired paths below.
+	authorized := true
 	if exists {
-		delete(h.pending, requestID)
+		authorized = h.isAuthorizedApprover(userID, pending.Request.Approvers)
+		if authorized {
+			delete(h.pending, requestID)
+		}
 	}
 	h.mu.Unlock()
 
@@ -424,6 +480,15 @@ func (h *SlackHandler) HandleInteraction(ctx context.Context, actionID, value, u
 			slog.String("decision", string(decision)),
 			slog.String("user", username))
 		return true // Still handled, just expired
+	}
+
+	if !authorized {
+		h.log.Info("Approval interaction from unauthorized user",
+			slog.String("request_id", requestID),
+			slog.String("decision", string(decision)),
+			slog.String("user", username),
+			slog.String("user_id", userID))
+		return true // Still handled — request stays pending for the real approver
 	}
 
 	if h.store != nil {

--- a/internal/approval/slack_test.go
+++ b/internal/approval/slack_test.go
@@ -441,6 +441,142 @@ func TestSlackHandler_HandleInteraction_Reject(t *testing.T) {
 	}
 }
 
+// TestSlackHandler_HandleInteraction_ApproversGate covers the GH-5156
+// identity check: when Request.Approvers is non-empty, only a userID that
+// exactly matches one of its entries may decide the request. A rejected
+// click must not mutate any state — the request stays pending so the real
+// approver can still act.
+func TestSlackHandler_HandleInteraction_ApproversGate(t *testing.T) {
+	client := &mockSlackClient{}
+	handler := NewSlackHandler(client, "#approvals")
+
+	req := &Request{
+		ID:        "req-approvers-gate",
+		TaskID:    "TASK-01",
+		Stage:     StagePreExecution,
+		Title:     "Test task",
+		Approvers: []string{"U12345", "U67890"},
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	respCh, err := handler.SendApprovalRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// A user not in Approvers must be rejected without consuming the request.
+	handled := handler.HandleInteraction(context.Background(), "approve", "approve:req-approvers-gate", "intruder", "intruder", "")
+	if !handled {
+		t.Error("expected interaction to be handled (even when unauthorized)")
+	}
+	select {
+	case resp := <-respCh:
+		t.Fatalf("expected no response for unauthorized click, got: %+v", resp)
+	default:
+	}
+	if len(client.updateCalls) != 0 {
+		t.Fatalf("expected no message update for an unauthorized click, got %d", len(client.updateCalls))
+	}
+
+	handler.mu.RLock()
+	_, stillPending := handler.pending["req-approvers-gate"]
+	handler.mu.RUnlock()
+	if !stillPending {
+		t.Fatal("expected request to remain pending after an unauthorized click")
+	}
+
+	// The listed approver can still decide it afterwards.
+	handled = handler.HandleInteraction(context.Background(), "approve", "approve:req-approvers-gate", "U67890", "approver", "")
+	if !handled {
+		t.Error("expected interaction to be handled")
+	}
+	select {
+	case resp := <-respCh:
+		if resp.Decision != DecisionApproved {
+			t.Errorf("expected approved, got %s", resp.Decision)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for response")
+	}
+}
+
+// TestSlackHandler_HandleInteraction_AllowlistFallback covers the GH-5156
+// fallback path: when Request.Approvers is empty, authorization falls back
+// to the handler-scoped allowlist set via WithAllowedUsers.
+func TestSlackHandler_HandleInteraction_AllowlistFallback(t *testing.T) {
+	client := &mockSlackClient{}
+	handler := NewSlackHandler(client, "#approvals").WithAllowedUsers([]string{"allowed-1"})
+
+	req := &Request{
+		ID:        "req-allowlist-fallback",
+		TaskID:    "TASK-01",
+		Stage:     StagePreExecution,
+		Title:     "Test task",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	respCh, err := handler.SendApprovalRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Not in the handler allowlist -> rejected.
+	handled := handler.HandleInteraction(context.Background(), "approve", "approve:req-allowlist-fallback", "not-allowed", "someone", "")
+	if !handled {
+		t.Error("expected interaction to be handled (even when unauthorized)")
+	}
+	select {
+	case resp := <-respCh:
+		t.Fatalf("expected no response for unauthorized click, got: %+v", resp)
+	default:
+	}
+
+	// In the handler allowlist -> authorized.
+	handled = handler.HandleInteraction(context.Background(), "approve", "approve:req-allowlist-fallback", "allowed-1", "someone-else", "")
+	if !handled {
+		t.Error("expected interaction to be handled")
+	}
+	select {
+	case resp := <-respCh:
+		if resp.Decision != DecisionApproved {
+			t.Errorf("expected approved, got %s", resp.Decision)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for response")
+	}
+}
+
+// TestSlackHandler_HandleInteraction_UnrestrictedWhenNoApproversOrAllowlist
+// covers the GH-5156 default: empty Approvers and no handler allowlist means
+// any user may decide the request (preserves prior behavior).
+func TestSlackHandler_HandleInteraction_UnrestrictedWhenNoApproversOrAllowlist(t *testing.T) {
+	client := &mockSlackClient{}
+	handler := NewSlackHandler(client, "#approvals")
+
+	req := &Request{
+		ID:        "req-unrestricted",
+		TaskID:    "TASK-01",
+		Stage:     StagePreExecution,
+		Title:     "Test task",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	respCh, err := handler.SendApprovalRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	handled := handler.HandleInteraction(context.Background(), "approve", "approve:req-unrestricted", "anyone", "anyone", "")
+	if !handled {
+		t.Error("expected interaction to be handled")
+	}
+	select {
+	case resp := <-respCh:
+		if resp.Decision != DecisionApproved {
+			t.Errorf("expected approved, got %s", resp.Decision)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for response")
+	}
+}
+
 func TestSlackHandler_HandleInteraction_NotFound(t *testing.T) {
 	client := &mockSlackClient{}
 	handler := NewSlackHandler(client, "#approvals")


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5156.

Closes #5156

## Changes

In internal/approval/slack.go HandleInteraction (~:399), add the same two-step identity guard as Telegram before any state mutation, preserving the same unrestricted-when-empty semantics.