### PR TITLE
GH-5203: fix(docs-ci): cleanup-registry script lines parse as YAML mappings — broke every GitLab docs pipeline since 08-22; sync will re-break the hot-fixed copy unless this merges first

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
       - name: Check knowledge-graph drift
         run: python3 scripts/check-graph.py
 
+      - name: Install pyyaml
+        run: pip install --quiet pyyaml
+
+      - name: Check docs/.gitlab-ci.yml script YAML validity
+        run: python3 scripts/check-gitlab-ci-yaml.py
+
       - name: Run checker tests
         run: python3 -m unittest discover -s scripts -p "*_test.py"
 

--- a/docs/.gitlab-ci.yml
+++ b/docs/.gitlab-ci.yml
@@ -73,5 +73,7 @@ cleanup-registry:
         echo "WARN: CLEANUP_TOKEN not set — skipping registry tag cleanup. See .agent/sops/integrations/gitlab-space-reclaim.md Step 3."
         exit 0
       fi
-    - REPO_ID=$(curl -sS --header "PRIVATE-TOKEN: ${CLEANUP_TOKEN}" "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/registry/repositories" | sed -n 's/.*"id":\([0-9]*\).*/\1/p' | head -1)
-    - curl -sS -X DELETE --header "PRIVATE-TOKEN: ${CLEANUP_TOKEN}" "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/registry/repositories/${REPO_ID}/tags?name_regex_delete=.*&keep_n=5&older_than=7d" || true
+    - |
+      REPO_ID=$(curl -sS --header "PRIVATE-TOKEN: ${CLEANUP_TOKEN}" "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/registry/repositories" | sed -n 's/.*"id":\([0-9]*\).*/\1/p' | head -1)
+    - |
+      curl -sS -X DELETE --header "PRIVATE-TOKEN: ${CLEANUP_TOKEN}" "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/registry/repositories/${REPO_ID}/tags?name_regex_delete=.*&keep_n=5&older_than=7d" || true

