### PR TITLE
GH-5197: fix(dashboard): tokens-card window label never renders at production magnitudes — formatCompact lacks a B tier so the '· all' suffix is width-dropped

### DIFF
--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -1944,7 +1944,11 @@ func truncateVisual(s string, targetWidth int) string {
 	return result + "..."
 }
 
-// formatCompact formats a number in compact form: 0, 999, 1.0K, 57.3K, 1.2M.
+// formatCompact formats a number in compact form: 0, 999, 1.0K, 57.3K, 1.2M,
+// 6.7B. The B tier matters at production scale (GH-5197): without it, a
+// count like 6,745,700,000 renders as "6745.7M", which blows the token
+// card's 19-char detail budget and silently drops the "· all[-time]"
+// window-label suffix (renderTokenCard's suffix-only-if-it-fits loop).
 func formatCompact(n int) string {
 	if n < 1000 {
 		return fmt.Sprintf("%d", n)
@@ -1952,7 +1956,10 @@ func formatCompact(n int) string {
 	if n < 1_000_000 {
 		return fmt.Sprintf("%.1fK", float64(n)/1000)
 	}
-	return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
+	if n < 1_000_000_000 {
+		return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
+	}
+	return fmt.Sprintf("%.1fB", float64(n)/1_000_000_000)
 }
 
 // --- Stat card renderers (grom demo gallery row-1 style) ---

--- a/internal/dashboard/tui_test.go
+++ b/internal/dashboard/tui_test.go
@@ -27,6 +27,8 @@ func TestFormatCompact(t *testing.T) {
 		{57300, "57.3K"},
 		{1000000, "1.0M"},
 		{1234567, "1.2M"},
+		{1_000_000_000, "1.0B"},
+		{6_745_700_000, "6.7B"},
 	}
 
 	for _, tt := range tests {
@@ -222,6 +224,36 @@ func TestRenderTokenCard_CacheBreakdown(t *testing.T) {
 	// substring, so this assertion holds regardless of card width.
 	if !strings.Contains(out, "· all") {
 		t.Errorf("renderTokenCard: expected a '· all[-time]' window label in output, got:\n%s", out)
+	}
+}
+
+// TestRenderTokenCard_ProductionScale guards GH-5197: at production
+// (billions-of-tokens) magnitude, formatCompact used to top out at an "M"
+// tier, so "6745.7M cached" (14 chars) plus the " · all" suffix (6 chars)
+// blew the 19-char detail budget (cardWidth 23, inner width cw-4) and the
+// window label silently dropped — K-scale fixtures like
+// TestRenderTokenCard_CacheBreakdown never caught this because they never
+// crossed the M/B boundary.
+func TestRenderTokenCard_ProductionScale(t *testing.T) {
+	m := NewModel("test")
+	m.metricsCard = MetricsCardData{
+		TotalTokens:      100_000_000,
+		InputTokens:      70_000_000,
+		OutputTokens:     30_000_000,
+		CacheReadTokens:  6_700_000_000,
+		CacheWriteTokens: 45_700_000,
+		TokenHistory:     []int64{100, 200, 300, 400, 500, 600, 700},
+	}
+
+	out := m.renderTokenCard(cardWidth)
+
+	// Cache total = 6_700_000_000 + 45_700_000 = 6_745_700_000 -> "6.7B".
+	if !strings.Contains(out, "6.7B cached") {
+		t.Errorf("renderTokenCard production-scale: expected '6.7B cached' detail in output, got:\n%s", out)
+	}
+	// The window label must survive at this magnitude, not be width-dropped.
+	if !strings.Contains(out, "· all") {
+		t.Errorf("renderTokenCard production-scale: expected a '· all[-time]' window label in output, got:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5197.

Closes #5197

## Changes

GitHub Issue GH-5197: fix(dashboard): tokens-card window label never renders at production magnitudes — formatCompact lacks a B tier so the '· all' suffix is width-dropped

## Context

Post-merge review of PR #5196 (TASK-484 leg B): the lifetime-window label is suffix-gated on fitting the 19-char detail budget. At production B-scale counts the check fails — `6745.7M cached` is 14 chars, ` · all` pushes it to 20 > 19, so the label silently drops. The lifetime-vs-30d cross-card confusion leg B targeted persists exactly at prod magnitude (probe-verified; K-scale test fixtures pass, which is why CI is green).

## Implementation

Add a B tier to `formatCompact` (`internal/dashboard/tui.go`, currently caps at M): `6745.7M` → `6.7B`, making `6.7B cached · all` = 17 chars ≤ 19. Update `TestRenderTokenCard_CacheBreakdown` with a B-scale case asserting the suffix survives.

## Acceptance

- [ ] At ≥1B tokens the detail line renders value + `cached` + window tag within the 19-char budget (test at 6745.7M-scale fixture).
- [ ] Headline grand total uses the same B formatting (consistency).

## Refs

- PR #5196 post-merge review 2026-08-24 · TASK-484 / #5192