### PR TITLE
GH-5159: feat(slack): wire allowlist from adapter config

### DIFF
--- a/.agent/tasks/gh-5159.md
+++ b/.agent/tasks/gh-5159.md
@@ -1,0 +1,10 @@
+# GH-5159
+
+**Created:** 2026-08-24
+
+## Problem
+
+Wire the Slack allowlist from the equivalent Slack adapter config field at the Slack handler construction site(s), analogous to the Telegram wiring.
+
+## Acceptance Criteria
+

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -846,6 +846,10 @@ Examples:
 							slackChannel = cfg.Adapters.Slack.Channel
 						}
 						gwSlackApprovalHandler = approval.NewSlackHandler(&slackApprovalClientAdapter{adapter: slackAdapter}, slackChannel)
+						// GH-5159: fallback allowlist consulted by isAuthorizedApprover
+						// when a request's own Approvers is empty (mirrors the Telegram
+						// wiring from cfg.Adapters.Telegram.AllowedIDs, GH-5158).
+						gwSlackApprovalHandler.WithAllowedIDs(cfg.Adapters.Slack.AllowedUsers)
 						// GH-4411: persist decisions directly to PRState via the manager so a
 						// button click on a Rehydrate-restored request isn't lost when no
 						// waiter goroutine survived the restart (mirrors GH-3825's Telegram fix).
@@ -2187,6 +2191,10 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				slackChannel = cfg.Adapters.Slack.Channel
 			}
 			slackApprovalHandlerImpl = approval.NewSlackHandler(&slackApprovalClientAdapter{adapter: slackAdapter}, slackChannel)
+			// GH-5159: fallback allowlist consulted by isAuthorizedApprover
+			// when a request's own Approvers is empty (mirrors the Telegram
+			// wiring from cfg.Adapters.Telegram.AllowedIDs, GH-5158).
+			slackApprovalHandlerImpl.WithAllowedIDs(cfg.Adapters.Slack.AllowedUsers)
 			// GH-4411: persist decisions directly to PRState via the manager so a
 			// button click on a Rehydrate-restored request isn't lost when no
 			// waiter goroutine survived the restart (mirrors GH-3825's Telegram fix).

--- a/internal/pilot/pilot.go
+++ b/internal/pilot/pilot.go
@@ -272,6 +272,10 @@ func New(cfg *config.Config, opts ...Option) (*Pilot, error) {
 				&slackApprovalClientAdapter{adapter: slackAdapter},
 				approvalChannel,
 			)
+			// GH-5159: fallback allowlist consulted by isAuthorizedApprover
+			// when a request's own Approvers is empty (mirrors the Telegram
+			// wiring from cfg.Adapters.Telegram.AllowedIDs, GH-5158).
+			p.slackApprovalHdlr.WithAllowedIDs(cfg.Adapters.Slack.AllowedUsers)
 			// GH-4411: persist decisions directly to PRState via the manager so a
 			// button click on a Rehydrate-restored request isn't lost when no
 			// waiter goroutine survived the restart (mirrors GH-3825's Telegram fix).


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5159.

Closes #5159

## Changes

Wire the Slack allowlist from the equivalent Slack adapter config field at the Slack handler construction site(s), analogous to the Telegram wiring.