### PR TITLE
GH-5193: fix(dispatch): base-presence gate wedges tasks on cross-repo/nonexistent path mentions — no hold cap, and the parsed prerequisite is cached so body edits never clear it

### DIFF
--- a/.agent/tasks/gh-5193.md
+++ b/.agent/tasks/gh-5193.md
@@ -26,13 +26,41 @@ Two distinct defects:
 
 ## Acceptance
 
-- [ ] A task whose body mentions a nonexistent path either dispatches with a warning or escalates within a bounded number of holds — regression test at the dispatcher level.
-- [ ] Editing the body to remove the offending reference clears the hold on the next tick without cancel/relabel — test.
-- [ ] Existing legitimate prerequisite holds (real this-repo paths pending merge) unchanged.
+- [x] A task whose body mentions a nonexistent path either dispatches with a warning or escalates within a bounded number of holds — regression test at the dispatcher level.
+- [x] Editing the body to remove the offending reference clears the hold on the next tick without cancel/relabel — test.
+- [x] Existing legitimate prerequisite holds (real this-repo paths pending merge) unchanged.
+
+## Resolution
+
+Defect 1 (no hold cap) turned out to already be implemented: the
+GH-5045/GH-5052/GH-5133 escalation path (`checkBasePresence` hold-count
+tracking + `escalateBasePresenceHold`, `dispatcher.go`) already bounds
+holds at `BasePresenceHoldMaxCycles` (default 20) for *any* extracted
+prerequisite — ref or path — applying `pilot-needs-human` and parking the
+row (`ExecStatusSkipped`) so the queue head advances. What was missing was
+regression coverage pinning that the cap applies to the **path** shape
+specifically (the GH-5189/GH-5145 incident shape), not just the
+pre-existing ref shape — added as
+`TestProcessQueue_BasePresence_NeverSatisfiablePathEscalatesWithinBoundedHolds`
+in `internal/executor/base_presence_test.go`. GH-5189/GH-5145 held past
+the operator's patience (10 and 20+ cycles) because escalation requires
+reaching the cap, not because escalation was absent or broken.
+
+Defect 2 (cached parse blocks self-heal) was the actual code change:
+`GetIssueState`/`IssueState.Body` (`internal/executor/issue_state.go`,
+`internal/adapters/sdkshim/github_issue_state_checker.go`) now carries the
+live issue body from the same revalidation fetch dispatcher.go already
+performs each tick, and `processQueue` extracts refs/paths from that live
+body (falling back to the queue-time `task.Description` snapshot when
+unavailable) instead of always re-parsing the frozen snapshot — see
+`TestProcessQueue_BasePresence_BodyEditRemovingPathClearsHoldAcrossTicks`.
+
+Criterion 3 (legitimate ref-based holds unchanged) is covered by the
+pre-existing `TestProcessQueue_BasePresence_*` tests (DualShape,
+EscalatesOnceThenQueueHeadAdvances, NaturalReleaseResetsCounter,
+ClosingHeldIssueReleasesAcrossTicks), all still green.
 
 ## Refs
 
 - GH-5133 (glob false-hold, fixed in d8bfe62a — this is the same gate, two new defect classes) · GH-5145/#5148 (first wedge) · GH-5139 (re-arm semantics used for recovery) · GH-5189 (second wedge, recovered via cancel + label cycle)
-
-## Acceptance Criteria
 

