### PR TITLE
GH-5178: fix(spec-guard): return true on ListIssueComments error to defer dispatch

### DIFF
--- a/cmd/pilot/spec_guard_sdk.go
+++ b/cmd/pilot/spec_guard_sdk.go
@@ -32,9 +32,9 @@ import (
 func applySpecGuardSDK(ctx context.Context, client *githubSDK.Client, owner, repo string, issue *githubSDK.Issue, reasons []string) bool {
 	comments, err := client.ListIssueComments(ctx, owner, repo, issue.Number)
 	if err != nil {
-		slog.Warn("spec-guard(sdk): failed to list comments, skipping guard",
+		slog.Warn("spec-guard(sdk): failed to list comments — deferring dispatch to next tick, no strike",
 			slog.Int("issue", issue.Number), slog.Any("error", err))
-		return false
+		return true
 	}
 
 	// Walk in order and keep the last marker seen — if the guard has fired

--- a/cmd/pilot/spec_guard_sdk_test.go
+++ b/cmd/pilot/spec_guard_sdk_test.go
@@ -17,13 +17,14 @@ import (
 )
 
 type specGuardFake struct {
-	server           *httptest.Server
-	mu               sync.Mutex
-	existing         []string // comment bodies returned by ListIssueComments
-	labelsAdded      []string
-	commentsAdded    []string
-	freshIssueBody   string // JSON body returned for the single-issue GET (GH-4634 pre-escalation re-fetch)
-	freshIssueStatus int    // HTTP status for the single-issue GET; 0 means default 200
+	server             *httptest.Server
+	mu                 sync.Mutex
+	existing           []string // comment bodies returned by ListIssueComments
+	labelsAdded        []string
+	commentsAdded      []string
+	freshIssueBody     string // JSON body returned for the single-issue GET (GH-4634 pre-escalation re-fetch)
+	freshIssueStatus   int    // HTTP status for the single-issue GET; 0 means default 200
+	listCommentsStatus int    // HTTP status for ListIssueComments; 0 means default 200
 }
 
 func newSpecGuardFake(existingComments ...string) *specGuardFake {
@@ -32,6 +33,13 @@ func newSpecGuardFake(existingComments ...string) *specGuardFake {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/comments"):
+			f.mu.Lock()
+			status := f.listCommentsStatus
+			f.mu.Unlock()
+			if status != 0 && status != http.StatusOK {
+				w.WriteHeader(status)
+				return
+			}
 			type c struct {
 				Body string `json:"body"`
 			}
@@ -112,6 +120,35 @@ func TestApplySpecGuardSDK_FirstStrike(t *testing.T) {
 	wantFingerprint := specBodyFingerprint(issue.Body)
 	if len(f.commentsAdded) != 1 || !strings.Contains(f.commentsAdded[0], ghissue.BuildSpecCommentMarker(wantFingerprint)) {
 		t.Errorf("first-strike comment missing fingerprinted marker; comments = %v", f.commentsAdded)
+	}
+}
+
+// TestApplySpecGuardSDK_ListCommentsErrorDefersDispatch covers GH-5178: if
+// ListIssueComments itself errors, the guard cannot tell whether this issue
+// has ever been struck before, so it must defer dispatch to the next poll
+// tick (return true) rather than silently letting a possibly-thin issue
+// through (which the old `return false` did). No strike is recorded either:
+// zero labels added, zero comments posted.
+func TestApplySpecGuardSDK_ListCommentsErrorDefersDispatch(t *testing.T) {
+	f := newSpecGuardFake()
+	defer f.server.Close()
+	f.listCommentsStatus = http.StatusInternalServerError
+
+	client := githubSDK.NewClientWithBaseURL(testutil.FakeGitHubToken, f.server.URL)
+	issue := &githubSDK.Issue{Number: 7, Title: "thin", Body: "too thin"}
+
+	skipped := applySpecGuardSDK(context.Background(), client, "o", "r", issue, []string{"body too short"})
+	if !skipped {
+		t.Fatal("guard must defer dispatch (return true) when ListIssueComments errors")
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.labelsAdded) != 0 {
+		t.Errorf("labels added = %v, want none (list-comments error must not record a strike)", f.labelsAdded)
+	}
+	if len(f.commentsAdded) != 0 {
+		t.Errorf("comments added = %v, want none (list-comments error must not record a strike)", f.commentsAdded)
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5178.

Closes #5178

## Changes

In cmd/pilot/spec_guard_sdk.go:37, change `return false` to `return true` in the ListIssueComments-error branch so the contract matches the documented "returns true when dispatch should be skipped" semantics. Reword the warn log from "failed to list comments, skipping guard" to deferring language (e.g. "failed to list comments — deferring dispatch to next tick, no strike"). Add a new test in cmd/pilot/spec_guard_sdk_test.go using the existing specGuardFake httptest server: configure the list-comments route to return HTTP 500 and assert the return is true, zero labels added, zero comments posted. Ensure the existing TestGithubHandlerSDK_SpecGuardWired source-grep test still passes.