### PR TITLE
GH-5164: docs(config): update pilot.example.yaml for approvers config

### DIFF
--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -442,6 +442,15 @@ executor:
 #   default_action: rejected    # "approved" or "rejected" on timeout
 #   pre_merge:
 #     enabled: false
+#     # Per-user authorization (isAuthorizedApprover in telegram.go/slack.go)
+#     # matches the tapping user's numeric ID against these entries via exact
+#     # string equality — use numeric chat/user IDs here, not "@handle"s, or
+#     # nobody will ever be recognized as an authorized approver.
+#     # A "@handle" entry is still accepted, but only acts as a destination
+#     # override: TelegramHandler.resolveDestChatID sends the approval prompt
+#     # to approvers[0] instead of the handler's configured chat_id when it
+#     # looks like a valid Telegram destination (numeric ID or "@handle").
+#     # It does not grant that handle authorization to decide the request.
 #     approvers:
 #       - "${TELEGRAM_APPROVER_CHAT_ID}"   # Chat ID of the approver
 #     timeout: 24h


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5164.

Closes #5164

## Changes

GitHub Issue GH-5164: docs(config): update pilot.example.yaml for approvers config

<!--autopilot-meta
parent: GH-5153
inherited-spec: true
-->

Parent: GH-5153

Update the approvers: comment in configs/pilot.example.yaml to document that numeric IDs are required for per-user authorization, and that @handle entries only act as destination overrides via resolveDestChatID.

## Scope fence

Implement ONLY the slice described above. The parent issue GH-5153 is decomposed
into sibling sub-issues that cover the rest of its spec — consult the parent
for context, but do NOT implement parts of it that fall outside this subtask.