### PR TITLE
GH-5198: fix(executor): extraFixesKeyword still promotes quoted markers inside negated instructions

### DIFF
--- a/.agent/tasks/gh-5198.md
+++ b/.agent/tasks/gh-5198.md
@@ -1,0 +1,25 @@
+# GH-5198
+
+**Created:** 2026-08-24
+
+## Problem
+
+GitHub Issue GH-5198: fix(executor): extraFixesKeyword still promotes quoted markers inside negated instructions
+
+## Context
+
+PR #5194 (GH-5191) narrowed `extraFixesKeyword` to line-anchored or fully-quoted markers. The quoted alternative was kept because the #5149 repro is itself a quoted instruction — but that leaves the exact class GH-5191 was filed about (probe-verified on main, `internal/executor/pr_fixes_ref.go:35`):
+
+1. A body line saying: Do not write (quoted) closes #123 in the PR body — still promotes `Fixes #123` (quoted marker inside a negation).
+2. A line starting `Closes #123, but only partially — needs follow-up` — promotes (punctuation terminator admits trailing prose; looser than the line-anchored sketch in #5191). No test covers either.
+
+## Approach
+
+Either tighten (quoted shape must also be line-ish-anchored or preceded by an imperative cue like "include"/"add"; line-anchored shape must end at the ref or a bare period), keeping the existing #5149-closure test green — or record an explicit wontfix rationale in the function comment if the residual risk is accepted. Add the two probe cases to the test table either way (as promotes-or-not per the decision).
+
+## Refs
+
+- PR #5194 post-merge review 2026-08-24 · #5191 · #5149 (quoted-closure use case that must keep working)
+
+## Acceptance Criteria
+

--- a/internal/executor/pr_fixes_ref.go
+++ b/internal/executor/pr_fixes_ref.go
@@ -21,18 +21,36 @@ import (
 // original version matched the keyword+number pair anywhere in prose, which
 // promoted incidental, quoted, negated, or descriptive mentions ("this bug
 // closes #123 prematurely", "the old fix resolves #99 only partially") into
-// live auto-close keywords on the generated PR. A structured marker is one
-// that stands alone as its own unit rather than being embedded mid-sentence:
-//   - at the start of a line (optionally after a "-"/"*"/"•" list bullet,
-//     e.g. a "## Refs" section entry), terminated by end-of-line, sentence
-//     punctuation, or a closing bracket, OR
-//   - wrapped in quotes with nothing else inside them (the GH-5165 repro:
-//     body text reading "Ensure the PR body includes 'Fixes #5149'.").
+// live auto-close keywords on the generated PR. GH-5198 tightened this
+// further: GH-5191's line-anchored shape used a single-character terminator
+// class (any of `.,;:!?)`) that only checked the character immediately
+// after the number, so "Closes #123, but only partially — needs follow-up"
+// still matched even though real prose followed the comma; and the
+// unconditional quoted shape promoted a quoted marker regardless of
+// surrounding context, so "Do not write 'closes #123' in the PR body" (a
+// negated instruction) still matched. A structured marker is now one of
+// exactly three shapes:
+//   - line-anchored: at the start of a line (optionally after a
+//     "-"/"*"/"•" list bullet, e.g. a "## Refs" section entry), terminated
+//     by end-of-line or a single bare trailing period — NOT by a comma,
+//     semicolon, colon, or other punctuation that could introduce trailing
+//     prose ("Closes #123, but only partially" no longer matches), OR
+//   - line-anchored and quoted: a quoted marker that itself starts the
+//     line (optionally after a bullet), with nothing else inside the
+//     quotes, OR
+//   - cue-prefixed and quoted: a quoted marker immediately preceded by an
+//     imperative cue ("include"/"includes"/"including"/"add"/"adds"/
+//     "adding") — the GH-5165 repro, "Ensure the PR body includes 'Fixes
+//     #5149'.". A quoted marker with no line-anchor and no imperative cue
+//     ("Do not write 'closes #123' in the PR body") matches none of the
+//     three shapes and is intentionally left as plain text, since the cue
+//     requirement is what distinguishes "insert this marker" instructions
+//     from "don't write/never say this marker" negations.
 //
 // Free-standing narrative usage — the keyword appearing after a subject
-// ("this bug closes #123...") — matches neither shape and is intentionally
-// left as plain text.
-var fixesRefRe = regexp.MustCompile(`(?im)(?:^[ \t]*(?:[-*•]\s+)?|['"“‘])(?:fixes|closes|resolves)\s+#(\d+)(?:['"”’]|[.,;:!?)]|[ \t]*$)`)
+// ("this bug closes #123...") — matches none of the three shapes and is
+// intentionally left as plain text.
+var fixesRefRe = regexp.MustCompile(`(?im)(?:^[ \t]*(?:[-*•]\s+)?(?:fixes|closes|resolves)\s+#(\d+)(?:\.|[ \t]*$)|^[ \t]*(?:[-*•]\s+)?['"“‘](?:fixes|closes|resolves)\s+#(\d+)['"”’]|(?:includes?|including|adds?|adding)\s+['"“‘](?:fixes|closes|resolves)\s+#(\d+)['"”’])`)
 
 // extraFixesKeyword scans description for fixesRefRe matches and returns a
 // "\nFixes #N" line for each referenced issue number distinct from
@@ -60,7 +78,16 @@ func extraFixesKeyword(description, ownIssueNum string) string {
 	seen := map[string]bool{ownIssueNum: true}
 	var b strings.Builder
 	for _, m := range matches {
+		// fixesRefRe has three alternative shapes, each with its own
+		// capture group (line-anchored, line-anchored+quoted,
+		// cue-prefixed+quoted) — exactly one is non-empty per match.
 		n := m[1]
+		if n == "" {
+			n = m[2]
+		}
+		if n == "" {
+			n = m[3]
+		}
 		if seen[n] {
 			continue
 		}

--- a/internal/executor/pr_fixes_ref_test.go
+++ b/internal/executor/pr_fixes_ref_test.go
@@ -93,6 +93,26 @@ func TestExtraFixesKeyword(t *testing.T) {
 			ownIssueNum: "5165",
 			want:        "\nFixes #789",
 		},
+		{
+			// GH-5198: a quoted marker with no line-anchor and no
+			// imperative cue ("include"/"add") preceding it must not be
+			// promoted, even when the surrounding sentence is itself a
+			// negated instruction not to write the marker.
+			name:        "negated instruction wrapping a quoted marker is not promoted",
+			description: `Do not write "closes #123" in the PR body.`,
+			ownIssueNum: "5165",
+			want:        "",
+		},
+		{
+			// GH-5198: a line-anchored marker followed by a comma and
+			// trailing prose must not be promoted — the terminator after
+			// the ref must be end-of-line or a bare period, not any
+			// punctuation character.
+			name:        "line-anchored marker with trailing prose after comma is not promoted",
+			description: "Closes #123, but only partially — needs follow-up",
+			ownIssueNum: "5165",
+			want:        "",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5198.

Closes #5198
Fixes #123

## Changes

GitHub Issue GH-5198: fix(executor): extraFixesKeyword still promotes quoted markers inside negated instructions

## Context

PR #5194 (GH-5191) narrowed `extraFixesKeyword` to line-anchored or fully-quoted markers. The quoted alternative was kept because the #5149 repro is itself a quoted instruction — but that leaves the exact class GH-5191 was filed about (probe-verified on main, `internal/executor/pr_fixes_ref.go:35`):

1. A body line saying: Do not write (quoted) closes #123 in the PR body — still promotes `Fixes #123` (quoted marker inside a negation).
2. A line starting `Closes #123, but only partially — needs follow-up` — promotes (punctuation terminator admits trailing prose; looser than the line-anchored sketch in #5191). No test covers either.

## Approach

Either tighten (quoted shape must also be line-ish-anchored or preceded by an imperative cue like "include"/"add"; line-anchored shape must end at the ref or a bare period), keeping the existing #5149-closure test green — or record an explicit wontfix rationale in the function comment if the residual risk is accepted. Add the two probe cases to the test table either way (as promotes-or-not per the decision).

## Refs

- PR #5194 post-merge review 2026-08-24 · #5191 · #5149 (quoted-closure use case that must keep working)