### PR TITLE
GH-5189: fix(slack): unauthorized-clicker ephemeral refusal never delivered on Socket Mode — bridge hard-codes empty responseURL

### DIFF
--- a/.agent/tasks/gh-5189.md
+++ b/.agent/tasks/gh-5189.md
@@ -1,0 +1,46 @@
+# GH-5189
+
+**Created:** 2026-08-24
+
+## Problem
+
+GitHub Issue GH-5189: fix(slack): unauthorized-clicker ephemeral refusal never delivered on Socket Mode — bridge hard-codes empty responseURL
+
+## Context
+
+PR #5173 (GH-5161) added an ephemeral "not authorized" response for unauthorized approval clicks, delivered via Slack `response_url`. Post-merge review found it only works on the HTTP interaction-webhook path (`internal/pilot/pilot.go:321-329` via `webhook.go:167`). On **Socket Mode — the primary deployment path** — the bridge passes `responseURL=""` (`internal/adapters/slack/handler.go:252`) because the SDK's core.MessageEvent type (defined in the studio-sdk repo, core package chat file) has no ResponseURL field, and `HandleInteraction` skips `PostEphemeral` when it's empty (`internal/approval/slack.go:495-501`). Result: the authorization guard holds (no bypass), but the unauthorized clicker gets silence instead of feedback.
+
+## Approach
+
+Prefer the pilot-side-only fix: when `responseURL` is empty, fall back to `chat.postEphemeral` (needs channel + clicker user ID — both available at the interaction site; add a small client method next to the existing `PostEphemeral` response_url variant in `internal/adapters/slack/client.go`). Extending the SDK event with `ResponseURL` is the alternative but costs a cross-repo release for no added capability.
+
+While in there (cosmetic, same surface): unify refusal copy with Telegram's "⛔ Not an approver" (Slack currently says "You are not authorized to decide this request"), and fix `configs/pilot.example.yaml`'s "numeric chat/user ID" wording — Slack user IDs are alphanumeric (`U…`).
+
+## Acceptance
+
+- [x] Unauthorized click over Socket Mode produces a visible ephemeral message to the clicker; approval card/buttons remain intact for the real approver.
+- [x] Existing response_url path unchanged (httptest-backed tests still pass).
+- [x] New test: empty responseURL → chat.postEphemeral fallback invoked with channel + clicker user, no RecordDecision call.
+- [x] Refusal copy consistent across Telegram/Slack; example yaml wording corrected.
+
+## Resolution
+
+Added `Client.PostEphemeralToUser` (`internal/adapters/slack/client.go`) — a
+bot-token-authenticated `chat.postEphemeral` call needing only channel +
+user, unlike the existing `PostEphemeral` response_url variant. Wired it
+through the `approval.SlackClient` interface and all three adapter/wrapper
+implementations (`internal/adapters/slack/webhook.go`,
+`internal/pilot/pilot.go`, `cmd/pilot/adapters.go`). `HandleInteraction`
+(`internal/approval/slack.go`) now falls back to it when `responseURL == ""`
+(the Socket Mode case), using `pending.Channel` + the clicker's user ID.
+Unified the refusal copy to `"⛔ Not an approver"` (was "You are not
+authorized to decide this request") via a shared `unauthorizedApproverText`
+constant. Corrected `configs/pilot.example.yaml`'s per-user authorization
+comment to note Slack IDs are alphanumeric (`U0123ABCD`), not numeric.
+
+## Refs
+
+- Post-merge review of PR #5173 (2026-08-24) · parent arc #5153 · guard intact, feedback-only defect
+
+## Acceptance Criteria
+

--- a/cmd/pilot/adapters.go
+++ b/cmd/pilot/adapters.go
@@ -110,6 +110,10 @@ func (a *slackApprovalClientAdapter) PostEphemeral(ctx context.Context, response
 	return a.adapter.PostEphemeral(ctx, responseURL, text)
 }
 
+func (a *slackApprovalClientAdapter) PostEphemeralToUser(ctx context.Context, channel, user, text string) error {
+	return a.adapter.PostEphemeralToUser(ctx, channel, user, text)
+}
+
 // wireProjectAccessChecker creates and wires a team-based project access checker on the runner (GH-635).
 // It opens the teams DB, resolves the configured member, and returns a cleanup function.
 // Returns nil cleanup if team config is absent or disabled.

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -443,9 +443,11 @@ executor:
 #   pre_merge:
 #     enabled: false
 #     # Per-user authorization (isAuthorizedApprover in telegram.go/slack.go)
-#     # matches the tapping user's numeric ID against these entries via exact
-#     # string equality — use numeric chat/user IDs here, not "@handle"s, or
-#     # nobody will ever be recognized as an authorized approver.
+#     # matches the tapping user's ID against these entries via exact string
+#     # equality — use the platform's real user/chat ID here (Telegram:
+#     # numeric chat ID; Slack: alphanumeric user ID like "U0123ABCD"), not
+#     # an "@handle", or nobody will ever be recognized as an authorized
+#     # approver.
 #     # A "@handle" entry is still accepted, but only acts as a destination
 #     # override: TelegramHandler.resolveDestChatID sends the approval prompt
 #     # to approvers[0] instead of the handler's configured chat_id when it

--- a/internal/adapters/slack/client.go
+++ b/internal/adapters/slack/client.go
@@ -331,6 +331,55 @@ func (c *Client) PostEphemeral(ctx context.Context, responseURL, text string) er
 	return nil
 }
 
