### PR TITLE
GH-5087: ci(lint): config-verify's remote schema fetch fails healthy PRs on network flakes — decouple verification from the per-PR hot path (PR#5082 casualty)

### DIFF
--- a/.agent/tasks/gh-5087.md
+++ b/.agent/tasks/gh-5087.md
@@ -1,0 +1,36 @@
+# GH-5087
+
+**Created:** 2026-08-24
+
+## Problem
+
+GitHub Issue GH-5087: ci(lint): config-verify's remote schema fetch fails healthy PRs on network flakes — decouple verification from the per-PR hot path (PR#5082 casualty)
+
+## Summary
+
+Every lint run has a hidden third-party network dependency: `golangci-lint-action` runs with `verify: true` (ci.yml lint job), and `golangci-lint config verify` fetches its JSON schema from `https://golangci-lint.run/jsonschema/golangci.v2.8.jsonschema.json` at runtime. On 2026-08-21 11:31:48Z that fetch hit `context deadline exceeded` → lint FAILURE on PR#5082 whose code was never linted at all → autopilot closed the green-code PR and spawned a phantom fix issue (#5083, closed with evidence). Same config passed on main at 11:30Z and 12:03Z.
+
+This is the second CI-infra failure mode that kills healthy PRs (first: the golangci cache self-poisoning, fixed via `skip-cache: true` on 08-18). Config verification is valuable at config-CHANGE time, not per-PR.
+
+## Options (founder call — CI surface)
+
+1. **`verify: false`** on the per-PR lint job + a separate config-verify job that runs only when `.golangci.yml` changes (`paths:` filter). Recommended: keeps the guard where it has signal, removes the network dependency from the hot path.
+2. Keep `verify: true` but treat verify-step network errors as neutral/retry (action doesn't support this natively — would need a wrapper step).
+3. Vendor the schema and pass a local path (check whether `config verify` supports `--schema` local file in v2.8).
+
+## Acceptance Criteria
+
+- [ ] A PR that doesn't touch `.golangci.yml` cannot fail lint due to schema-host unavailability.
+- [ ] A PR that DOES change `.golangci.yml` still gets config verification.
+- [ ] Chosen option stated with rationale in the PR body.
+
+## Note
+
+⚠ CI surface — unlabeled per policy; label `pilot` to dispatch.
+
+## Refs
+
+Run 32477596115 (the flake) · PR#5082 / #5083 (the casualty chain) · 08-18 skip-cache precedent (`049456d5`, pitfall `golangci-action-cache-self-poisoning-sa5011`)
+
+## Acceptance Criteria
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,3 +131,56 @@ jobs:
           # (#4956/#4958/#4960/#4969/#4971/#4973 chain). Fresh-cache runs are
           # deterministically green. Trade ~1min of lint time for correctness.
           skip-cache: true
+          # GH-5087: `verify: true` (the action's default) runs
+          # `golangci-lint config verify`, which fetches the JSON schema
+          # from https://golangci-lint.run at runtime. On 2026-08-21 that
+          # fetch hit `context deadline exceeded` and failed lint on
+          # PR#5082 whose code was never actually linted — autopilot closed
+          # the green PR and spawned a phantom fix issue (#5083). Config
+          # verification is only load-bearing when .golangci.yml changes,
+          # so it now runs in the separate `config-verify` job below
+          # instead of on every PR's hot path.
+          verify: false
+
+  # GH-5087: schema verification for .golangci.yml, split out of the
+  # per-PR lint job (see the `verify: false` note above). Only runs when
+  # .golangci.yml itself changes, so the remote schema-host dependency
+  # can no longer fail unrelated PRs — but a config change still gets
+  # verified before merge.
+  config-verify:
+    name: golangci-lint Config Verify
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check whether .golangci.yml changed
+        id: changed
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+          else
+            base="${{ github.event.before }}"
+          fi
+          if git diff --name-only "$base" "${{ github.sha }}" -- .golangci.yml | grep -qx '.golangci.yml'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Go
+        if: steps.changed.outputs.changed == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: golangci-lint config verify
+        if: steps.changed.outputs.changed == 'true'
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.8.0
+          args: --timeout=5m
+          skip-cache: true


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5087.

Closes #5087

## Changes

GitHub Issue GH-5087: ci(lint): config-verify's remote schema fetch fails healthy PRs on network flakes — decouple verification from the per-PR hot path (PR#5082 casualty)

## Summary

Every lint run has a hidden third-party network dependency: `golangci-lint-action` runs with `verify: true` (ci.yml lint job), and `golangci-lint config verify` fetches its JSON schema from `https://golangci-lint.run/jsonschema/golangci.v2.8.jsonschema.json` at runtime. On 2026-08-21 11:31:48Z that fetch hit `context deadline exceeded` → lint FAILURE on PR#5082 whose code was never linted at all → autopilot closed the green-code PR and spawned a phantom fix issue (#5083, closed with evidence). Same config passed on main at 11:30Z and 12:03Z.

This is the second CI-infra failure mode that kills healthy PRs (first: the golangci cache self-poisoning, fixed via `skip-cache: true` on 08-18). Config verification is valuable at config-CHANGE time, not per-PR.

## Options (founder call — CI surface)

1. **`verify: false`** on the per-PR lint job + a separate config-verify job that runs only when `.golangci.yml` changes (`paths:` filter). Recommended: keeps the guard where it has signal, removes the network dependency from the hot path.
2. Keep `verify: true` but treat verify-step network errors as neutral/retry (action doesn't support this natively — would need a wrapper step).
3. Vendor the schema and pass a local path (check whether `config verify` supports `--schema` local file in v2.8).

## Acceptance Criteria

- [ ] A PR that doesn't touch `.golangci.yml` cannot fail lint due to schema-host unavailability.
- [ ] A PR that DOES change `.golangci.yml` still gets config verification.
- [ ] Chosen option stated with rationale in the PR body.

## Note

⚠ CI surface — unlabeled per policy; label `pilot` to dispatch.

## Refs

Run 32477596115 (the flake) · PR#5082 / #5083 (the casualty chain) · 08-18 skip-cache precedent (`049456d5`, pitfall `golangci-action-cache-self-poisoning-sa5011`)