--- a/scripts/check-gitlab-ci-yaml.py
+++ b/scripts/check-gitlab-ci-yaml.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""GitLab CI YAML validity gate for docs/.gitlab-ci.yml.
+
+Fails when any job's `script` (or `before_script`/`after_script`) list
+contains a non-string item. A plain-scalar list entry with an unquoted
+colon-space (e.g. `- curl --header "PRIVATE-TOKEN: ${TOKEN}" ...`) parses
+as a nested YAML mapping instead of a string, and GitLab rejects the whole
+pipeline config with:
+
+  jobs:<job>:script config should be a string or a nested array of strings
+
+This exact regression shipped in #5134 (GH-5203): the cleanup-registry
+job's two curl lines broke every pilot-docs pipeline from 2026-08-22
+19:56Z to 2026-08-24 16:44Z because docs/.gitlab-ci.yml is synced
+verbatim to GitLab by sync-docs.yml on every release, and GitHub-side
+sync-docs stayed green (validation only happens on the GitLab side).
+
+Fix for a flagged line: wrap it as a `- |` literal block scalar instead
+of a plain `- ...` scalar.
+"""
+import glob
+import os
+import sys
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - exercised only when pyyaml is missing
+    print("ERROR: pyyaml is required to run this check (pip install pyyaml)", file=sys.stderr)
+    sys.exit(1)
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_PATH = os.path.join(REPO_ROOT, "docs", ".gitlab-ci.yml")
+SCRIPT_KEYS = ("script", "before_script", "after_script")
+
+
+def find_non_string_script_items(config):
+    """Return a list of (job_name, key, item) tuples for non-string script entries.
+
+    `config` is a parsed GitLab CI YAML document (top-level mapping of job
+    names to job definitions, plus reserved keys like `stages`, `image`,
+    hidden `.template` jobs, etc.). Any of those whose value is a dict and
+    contains one of SCRIPT_KEYS is inspected.
+    """
+    violations = []
+    if not isinstance(config, dict):
+        return violations
+    for job_name, job in config.items():
+        if not isinstance(job, dict):
+            continue
+        for key in SCRIPT_KEYS:
+            items = job.get(key)
+            if not isinstance(items, list):
+                continue
+            for item in items:
+                if not isinstance(item, str):
+                    violations.append((job_name, key, item))
+    return violations
+
+
+def check_file(path):
+    with open(path, "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+    return find_non_string_script_items(config)
+
+
+def main():
+    paths = sys.argv[1:] or [DEFAULT_PATH]
+    # Support glob patterns for convenience, mirroring how check-graph.py is invoked.
+    resolved = []
+    for p in paths:
+        matches = glob.glob(p)
+        resolved.extend(matches if matches else [p])
+
+    all_violations = []
+    for path in resolved:
+        violations = check_file(path)
+        for job_name, key, item in violations:
+            all_violations.append((path, job_name, key, item))
+
+    if all_violations:
+        print("GitLab CI YAML validity gate FAILED:", file=sys.stderr)
+        for path, job_name, key, item in all_violations:
+            print(
+                f"  {path}: jobs.{job_name}.{key} has a non-string item "
+                f"(parsed as {type(item).__name__}): {item!r}",
+                file=sys.stderr,
+            )
+        print(
+            "\nLikely cause: an unquoted 'Header: value' colon-space inside a "
+            "plain '- ...' script line, which YAML parses as a nested mapping. "
+            "Fix by converting that list item to a '- |' literal block scalar.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK: all script items are strings in {', '.join(resolved)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_gitlab_ci_yaml_test.py
+++ b/scripts/check_gitlab_ci_yaml_test.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Table-driven tests for scripts/check-gitlab-ci-yaml.py."""
+import importlib.util
+import os
+import tempfile
+import unittest
+
+SCRIPT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "check-gitlab-ci-yaml.py")
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+REAL_GITLAB_CI = os.path.join(REPO_ROOT, "docs", ".gitlab-ci.yml")
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_gitlab_ci_yaml", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+cgy = _load_module()
+
+
+class FindNonStringScriptItemsTest(unittest.TestCase):
+    def test_all_string_script_items_pass(self):
+        config = {
+            "build": {
+                "script": [
+                    "echo hi",
+                    "docker build .",
+                ]
+            }
+        }
+        self.assertEqual(cgy.find_non_string_script_items(config), [])
+
+    def test_colon_space_regression_is_flagged(self):
+        # Reproduces #5134 / GH-5203: an unquoted 'PRIVATE-TOKEN: ${TOKEN}'
+        # inside a plain scalar list item parses as a nested dict.
+        config = {
+            "cleanup-registry": {
+                "script": [
+                    {"curl -sS --header \"PRIVATE-TOKEN\"": "${CLEANUP_TOKEN}"},
+                ]
+            }
+        }
+        violations = cgy.find_non_string_script_items(config)
+        self.assertEqual(len(violations), 1)
+        job_name, key, item = violations[0]
+        self.assertEqual(job_name, "cleanup-registry")
+        self.assertEqual(key, "script")
+        self.assertIsInstance(item, dict)
+
+    def test_before_and_after_script_are_checked(self):
+        config = {
+            "deploy": {
+                "before_script": ["echo before"],
+                "script": ["echo main"],
+                "after_script": [{"bad": "entry"}],
+            }
+        }
+        violations = cgy.find_non_string_script_items(config)
+        self.assertEqual([v[1] for v in violations], ["after_script"])
+
+    def test_non_dict_jobs_are_ignored(self):
+        config = {"stages": ["build", "deploy"], "image": "docker:latest"}
+        self.assertEqual(cgy.find_non_string_script_items(config), [])
+
+    def test_job_without_script_key_is_ignored(self):
+        config = {"deploy": {"stage": "deploy-prod"}}
+        self.assertEqual(cgy.find_non_string_script_items(config), [])
+
+    def test_literal_block_scalars_pass(self):
+        # A YAML '- |' literal block always parses to a single string, even
+        # if its content contains colon-space sequences.
+        config = {
+            "cleanup-registry": {
+                "script": [
+                    'curl -sS --header "PRIVATE-TOKEN: ${CLEANUP_TOKEN}" "$URL"\n',
+                ]
+            }
+        }
+        self.assertEqual(cgy.find_non_string_script_items(config), [])
+
+
+class CheckFileTest(unittest.TestCase):
+    def test_flags_colon_space_plain_scalar(self):
+        content = (
+            "bad-job:\n"
+            "  script:\n"
+            "    - curl --header \"PRIVATE-TOKEN: ${TOKEN}\" \"$URL\"\n"
+        )
+        with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as f:
+            f.write(content)
+            path = f.name
+        try:
+            violations = cgy.check_file(path)
+            self.assertEqual(len(violations), 1)
+        finally:
+            os.unlink(path)
+
+    def test_real_docs_gitlab_ci_file_is_clean(self):
+        # Regression guard: the actual synced file must never regress to the
+        # #5134 / GH-5203 shape again.
+        self.assertTrue(os.path.exists(REAL_GITLAB_CI), REAL_GITLAB_CI)
+        violations = cgy.check_file(REAL_GITLAB_CI)
+        self.assertEqual(violations, [])
+
+
+class MainTest(unittest.TestCase):
+    def test_main_returns_zero_on_real_file(self):
+        self.assertEqual(_run_main(), 0)
+
+
+def _run_main():
+    import sys
+
+    argv = sys.argv
+    sys.argv = ["check-gitlab-ci-yaml.py", REAL_GITLAB_CI]
+    try:
+        return cgy.main()
+    finally:
+        sys.argv = argv
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5203.