--- a/.agent/tasks/gh-5193.md
+++ b/.agent/tasks/gh-5193.md
@@ -1,0 +1,38 @@
+# GH-5193
+
+**Created:** 2026-08-24
+
+## Problem
+
+GitHub Issue GH-5193: fix(dispatch): base-presence gate wedges tasks on cross-repo/nonexistent path mentions — no hold cap, and the parsed prerequisite is cached so body edits never clear it
+
+## Context
+
+Two live incidents of the same wedge (both 2026-08-24 daemon log):
+
+- GH-5189: issue body mentioned a **studio-sdk** file path in backticks as context. The base-presence gate parsed it as a this-repo prerequisite, and the task held at queue head every ~5min with reason: referenced path not found on default branch — hold_count reached 10 before manual intervention. The path can NEVER appear on this repo's main; the hold is unbounded.
+- GH-5145 (08-23): same shape, hold_count reached 20+, resolved only by closing and refiling (#5148).
+
+Two distinct defects:
+
+1. **No escape for never-satisfiable prerequisites.** The gate (GH-5133 family, dispatcher) treats every path-like token in the body as a must-exist-on-main prerequisite. A cross-repo path, a deleted file, or an illustrative example path holds the task forever. There is no hold cap, no escalation to pilot-needs-clarification, no alert.
+2. **Prerequisite parse is cached in the execution row.** Editing the issue body to remove the offending reference does NOT clear the hold — verified live on GH-5189: body fixed at 14:46Z, ticks at 14:48Z still held on the removed path. The only recovery is task cancel + label-cycle re-arm (GH-5139), which operators have to know by heart.
+
+## Approach
+
+- Cap holds: after N consecutive holds on the same unresolved path (e.g. 5, ~25min), stop holding — either dispatch anyway with a warning comment on the issue, or label pilot-needs-clarification and release the queue head. Never hold unbounded.
+- Re-read the issue body (or invalidate the cached parse) on each hold re-check, so an operator fixing the body self-heals the task.
+- Optionally: only treat paths as prerequisites when they appear in a structured section (Refs/Depends), not anywhere in prose — mirrors the #5191 lesson about prose-scanning promotion.
+
+## Acceptance
+
+- [ ] A task whose body mentions a nonexistent path either dispatches with a warning or escalates within a bounded number of holds — regression test at the dispatcher level.
+- [ ] Editing the body to remove the offending reference clears the hold on the next tick without cancel/relabel — test.
+- [ ] Existing legitimate prerequisite holds (real this-repo paths pending merge) unchanged.
+
+## Refs
+
+- GH-5133 (glob false-hold, fixed in d8bfe62a — this is the same gate, two new defect classes) · GH-5145/#5148 (first wedge) · GH-5139 (re-arm semantics used for recovery) · GH-5189 (second wedge, recovered via cancel + label cycle)
+
+## Acceptance Criteria
+

--- a/internal/adapters/sdkshim/github_issue_state_checker.go
+++ b/internal/adapters/sdkshim/github_issue_state_checker.go
@@ -28,7 +28,9 @@ func NewGitHubIssueStateChecker(client *githubSDK.Client) *GitHubIssueStateCheck
 }
 
 // GetIssueState fetches the live state of issue number via a single GetIssue
