### PR TITLE
GH-5191: fix(executor): extraFixesKeyword promotes prose mentions of 'closes #N' into live auto-close keywords — restrict to structured marker; GitLab MRs get GitHub syntax

### DIFF
--- a/.agent/tasks/archive/gh-5191.md
+++ b/.agent/tasks/archive/gh-5191.md
@@ -1,0 +1,43 @@
+# GH-5191
+
+**Created:** 2026-08-24
+
+## Problem
+
+GitHub Issue GH-5191: fix(executor): extraFixesKeyword promotes prose mentions of 'closes #N' into live auto-close keywords — restrict to structured marker; GitLab MRs get GitHub syntax
+
+## Context
+
+PR #5177 (GH-5165) added `internal/executor/pr_fixes_ref.go`: `extraFixesKeyword()` scans the task description for `Fixes/Closes/Resolves #N` mentions and promotes them into real closing-keyword lines on generated PR bodies (dedup'd, own-issue excluded; wired at 7 PR/MR body sites in `runner.go` and `runner_decompose.go`). It works — #5149 auto-closed the second PR #5171's arc landed. Two risks from post-merge review:
+
+1. **Over-matching**: the regex matches any prose occurrence — quoted, negated, or descriptive text ("this bug closes #123 prematurely", "the old fix resolves #99 only partially") in a future issue body becomes a live auto-close keyword on the PR, silently closing an unrelated issue on merge.
+2. **Cross-platform syntax**: the GitLab MR body paths (`runner_decompose.go:548,567,586`) emit GitHub-style `Fixes #N` lines from description numbers; GitLab closing-pattern syntax and issue-number semantics differ.
+
+## Approach
+
+Restrict promotion to a structured marker (e.g. only lines matching `^(Fixes|Closes|Resolves) #N$` or a dedicated `## Refs`-section scan), and gate the GitLab paths to GitLab syntax or skip promotion there. Keep dedup + own-issue exclusion.
+
+## Acceptance
+
+- [x] Prose/negated mentions no longer promoted (table-driven cases for quoted/negated/descriptive text).
+- [x] GitLab MR bodies get correct syntax or no promotion. (chose: no promotion — extraFixesKeyword no longer called on the non-GitHub PRCreator path in runner.go/runner_decompose.go)
+- [x] Existing behavior for structured refs unchanged (#5149-style closure still works).
+
+## Resolution
+
+`fixesRefRe` (internal/executor/pr_fixes_ref.go) now only matches a
+structured marker: start-of-line (optionally after a `-`/`*`/`•` bullet)
+terminated by end-of-line/punctuation, or a keyword+number wrapped in
+quotes with nothing else inside. Narrative usage ("this bug closes #123
+prematurely") no longer matches. The two non-GitHub PRCreator call sites
+(runner.go, runner_decompose.go — GitLab MR / future adapter paths) no
+longer call extraFixesKeyword at all, since its output is GitHub-specific
+"Fixes #N" syntax. See doc comments on `fixesRefRe` and `extraFixesKeyword`
+for details.
+
+## Refs
+
+- PR #5177 post-merge review 2026-08-24 · parent #5153
+
+## Acceptance Criteria
+

--- a/internal/executor/pr_fixes_ref.go
+++ b/internal/executor/pr_fixes_ref.go
@@ -16,10 +16,23 @@ import (
 	"strings"
 )
 
-// fixesRefRe matches an explicit GitHub closing-keyword reference ("Fixes
-// #N", "Closes #N", "Resolves #N", case-insensitive) anywhere in an issue
-// body.
-var fixesRefRe = regexp.MustCompile(`(?i)\b(?:fixes|closes|resolves)\s+#(\d+)\b`)
+// fixesRefRe matches a *structured* GitHub closing-keyword marker ("Fixes
+// #N", "Closes #N", "Resolves #N", case-insensitive) — GH-5191: the
+// original version matched the keyword+number pair anywhere in prose, which
+// promoted incidental, quoted, negated, or descriptive mentions ("this bug
+// closes #123 prematurely", "the old fix resolves #99 only partially") into
+// live auto-close keywords on the generated PR. A structured marker is one
+// that stands alone as its own unit rather than being embedded mid-sentence:
+//   - at the start of a line (optionally after a "-"/"*"/"•" list bullet,
+//     e.g. a "## Refs" section entry), terminated by end-of-line, sentence
+//     punctuation, or a closing bracket, OR
+//   - wrapped in quotes with nothing else inside them (the GH-5165 repro:
+//     body text reading "Ensure the PR body includes 'Fixes #5149'.").
+//
+// Free-standing narrative usage — the keyword appearing after a subject
+// ("this bug closes #123...") — matches neither shape and is intentionally
+// left as plain text.
+var fixesRefRe = regexp.MustCompile(`(?im)(?:^[ \t]*(?:[-*•]\s+)?|['"“‘])(?:fixes|closes|resolves)\s+#(\d+)(?:['"”’]|[.,;:!?)]|[ \t]*$)`)
 
 // extraFixesKeyword scans description for fixesRefRe matches and returns a
 // "\nFixes #N" line for each referenced issue number distinct from
@@ -29,6 +42,15 @@ var fixesRefRe = regexp.MustCompile(`(?i)\b(?:fixes|closes|resolves)\s+#(\d+)\b`
 // the external report a decomposed epic ultimately resolves) carries that
 // reference forward as a real closing keyword on the generated PR — not
 // merely as quoted text inside the copied description.
+//
+// GH-5191: the emitted "Fixes #N" line is GitHub closing-keyword syntax.
+// Callers on non-GitHub PR/MR creation paths (GitLab MRs and, per the
+// PRCreator interface's own doc comment, any future Azure DevOps/Jira/
+// Linear implementation) must NOT call this — the referenced #N could be a
+// same-project GitLab IID, a GitHub issue number quoted from an epic's
+// original report, or something else entirely, and there is no reliable way
+// to tell which without adapter-specific context. Those paths should either
+// skip promotion or build their own adapter-native equivalent.
 func extraFixesKeyword(description, ownIssueNum string) string {
 	matches := fixesRefRe.FindAllStringSubmatch(description, -1)
 	if len(matches) == 0 {

--- a/internal/executor/pr_fixes_ref_test.go
+++ b/internal/executor/pr_fixes_ref_test.go
@@ -8,6 +8,12 @@ import "testing"
 // generated PR body as a real "Fixes #N" line — the actual repro that
 // motivated this: GH-5165's own body reads "Ensure the PR body includes
 // 'Fixes #5149'."
+//
+// GH-5191: it must NOT promote prose occurrences of the same keywords —
+// quoted-but-embedded, negated, or merely descriptive mentions of "closes
+// #N"/"fixes #N"/"resolves #N" mid-sentence must stay plain text, since
+// promoting them would silently attach an unrelated auto-close keyword to
+// the generated PR.
 func TestExtraFixesKeyword(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -50,6 +56,42 @@ func TestExtraFixesKeyword(t *testing.T) {
 			description: "",
 			ownIssueNum: "5165",
 			want:        "",
+		},
+		{
+			name:        "descriptive mid-sentence usage is not promoted",
+			description: "this bug closes #123 prematurely, which is itself the defect",
+			ownIssueNum: "5165",
+			want:        "",
+		},
+		{
+			name:        "descriptive mid-sentence usage with resolves is not promoted",
+			description: "the old fix resolves #99 only partially and needs revisiting",
+			ownIssueNum: "5165",
+			want:        "",
+		},
+		{
+			name:        "negated narrative usage is not promoted",
+			description: "It never really fixes #42, that ticket needs separate follow-up work.",
+			ownIssueNum: "5165",
+			want:        "",
+		},
+		{
+			name:        "quoted marker with trailing words is not promoted",
+			description: `The changelog says "this closes #123 in theory" but actually doesn't.`,
+			ownIssueNum: "5165",
+			want:        "",
+		},
+		{
+			name:        "structured marker still promoted alongside descriptive noise",
+			description: "This description mentions that the bug closes #123 prematurely, but the real fix is:\nFixes #456",
+			ownIssueNum: "5165",
+			want:        "\nFixes #456",
+		},
+		{
+			name:        "bullet-list Refs-style marker is promoted",
+			description: "## Refs\n\n- Closes #789\n- Related to the epic, not a closer: fixes #999 in another package though",
+			ownIssueNum: "5165",
+			want:        "\nFixes #789",
 		},
 	}
 

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -5410,10 +5410,15 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 				}
 			} else if r.prCreator != nil && task.SourceAdapter != "" && task.SourceAdapter != "github" {
 				// Non-GitHub adapter: use PRCreator (e.g., GitLab MR API)
-				// Include "Closes #N" keyword so GitLab auto-closes the source issue on merge
+				// Include "Closes #N" keyword so GitLab auto-closes the source issue on merge.
+				// GH-5191: deliberately skip extraFixesKeyword here — it emits
+				// GitHub closing-keyword syntax ("Fixes #N"), and any extra
+				// issue numbers named in the description aren't guaranteed to
+				// be same-project GitLab IIDs (or valid at all for whatever
+				// non-GitHub adapter is wired to r.prCreator).
 				closeKeyword := ""
 				if task.SourceIssueID != "" {
-					closeKeyword = fmt.Sprintf("\n\nCloses #%s", task.SourceIssueID) + extraFixesKeyword(task.Description, task.SourceIssueID)
+					closeKeyword = fmt.Sprintf("\n\nCloses #%s", task.SourceIssueID)
 				}
 				prBody := fmt.Sprintf("## Summary\n\nAutomated MR created by Pilot for task %s.%s\n\n## Changes\n\n%s", task.ID, closeKeyword, task.Description)
 				// Retry MR creation before giving up (GH-3785): the branch is

--- a/internal/executor/runner_decompose.go
+++ b/internal/executor/runner_decompose.go
@@ -562,9 +562,11 @@ func (r *Runner) finalizeDecomposedParentPR(ctx context.Context, task *Task, git
 			}
 		}
 	case r.prCreator != nil && task.SourceAdapter != "" && task.SourceAdapter != "github":
+		// GH-5191: no extraFixesKeyword here — see the comment on the
+		// sibling non-GitHub branch in executeWithOptions (runner.go).
 		closeKeyword := ""
 		if task.SourceIssueID != "" {
-			closeKeyword = fmt.Sprintf("\n\nCloses #%s", task.SourceIssueID) + extraFixesKeyword(task.Description, task.SourceIssueID)
+			closeKeyword = fmt.Sprintf("\n\nCloses #%s", task.SourceIssueID)
 		}
 		prBody := fmt.Sprintf("## Summary\n\nAutomated MR created by Pilot for task %s.%s\n\n## Changes\n\n%s", task.ID, closeKeyword, task.Description)
 		for attempt := 1; attempt <= prCreateRetryAttempts; attempt++ {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5191.

Closes #5191
Fixes #123
Fixes #99

## Changes

GitHub Issue GH-5191: fix(executor): extraFixesKeyword promotes prose mentions of 'closes #N' into live auto-close keywords — restrict to structured marker; GitLab MRs get GitHub syntax

## Context

PR #5177 (GH-5165) added `internal/executor/pr_fixes_ref.go`: `extraFixesKeyword()` scans the task description for `Fixes/Closes/Resolves #N` mentions and promotes them into real closing-keyword lines on generated PR bodies (dedup'd, own-issue excluded; wired at 7 PR/MR body sites in `runner.go` and `runner_decompose.go`). It works — #5149 auto-closed the second PR #5171's arc landed. Two risks from post-merge review:

1. **Over-matching**: the regex matches any prose occurrence — quoted, negated, or descriptive text ("this bug closes #123 prematurely", "the old fix resolves #99 only partially") in a future issue body becomes a live auto-close keyword on the PR, silently closing an unrelated issue on merge.
2. **Cross-platform syntax**: the GitLab MR body paths (`runner_decompose.go:548,567,586`) emit GitHub-style `Fixes #N` lines from description numbers; GitLab closing-pattern syntax and issue-number semantics differ.

## Approach

Restrict promotion to a structured marker (e.g. only lines matching `^(Fixes|Closes|Resolves) #N$` or a dedicated `## Refs`-section scan), and gate the GitLab paths to GitLab syntax or skip promotion there. Keep dedup + own-issue exclusion.

## Acceptance

- [ ] Prose/negated mentions no longer promoted (table-driven cases for quoted/negated/descriptive text).
- [ ] GitLab MR bodies get correct syntax or no promotion.
- [ ] Existing behavior for structured refs unchanged (#5149-style closure still works).

## Refs

- PR #5177 post-merge review 2026-08-24 · parent #5153