### PR TITLE
GH-5209: fix(alerts): circuit_breaker_trip re-fires critical every 30min off the windowed trips counter — no live trip, no state to clear, Slack channel spammed indefinitely

### DIFF
--- a/.agent/tasks/gh-5209.md
+++ b/.agent/tasks/gh-5209.md
@@ -1,0 +1,32 @@
+# GH-5209
+
+**Created:** 2026-08-24
+
+## Problem
+
+GitHub Issue GH-5209: fix(alerts): circuit_breaker_trip re-fires critical every 30min off the windowed trips counter — no live trip, no state to clear, Slack channel spammed indefinitely
+
+## Context
+
+Since 2026-08-24 19:53Z the `circuit_breaker_trip` rule (severity critical, delivered to slack-engineering) fires exactly every cooldown period (30m) with no end in sight. Evidence:
+
+- Last genuine `per-PR circuit breaker open` log line is 2026-08-17 (sdk PR#118 era) — a week before the alerts began.
+- `pilot_platform_breaker_open` = 0; autopilot merged PRs straight through the alert window (PR#5208 auto-merged 20:19Z, 26 min after the first alert).
+- The rule's condition is `ConsecutiveFailures: 1` ("any trip", `internal/alerts/types.go:409`) and the engine reads `circuit_breaker_trips` from event metadata (`internal/alerts/engine.go:1434`) — which the periodic window-stats seeding supplies as a cumulative/windowed counter (`window stats seeded` every 5m; lifetime `pilot_circuit_breaker_trips_total` = 85). Once the windowed count is nonzero — e.g. from 08-24's autopilot false-closure incidents — the condition is permanently true and cooldown just paces the spam.
+
+## Implementation
+
+Make the rule edge-triggered, not level-triggered: alert on trips-count INCREASE since the last evaluation (delta > 0), or on an explicit trip event, never on a standing nonzero counter. Persist the last-seen count across restarts so a reboot doesn't re-fire the whole backlog. Add a test: stats event with unchanged nonzero trips → no alert; increment → one alert.
+
+## Acceptance
+
+- [ ] Standing nonzero windowed/lifetime trips counter produces zero alerts.
+- [ ] A fresh trip produces exactly one critical alert (plus cooldown suppression as today).
+- [ ] Restart does not re-fire for pre-restart trips.
+
+## Refs
+
+- Daemon log 08-24 19:53→22:36 (7 identical criticals) · alert engine metadata path engine.go:1425-1434 · 08-24 incident chain that likely seeded the counter (#5167/#5175/#5183)
+
+## Acceptance Criteria
+

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1050,6 +1050,11 @@ Examples:
 						// gateway mode's alert engine construction site, same
 						// dead-plumbing gap as the polling-mode site above (GH-4716).
 						gwEngineOpts = append(gwEngineOpts, alerts.WithActiveAlertStore(gwStore))
+						// GH-5209: wire counter-checkpoint persistence so
+						// level-triggered stats-event rules (circuit_breaker_trip)
+						// survive a restart without replaying their pre-restart
+						// standing counter as a fresh alert.
+						gwEngineOpts = append(gwEngineOpts, alerts.WithAlertCounterStore(gwStore))
 					}
 					gwAlertsEngine = alerts.NewEngine(alertsCfg, gwEngineOpts...)
 					if alertErr := gwAlertsEngine.Start(ctx); alertErr != nil {
@@ -3118,6 +3123,11 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			// currently-firing alert state despite the persistence layer
 			// existing and being fully tested (GH-4716 dead-plumbing class).
 			engineOpts = append(engineOpts, alerts.WithActiveAlertStore(store))
+			// GH-5209: wire counter-checkpoint persistence so level-triggered
+			// stats-event rules (circuit_breaker_trip) survive a restart
+			// without replaying their pre-restart standing counter as a
+			// fresh alert.
+			engineOpts = append(engineOpts, alerts.WithAlertCounterStore(store))
 		}
 		alertsEngine = alerts.NewEngine(alertsCfg, engineOpts...)
 		if err := alertsEngine.Start(ctx); err != nil {

--- a/internal/alerts/alert_counter_store.go
+++ b/internal/alerts/alert_counter_store.go
@@ -1,0 +1,21 @@
+package alerts
+
+import "github.com/qf-studio/pilot/internal/memory"
+
+// AlertCounterStore persists the last-seen value of level-triggered
+// stats-event counters (e.g. circuit_breaker_trips) across restarts, so
+// Engine can fire on an increase since the checkpoint instead of on the
+// counter simply being nonzero (GH-5209). Optional: an Engine constructed
+// without one (WithAlertCounterStore never called) keeps checkpoint state
+// only in memory — a restart forgets it and treats the first post-restart
+// observation as a fresh baseline, same as before this store existed.
+//
+// *memory.Store satisfies this interface directly — same optional-store
+// shape as ActiveAlertStore.
+type AlertCounterStore interface {
+	UpsertAlertCounter(ruleName, source string, value int) error
+	LoadAlertCounters() ([]*memory.AlertCounter, error)
+}
+
+// Compile-time assertion that *memory.Store satisfies AlertCounterStore.
+var _ AlertCounterStore = (*memory.Store)(nil)

--- a/internal/alerts/circuit_breaker_trip_test.go
+++ b/internal/alerts/circuit_breaker_trip_test.go
@@ -1,0 +1,142 @@
+package alerts
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// circuitBreakerTripEvent builds a synthetic autopilot-metrics stats event
+// carrying the given windowed/cumulative circuit_breaker_trips count, the
+// same metadata shape metrics_alerter.go emits every poll tick.
+func circuitBreakerTripEvent(trips int) Event {
+	return Event{
+		Type: EventTypeAutopilotMetrics,
+		Metadata: map[string]string{
+			"circuit_breaker_trips": fmt.Sprintf("%d", trips),
+		},
+	}
+}
+
+// newCircuitBreakerTestEngine builds a minimal engine with only the
+// circuit_breaker_trip rule enabled and no cooldown, so tests can isolate
+// the edge-trigger logic (counterDelta) from cooldown suppression.
+// counterStore may be nil (in-memory-only checkpoint state).
+func newCircuitBreakerTestEngine(t *testing.T, counterStore AlertCounterStore) (*Engine, *mockChannel) {
+	t.Helper()
+	config := &AlertConfig{
+		Enabled: true,
+		Channels: []ChannelConfig{
+			{Name: "test-channel", Type: "webhook", Enabled: true},
+		},
+		Rules: []AlertRule{
+			{
+				Name:     "circuit_breaker_trip",
+				Type:     AlertTypeCircuitBreakerTrip,
+				Enabled:  true,
+				Severity: SeverityCritical,
+			},
+		},
+	}
+	mockCh := newMockChannel("test-channel", "webhook")
+	dispatcher := NewDispatcher(config)
+	dispatcher.RegisterChannel(mockCh)
+
+	opts := []EngineOption{WithDispatcher(dispatcher)}
+	if counterStore != nil {
+		opts = append(opts, WithAlertCounterStore(counterStore))
+	}
+	engine := NewEngine(config, opts...)
+	return engine, mockCh
+}
+
+// TestCircuitBreakerTrip_StandingNonzeroCounterNoAlert is the GH-5209
+// regression pin: handleAutopilotMetrics must not fire on a counter that is
+// merely nonzero. metrics_hydrator.go seeds circuit_breaker_trips
+// periodically regardless of whether a trip just happened, so a
+// level-triggered "cbTrips > 0" condition re-fires every cooldown period
+// forever once the counter goes nonzero, with no live trip and no state to
+// clear (the 2026-08-24 incident this issue reports).
+func TestCircuitBreakerTrip_StandingNonzeroCounterNoAlert(t *testing.T) {
+	engine, mockCh := newCircuitBreakerTestEngine(t, nil)
+	ctx := context.Background()
+
+	for i := 0; i < 4; i++ {
+		engine.handleAutopilotMetrics(ctx, circuitBreakerTripEvent(5))
+	}
+
+	if got := len(mockCh.getAlerts()); got != 0 {
+		t.Fatalf("dispatched %d alerts for a standing nonzero counter, want 0", got)
+	}
+}
+
+// TestCircuitBreakerTrip_IncreaseFiresExactlyOnce is the GH-5209 edge-trigger
+// acceptance test: an increase over the last-observed value fires exactly
+// one alert, the baseline-establishing first observation fires none even
+// though nonzero, and repeating the new (now-unchanged) value again does not
+// fire a second alert.
+func TestCircuitBreakerTrip_IncreaseFiresExactlyOnce(t *testing.T) {
+	engine, mockCh := newCircuitBreakerTestEngine(t, nil)
+	ctx := context.Background()
+
+	// Baseline observation: establishes last-seen=5, must not fire even
+	// though the value is nonzero (GH-5209).
+	engine.handleAutopilotMetrics(ctx, circuitBreakerTripEvent(5))
+	if got := len(mockCh.getAlerts()); got != 0 {
+		t.Fatalf("baseline observation dispatched %d alerts, want 0", got)
+	}
+
+	// Fresh trip: counter increases 5 -> 6.
+	engine.handleAutopilotMetrics(ctx, circuitBreakerTripEvent(6))
+	if got := len(mockCh.getAlerts()); got != 1 {
+		t.Fatalf("dispatched %d alerts after counter increase, want exactly 1", got)
+	}
+
+	// Repeating the same (now-unchanged) value must not fire again.
+	engine.handleAutopilotMetrics(ctx, circuitBreakerTripEvent(6))
+	if got := len(mockCh.getAlerts()); got != 1 {
+		t.Fatalf("dispatched %d alerts after repeating unchanged value, want still 1", got)
+	}
+}
+
+// TestCircuitBreakerTrip_RestartDoesNotRefire is the GH-5209 end-to-end
+// acceptance test against real SQLite: a restart must rehydrate the
+// pre-restart counter checkpoint, so the first post-restart stats event —
+// which still carries the same value the daemon already alerted on — does
+// not replay as a fresh alert, while a genuine increase after restart still
+// fires normally.
+func TestCircuitBreakerTrip_RestartDoesNotRefire(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	ctx := context.Background()
+
+	// --- pre-restart process: baseline + one genuine trip ---
+	engine1, mockCh1 := newCircuitBreakerTestEngine(t, store)
+	engine1.handleAutopilotMetrics(ctx, circuitBreakerTripEvent(5))
+	engine1.handleAutopilotMetrics(ctx, circuitBreakerTripEvent(6))
+	if got := len(mockCh1.getAlerts()); got != 1 {
+		t.Fatalf("pre-restart: dispatched %d alerts, want 1", got)
+	}
+
+	// --- restart: fresh Engine, fresh dispatcher/channel, same store ---
+	engine2, mockCh2 := newCircuitBreakerTestEngine(t, store)
+
+	// First post-restart event still carries the pre-restart value: must not
+	// re-fire the backlog.
+	engine2.handleAutopilotMetrics(ctx, circuitBreakerTripEvent(6))
+	if got := len(mockCh2.getAlerts()); got != 0 {
+		t.Fatalf("first post-restart event (unchanged value) dispatched %d alerts, want 0", got)
+	}
+
+	// A genuine new trip after restart still fires normally.
+	engine2.handleAutopilotMetrics(ctx, circuitBreakerTripEvent(7))
+	if got := len(mockCh2.getAlerts()); got != 1 {
+		t.Fatalf("post-restart increase dispatched %d alerts, want 1", got)
+	}
+}

--- a/internal/alerts/engine.go
+++ b/internal/alerts/engine.go
@@ -81,6 +81,21 @@ type Engine struct {
 	// existed. Writes are best-effort and off the alerting path: a store
 	// error is logged and the alert still fires/resolves.
 	activeAlertStore ActiveAlertStore
+
+	// lastSeenCounters is the in-memory checkpoint of level-triggered
+	// stats-event counters (e.g. circuit_breaker_trips), keyed by
+	// activeAlertKey(ruleName, eventSource). counterDelta reads and updates
+	// this on every stats event; counterStore (if wired) mirrors it to disk
+	// so a restart rehydrates from the pre-restart value instead of treating
+	// the standing counter as a fresh trip (GH-5209).
+	lastSeenCounters map[string]int
+
+	// counterStore persists lastSeenCounters across restarts (GH-5209). nil
+	// (the default, unless WithAlertCounterStore is passed) makes every
+	// persistence call a no-op — checkpoints then live only in memory and a
+	// restart re-baselines on the first post-restart observation, same as an
+	// engine that never had this store wired.
+	counterStore AlertCounterStore
 }
 
 // minOrphanEvictionThreshold floors evaluateStuckTasks' orphan-eviction window
@@ -281,6 +296,20 @@ func WithActiveAlertStore(store ActiveAlertStore) EngineOption {
 	}
 }
 
+// WithAlertCounterStore wires the optional persistence store for
+// level-triggered stats-event counter checkpoints (GH-5209). When set, the
+// engine writes through to the store every time a tracked counter (e.g.
+// circuit_breaker_trips) changes, and NewEngine rehydrates the in-memory
+// lastSeenCounters map from it — so a restart resumes from the pre-restart
+// counter value instead of re-baselining and, worse, instead of the old
+// level-triggered behavior re-firing the whole standing backlog. Omitting
+// this option (the default) keeps checkpoint state in memory only.
+func WithAlertCounterStore(store AlertCounterStore) EngineOption {
+	return func(e *Engine) {
+		e.counterStore = store
+	}
+}
+
 // NewEngine creates a new alerting engine
 func NewEngine(config *AlertConfig, opts ...EngineOption) *Engine {
 	e := &Engine{
@@ -299,6 +328,7 @@ func NewEngine(config *AlertConfig, opts ...EngineOption) *Engine {
 		dispatchCh:          make(chan dispatchJob, dispatchBacklog),
 		recentAlerts:        make(map[string]time.Time),
 		metrics:             NewAlertMetrics(),
+		lastSeenCounters:    make(map[string]int),
 	}
 
 	for _, opt := range opts {
@@ -306,6 +336,7 @@ func NewEngine(config *AlertConfig, opts ...EngineOption) *Engine {
 	}
 
 	e.rehydrateActiveAlerts()
+	e.rehydrateAlertCounters()
 
 	return e
 }
@@ -408,6 +439,83 @@ func (e *Engine) deletePersistedActiveAlert(ruleName, source string) {
 			"error", err,
 		)
 	}
+}
+
+// rehydrateAlertCounters loads persisted counter checkpoints (if a store was
+// wired via WithAlertCounterStore) into lastSeenCounters (GH-5209). Runs
+// once, at construction, so a restart resumes edge-triggering from the
+// pre-restart counter value instead of re-baselining on the first
+// post-restart stats event (which would itself be harmless — see
+// counterDelta — but would also discard a genuine in-flight increase that
+// happened to land exactly at restart). A load failure is logged and
+// treated as "nothing to rehydrate" — best-effort, off the alerting path.
+func (e *Engine) rehydrateAlertCounters() {
+	if e.counterStore == nil {
+		return
+	}
+	rows, err := e.counterStore.LoadAlertCounters()
+	if err != nil {
+		e.logger.Warn("failed to rehydrate alert counters from store", "error", err)
+		return
+	}
+	if len(rows) == 0 {
+		return
+	}
+
+	e.mu.Lock()
+	for _, row := range rows {
+		e.lastSeenCounters[activeAlertKey(row.RuleName, row.Source)] = row.LastValue
+	}
+	e.mu.Unlock()
+
+	e.logger.Info("rehydrated alert counters from store", "count", len(rows))
+}
+
+// persistAlertCounter writes a counter checkpoint through to the store, if
+// one is wired (GH-5209). Best-effort and off the alerting path: a store
+// error is logged, never returned — the in-memory checkpoint (and any alert
+// decision made from it) is unaffected.
+func (e *Engine) persistAlertCounter(ruleName, source string, value int) {
+	if e.counterStore == nil {
+		return
+	}
+	if err := e.counterStore.UpsertAlertCounter(ruleName, source, value); err != nil {
+		e.logger.Warn("failed to persist alert counter",
+			"rule", ruleName,
+			"source", source,
+			"error", err,
+		)
+	}
+}
+
+// counterDelta makes a level-triggered stats-event counter (e.g.
+// circuit_breaker_trips) edge-triggered (GH-5209): it reports increased=true
+// only when value is strictly greater than the last value this method
+// observed for (ruleName, eventSource(event)) — never merely because value
+// is nonzero. The very first observation for a given key — whether this is
+// the first stats event this process has ever seen, or the first one after
+// a restart with no persisted checkpoint — always returns increased=false;
+// it only establishes the baseline. That is deliberate: a counter that was
+// already nonzero before this code (or before this process) started is a
+// standing value, not a fresh trip, and must not be reported as one.
+//
+// The checkpoint always advances to the latest value (even when it
+// decreases, e.g. a windowed counter's window rolling over), so a later
+// increase is measured against the true last-seen value rather than a stale
+// high-water mark that would otherwise suppress it.
+func (e *Engine) counterDelta(ruleName string, event Event, value int) (increased bool) {
+	key := activeAlertKey(ruleName, eventSource(event))
+
+	e.mu.Lock()
+	last, seen := e.lastSeenCounters[key]
+	changed := !seen || value != last
+	e.lastSeenCounters[key] = value
+	e.mu.Unlock()
+
+	if changed {
+		e.persistAlertCounter(ruleName, eventSource(event), value)
+	}
+	return seen && value > last
 }
 
 // Start starts the alerting engine
@@ -1209,12 +1317,24 @@ func (e *Engine) shouldFire(rule AlertRule) bool {
 	return time.Since(lastFired) >= rule.Cooldown
 }
 
+// eventSource returns the key used to scope per-source engine state (active
+// alerts, counter checkpoints) for an event: event.Source when set, else a
+// "task:<TaskID>" fallback. Shared by createAlert (Alert.Source) and
+// counterDelta (GH-5209) so counter checkpoints line up with the alerts they
+// gate.
+func eventSource(event Event) string {
+	if event.Source != "" {
+		return event.Source
+	}
+	if event.TaskID != "" {
+		return fmt.Sprintf("task:%s", event.TaskID)
+	}
+	return ""
+}
+
 // createAlert creates an alert from a rule and event
 func (e *Engine) createAlert(rule AlertRule, event Event, message string) *Alert {
-	source := event.Source
-	if source == "" && event.TaskID != "" {
-		source = fmt.Sprintf("task:%s", event.TaskID)
-	}
+	source := eventSource(event)
 
 	return &Alert{
 		ID:          uuid.New().String(),
@@ -1465,8 +1585,16 @@ func (e *Engine) handleAutopilotMetrics(ctx context.Context, event Event) {
 				e.fireAlert(ctx, rule, alert)
 			}
 
+		// GH-5209: circuit_breaker_trips is a windowed/cumulative counter
+		// seeded periodically by the metrics hydrator, not a per-event
+		// "did it trip just now" flag — evaluating rule.Condition against
+		// "cbTrips > 0" is level-triggered and fires every cooldown period
+		// forever once the counter goes nonzero, even with zero live trips
+		// and nothing to clear. counterDelta makes this edge-triggered:
+		// alert only on an increase since the last-observed value, never on
+		// a standing nonzero count.
 		case AlertTypeCircuitBreakerTrip:
-			if cbTrips > 0 && e.shouldFire(rule) {
+			if e.counterDelta(rule.Name, event, cbTrips) && e.shouldFire(rule) {
 				alert := e.createAlert(rule, event,
 					fmt.Sprintf("Autopilot circuit breaker tripped (%d trips)", cbTrips))
 				e.fireAlert(ctx, rule, alert)

--- a/internal/memory/alert_counter_store.go
+++ b/internal/memory/alert_counter_store.go
@@ -1,0 +1,71 @@
+package memory
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// AlertCounter is a persisted checkpoint of the last-seen value of a
+// windowed/cumulative stats counter (e.g. autopilot's circuit_breaker_trips)
+// for a given (rule, source) pair. alerts.Engine uses it to make
+// level-triggered stats-event rules edge-triggered — firing only when the
+// counter increases since this checkpoint, never on a standing nonzero
+// value — and to survive restarts without replaying the pre-restart backlog
+// as fresh alerts (GH-5209).
+type AlertCounter struct {
+	RuleName  string
+	Source    string
+	LastValue int
+	UpdatedAt time.Time
+}
+
+// UpsertAlertCounter persists the last-seen counter value for (ruleName,
+// source), replacing any prior checkpoint. UpdatedAt is set to now.
+func (s *Store) UpsertAlertCounter(ruleName, source string, value int) error {
+	return s.withRetry("UpsertAlertCounter", func() error {
+		_, err := s.db.Exec(`
+			INSERT INTO alert_counters (rule_name, source, last_value, updated_at)
+			VALUES (?, ?, ?, ?)
+			ON CONFLICT(rule_name, source) DO UPDATE SET
+				last_value = excluded.last_value,
+				updated_at = excluded.updated_at
+		`, ruleName, source, value, time.Now().UTC())
+		return err
+	})
+}
+
+// GetAlertCounter returns the last persisted checkpoint for (ruleName,
+// source), or found=false if none exists yet.
+func (s *Store) GetAlertCounter(ruleName, source string) (value int, found bool, err error) {
+	row := s.db.QueryRow(`SELECT last_value FROM alert_counters WHERE rule_name = ? AND source = ?`, ruleName, source)
+	if scanErr := row.Scan(&value); scanErr != nil {
+		if errors.Is(scanErr, sql.ErrNoRows) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("GetAlertCounter: scan: %w", scanErr)
+	}
+	return value, true, nil
+}
+
+// LoadAlertCounters returns every persisted checkpoint. Called once at
+// engine construction to rehydrate the in-memory last-seen map after a
+// restart, mirroring LoadActiveAlerts.
+func (s *Store) LoadAlertCounters() ([]*AlertCounter, error) {
+	rows, err := s.db.Query(`SELECT rule_name, source, last_value, updated_at FROM alert_counters`)
+	if err != nil {
+		return nil, fmt.Errorf("LoadAlertCounters: query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []*AlertCounter
+	for rows.Next() {
+		var c AlertCounter
+		if err := rows.Scan(&c.RuleName, &c.Source, &c.LastValue, &c.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("LoadAlertCounters: scan: %w", err)
+		}
+		out = append(out, &c)
+	}
+	return out, rows.Err()
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -490,6 +490,21 @@ func (s *Store) migrate() error {
 			created_at DATETIME NOT NULL,
 			PRIMARY KEY (rule_name, source)
 		)`,
+		// GH-5209: last-seen checkpoint for level-triggered stats-event alert
+		// rules (e.g. circuit_breaker_trip) that must fire on an INCREASE of a
+		// windowed/cumulative counter, not on the counter simply being
+		// nonzero. Without a persisted checkpoint, a restart forgets the
+		// pre-restart counter value and the next stats event — which still
+		// carries the old, already-alerted-on count — reads as a fresh
+		// increase and replays the entire backlog as new alerts. Primary key
+		// mirrors active_alerts: rule name + source (alerts.activeAlertKey).
+		`CREATE TABLE IF NOT EXISTS alert_counters (
+			rule_name TEXT NOT NULL,
+			source TEXT NOT NULL,
+			last_value INTEGER NOT NULL DEFAULT 0,
+			updated_at DATETIME NOT NULL,
+			PRIMARY KEY (rule_name, source)
+		)`,
 	}
 
 	for _, migration := range migrations {

--- a/internal/pilot/pilot.go
+++ b/internal/pilot/pilot.go
@@ -1679,6 +1679,10 @@ func (p *Pilot) initAlerts(cfg *config.Config) {
 		// legacy orchestrator/webhook-mode path's alert engine construction
 		// site, same dead-plumbing gap as the two cmd/pilot sites (GH-4716).
 		alerts.WithActiveAlertStore(p.store),
+		// GH-5209: wire counter-checkpoint persistence so level-triggered
+		// stats-event rules (circuit_breaker_trip) survive a restart without
+		// replaying their pre-restart standing counter as a fresh alert.
+		alerts.WithAlertCounterStore(p.store),
 	)
 
 	// Wire alerts engine to executor via adapter


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5209.

Closes #5209

## Changes

GitHub Issue GH-5209: fix(alerts): circuit_breaker_trip re-fires critical every 30min off the windowed trips counter — no live trip, no state to clear, Slack channel spammed indefinitely

## Context

Since 2026-08-24 19:53Z the `circuit_breaker_trip` rule (severity critical, delivered to slack-engineering) fires exactly every cooldown period (30m) with no end in sight. Evidence:

- Last genuine `per-PR circuit breaker open` log line is 2026-08-17 (sdk PR#118 era) — a week before the alerts began.
- `pilot_platform_breaker_open` = 0; autopilot merged PRs straight through the alert window (PR#5208 auto-merged 20:19Z, 26 min after the first alert).
- The rule's condition is `ConsecutiveFailures: 1` ("any trip", `internal/alerts/types.go:409`) and the engine reads `circuit_breaker_trips` from event metadata (`internal/alerts/engine.go:1434`) — which the periodic window-stats seeding supplies as a cumulative/windowed counter (`window stats seeded` every 5m; lifetime `pilot_circuit_breaker_trips_total` = 85). Once the windowed count is nonzero — e.g. from 08-24's autopilot false-closure incidents — the condition is permanently true and cooldown just paces the spam.

## Implementation

Make the rule edge-triggered, not level-triggered: alert on trips-count INCREASE since the last evaluation (delta > 0), or on an explicit trip event, never on a standing nonzero counter. Persist the last-seen count across restarts so a reboot doesn't re-fire the whole backlog. Add a test: stats event with unchanged nonzero trips → no alert; increment → one alert.

## Acceptance

- [ ] Standing nonzero windowed/lifetime trips counter produces zero alerts.
- [ ] A fresh trip produces exactly one critical alert (plus cooldown suppression as today).
- [ ] Restart does not re-fire for pre-restart trips.

## Refs

- Daemon log 08-24 19:53→22:36 (7 identical criticals) · alert engine metadata path engine.go:1425-1434 · 08-24 incident chain that likely seeded the counter (#5167/#5175/#5183)