-// call.
+// call — including the current body text (GH-5193), so dispatcher.go's
+// base-presence hold re-check can re-extract refs/paths from the live issue
+// instead of the execution row's queue-time snapshot.
 func (g *GitHubIssueStateChecker) GetIssueState(ctx context.Context, owner, repo string, number int) (executor.IssueState, error) {
 	issue, err := g.client.GetIssue(ctx, owner, repo, number)
 	if err != nil {
@@ -41,5 +43,6 @@ func (g *GitHubIssueStateChecker) GetIssueState(ctx context.Context, owner, repo
 	return executor.IssueState{
 		Closed: strings.EqualFold(strings.TrimSpace(issue.State), "closed"),
 		Labels: labels,
+		Body:   issue.Body,
 	}, nil
 }

--- a/internal/executor/base_presence_test.go
+++ b/internal/executor/base_presence_test.go
@@ -479,6 +479,145 @@ func TestProcessQueue_BasePresence_EscalatesOnceThenQueueHeadAdvances(t *testing
 	}
 }
 
+// (2b) GH-5193 acceptance: a task whose body cites a path that can never
+// land on this repo's default branch (the GH-5189/GH-5145 incident shape —
+// a cross-repo path, e.g. a studio-sdk file mentioned as context, not an
+// actual this-repo prerequisite) escalates within a bounded number of
+// holds instead of holding forever. Mirrors
+// TestProcessQueue_BasePresence_EscalatesOnceThenQueueHeadAdvances exactly,
+// except the extracted prerequisite is a path (never satisfied) rather
+// than a ref — pinning that the bounded-escalation cap applies uniformly
+// to both dependency-ref shapes and the path shape the two live incidents
+// actually hit.
+func TestProcessQueue_BasePresence_NeverSatisfiablePathEscalatesWithinBoundedHolds(t *testing.T) {
+	logFile := setupFakeGhCLI(t)
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	projectPath := setupPRGuardRepo(t, "pilot/GH-9304", false)
+
+	const phantomPath = "studio-sdk/internal/example.go"
+	held := &memory.Execution{
+		ID:              "exec-gh5193-path-escalate-held",
+		TaskID:          "GH-9303",
+		ProjectPath:     projectPath,
+		Status:          "queued",
+		TaskBranch:      "pilot/GH-9303",
+		TaskCreatePR:    true,
+		TaskDescription: "See `" + phantomPath + "` for context.",
+	}
+	if err := store.SaveExecution(held); err != nil {
+		t.Fatalf("SaveExecution(held): %v", err)
+	}
+	// A second task queued after the held one for the SAME project — it
+	// must become reachable once the first is parked.
+	second := &memory.Execution{
+		ID:              "exec-gh5193-path-escalate-second",
+		TaskID:          "GH-9304",
+		ProjectPath:     projectPath,
+		Status:          "queued",
+		TaskBranch:      "pilot/GH-9304",
+		TaskCreatePR:    true,
+		TaskDescription: "No dependency markers here.",
+	}
+	if err := store.SaveExecution(second); err != nil {
+		t.Fatalf("SaveExecution(second): %v", err)
+	}
+
+	// The live body always still cites the phantom path — an operator who
+	// never edits the issue (unlike the self-heal scenario covered by
+	// TestProcessQueue_BasePresence_BodyEditRemovingPathClearsHoldAcrossTicks)
+	// must still see the hold bounded rather than wedge forever. Scoped to
+	// the held task's ID: returning held's body unconditionally for every
+	// task (including the second, unrelated task) would leak the phantom
+	// path into the second task's presence check too, since dispatcher.go
+	// prefers a non-empty live Body over task.Description for ANY task this
+	// stub is consulted for.
+	stubFetchIssueState(t, func(_ context.Context, _ *Runner, task *Task, _ string) (IssueState, error) {
+		if task.ID == "GH-9303" {
+			return IssueState{Closed: false, Body: held.TaskDescription}, nil
+		}
+		return IssueState{Closed: false}, nil
+	})
+	origMergedPR := mergedPRPreflightCheck
+	mergedPRPreflightCheck = func(_ context.Context, _, _ string) (string, error) { return "", nil }
+	t.Cleanup(func() { mergedPRPreflightCheck = origMergedPR })
+
+	stubCheckBasePresence(t, func(_ context.Context, _ *Runner, task *Task, _ string, _ []int, paths []string) (BasePresenceHold, error) {
+		if task.ID != "GH-9303" {
+			t.Fatalf("checkBasePresence unexpectedly called for task %q", task.ID)
+		}
+		for _, p := range paths {
+			if p == phantomPath {
+				return BasePresenceHold{Held: true, Reason: "referenced path \"" + p + "\" not found on default branch"}, nil
+			}
+		}
+		t.Fatalf("checkBasePresence called without the phantom path in paths %v", paths)
+		return BasePresenceHold{}, nil
+	})
+
+	backend := &mockFixedBackend{result: &BackendResult{Success: true, Output: "should only run for the second task"}}
+	runner := NewRunnerWithBackend(backend)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+	worker := NewProjectWorker(projectPath, store, runner, slog.Default())
+	worker.setBasePresenceHoldMaxCycles(2)
+
+	// Tick 1: held, not yet escalated (count reaches 1 < max=2).
+	worker.processQueue(context.Background())
+
+	backend.mu.Lock()
+	count := backend.execCount
+	backend.mu.Unlock()
+	if count != 0 {
+		t.Fatalf("expected zero backend invocations before escalation, got %d", count)
+	}
+	if data, err := os.ReadFile(logFile); err == nil && strings.Contains(string(data), "issue edit") {
+		t.Fatalf("expected no escalation before the max-cycles threshold, got gh CLI log: %q", string(data))
+	}
+
+	// Tick 2: count reaches 2 == max, escalates, parks the row, then the SAME
+	// tick advances to the second queued task and executes it — the queue
+	// head must not wedge on a never-satisfiable path forever.
+	worker.processQueue(context.Background())
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read gh CLI log: %v", err)
+	}
+	log := string(data)
+	if got := strings.Count(log, "issue edit 9303"); got != 1 {
+		t.Errorf("expected exactly one `gh issue edit 9303` escalation call, got %d (log: %q)", got, log)
+	}
+	if !strings.Contains(log, "--add-label pilot-needs-human") {
+		t.Errorf("expected the escalation call to add the pilot-needs-human label, got log: %q", log)
+	}
+
+	heldExec, err := store.GetExecution(held.ID)
+	if err != nil {
+		t.Fatalf("GetExecution(held): %v", err)
+	}
+	if heldExec.Status != string(ExecStatusSkipped) {
+		t.Errorf("expected the escalated row to be parked as %q, got %q", ExecStatusSkipped, heldExec.Status)
+	}
+
+	backend.mu.Lock()
+	count = backend.execCount
+	backend.mu.Unlock()
+	if count == 0 {
+		t.Errorf("expected the queue head to advance to the second task within the same tick and execute it, got %d backend invocations", count)
+	}
+
+	secondExec, err := store.GetExecution(second.ID)
+	if err != nil {
+		t.Fatalf("GetExecution(second): %v", err)
+	}
+	if secondExec.Status == "queued" {
+		t.Errorf("expected the second task to have been picked up off the queue, got status %q", secondExec.Status)
+	}
+}
+
 // (3) closing the held issue releases the hold across ticks — the GH-4656
 // revalidation must run even while a row is held, not be short-circuited by
 // the hold path's early return.