+// PostEphemeralToUser sends a message visible only to user in channel via
+// the bot-token-authenticated chat.postEphemeral API (GH-5189). Unlike
+// PostEphemeral (which POSTs to a per-interaction response_url), this works
+// whenever a channel + user ID are known even when no response_url was
+// supplied — the case on the Socket Mode path, where the SDK's
+// core.MessageEvent carries no ResponseURL field.
+func (c *Client) PostEphemeralToUser(ctx context.Context, channel, user, text string) error {
+	payload := struct {
+		Channel string `json:"channel"`
+		User    string `json:"user"`
+		Text    string `json:"text"`
+	}{
+		Channel: channel,
+		User:    user,
+		Text:    text,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal ephemeral response: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat.postEphemeral", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.botToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to post ephemeral response: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error,omitempty"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+	if !result.OK {
+		return fmt.Errorf("slack API error: %s", result.Error)
+	}
+
+	return nil
+}
+
 // UpdateInteractiveMessage updates an existing message (removes buttons, updates text)
 func (c *Client) UpdateInteractiveMessage(ctx context.Context, channel, ts string, blocks []interface{}, text string) error {
 	payload := struct {

--- a/internal/adapters/slack/client_test.go
+++ b/internal/adapters/slack/client_test.go
@@ -1320,3 +1320,74 @@ func TestClientPostEphemeralErrorStatus(t *testing.T) {
 		t.Errorf("error = %q, want it to contain the response body", err.Error())
 	}
 }
+
+// TestClientPostEphemeralToUser covers GH-5189: PostEphemeralToUser POSTs to
+// the bot-token-authenticated chat.postEphemeral API (unlike PostEphemeral,
+// which uses the pre-authenticated response_url) with channel/user/text.
+func TestClientPostEphemeralToUser(t *testing.T) {
+	var gotAuth, gotContentType, gotPath string
+	var gotBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read body: %v", err)
+		}
+		if err := json.Unmarshal(body, &gotBody); err != nil {
+			t.Fatalf("failed to parse request body: %v", err)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeSlackBotToken, server.URL)
+	ctx := context.Background()
+	if err := client.PostEphemeralToUser(ctx, "#approvals", "U-intruder", "⛔ Not an approver"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotPath != "/chat.postEphemeral" {
+		t.Errorf("path = %q, want /chat.postEphemeral", gotPath)
+	}
+	if gotAuth != "Bearer "+testutil.FakeSlackBotToken {
+		t.Errorf("Authorization = %q, want bot-token bearer", gotAuth)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotContentType)
+	}
+	if gotBody["channel"] != "#approvals" {
+		t.Errorf("channel = %v, want #approvals", gotBody["channel"])
+	}
+	if gotBody["user"] != "U-intruder" {
+		t.Errorf("user = %v, want U-intruder", gotBody["user"])
+	}
+	if gotBody["text"] != "⛔ Not an approver" {
+		t.Errorf("text = %v, want the refusal message", gotBody["text"])
+	}
+}
+
+// TestClientPostEphemeralToUserAPIError covers the ok:false path: Slack's
+// chat.postEphemeral returns 200 with an error code in the body on failure
+// (unlike the response_url variant, which uses HTTP status).
+func TestClientPostEphemeralToUserAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":false,"error":"channel_not_found"}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeSlackBotToken, server.URL)
+	err := client.PostEphemeralToUser(context.Background(), "#bogus", "U-intruder", "test")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "channel_not_found") {
+		t.Errorf("error = %q, want it to contain the Slack error code", err.Error())
+	}
+}

