### PR TITLE
fix(cmd/pilot): wire orchestrator.execution.mode into the GitHub SDK poller

### DIFF
--- a/cmd/pilot/poller_github.go
+++ b/cmd/pilot/poller_github.go
@@ -205,9 +205,6 @@ func (s sdkRateLimitScheduler) QueueRetryIfRateLimited(taskID, title, body, errT
 // parsed off adapters.github.use_sdk_poller for backward-compat config loading
 // but no longer gates anything here (see config.CheckDeprecations for the
 // startup warning).
-//
-// Known 4b limitation: the SDK adapter runs ExecutionModeAuto only —
-// execution.mode=sequential configs are not supported.
 func githubPollerRegistration() PollerRegistration {
 	return PollerRegistration{
 		Name: "github",

--- a/cmd/pilot/poller_github.go
+++ b/cmd/pilot/poller_github.go
@@ -467,6 +467,14 @@ func startGithubSDKPollerForRepo(ctx context.Context, deps *PollerDeps, log *slo
 	if deps.Cfg.Orchestrator.MaxConcurrent > 0 {
 		pollerDeps.MaxConcurrent = deps.Cfg.Orchestrator.MaxConcurrent
 	}
+	// orchestrator.execution.mode was validated in config but never reached
+	// the SDK poller, so sequential configs silently ran in auto (parallel)
+	// mode while the startup banner claimed "waiting for PR merge". Pass the
+	// configured mode through; the SDK maps it to the GitHub poller option.
+	// Empty mode keeps the SDK default (auto), matching prior behavior.
+	if deps.Cfg.Orchestrator.Execution != nil && deps.Cfg.Orchestrator.Execution.Mode != "" {
+		pollerDeps.ExecutionMode = deps.Cfg.Orchestrator.Execution.Mode
+	}
 
 	// M7 4d.2b: per-repo autopilot controller (keyed owner/repo). The default repo
 	// falls back to the backwards-compat singular controller. When autopilot is

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/qf-studio/grom v0.2.0
-	github.com/qf-studio/studio-sdk v0.36.0
+	github.com/qf-studio/studio-sdk v0.38.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2
 	github.com/wailsapp/wails/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/qf-studio/grom v0.2.0 h1:EefLLr794KGk8ihdpKBgJnmSyUc//b/n8zZ77VbeuXY=
 github.com/qf-studio/grom v0.2.0/go.mod h1:YVihqE0treA2091TLNhGWvGi5+vMYv/ZBlAlX7Mr/JI=
-github.com/qf-studio/studio-sdk v0.36.0 h1:1AVe+SSZjEPXzmBuVfK8+sVpD9Txyi71ESHkNU3dnF4=
-github.com/qf-studio/studio-sdk v0.36.0/go.mod h1:M/uFBeXsPAtsrO7wiIgE/GgWzfw80ftW6BrQUIOwxUM=
+github.com/qf-studio/studio-sdk v0.38.0 h1:zR/5Y9pOs9TYjzKmvmNXQEgneNBHFVoTy4YPQmCFRWg=
+github.com/qf-studio/studio-sdk v0.38.0/go.mod h1:M/uFBeXsPAtsrO7wiIgE/GgWzfw80ftW6BrQUIOwxUM=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
Closes #5151 (pilot side; SDK side already merged and released as studio-sdk v0.38.0 via qf-studio/studio-sdk#137).

## What this does

1. **Wires `orchestrator.execution.mode` into the GitHub SDK poller** — `cmd/pilot/poller_github.go` now passes the configured mode through `core.PollerDeps.ExecutionMode`; empty mode keeps the SDK default (auto), so existing configs are unaffected.
2. **Bumps the studio-sdk pin v0.35.2 → v0.38.0** — v0.38.0 carries the SDK leg (`PollerDeps.ExecutionMode` honored via `WithExecutionMode`, re-blessed public API golden).

## Result

`orchestrator.execution.mode: sequential` now behaves as documented in `docs/content/features/execution-modes.mdx` and as claimed by the startup banner: the GitHub poller runs `startSequential` — oldest issue first, blocking `MergeWaiter` on the open PR, default-branch sync after merge — instead of silently dispatching in parallel. Observed failure this fixes (live on v2.265.0): three labeled issues dispatched concurrently despite `mode: sequential`, before the first one merged.

## Verification

- `go build ./cmd/pilot/...`, `go vet ./cmd/pilot/...` — green against studio-sdk **v0.38.0** (real release, no replace)
- `go test ./cmd/pilot/ -run 'Github|Poller|Sequential|Execution|SpecGuard' -count=1` — green
- Branch rebased on current `main`

---
*Prepared with AI assistance (Claude) under the direction of the submitting author.*