Closes #5203

## Changes

GitHub Issue GH-5203: fix(docs-ci): cleanup-registry script lines parse as YAML mappings — broke every GitLab docs pipeline since 08-22; sync will re-break the hot-fixed copy unless this merges first

## Context

**URGENT — must merge before the next release train, or the docs deploy re-breaks.**

`docs/.gitlab-ci.yml` (synced verbatim to quant-flow/pilot-docs by sync-docs on every release) has invalid YAML in the `cleanup-registry` job added by #5134: the two curl script lines contain unquoted colon-space (`PRIVATE-TOKEN: ${CLEANUP_TOKEN}`), so YAML parses them as nested mappings and GitLab rejects the whole config with `jobs:cleanup-registry:script config should be a string or a nested array of strings`. Every pilot-docs pipeline from 2026-08-22 19:56Z to 2026-08-24 16:44Z failed at validation with zero jobs; the docs site sat on prod-2.266.0 while GitHub-side sync-docs stayed green (the silent-failure mode documented in the gitlab-space-reclaim SOP).

The GitLab copy is already hot-fixed (pilot-docs main commit 427bd845, deployed prod-2.268.0-1787589883, verified live) — this issue is the source-side fix so the next sync does not overwrite it with the broken version.

## Implementation

In `docs/.gitlab-ci.yml`, `cleanup-registry.script`: convert the two `- curl ...` / `- REPO_ID=$(curl ...)` plain-scalar list items to `- |` literal blocks (exactly as done in pilot-docs commit 427bd845 — copy that file's job verbatim). No other changes.

Verification that must be in the PR: a check that the file parses with every `script` item as a string — e.g. extend or add a test/CI step running `python3 -c "import yaml,sys; d=yaml.safe_load(open('docs/.gitlab-ci.yml')); assert all(isinstance(x,str) for j in d.values() if isinstance(j,dict) and 'script' in j for x in j['script'])"` so a colon-space regression can never ship again.

## Acceptance

- [ ] `docs/.gitlab-ci.yml` byte-matches the hot-fixed pilot-docs version for the `cleanup-registry` job (literal blocks).
- [ ] YAML-validity guard (script items are strings) runs in CI or tests.
- [ ] No changes outside `docs/.gitlab-ci.yml` + the guard.

## Refs

- Incident 2026-08-24 (this session): GraphQL failureReason + zero-jobs signature · hot-fix pilot-docs@427bd845 · #5134 (introduced the job) · gitlab-space-reclaim SOP (recurrence #4 being recorded)