### PR TITLE
GH-5158: feat(telegram): wire allowlist from config at both construction sites

### DIFF
--- a/.agent/tasks/gh-5158.md
+++ b/.agent/tasks/gh-5158.md
@@ -1,0 +1,10 @@
+# GH-5158
+
+**Created:** 2026-08-24
+
+## Problem
+
+Wire the Telegram allowlist from cfg.Adapters.Telegram.AllowedIDs (converting int64 to decimal strings) at both TelegramHandler construction sites in cmd/pilot/main.go (~:2895-2958 chat mode and ~:3627 gateway).
+
+## Acceptance Criteria
+

--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -1295,6 +1296,21 @@ func parseInt64(s string) (int64, error) {
 	var id int64
 	_, err := fmt.Sscanf(s, "%d", &id)
 	return id, err
+}
+
+// telegramAllowedUserIDStrings converts cfg.Adapters.Telegram.AllowedIDs
+// (numeric Telegram user/chat IDs) to decimal strings, for use with
+// approval.TelegramHandler.WithAllowedUsers, which compares by plain string
+// equality against Approvers entries (GH-5158).
+func telegramAllowedUserIDStrings(ids []int64) []string {
+	if len(ids) == 0 {
+		return nil
+	}
+	strs := make([]string, len(ids))
+	for i, id := range ids {
+		strs[i] = strconv.FormatInt(id, 10)
+	}
+	return strs
 }
 
 // stampPilotFailedWithLadder applies the pilot-failed label to issueNum and

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -819,6 +819,10 @@ Examples:
 					(cfg.Adapters.Telegram.Approval == nil || cfg.Adapters.Telegram.Approval.Enabled) {
 					tgClient := telegram.NewClient(cfg.Adapters.Telegram.BotToken)
 					gwTgApprovalHandler = approval.NewTelegramHandler(&telegramApprovalAdapter{client: tgClient}, cfg.Adapters.Telegram.ChatID, cfg.Adapters.Telegram.MessageThreadID)
+					// GH-5158: fall back to the configured allowlist for requests
+					// whose own Request.Approvers is empty, instead of leaving
+					// decisions unrestricted to any tapper.
+					gwTgApprovalHandler.WithAllowedUsers(telegramAllowedUserIDStrings(cfg.Adapters.Telegram.AllowedIDs))
 					// GH-3825: persist decisions directly to PRState via the manager so a
 					// button tap on a Rehydrate-restored request isn't lost when no
 					// waiter goroutine survived the restart.
@@ -2166,6 +2170,10 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		(cfg.Adapters.Telegram.Approval == nil || cfg.Adapters.Telegram.Approval.Enabled) {
 		tgApprovalClient := telegram.NewClient(cfg.Adapters.Telegram.BotToken)
 		tgApprovalHandlerImpl = approval.NewTelegramHandler(&telegramApprovalAdapter{client: tgApprovalClient}, cfg.Adapters.Telegram.ChatID, cfg.Adapters.Telegram.MessageThreadID)
+		// GH-5158: fall back to the configured allowlist for requests whose
+		// own Request.Approvers is empty, instead of leaving decisions
+		// unrestricted to any tapper.
+		tgApprovalHandlerImpl.WithAllowedUsers(telegramAllowedUserIDStrings(cfg.Adapters.Telegram.AllowedIDs))
 		// GH-3825: persist decisions directly to PRState via the manager so a
 		// button tap on a Rehydrate-restored request isn't lost when no waiter
 		// goroutine survived the restart.

--- a/cmd/pilot/wiring_test.go
+++ b/cmd/pilot/wiring_test.go
@@ -1086,3 +1086,85 @@ func TestAutopilotProviderAdapter_ImplementsInterface(t *testing.T) {
 	// (if the interface signature changes, this file will fail to compile)
 	_ = &autopilotProviderAdapter{}
 }
+
+// =============================================================================
+// GH-5158: Telegram approval allowlist wiring
+// =============================================================================
+
+// TestTelegramAllowedUserIDStrings verifies the []int64 -> []string decimal
+// conversion used to feed approval.TelegramHandler.WithAllowedUsers, which
+// compares by plain string equality (GH-5155).
+func TestTelegramAllowedUserIDStrings(t *testing.T) {
+	tests := []struct {
+		name string
+		ids  []int64
+		want []string
+	}{
+		{name: "nil", ids: nil, want: nil},
+		{name: "empty", ids: []int64{}, want: nil},
+		{name: "single", ids: []int64{123456789}, want: []string{"123456789"}},
+		{name: "multiple", ids: []int64{111, -222, 333}, want: []string{"111", "-222", "333"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := telegramAllowedUserIDStrings(tt.ids)
+			if len(got) != len(tt.want) {
+				t.Fatalf("telegramAllowedUserIDStrings(%v) = %v, want %v", tt.ids, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("telegramAllowedUserIDStrings(%v)[%d] = %q, want %q", tt.ids, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestTelegramApprovalAllowlistWiredAtBothConstructionSites verifies that
+// every approval.NewTelegramHandler(...) call site in main.go also wires
+// WithAllowedUsers(telegramAllowedUserIDStrings(cfg.Adapters.Telegram.AllowedIDs))
+// (GH-5158). Without this, an approval request whose own Request.Approvers
+// is empty falls back to h.allowedUsers, which is nil/unrestricted for both
+// the gateway-mode and chat-mode (polling) handlers — any tapper could
+// decide it.
+func TestTelegramApprovalAllowlistWiredAtBothConstructionSites(t *testing.T) {
+	mainContent, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	src := string(mainContent)
+
+	constructCount := strings.Count(src, "approval.NewTelegramHandler(")
+	wireCount := strings.Count(src, "WithAllowedUsers(telegramAllowedUserIDStrings(cfg.Adapters.Telegram.AllowedIDs))")
+
+	if constructCount != 2 {
+		t.Fatalf("approval.NewTelegramHandler( occurs %d times in main.go, want 2 — this test's baseline assumption is stale, update it", constructCount)
+	}
+	if wireCount != constructCount {
+		t.Errorf("WithAllowedUsers(telegramAllowedUserIDStrings(...)) occurs %d times in main.go, want %d (parity with approval.NewTelegramHandler's %d construction sites, GH-5158) — "+
+			"a Telegram approval handler constructed without the allowlist wired leaves fallback approver checks unrestricted",
+			wireCount, constructCount, constructCount)
+	}
+
+	wantPairs := []string{
+		"gwTgApprovalHandler.WithAllowedUsers(telegramAllowedUserIDStrings(cfg.Adapters.Telegram.AllowedIDs))",
+		"tgApprovalHandlerImpl.WithAllowedUsers(telegramAllowedUserIDStrings(cfg.Adapters.Telegram.AllowedIDs))",
+	}
+	for _, want := range wantPairs {
+		if !strings.Contains(src, want) {
+			t.Errorf("expected to find allowlist wiring call %q", want)
+		}
+	}
+}
+
+// TestTelegramApprovalHandler_WithAllowedUsersChains verifies that wiring
+// the allowlist via the same helper used in main.go still returns the
+// handler for chaining with the other builder calls at each construction
+// site (WithDecisionRecorder, WithStore).
+func TestTelegramApprovalHandler_WithAllowedUsersChains(t *testing.T) {
+	handler := approval.NewTelegramHandler(nil, "chat123", 0).
+		WithAllowedUsers(telegramAllowedUserIDStrings([]int64{123456789}))
+	if handler == nil {
+		t.Fatal("WithAllowedUsers returned nil, want chainable *TelegramHandler")
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5158.

Closes #5158

## Changes

Wire the Telegram allowlist from cfg.Adapters.Telegram.AllowedIDs (converting int64 to decimal strings) at both TelegramHandler construction sites in cmd/pilot/main.go (~:2895-2958 chat mode and ~:3627 gateway).