--- a/internal/executor/base_presence_test.go
+++ b/internal/executor/base_presence_test.go
@@ -711,7 +711,112 @@ func TestProcessQueue_BasePresence_FastPathSkipsCheckWhenNothingExtracted(t *tes
 	}
 }
 
-// (6) ledger event + log + progress observability: a held cycle records a
+// (6) GH-5193: editing the live issue body to remove the offending
+// cross-repo/nonexistent path reference clears an active hold on the very
+// next tick — no cancel/relabel cycle required. Pins the fix for the cache
+// defect verified live on GH-5189: the issue body was fixed at 14:46Z but
+// the tick at 14:48Z still held on the removed path, because refs/paths
+// were always re-extracted from the execution row's frozen TaskDescription
+// snapshot (never updated after the row is queued) rather than the live
+// issue body fetchIssueState already fetches on every tick.
+func TestProcessQueue_BasePresence_BodyEditRemovingPathClearsHoldAcrossTicks(t *testing.T) {
+	const branch = "pilot/GH-9206"
+	dir := setupPRGuardRepo(t, branch, false)
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	const phantomPath = "studio-sdk/internal/example.go"
+	const staleBody = "See `" + phantomPath + "` for context."
+	const fixedBody = "No file citation here anymore."
+
+	exec := &memory.Execution{
+		ID:           "exec-gh5193-body-edit-clears-hold",
+		TaskID:       "GH-9206",
+		ProjectPath:  dir,
+		Status:       "queued",
+		TaskBranch:   branch,
+		TaskCreatePR: true,
+		// GH-5193: the execution row's snapshot is frozen at queue time —
+		// the fix must consult the live body stubbed via fetchIssueState
+		// below (once available), not this field, on every tick.
+		TaskDescription: staleBody,
+	}
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	var mu sync.Mutex
+	liveBody := staleBody
+	stubFetchIssueState(t, func(_ context.Context, _ *Runner, _ *Task, _ string) (IssueState, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		return IssueState{Closed: false, Body: liveBody}, nil
+	})
+	origMergedPR := mergedPRPreflightCheck
+	mergedPRPreflightCheck = func(_ context.Context, _, _ string) (string, error) { return "", nil }
+	t.Cleanup(func() { mergedPRPreflightCheck = origMergedPR })
+
+	stubCheckBasePresence(t, func(_ context.Context, _ *Runner, _ *Task, _ string, _ []int, paths []string) (BasePresenceHold, error) {
+		for _, p := range paths {
+			if p == phantomPath {
+				return BasePresenceHold{Held: true, Reason: "referenced path \"" + p + "\" not found on default branch"}, nil
+			}
+		}
+		return BasePresenceHold{}, nil
+	})
+
+	backend := &mockFixedBackend{result: &BackendResult{Success: true, Output: "done"}}
+	runner := NewRunnerWithBackend(backend)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+	worker := NewProjectWorker(dir, store, runner, slog.Default())
+
+	// Tick 1: live body still carries the cross-repo path -> held.
+	worker.processQueue(context.Background())
+
+	backend.mu.Lock()
+	count := backend.execCount
+	backend.mu.Unlock()
+	if count != 0 {
+		t.Fatalf("expected zero backend invocations while held, got %d", count)
+	}
+	got, err := store.GetExecution(exec.ID)
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if got.Status != "queued" {
+		t.Errorf("expected status to remain queued while held, got %q", got.Status)
+	}
+
+	// Operator edits the issue body to drop the phantom cross-repo path —
+	// the execution row's TaskDescription is untouched, mirroring GH-5189's
+	// reality: nothing rewrites the stored snapshot on a live body edit.
+	mu.Lock()
+	liveBody = fixedBody
+	mu.Unlock()
+
+	// Tick 2: must clear on THIS tick, without any cancel/relabel cycle.
+	worker.processQueue(context.Background())
+
+	backend.mu.Lock()
+	count = backend.execCount
+	backend.mu.Unlock()
+	if count == 0 {
+		t.Error("expected the backend to run once the live body no longer references the missing path — a body edit must self-heal the hold on the next tick")
+	}
+
+	key := repickBackoffKey(dir, "GH-9206")
+	holdCount, found, err := store.GetBasePresenceHoldCount(key)
+	if err != nil {
+		t.Fatalf("GetBasePresenceHoldCount: %v", err)
+	}
+	if !found || holdCount != 0 {
+		t.Errorf("expected the hold count to reset to 0 once the body edit released the hold, got %d (found=%v)", holdCount, found)
+	}
+}
+
+// (7) ledger event + log + progress observability: a held cycle records a
 // StageBasePresenceHeld execution event carrying the unmet-prerequisite
 // reason.
 func TestProcessQueue_BasePresence_RecordsLedgerEventOnHold(t *testing.T) {

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -2898,6 +2898,21 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 		// that closing the held issue out from under a base-presence hold
 		// always releases it on the very next tick — a hold must never make
 		// this revalidation unreachable.
+		//
+		// GH-5193: presenceCheckBody defaults to the execution row's
+		// queue-time TaskDescription snapshot, then is overridden below with
+		// the live issue body fetched by this SAME revalidation call — no
+		// extra GitHub round trip. Before this, ExtractDependencyRefs/
+		// ExtractReferencedPaths (below) always re-parsed the frozen
+		// snapshot, so an operator editing the live issue body to remove a
+		// phantom prerequisite (a cross-repo path, a deleted file) could
+		// never clear an active hold — verified live on GH-5189: the body
+		// was fixed at 14:46Z, but the tick at 14:48Z still held on the
+		// removed path because task.Description never changes for a given
+		// execution row. Falls back to task.Description when Body is ""
+		// (non-github source adapters, or a probe that fails/doesn't
+		// populate it) — identical to the pre-GH-5193 behavior in that case.
+		presenceCheckBody := task.Description
 		if task.SourceAdapter == "" || task.SourceAdapter == "github" {
 			if state, ghErr := fetchIssueState(ctx, w.runner, task, exec.ProjectPath); ghErr != nil {
 				w.log.Warn("Failed to revalidate issue state before pickup; proceeding (fail-open)",
@@ -2929,6 +2944,10 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 				}
 				w.currentTaskID.Store("")
 				continue
+			} else if state.Body != "" {
+				// GH-5193: prefer the live body just fetched above over the
+				// queue-time snapshot for this tick's ref/path extraction.
+				presenceCheckBody = state.Body
 			}
 		}
 
@@ -2939,9 +2958,16 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 		// an issue whose attached PR is still open-unmerged), or a
 		// backtick-quoted file path missing from the target repo's default
 		// branch — have actually landed on main yet. When neither refs nor
-		// paths are extracted this whole block is skipped: zero probe
-		// calls, byte-identical to the pre-GH-5045 pickup path.
-		if refs, paths := ExtractDependencyRefs(task.Description), ExtractReferencedPaths(task.Description); len(refs) > 0 || len(paths) > 0 {
+		// paths are extracted, checkBasePresence is never called — zero
+		// probe calls, byte-identical to the pre-GH-5045 pickup path (GH-5193
+		// only adds the cheap hold-count reset below on this branch, never a
+		// probe/checkBasePresence call).
+		//
+		// GH-5193: extracted from presenceCheckBody (the live issue body
+		// when available, set above), not the raw task.Description, so a
+		// body edit that removes the offending ref/path is honored on this
+		// very tick instead of the queue-time snapshot forever re-matching.
+		if refs, paths := ExtractDependencyRefs(presenceCheckBody), ExtractReferencedPaths(presenceCheckBody); len(refs) > 0 || len(paths) > 0 {
 			key := repickBackoffKey(exec.ProjectPath, exec.TaskID)
 			hold, checkErr := checkBasePresence(ctx, w.runner, task, exec.ProjectPath, refs, paths)
 			if checkErr != nil {
@@ -3025,6 +3051,29 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 						w.log.Warn("base-presence hold: failed to reset hold count on natural release",
 							slog.String("execution_id", exec.ID), slog.Any("error", clrErr))
 					}
+				}
+			}
+		} else {
+			// GH-5193: nothing extracted this tick — most commonly a task
+			// that never had a ref/path (the common case, matching the
+			// pre-GH-5045 path above), but also the self-heal case: a body
+			// edit removed the last extracted ref/path that had this row
+			// held on a prior tick. Reset any stale hold count so a later,
+			// unrelated hold starts counting from zero instead of inheriting
+			// a count run up against a since-resolved prerequisite — the
+			// same gap the "if" branch's natural-release reset closes for
+			// held-then-released tasks, just reached via the fast path
+			// instead. One cheap local read (+ conditional write only when a
+			// nonzero count is actually found) — no probe/checkBasePresence
+			// call, so the zero-probe-calls guarantee above is unaffected.
+			key := repickBackoffKey(exec.ProjectPath, exec.TaskID)
+			if count, found, cErr := w.store.GetBasePresenceHoldCount(key); cErr != nil {
+				w.log.Warn("base-presence hold: failed to read hold count for fast-path reset",
+					slog.String("execution_id", exec.ID), slog.Any("error", cErr))
+			} else if found && count != 0 {
+				if clrErr := w.store.SetBasePresenceHoldCount(key, 0); clrErr != nil {
+					w.log.Warn("base-presence hold: failed to reset hold count on fast-path release",
+						slog.String("execution_id", exec.ID), slog.Any("error", clrErr))
 				}
 			}
 		}

