### PR TITLE
GH-5161: feat(slack): implement refusal behavior on unauthorized tap

### DIFF
--- a/.agent/tasks/gh-5161.md
+++ b/.agent/tasks/gh-5161.md
@@ -1,0 +1,10 @@
+# GH-5161
+
+**Created:** 2026-08-24
+
+## Problem
+
+On refusal, send the ephemeral "not an approver" interaction response, emit an equivalent warn log with request_id/user attrs, skip RecordDecision, leave the pending map untouched, and return true (interaction consumed).
+
+## Acceptance Criteria
+

--- a/cmd/pilot/adapters.go
+++ b/cmd/pilot/adapters.go
@@ -106,6 +106,10 @@ func (a *slackApprovalClientAdapter) UpdateInteractiveMessage(ctx context.Contex
 	return a.adapter.UpdateInteractiveMessage(ctx, channel, ts, blocks, text)
 }
 
+func (a *slackApprovalClientAdapter) PostEphemeral(ctx context.Context, responseURL, text string) error {
+	return a.adapter.PostEphemeral(ctx, responseURL, text)
+}
+
 // wireProjectAccessChecker creates and wires a team-based project access checker on the runner (GH-635).
 // It opens the teams DB, resolves the configured member, and returns a cleanup function.
 // Returns nil cleanup if team config is absent or disabled.

--- a/internal/adapters/slack/client.go
+++ b/internal/adapters/slack/client.go
@@ -289,6 +289,48 @@ func (c *Client) PostInteractiveMessage(ctx context.Context, msg *InteractiveMes
 	return &result, nil
 }
 
+// PostEphemeral sends a message visible only to the triggering user by
+// POSTing to a Slack interaction's response_url (GH-5161). response_url
+// requests are pre-authenticated by Slack, so — unlike PostMessage/
+// PostInteractiveMessage — no bot token is sent. replace_original is left
+// false so the original message (and its buttons, for the real approver)
+// stays intact.
+func (c *Client) PostEphemeral(ctx context.Context, responseURL, text string) error {
+	payload := struct {
+		ResponseType    string `json:"response_type"`
+		Text            string `json:"text"`
+		ReplaceOriginal bool   `json:"replace_original"`
+	}{
+		ResponseType:    "ephemeral",
+		Text:            text,
+		ReplaceOriginal: false,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal ephemeral response: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, responseURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to post ephemeral response: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("slack response_url returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return nil
+}
+
 // UpdateInteractiveMessage updates an existing message (removes buttons, updates text)
 func (c *Client) UpdateInteractiveMessage(ctx context.Context, channel, ts string, blocks []interface{}, text string) error {
 	payload := struct {

--- a/internal/adapters/slack/client_test.go
+++ b/internal/adapters/slack/client_test.go
@@ -1248,3 +1248,75 @@ func TestClientUpdateMessageInvalidJSON(t *testing.T) {
 		t.Errorf("error = %q, want to contain 'failed to parse response'", err.Error())
 	}
 }
+
+// TestClientPostEphemeral covers GH-5161: PostEphemeral POSTs directly to
+// the given response_url (not the botToken-authenticated Slack API base
+// URL) with an ephemeral, non-replacing payload.
+func TestClientPostEphemeral(t *testing.T) {
+	var gotAuth, gotContentType, gotMethod string
+	var gotBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read body: %v", err)
+		}
+		if err := json.Unmarshal(body, &gotBody); err != nil {
+			t.Fatalf("failed to parse request body: %v", err)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(testutil.FakeSlackBotToken)
+	ctx := context.Background()
+	if err := client.PostEphemeral(ctx, server.URL, "You are not authorized to decide this request"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotContentType)
+	}
+	// response_url requests are pre-authenticated by Slack; no bot token
+	// should be sent.
+	if gotAuth != "" {
+		t.Errorf("Authorization = %q, want empty (response_url is pre-authenticated)", gotAuth)
+	}
+	if gotBody["response_type"] != "ephemeral" {
+		t.Errorf("response_type = %v, want ephemeral", gotBody["response_type"])
+	}
+	if gotBody["text"] != "You are not authorized to decide this request" {
+		t.Errorf("text = %v, want the refusal message", gotBody["text"])
+	}
+	if gotBody["replace_original"] != false {
+		t.Errorf("replace_original = %v, want false (original message must stay clickable)", gotBody["replace_original"])
+	}
+}
+
+// TestClientPostEphemeralErrorStatus covers the non-200 response_url path
+// (GH-5161): Slack returns a plain-text error body on failure, which
+// PostEphemeral must surface rather than silently succeed.
+func TestClientPostEphemeralErrorStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusGone)
+		_, _ = w.Write([]byte("expired_url"))
+	}))
+	defer server.Close()
+
+	client := NewClient(testutil.FakeSlackBotToken)
+	err := client.PostEphemeral(context.Background(), server.URL, "test")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "expired_url") {
+		t.Errorf("error = %q, want it to contain the response body", err.Error())
+	}
+}

