### PR TITLE
GH-5190: docs(quality-gates): spec-guard section overstates header matching as case-sensitive/exact — regex is case-insensitive and prefix-tolerant

### DIFF
--- a/.agent/tasks/gh-5190.md
+++ b/.agent/tasks/gh-5190.md
@@ -1,0 +1,23 @@
+# GH-5190
+
+**Created:** 2026-08-24
+
+## Problem
+
+GitHub Issue GH-5190: docs(quality-gates): spec-guard section overstates header matching as case-sensitive/exact — regex is case-insensitive and prefix-tolerant
+
+## Context
+
+Post-merge review of PR #5184: `docs/content/features/quality-gates.mdx:129` says the header must be an "exact, case-sensitive English word", but the real rule (`internal/ghissue/spec.go:55`) is `(?im)^#{2,6}\s+(Acceptance|Implementation|Context|Background|Approach|Design|Refs)\b` — case-INSENSITIVE with a word-boundary, so `## acceptance`, `## CONTEXT`, and `## Acceptance Criteria` all pass (verified empirically). The doc is stricter than the code — no false-block risk, but this page exists because #5152 complained about undocumented rules, so it should be precise. The reason string from PR #5182 (`spec.go:110-111`, "must match one of these words exactly in English") slightly overstates the same way.
+
+## Implementation
+
+- Fix `quality-gates.mdx` wording: case-insensitive; the heading must START with one of the seven words (trailing words allowed, e.g. `## Acceptance Criteria`); H2–H6.
+- Align the `spec.go:110-111` reason string the same way (flows into strike comments + logs); sync any test assertions on that string.
+
+## Refs
+
+- PR #5184, PR #5182 post-merge review 2026-08-24 · #5152
+
+## Acceptance Criteria
+

--- a/docs/content/features/quality-gates.mdx
+++ b/docs/content/features/quality-gates.mdx
@@ -126,9 +126,11 @@ An issue body must satisfy all of the following to pass:
   - `Design`
   - `Refs`
 
-  The match is an exact, case-sensitive English word (e.g. `## Context`) —
-  headers like `## Problem`, `## Summary`, or `## Goal` are **not**
-  recognized, even though they read as reasonable section titles.
+  The match is case-insensitive and only requires the heading to **start**
+  with one of these words — trailing words are allowed (e.g. `## Acceptance
+  Criteria` or `## context`) — but headers like `## Problem`, `## Summary`,
+  or `## Goal` are **not** recognized, even though they read as reasonable
+  section titles.
 
 - **H2–H6 scope.** The header must be a Markdown H2 through H6
   (`##` to `######`). An H1 (`#`) does not satisfy the check — issue titles

--- a/internal/ghissue/spec.go
+++ b/internal/ghissue/spec.go
@@ -108,7 +108,7 @@ func ValidateSpec(issue *github.Issue, parentResolver func(int) (*github.Issue, 
 
 	if !sectionHeaderRe.MatchString(body) {
 		reasons = append(reasons,
-			"no structural section header (need one of Acceptance, Implementation, Context, Background, Approach, Design, or Refs as an H2–H6 header — H1 is not accepted; only the heading text is checked, and it must match one of these words exactly in English — the body content underneath the heading may be written in any language)")
+			"no structural section header (need one of Acceptance, Implementation, Context, Background, Approach, Design, or Refs as an H2–H6 header — H1 is not accepted; only the heading text is checked, matching is case-insensitive and the heading must start with one of these English words (trailing words allowed, e.g. \"## Acceptance Criteria\") — the body content underneath the heading may be written in any language)")
 	}
 
 	return SpecValidationResult{

--- a/internal/ghissue/spec_test.go
+++ b/internal/ghissue/spec_test.go
@@ -170,7 +170,8 @@ func TestValidateSpec_SectionHeaderVariants(t *testing.T) {
 	}
 
 	// A translated (non-English) heading is not recognized — the heading
-	// text itself must match one of the accepted words exactly in English.
+	// text itself must start with one of the accepted English words
+	// (matching is case-insensitive, but not language-insensitive).
 	translatedHeader := strings.Repeat("x", 80) + "\n\n## Aceptación\n\nsome content here and there\n"
 	issue = &github.Issue{Number: 8, Body: translatedHeader}
 	result = ValidateSpec(issue, nil)
@@ -179,12 +180,12 @@ func TestValidateSpec_SectionHeaderVariants(t *testing.T) {
 	}
 	foundHeader := false
 	for _, r := range result.FailureReasons {
-		if strings.Contains(r, "structural section header") && strings.Contains(r, "H1 is not accepted") && strings.Contains(r, "exactly in English") && strings.Contains(r, "any language") {
+		if strings.Contains(r, "structural section header") && strings.Contains(r, "H1 is not accepted") && strings.Contains(r, "case-insensitive") && strings.Contains(r, "any language") {
 			foundHeader = true
 		}
 	}
 	if !foundHeader {
-		t.Errorf("expected reason explaining exact-English heading match and any-language body content, got %v", result.FailureReasons)
+		t.Errorf("expected reason explaining case-insensitive English heading match and any-language body content, got %v", result.FailureReasons)
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5190.

Closes #5190

## Changes

GitHub Issue GH-5190: docs(quality-gates): spec-guard section overstates header matching as case-sensitive/exact — regex is case-insensitive and prefix-tolerant

## Context

Post-merge review of PR #5184: `docs/content/features/quality-gates.mdx:129` says the header must be an "exact, case-sensitive English word", but the real rule (`internal/ghissue/spec.go:55`) is `(?im)^#{2,6}\s+(Acceptance|Implementation|Context|Background|Approach|Design|Refs)\b` — case-INSENSITIVE with a word-boundary, so `## acceptance`, `## CONTEXT`, and `## Acceptance Criteria` all pass (verified empirically). The doc is stricter than the code — no false-block risk, but this page exists because #5152 complained about undocumented rules, so it should be precise. The reason string from PR #5182 (`spec.go:110-111`, "must match one of these words exactly in English") slightly overstates the same way.

## Implementation

- Fix `quality-gates.mdx` wording: case-insensitive; the heading must START with one of the seven words (trailing words allowed, e.g. `## Acceptance Criteria`); H2–H6.
- Align the `spec.go:110-111` reason string the same way (flows into strike comments + logs); sync any test assertions on that string.

## Refs

- PR #5184, PR #5182 post-merge review 2026-08-24 · #5152