--- a/internal/executor/issue_state.go
+++ b/internal/executor/issue_state.go
@@ -33,9 +33,17 @@ const labelPilotSuperseded = "pilot-superseded"
 // IssueState is the live GitHub issue state fetched by IssueStateChecker —
 // just enough to decide whether a queued or in-flight execution's issue has
 // been closed/superseded out from under it.
+//
+// Body (GH-5193) is the issue's current body text. Populated on a
+// best-effort basis: implementations that can't cheaply fetch it (or that
+// error before reaching it) leave it "", and callers must treat "" as "no
+// live body available" rather than "body is empty" — see
+// dispatcher.go's base-presence hold re-check, which falls back to the
+// execution row's cached TaskDescription when Body is "".
 type IssueState struct {
 	Closed bool
 	Labels []string
+	Body   string
 }
 
 // HasLabel reports whether name is present in Labels (case-insensitive).
@@ -76,9 +84,10 @@ type IssueStateChecker interface {
 type ghCLIIssueStateChecker struct{}
 
 // GetIssueState implements IssueStateChecker via `gh issue view --repo
-// owner/repo <number> --json state,labels`, one process invocation (one
-// GitHub API call). Never shells out during `go test` — tests override
-// fetchIssueState (or inject a fake IssueStateChecker via
+// owner/repo <number> --json state,labels,body` (body added GH-5193 so the
+// base-presence hold re-check tracks live body edits), one process
+// invocation (one GitHub API call). Never shells out during `go test` —
+// tests override fetchIssueState (or inject a fake IssueStateChecker via
 // RegisterIssueStateChecker) instead of exercising this path.
 func (ghCLIIssueStateChecker) GetIssueState(ctx context.Context, owner, repo string, number int) (IssueState, error) {
 	if testing.Testing() {
@@ -87,7 +96,7 @@ func (ghCLIIssueStateChecker) GetIssueState(ctx context.Context, owner, repo str
 	args := []string{
 		"issue", "view", strconv.Itoa(number),
 		"--repo", owner + "/" + repo,
-		"--json", "state,labels",
+		"--json", "state,labels,body",
 	}
 	cmd := withGhCredentials(ctx, exec.CommandContext(ctx, "gh", args...))
 	var stdout, stderr bytes.Buffer
@@ -99,6 +108,7 @@ func (ghCLIIssueStateChecker) GetIssueState(ctx context.Context, owner, repo str
 
 	var resp struct {
 		State  string `json:"state"`
+		Body   string `json:"body"`
 		Labels []struct {
 			Name string `json:"name"`
 		} `json:"labels"`
@@ -114,6 +124,7 @@ func (ghCLIIssueStateChecker) GetIssueState(ctx context.Context, owner, repo str
 	return IssueState{
 		Closed: strings.EqualFold(strings.TrimSpace(resp.State), "closed"),
 		Labels: labels,
+		Body:   resp.Body,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5193.

Closes #5193

## Changes

GitHub Issue GH-5193: fix(dispatch): base-presence gate wedges tasks on cross-repo/nonexistent path mentions — no hold cap, and the parsed prerequisite is cached so body edits never clear it

## Context

Two live incidents of the same wedge (both 2026-08-24 daemon log):

- GH-5189: issue body mentioned a **studio-sdk** file path in backticks as context. The base-presence gate parsed it as a this-repo prerequisite, and the task held at queue head every ~5min with reason: referenced path not found on default branch — hold_count reached 10 before manual intervention. The path can NEVER appear on this repo's main; the hold is unbounded.
- GH-5145 (08-23): same shape, hold_count reached 20+, resolved only by closing and refiling (#5148).

Two distinct defects:

1. **No escape for never-satisfiable prerequisites.** The gate (GH-5133 family, dispatcher) treats every path-like token in the body as a must-exist-on-main prerequisite. A cross-repo path, a deleted file, or an illustrative example path holds the task forever. There is no hold cap, no escalation to pilot-needs-clarification, no alert.
2. **Prerequisite parse is cached in the execution row.** Editing the issue body to remove the offending reference does NOT clear the hold — verified live on GH-5189: body fixed at 14:46Z, ticks at 14:48Z still held on the removed path. The only recovery is task cancel + label-cycle re-arm (GH-5139), which operators have to know by heart.

## Approach

- Cap holds: after N consecutive holds on the same unresolved path (e.g. 5, ~25min), stop holding — either dispatch anyway with a warning comment on the issue, or label pilot-needs-clarification and release the queue head. Never hold unbounded.
- Re-read the issue body (or invalidate the cached parse) on each hold re-check, so an operator fixing the body self-heals the task.
- Optionally: only treat paths as prerequisites when they appear in a structured section (Refs/Depends), not anywhere in prose — mirrors the #5191 lesson about prose-scanning promotion.

## Acceptance

- [ ] A task whose body mentions a nonexistent path either dispatches with a warning or escalates within a bounded number of holds — regression test at the dispatcher level.
- [ ] Editing the body to remove the offending reference clears the hold on the next tick without cancel/relabel — test.
- [ ] Existing legitimate prerequisite holds (real this-repo paths pending merge) unchanged.

## Refs

- GH-5133 (glob false-hold, fixed in d8bfe62a — this is the same gate, two new defect classes) · GH-5145/#5148 (first wedge) · GH-5139 (re-arm semantics used for recovery) · GH-5189 (second wedge, recovered via cancel + label cycle)