--- a/internal/adapters/slack/webhook.go
+++ b/internal/adapters/slack/webhook.go
@@ -280,6 +280,11 @@ func (a *SlackClientAdapter) PostEphemeral(ctx context.Context, responseURL, tex
 	return a.client.PostEphemeral(ctx, responseURL, text)
 }
 
+// PostEphemeralToUser implements approval.SlackClient
+func (a *SlackClientAdapter) PostEphemeralToUser(ctx context.Context, channel, user, text string) error {
+	return a.client.PostEphemeralToUser(ctx, channel, user, text)
+}
+
 // SlackApprovalMessage mirrors the approval package's message type
 type SlackApprovalMessage struct {
 	Channel string        `json:"channel"`

--- a/internal/approval/slack.go
+++ b/internal/approval/slack.go
@@ -23,6 +23,11 @@ type SlackClient interface {
 	// message — e.g. telling an unauthorized clicker they aren't an
 	// approver, mirroring TelegramHandler's AnswerCallback toast.
 	PostEphemeral(ctx context.Context, responseURL, text string) error
+	// PostEphemeralToUser is the response_url-less fallback (GH-5189): posts
+	// an ephemeral message to user in channel via the bot-token-authenticated
+	// chat.postEphemeral API. Used when responseURL is empty — the Socket
+	// Mode path, where the SDK event carries no ResponseURL field.
+	PostEphemeralToUser(ctx context.Context, channel, user, text string) error
 }
 
 // SlackInteractiveMessage represents a Slack message with interactive buttons
@@ -68,6 +73,12 @@ type SlackActionsBlock struct {
 	BlockID  string               `json:"block_id,omitempty"`
 	Elements []SlackButtonElement `json:"elements"`
 }
+
+// unauthorizedApproverText is the ephemeral refusal shown to a clicker who
+// isn't in the request's approver list. Unified with TelegramHandler's
+// AnswerCallback toast text (GH-5189) so the refusal reads the same across
+// both adapters.
+const unauthorizedApproverText = "⛔ Not an approver"
 
 // SlackHandler handles approval requests via Slack
 type SlackHandler struct {
@@ -495,8 +506,20 @@ func (h *SlackHandler) HandleInteraction(ctx context.Context, actionID, value, u
 			slog.String("decision", string(decision)),
 			slog.String("user", username),
 			slog.String("user_id", userID))
+		// GH-5189: on Socket Mode (the primary deployment path) the SDK's
+		// core.MessageEvent has no ResponseURL field, so responseURL arrives
+		// empty here and the response_url branch below can never fire. Fall
+		// back to the bot-token-authenticated chat.postEphemeral API using
+		// the channel + clicker user ID, both already known at this call
+		// site — otherwise the authorization guard holds but the unauthorized
+		// clicker gets silence instead of feedback.
 		if responseURL != "" {
-			if err := h.client.PostEphemeral(ctx, responseURL, "You are not authorized to decide this request"); err != nil {
+			if err := h.client.PostEphemeral(ctx, responseURL, unauthorizedApproverText); err != nil {
+				h.log.Warn("failed to send unauthorized approval ephemeral response",
+					slog.String("request_id", requestID), slog.Any("error", err))
+			}
+		} else if pending.Channel != "" && userID != "" {
+			if err := h.client.PostEphemeralToUser(ctx, pending.Channel, userID, unauthorizedApproverText); err != nil {
 				h.log.Warn("failed to send unauthorized approval ephemeral response",
 					slog.String("request_id", requestID), slog.Any("error", err))
 			}

--- a/internal/approval/slack_test.go
+++ b/internal/approval/slack_test.go
@@ -23,6 +23,12 @@ type mockSlackClient struct {
 	// assert an unauthorized click gets answered via response_url (GH-5161).
 	ephemeralCalls []mockSlackEphemeralCall
 	ephemeralError error
+
+	// ephemeralToUserCalls records every PostEphemeralToUser invocation so
+	// tests can assert the responseURL-less (Socket Mode) fallback fires
+	// with the right channel + user (GH-5189).
+	ephemeralToUserCalls []mockSlackEphemeralToUserCall
+	ephemeralToUserError error
 }
 
 type mockSlackUpdateCall struct {
@@ -35,6 +41,12 @@ type mockSlackUpdateCall struct {
 type mockSlackEphemeralCall struct {
 	ResponseURL string
 	Text        string
+}
+
+type mockSlackEphemeralToUserCall struct {
+	Channel string
+	User    string
+	Text    string
 }
 
 func (m *mockSlackClient) PostInteractiveMessage(ctx context.Context, msg *SlackInteractiveMessage) (*SlackPostMessageResponse, error) {
@@ -57,6 +69,11 @@ func (m *mockSlackClient) UpdateInteractiveMessage(ctx context.Context, channel,
 func (m *mockSlackClient) PostEphemeral(ctx context.Context, responseURL, text string) error {
 	m.ephemeralCalls = append(m.ephemeralCalls, mockSlackEphemeralCall{ResponseURL: responseURL, Text: text})
 	return m.ephemeralError
+}
+
+func (m *mockSlackClient) PostEphemeralToUser(ctx context.Context, channel, user, text string) error {
+	m.ephemeralToUserCalls = append(m.ephemeralToUserCalls, mockSlackEphemeralToUserCall{Channel: channel, User: user, Text: text})
+	return m.ephemeralToUserError
 }
 
 func TestSlackHandler_Name(t *testing.T) {
@@ -1057,8 +1074,8 @@ func TestSlackHandler_HandleInteraction_UnauthorizedSendsEphemeralAndWarns(t *te
 	if got := client.ephemeralCalls[0].ResponseURL; got != responseURL {
 		t.Errorf("ephemeral response_url = %q, want %q", got, responseURL)
 	}
-	if !containsString(client.ephemeralCalls[0].Text, "not authorized") {
-		t.Errorf("ephemeral text = %q, want it to mention not being authorized", client.ephemeralCalls[0].Text)
+	if client.ephemeralCalls[0].Text != unauthorizedApproverText {
+		t.Errorf("ephemeral text = %q, want %q", client.ephemeralCalls[0].Text, unauthorizedApproverText)
 	}
 
 	// (2) warn log with request_id/user attrs.
@@ -1081,6 +1098,74 @@ func TestSlackHandler_HandleInteraction_UnauthorizedSendsEphemeralAndWarns(t *te
 	// (4) request left pending.
 	handler.mu.RLock()
 	_, stillPending := handler.pending["req-ephemeral-refusal"]
+	handler.mu.RUnlock()
+	if !stillPending {
+		t.Fatal("expected request to remain pending after an unauthorized click")
+	}
+	select {
+	case resp := <-respCh:
+		t.Fatalf("expected no response for unauthorized click, got: %+v", resp)
+	default:
+	}
+}
+
+// TestSlackHandler_HandleInteraction_UnauthorizedEmptyResponseURLFallsBackToPostEphemeralToUser
+// covers GH-5189: on Socket Mode the bridge passes responseURL="" (the SDK's
+// core.MessageEvent has no ResponseURL field), so HandleInteraction must fall
+// back to the bot-token-authenticated chat.postEphemeral API using the
+// pending request's channel + clicker user ID — otherwise the unauthorized
+// clicker gets silence instead of a refusal. Must not call RecordDecision.
+func TestSlackHandler_HandleInteraction_UnauthorizedEmptyResponseURLFallsBackToPostEphemeralToUser(t *testing.T) {
+	client := &mockSlackClient{}
+	recorder := &mockDecisionRecorder{}
+	handler := NewSlackHandler(client, "#approvals").WithDecisionRecorder(recorder)
+
+	req := &Request{
+		ID:        "req-socketmode-refusal",
+		TaskID:    "TASK-01",
+		Stage:     StagePreExecution,
+		Title:     "Test task",
+		Approvers: []string{"U-allowed"},
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	respCh, err := handler.SendApprovalRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	handled := handler.HandleInteraction(context.Background(), "approve", "approve:req-socketmode-refusal", "intruder", "intruder", "")
+	if !handled {
+		t.Error("expected interaction to be handled (even when unauthorized)")
+	}
+
+	// response_url path must not fire — responseURL was empty.
+	if len(client.ephemeralCalls) != 0 {
+		t.Fatalf("expected no PostEphemeral (response_url) calls, got %d", len(client.ephemeralCalls))
+	}
+
+	// chat.postEphemeral fallback invoked with channel + clicker user.
+	if len(client.ephemeralToUserCalls) != 1 {
+		t.Fatalf("expected 1 PostEphemeralToUser call, got %d", len(client.ephemeralToUserCalls))
+	}
+	call := client.ephemeralToUserCalls[0]
+	if call.Channel != "#approvals" {
+		t.Errorf("ephemeral channel = %q, want %q", call.Channel, "#approvals")
+	}
+	if call.User != "intruder" {
+		t.Errorf("ephemeral user = %q, want %q", call.User, "intruder")
+	}
+	if call.Text != unauthorizedApproverText {
+		t.Errorf("ephemeral text = %q, want %q", call.Text, unauthorizedApproverText)
+	}
+
+	// No decision recorded for an unauthorized click.
+	if calls := recorder.getCalls(); len(calls) != 0 {
+		t.Fatalf("expected RecordDecision NOT to be called for an unauthorized click, got %d calls", len(calls))
+	}
+
+	// Request left pending.
+	handler.mu.RLock()
+	_, stillPending := handler.pending["req-socketmode-refusal"]
 	handler.mu.RUnlock()
 	if !stillPending {
 		t.Fatal("expected request to remain pending after an unauthorized click")
@@ -1204,8 +1289,8 @@ func TestSlackHandler_HandleInteraction_NonApproverRefused(t *testing.T) {
 	if len(client.ephemeralCalls) != 1 {
 		t.Fatalf("expected 1 ephemeral response, got %d", len(client.ephemeralCalls))
 	}
-	if !containsString(client.ephemeralCalls[0].Text, "not authorized") {
-		t.Errorf("ephemeral text = %q, want it to mention not being authorized", client.ephemeralCalls[0].Text)
+	if client.ephemeralCalls[0].Text != unauthorizedApproverText {
+		t.Errorf("ephemeral text = %q, want %q", client.ephemeralCalls[0].Text, unauthorizedApproverText)
 	}
 
 	// Warn log.

--- a/internal/autopilot/restart_approval_slack_integration_test.go
+++ b/internal/autopilot/restart_approval_slack_integration_test.go
@@ -29,6 +29,10 @@ func (f *fakeRestartSlackClient) PostEphemeral(_ context.Context, _, _ string) e
 	return nil
 }
 
+func (f *fakeRestartSlackClient) PostEphemeralToUser(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
 // TestRestartApprovalFlow_Slack_WritesExecutionDecisionAndResumesMerge is the
 // Slack counterpart of TestRestartApprovalFlow_WritesExecutionDecisionAndResumesMerge
 // (GH-3825's Telegram regression test). It exercises the GH-4411 chain

--- a/internal/pilot/pilot.go
+++ b/internal/pilot/pilot.go
@@ -115,6 +115,10 @@ func (a *slackApprovalClientAdapter) PostEphemeral(ctx context.Context, response
 	return a.adapter.PostEphemeral(ctx, responseURL, text)
 }
 
+func (a *slackApprovalClientAdapter) PostEphemeralToUser(ctx context.Context, channel, user, text string) error {
+	return a.adapter.PostEphemeralToUser(ctx, channel, user, text)
+}
+
 // linearTaskInfo tracks Linear issue info for completion callbacks (GH-391)
 type linearTaskInfo struct {
 	IssueID       string


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5189.

Closes #5189

## Changes

GitHub Issue GH-5189: fix(slack): unauthorized-clicker ephemeral refusal never delivered on Socket Mode — bridge hard-codes empty responseURL

## Context

PR #5173 (GH-5161) added an ephemeral "not authorized" response for unauthorized approval clicks, delivered via Slack `response_url`. Post-merge review found it only works on the HTTP interaction-webhook path (`internal/pilot/pilot.go:321-329` via `webhook.go:167`). On **Socket Mode — the primary deployment path** — the bridge passes `responseURL=""` (`internal/adapters/slack/handler.go:252`) because the SDK's core.MessageEvent type (defined in the studio-sdk repo, core package chat file) has no ResponseURL field, and `HandleInteraction` skips `PostEphemeral` when it's empty (`internal/approval/slack.go:495-501`). Result: the authorization guard holds (no bypass), but the unauthorized clicker gets silence instead of feedback.

## Approach

Prefer the pilot-side-only fix: when `responseURL` is empty, fall back to `chat.postEphemeral` (needs channel + clicker user ID — both available at the interaction site; add a small client method next to the existing `PostEphemeral` response_url variant in `internal/adapters/slack/client.go`). Extending the SDK event with `ResponseURL` is the alternative but costs a cross-repo release for no added capability.

While in there (cosmetic, same surface): unify refusal copy with Telegram's "⛔ Not an approver" (Slack currently says "You are not authorized to decide this request"), and fix `configs/pilot.example.yaml`'s "numeric chat/user ID" wording — Slack user IDs are alphanumeric (`U…`).

## Acceptance

- [ ] Unauthorized click over Socket Mode produces a visible ephemeral message to the clicker; approval card/buttons remain intact for the real approver.
- [ ] Existing response_url path unchanged (httptest-backed tests still pass).
- [ ] New test: empty responseURL → chat.postEphemeral fallback invoked with channel + clicker user, no RecordDecision call.
- [ ] Refusal copy consistent across Telegram/Slack; example yaml wording corrected.

## Refs

- Post-merge review of PR #5173 (2026-08-24) · parent arc #5153 · guard intact, feedback-only defect