### PR TITLE
fix(dashboard): honest queue-card title, legible cached band, Claude 5 pricing

### DIFF
--- a/.agent/tasks/gh-5192.md
+++ b/.agent/tasks/gh-5192.md
@@ -1,0 +1,50 @@
+# GH-5192
+
+**Created:** 2026-08-24
+
+## Problem
+
+GitHub Issue GH-5192: TASK-484: Dashboard metrics cards — honest labeling, legible cached band, Claude 5 pricing
+
+# TASK-484: Dashboard metrics cards — honest labeling, legible cached band, Claude 5 pricing
+
+**Status**: 📋 Ready to dispatch
+**Source**: Founder report 2026-08-24 (screenshot review) + code verification + box-ledger verification via SSM.
+
+## Context
+
+Three verified defects in the three stat cards (`internal/dashboard/tui.go`):
+
+1. **Queue-depth card lies about its graph** (`renderTaskCard`, tui.go:2035-2066). Title says "queue depth"; headline = instantaneous active count; ✓/✗ detail = 30-day windowed totals; sparkline = **succeeded/day vs failed/day over 7 days** (SuccessHistory/FailedHistory). Operator read red dots as "problems in the queue now" while the queue was empty — ledger check confirmed the red band was 4 historical failure-days (08-18×2, 08-20×3, 08-22×1, 08-24×1 infra flake). No queue-depth time series exists in the store, so the graph cannot show depth without new sampling.
+2. **Tokens card cached band is illegible** (`renderTokenCard`, tui.go:1963-1980). At the current 96.7% cache ratio the stacked sparkline degenerates: cached base is dimmed to 0.45 accent (reads as empty on dark bg) and the bright fresh cap is ~3% of stack height (subpixel). Also: the detail line prints `CacheReadTokens` only, labeled "cached", while the headline grand total includes read+write. Also: tokens card is **lifetime** while the cost card is a 30d window (GH-4735) — nothing labels the tokens card's window, so cross-card mental division produces nonsense rates.
+3. **`modelPricing` has no Claude 5 entries** (`internal/executor/runner.go:6686-6726`). `sonnet-5` matches only the `default:` fallback → $3/$15 (correct standard rate; do NOT encode the intro pricing — it expires 2026-08-31). `fable`/`mythos` match nothing → priced as Sonnet, a 3.3× underestimate ($10/$50 actual). Add explicit cases: sonnet-5 → 3/15; opus-5 already lands correctly via `contains "opus"` → 5/25 but add an explicit case ahead of the opus-4-1 legacy check ordering; fable/mythos → 10/50. Cache multipliers (1.25× write, 0.10× read in `estimateCostWithCache`) are correct — leave untouched.
+
+## Implementation
+
+### Leg A — queue card honesty (tui.go)
+- Retitle the card so all three rows are coherent. Recommended minimal fix: keep headline `N` + title "queue depth", but re-key the sparkline meaning into the card: change the detail line to act as the graph key it already visually is, and add the trend label to the card title zone (e.g. title "queue · 7d outcomes") — or split title/subtitle if `buildStatCardStacked` supports it. Do NOT add depth sampling in this task (needs a new time series; out of scope).
+- Non-failure terminal outcomes handling (TASK-358 suffix) unchanged.
+
+### Leg B — tokens card legibility + window label (tui.go)
+- Make the stacked bands legible at extreme ratios: raise the cached tone dim factor (0.45 → ~0.65) AND floor the minority band to ≥1 braille row when non-zero (or switch the stack to sqrt/log scaling — pick one, document choice in a comment).
+- Detail line: include cache-write, e.g. `X cached` where X = read+write, matching the headline's composition.
+- Label the tokens card window: it is lifetime — append `· all-time` to the detail line so it can't be confused with the cost card's `· 30d`.
+
+### Leg C — pricing table (runner.go)
+- Add explicit cases BEFORE existing ones where ordering matters: `fable`/`mythos` → 10.00/50.00; `sonnet-5` → 3.00/15.00 (falls to same values as default today — the case exists so future default changes can't silently reprice it); explicit `opus-5` → 5.00/25.00.
+- Table-driven test for modelPricing covering: sonnet-5, opus-5, fable-5, mythos-5, haiku, legacy opus-4-1, unknown-default.
+
+## Acceptance
+
+- [ ] Queue card: graph meaning is explicit in the card chrome; no metric renamed in the store; existing width/truncation tests (`queue_width_test.go`, `task_card_test.go`) updated and green.
+- [ ] Tokens card: at a 97/3 cached/fresh ratio both bands are visually distinguishable in a 7-col sparkline; detail = read+write; `· all-time` label present.
+- [ ] `modelPricing("claude-fable-5")` returns 10/50; new table test green; `estimateCostWithCache` untouched.
+- [ ] `make test` green.
+
+## Refs
+
+- Assessment: session 2026-08-24 (marker `2026-08-24_d3rowy-triage-four-issues.md` § dashboard cards)
+- GH-4735 (windowed cost card), TASK-390 (cached token split), TASK-358 (outcome suffix), GH-2164 (cache-aware pricing)
+
+## Acceptance Criteria
+

--- a/internal/dashboard/grom_chrome_test.go
+++ b/internal/dashboard/grom_chrome_test.go
@@ -65,7 +65,7 @@ func TestFullDashboardRender_WidthInvariants(t *testing.T) {
 	// Grom chrome landmarks: lowercase titles, legend in the queue border.
 	plain := stripANSI(out)
 	for _, want := range []string{
-		"╭─ tokens ", "╭─ cost ", "╭─ queue depth ",
+		"╭─ tokens ", "╭─ cost ", "╭─ queue · outcomes ",
 		"┤ ● 1 running  ● gh  ● tg  ○ 1 idle ├", "╭─ autopilot ", "╭─ history ", "╭─ logs ",
 		" pilot ●",
 		"✓ GH-4018", "■■■■■■■ released", "✗ GH-4008", "■■■■■■■ ci_failed",

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -3,6 +3,7 @@ package dashboard
 import (
 	"fmt"
 	"log/slog"
+	"math"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -1959,21 +1960,48 @@ func formatCompact(n int) string {
 // renderTokenCard renders the tokens stat card: grand total (input + output +
 // cache read/write), cached share detail, 7-day stacked braille trend —
 // dim accent base = cached volume, bright accent cap = fresh input+output.
-// The detail line doubles as the color key ("cached" in the base tone).
+// The detail line doubles as the color key ("cached" in the base tone) and
+// carries a "· all-time" window label since this card is a lifetime total,
+// unlike the cost card's rolling window (GH-4735) — without the label the
+// two are easy to mentally divide into a nonsense rate.
 func (m Model) renderTokenCard(cw int) string {
+	ciw := cw - 4 // inner width; mirrors buildStatCardStacked's InnerSize(cw, statCardHeight)
 	grandTotal := m.metricsCard.TotalTokens + m.metricsCard.CacheReadTokens + m.metricsCard.CacheWriteTokens
 	value := boldLabelStyle.Render(formatCompact(grandTotal))
-	cachedTone := render.Dim(gromTheme.Accent, 0.45)
+	// 0.65 (was 0.45): at 0.45 the cached band reads as empty against the
+	// dark background, defeating its purpose as the base of the stack.
+	cachedTone := render.Dim(gromTheme.Accent, 0.65)
 	cachedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(cachedTone))
-	detail := cachedStyle.Render(fmt.Sprintf("%s cached", formatCompact(m.metricsCard.CacheReadTokens)))
+	// Cached total matches the composition of the headline grand total
+	// (read+write), not just CacheReadTokens.
+	cachedTotal := m.metricsCard.CacheReadTokens + m.metricsCard.CacheWriteTokens
+	base := fmt.Sprintf("%s cached", formatCompact(cachedTotal))
+	// The full "· all-time" label plus "cached" and a realistic (5-6 digit)
+	// token count doesn't fit the card's default inner width (19 cols) — try
+	// the full label first for wide cards, degrade to the terser "· all" tag
+	// so the window is still marked at the default width, matching the
+	// suffix-only-if-it-fits pattern already used by the queue card
+	// (nonFailureSuffix) rather than truncating mid-word.
+	detailText := base
+	for _, suffix := range []string{" · all-time", " · all"} {
+		if candidate := base + suffix; lipgloss.Width(candidate) <= ciw {
+			detailText = candidate
+			break
+		}
+	}
+	detail := cachedStyle.Render(detailText)
 
+	// Real-world cache ratios routinely exceed 95%, which degenerates a
+	// linearly-stacked sparkline: the minority band's dot-height rounds to
+	// zero. sqrt-compress each series before stacking so a nonzero minority
+	// band still occupies visible dot rows instead of vanishing.
 	cached := make([]float64, len(m.metricsCard.CachedTokenHistory))
 	for i, v := range m.metricsCard.CachedTokenHistory {
-		cached[i] = float64(v)
+		cached[i] = math.Sqrt(float64(v))
 	}
 	fresh := make([]float64, len(m.metricsCard.TokenHistory))
 	for i, v := range m.metricsCard.TokenHistory {
-		fresh[i] = float64(v)
+		fresh[i] = math.Sqrt(float64(v))
 	}
 	return buildStatCardStacked("tokens", value, detail,
 		[][]float64{cached, fresh}, []string{cachedTone, gromTheme.Accent}, cw)
@@ -2032,6 +2060,14 @@ func nonFailureSuffix(c MetricsCardData) string {
 // suffix when the whole line fits the card — otherwise show just the headline.
 // Truncating a styled multi-segment string blanks the line (the empty "failed"
 // row seen on v2.166.10).
+//
+// GH-5192: the card title used to read "queue depth" for all three rows, but
+// only the headline is an instantaneous queue depth — the ✓/✗ detail is a
+// windowed lifetime total and the sparkline is succeeded/failed *per day*
+// over 7 days, not depth over time (no queue-depth time series exists in the
+// store; sampling one is out of scope here). An operator misread the failed
+// band as live queue problems. The title now names what the graph actually
+// plots ("· outcomes") so headline and chart don't imply the same metric.
 func (m Model) renderTaskCard(cw int) string {
 	ciw := cw - 4
 	activeCount := 0
@@ -2061,7 +2097,7 @@ func (m Model) renderTaskCard(cw int) string {
 	for i, v := range m.metricsCard.FailedHistory {
 		failed[i] = float64(v)
 	}
-	return buildStatCardStacked("queue depth", value, detail,
+	return buildStatCardStacked("queue · outcomes", value, detail,
 		[][]float64{succeeded, failed}, []string{gromTheme.Success, gromTheme.Error}, cw)
 }
 

--- a/internal/dashboard/tui_test.go
+++ b/internal/dashboard/tui_test.go
@@ -212,8 +212,16 @@ func TestRenderTokenCard_CacheBreakdown(t *testing.T) {
 	if !strings.Contains(out, "105.0K") {
 		t.Errorf("renderTokenCard: expected grand total 105.0K in output, got:\n%s", out)
 	}
-	if !strings.Contains(out, "90.0K cached") {
-		t.Errorf("renderTokenCard: expected '90.0K cached' detail in output, got:\n%s", out)
+	// Detail = cache read + write (95_000), matching the headline's
+	// composition (GH-5192) — not CacheReadTokens alone.
+	if !strings.Contains(out, "95.0K cached") {
+		t.Errorf("renderTokenCard: expected '95.0K cached' detail in output, got:\n%s", out)
+	}
+	// Window label: full "· all-time" on wide cards, terse "· all" once the
+	// card is too narrow to fit the whole word — either way "· all" is a
+	// substring, so this assertion holds regardless of card width.
+	if !strings.Contains(out, "· all") {
+		t.Errorf("renderTokenCard: expected a '· all[-time]' window label in output, got:\n%s", out)
 	}
 }
 

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -6698,10 +6698,30 @@ func modelPricing(model string) (inputPrice, outputPrice float64) {
 		// Haiku 4.5
 		haikuInputPrice  = 1.00
 		haikuOutputPrice = 5.00
+		// Claude 5 Fable/Mythos
+		fableInputPrice  = 10.00
+		fableOutputPrice = 50.00
 	)
 
 	modelLower := strings.ToLower(model)
 	switch {
+	case strings.Contains(modelLower, "fable") || strings.Contains(modelLower, "mythos"):
+		// Claude 5 Fable/Mythos ($10/$50) — without this, these match nothing
+		// below and silently fall through to the Sonnet default, a 3.3x
+		// underestimate.
+		return fableInputPrice, fableOutputPrice
+	case strings.Contains(modelLower, "opus-5"):
+		// Claude Opus 5 ($5/$25). This already lands correctly via the
+		// generic "opus" case below, but is made explicit — ahead of the
+		// opus-4-1 legacy check — so a future default change can't silently
+		// reprice it.
+		return opusInputPrice, opusOutputPrice
+	case strings.Contains(modelLower, "sonnet-5"):
+		// Claude Sonnet 5 ($3/$15) — same as the standard default today.
+		// Kept explicit (rather than relying on fallthrough to default) so a
+		// future default change can't silently reprice it. Do NOT encode the
+		// 2026-08-31 intro pricing here.
+		return sonnetInputPrice, sonnetOutputPrice
 	case strings.Contains(modelLower, "opus-4-1") || strings.Contains(modelLower, "opus-4-0") || model == "claude-opus-4":
 		// Legacy Opus 4.1/4.0
 		return opus41InputPrice, opus41OutputPrice

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -953,6 +953,40 @@ func TestEstimateCostWithCache(t *testing.T) {
 	})
 }
 
+// TestModelPricing is a table-driven check of modelPricing across the
+// Claude model families, including the Claude 5 entries added in GH-5192:
+// sonnet-5 and opus-5 were previously reachable only via fallback/generic
+// "opus" matching, and fable/mythos matched nothing at all — silently
+// pricing at the Sonnet rate, a 3.3x underestimate.
+func TestModelPricing(t *testing.T) {
+	tests := []struct {
+		name            string
+		model           string
+		wantInputPrice  float64
+		wantOutputPrice float64
+	}{
+		{"sonnet-5", "claude-sonnet-5", 3.00, 15.00},
+		{"opus-5", "claude-opus-5", 5.00, 25.00},
+		{"fable-5", "claude-fable-5", 10.00, 50.00},
+		{"mythos-5", "claude-mythos-5", 10.00, 50.00},
+		{"haiku", "claude-haiku-4-5", 1.00, 5.00},
+		{"legacy opus-4-1", "claude-opus-4-1", 15.00, 75.00},
+		{"unknown falls back to default (sonnet)", "some-unknown-model", 3.00, 15.00},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inputPrice, outputPrice := modelPricing(tt.model)
+			if inputPrice != tt.wantInputPrice {
+				t.Errorf("modelPricing(%q) inputPrice = %f, want %f", tt.model, inputPrice, tt.wantInputPrice)
+			}
+			if outputPrice != tt.wantOutputPrice {
+				t.Errorf("modelPricing(%q) outputPrice = %f, want %f", tt.model, outputPrice, tt.wantOutputPrice)
+			}
+		})
+	}
+}
+
 func TestUsageInfoCacheFields(t *testing.T) {
 	// Verify UsageInfo correctly unmarshals cache token fields from stream-json
 	jsonStr := `{"input_tokens": 1000, "output_tokens": 500, "cache_creation_input_tokens": 200, "cache_read_input_tokens": 800}`


### PR DESCRIPTION
## Summary
- **Queue card (Leg A)**: retitled `queue depth` → `queue · outcomes` — the sparkline plots succeeded/failed per day over 7 days, not queue depth over time, and an operator misread the failed band as live queue problems. No depth time series exists to sample from (out of scope); this fixes the chrome to match what's actually plotted.
- **Tokens card (Leg B)**: raised the dim cache-tone factor (0.45 → 0.65, previously read as empty on dark bg), sqrt-compress both stacked series so the minority band stays visible at real-world ~97% cache ratios, fixed the detail line to sum cache read+write (matching the headline composition), and added a window label (`· all-time` / terser `· all` when the card is too narrow for the full word) so it can't be confused with the cost card's rolling `· 30d`.
- **Pricing table (Leg C)**: `modelPricing` had no explicit Claude 5 cases — `fable`/`mythos` matched nothing and silently fell back to Sonnet pricing (3.3x underestimate). Added explicit `fable`/`mythos` (10/50), `opus-5` (5/25), and `sonnet-5` (3/15, same as default today) cases ahead of the legacy opus-4-1 check, plus a table-driven `TestModelPricing`.

Closes GH-5192 (TASK-484).

## Test plan
- [x] `go build ./...`
- [x] `make test` (full suite, green)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] Updated `grom_chrome_test.go` / `tui_test.go` landmarks for the new queue title and token detail line; existing width-invariant tests still pass