--- a/internal/adapters/slack/webhook.go
+++ b/internal/adapters/slack/webhook.go
@@ -275,6 +275,11 @@ func (a *SlackClientAdapter) UpdateInteractiveMessage(ctx context.Context, chann
 	return a.client.UpdateInteractiveMessage(ctx, channel, ts, blocks, text)
 }
 
+// PostEphemeral implements approval.SlackClient
+func (a *SlackClientAdapter) PostEphemeral(ctx context.Context, responseURL, text string) error {
+	return a.client.PostEphemeral(ctx, responseURL, text)
+}
+
 // SlackApprovalMessage mirrors the approval package's message type
 type SlackApprovalMessage struct {
 	Channel string        `json:"channel"`

--- a/internal/approval/slack.go
+++ b/internal/approval/slack.go
@@ -17,6 +17,12 @@ import (
 type SlackClient interface {
 	PostInteractiveMessage(ctx context.Context, msg *SlackInteractiveMessage) (*SlackPostMessageResponse, error)
 	UpdateInteractiveMessage(ctx context.Context, channel, ts string, blocks []interface{}, text string) error
+	// PostEphemeral sends a message visible only to the user who triggered
+	// the interaction, delivered via the interaction's response_url
+	// (GH-5161). Used to answer a click without mutating the original
+	// message — e.g. telling an unauthorized clicker they aren't an
+	// approver, mirroring TelegramHandler's AnswerCallback toast.
+	PostEphemeral(ctx context.Context, responseURL, text string) error
 }
 
 // SlackInteractiveMessage represents a Slack message with interactive buttons
@@ -484,11 +490,17 @@ func (h *SlackHandler) HandleInteraction(ctx context.Context, actionID, value, u
 	}
 
 	if !authorized {
-		h.log.Info("Approval interaction from unauthorized user",
+		h.log.Warn("Approval interaction from unauthorized user",
 			slog.String("request_id", requestID),
 			slog.String("decision", string(decision)),
 			slog.String("user", username),
 			slog.String("user_id", userID))
+		if responseURL != "" {
+			if err := h.client.PostEphemeral(ctx, responseURL, "You are not authorized to decide this request"); err != nil {
+				h.log.Warn("failed to send unauthorized approval ephemeral response",
+					slog.String("request_id", requestID), slog.Any("error", err))
+			}
+		}
 		return true
 	}
 

--- a/internal/approval/slack_test.go
+++ b/internal/approval/slack_test.go
@@ -18,6 +18,11 @@ type mockSlackClient struct {
 	// can assert on the text/blocks a race-loss vs. a real decision produces
 	// (GH-4777).
 	updateCalls []mockSlackUpdateCall
+
+	// ephemeralCalls records every PostEphemeral invocation so tests can
+	// assert an unauthorized click gets answered via response_url (GH-5161).
+	ephemeralCalls []mockSlackEphemeralCall
+	ephemeralError error
 }
 
 type mockSlackUpdateCall struct {
@@ -25,6 +30,11 @@ type mockSlackUpdateCall struct {
 	TS      string
 	Blocks  []interface{}
 	Text    string
+}
+
+type mockSlackEphemeralCall struct {
+	ResponseURL string
+	Text        string
 }
 
 func (m *mockSlackClient) PostInteractiveMessage(ctx context.Context, msg *SlackInteractiveMessage) (*SlackPostMessageResponse, error) {
@@ -42,6 +52,11 @@ func (m *mockSlackClient) PostInteractiveMessage(ctx context.Context, msg *Slack
 func (m *mockSlackClient) UpdateInteractiveMessage(ctx context.Context, channel, ts string, blocks []interface{}, text string) error {
 	m.updateCalls = append(m.updateCalls, mockSlackUpdateCall{Channel: channel, TS: ts, Blocks: blocks, Text: text})
 	return m.updateError
+}
+
+func (m *mockSlackClient) PostEphemeral(ctx context.Context, responseURL, text string) error {
+	m.ephemeralCalls = append(m.ephemeralCalls, mockSlackEphemeralCall{ResponseURL: responseURL, Text: text})
+	return m.ephemeralError
 }
 
 func TestSlackHandler_Name(t *testing.T) {
@@ -1001,6 +1016,79 @@ func TestSlackHandler_HandleInteraction_AllowlistFallback(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for response")
+	}
+}
+
+// TestSlackHandler_HandleInteraction_UnauthorizedSendsEphemeralAndWarns
+// covers GH-5161: on refusal HandleInteraction must (1) send the ephemeral
+// "not an approver" response via the interaction's response_url, (2) log a
+// warn with request_id/user attrs, (3) skip RecordDecision, (4) leave the
+// request pending, and (5) still report the interaction as consumed.
+func TestSlackHandler_HandleInteraction_UnauthorizedSendsEphemeralAndWarns(t *testing.T) {
+	client := &mockSlackClient{}
+	recorder := &mockDecisionRecorder{}
+	handler := NewSlackHandler(client, "#approvals").WithDecisionRecorder(recorder)
+	logger, logBuf := newCapturingLogger()
+	handler.log = logger
+
+	req := &Request{
+		ID:        "req-ephemeral-refusal",
+		TaskID:    "TASK-01",
+		Stage:     StagePreExecution,
+		Title:     "Test task",
+		Approvers: []string{"U-allowed"},
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	respCh, err := handler.SendApprovalRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	const responseURL = "https://hooks.slack.com/actions/T000/B000/xyz"
+	handled := handler.HandleInteraction(context.Background(), "approve", "approve:req-ephemeral-refusal", "intruder", "intruder", responseURL)
+	if !handled {
+		t.Error("expected interaction to be handled (even when unauthorized)")
+	}
+
+	// (1) ephemeral response sent to the response_url.
+	if len(client.ephemeralCalls) != 1 {
+		t.Fatalf("expected 1 ephemeral response, got %d", len(client.ephemeralCalls))
+	}
+	if got := client.ephemeralCalls[0].ResponseURL; got != responseURL {
+		t.Errorf("ephemeral response_url = %q, want %q", got, responseURL)
+	}
+	if !containsString(client.ephemeralCalls[0].Text, "not authorized") {
+		t.Errorf("ephemeral text = %q, want it to mention not being authorized", client.ephemeralCalls[0].Text)
+	}
+
+	// (2) warn log with request_id/user attrs.
+	logOut := logBuf.String()
+	if !containsString(logOut, "level=WARN") {
+		t.Errorf("log output = %q, want a WARN-level record", logOut)
+	}
+	if !containsString(logOut, "request_id=req-ephemeral-refusal") {
+		t.Errorf("log output = %q, want request_id attr", logOut)
+	}
+	if !containsString(logOut, "user_id=intruder") {
+		t.Errorf("log output = %q, want user_id attr", logOut)
+	}
+
+	// (3) RecordDecision skipped.
+	if len(recorder.getCalls()) != 0 {
+		t.Fatalf("expected no decision recorded for an unauthorized click, got %d", len(recorder.getCalls()))
+	}
+
+	// (4) request left pending.
+	handler.mu.RLock()
+	_, stillPending := handler.pending["req-ephemeral-refusal"]
+	handler.mu.RUnlock()
+	if !stillPending {
+		t.Fatal("expected request to remain pending after an unauthorized click")
+	}
+	select {
+	case resp := <-respCh:
+		t.Fatalf("expected no response for unauthorized click, got: %+v", resp)
+	default:
 	}
 }
 

--- a/internal/autopilot/restart_approval_slack_integration_test.go
+++ b/internal/autopilot/restart_approval_slack_integration_test.go
@@ -25,6 +25,10 @@ func (f *fakeRestartSlackClient) UpdateInteractiveMessage(_ context.Context, _, 
 	return nil
 }
 
+func (f *fakeRestartSlackClient) PostEphemeral(_ context.Context, _, _ string) error {
+	return nil
+}
+
 // TestRestartApprovalFlow_Slack_WritesExecutionDecisionAndResumesMerge is the
 // Slack counterpart of TestRestartApprovalFlow_WritesExecutionDecisionAndResumesMerge
 // (GH-3825's Telegram regression test). It exercises the GH-4411 chain

--- a/internal/pilot/pilot.go
+++ b/internal/pilot/pilot.go
@@ -111,6 +111,10 @@ func (a *slackApprovalClientAdapter) UpdateInteractiveMessage(ctx context.Contex
 	return a.adapter.UpdateInteractiveMessage(ctx, channel, ts, blocks, text)
 }
 
+func (a *slackApprovalClientAdapter) PostEphemeral(ctx context.Context, responseURL, text string) error {
+	return a.adapter.PostEphemeral(ctx, responseURL, text)
+}
+
 // linearTaskInfo tracks Linear issue info for completion callbacks (GH-391)
 type linearTaskInfo struct {
 	IssueID       string


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5161.

Closes #5161

## Changes

On refusal, send the ephemeral "not an approver" interaction response, emit an equivalent warn log with request_id/user attrs, skip RecordDecision, leave the pending map untouched, and return true (interaction consumed).