### PR TITLE
GH-5179: fix(ghissue): expand spec validation reason to state H2–H6 scope and language nuance

### DIFF
--- a/internal/ghissue/spec.go
+++ b/internal/ghissue/spec.go
@@ -108,7 +108,7 @@ func ValidateSpec(issue *github.Issue, parentResolver func(int) (*github.Issue, 
 
 	if !sectionHeaderRe.MatchString(body) {
 		reasons = append(reasons,
-			"no structural section header (need one of Acceptance, Implementation, Context, Background, Approach, Design, or Refs as an H2–H6 header)")
+			"no structural section header (need one of Acceptance, Implementation, Context, Background, Approach, Design, or Refs as an H2–H6 header — H1 is not accepted; only the heading text is checked, and it must match one of these words exactly in English — the body content underneath the heading may be written in any language)")
 	}
 
 	return SpecValidationResult{

--- a/internal/ghissue/spec_test.go
+++ b/internal/ghissue/spec_test.go
@@ -159,6 +159,33 @@ func TestValidateSpec_SectionHeaderVariants(t *testing.T) {
 			t.Errorf("header %q should make body valid, got reasons=%v", h, result.FailureReasons)
 		}
 	}
+
+	// Body content underneath a valid English header may be written in any
+	// language — only the heading text itself is checked.
+	nonEnglishBodyContent := strings.Repeat("x", 80) + "\n\n## Acceptance\n\nContenido de aceptación en español aquí.\n"
+	issue := &github.Issue{Number: 8, Body: nonEnglishBodyContent}
+	result := ValidateSpec(issue, nil)
+	if !result.Valid {
+		t.Errorf("non-English body content under a valid English header should still be valid, got reasons=%v", result.FailureReasons)
+	}
+
+	// A translated (non-English) heading is not recognized — the heading
+	// text itself must match one of the accepted words exactly in English.
+	translatedHeader := strings.Repeat("x", 80) + "\n\n## Aceptación\n\nsome content here and there\n"
+	issue = &github.Issue{Number: 8, Body: translatedHeader}
+	result = ValidateSpec(issue, nil)
+	if result.Valid {
+		t.Error("translated (non-English) heading '## Aceptación' should NOT be accepted as a structural section header")
+	}
+	foundHeader := false
+	for _, r := range result.FailureReasons {
+		if strings.Contains(r, "structural section header") && strings.Contains(r, "H1 is not accepted") && strings.Contains(r, "exactly in English") && strings.Contains(r, "any language") {
+			foundHeader = true
+		}
+	}
+	if !foundHeader {
+		t.Errorf("expected reason explaining exact-English heading match and any-language body content, got %v", result.FailureReasons)
+	}
 }
 
 func TestValidateSpec_H3ToH6SectionHeaders(t *testing.T) {

--- a/internal/ghissue/spec_test.go
+++ b/internal/ghissue/spec_test.go
@@ -81,12 +81,12 @@ func TestValidateSpec_NoSectionHeader(t *testing.T) {
 	}
 	foundHeader := false
 	for _, r := range result.FailureReasons {
-		if strings.Contains(r, "structural section header") {
+		if strings.Contains(r, "structural section header") && strings.Contains(r, "H1 is not accepted") && strings.Contains(r, "any language") {
 			foundHeader = true
 		}
 	}
 	if !foundHeader {
-		t.Errorf("expected 'structural section header' reason, got %v", result.FailureReasons)
+		t.Errorf("expected reason explaining H2-H6 range, H1 rejection, and any-language body content, got %v", result.FailureReasons)
 	}
 }
 
@@ -187,11 +187,11 @@ func TestValidateSpec_H3ToH6SectionHeaders(t *testing.T) {
 	}
 	foundHeader := false
 	for _, r := range result.FailureReasons {
-		if strings.Contains(r, "structural section header") {
+		if strings.Contains(r, "structural section header") && strings.Contains(r, "H1 is not accepted") {
 			foundHeader = true
 		}
 	}
 	if !foundHeader {
-		t.Errorf("expected 'structural section header' failure reason for H1 body, got %v", result.FailureReasons)
+		t.Errorf("expected reason explaining H1 rejection for H1 body, got %v", result.FailureReasons)
 	}
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5179.

Closes #5179

## Changes

In internal/ghissue/spec.go:110-111, expand the reason string to explicitly state the H2–H6 header range (H1 rejected), that only the heading text is checked (exact English match), and that body content under the heading may be any language. This reason string flows verbatim into both buildSpecIncompleteComment and buildSpecEscalationComment as well as log lines, so a single edit updates all surfaces. Update assertions in internal/ghissue/spec_test.go that pin the old reason string (TestValidateSpec_NoSectionHeader, SectionHeaderVariants, H3ToH6SectionHeaders) to match the new phrasing. Run make test to confirm green.