### PR TITLE
GH-5211: feat(executor): env-class failure classifier — credential/env failures exempt from identical-failure streak escalation

### DIFF
--- a/.agent/tasks/gh-5211.md
+++ b/.agent/tasks/gh-5211.md
@@ -1,0 +1,79 @@
+# GH-5211
+
+**Created:** 2026-08-25
+
+## Problem
+
+GitHub Issue GH-5211: feat(executor): env-class failure classifier — credential/env failures exempt from identical-failure streak escalation
+
+## Context
+
+Part of #5008 / TASK-485 (hosted retry path). Founder-scoped 2026-08-25.
+
+Live repro: an execution failed in ~4s with a missing ANTHROPIC_API_KEY (0 tokens, no diff, exit 1). Because the failure reproduces byte-identically on every retry, it tripped `consecutiveIdenticalFailureStreak` (threshold 2, `internal/executor/dispatcher.go:1427`) and was escalated to stalled + pilot-blocked after just two attempts — treated as a genuine code failure when it is infrastructure.
+
+No existing classifier recognizes this class: `permanentFailurePatterns` (`internal/executor/runner.go:30-47`), `rateLimitedSignatures` (`internal/executor/runner.go:201-205`), and `IsInfraNoise` (`internal/executor/runner.go:124-139`) all miss credential/env failures.
+
+## Task
+
+Do not decompose this issue — it is a single-subsystem change that must land as one PR.
+
+Add an env-class failure predicate and route matching failures around the identical-failure streak escalation:
+
+1. New signature set + predicate in `internal/executor/runner.go`, following the existing signature-set idiom there. A failure is env-class when BOTH hold:
+   - error text matches credential/env signatures: missing or invalid ANTHROPIC_API_KEY / PILOT_ENGINE_API_KEY / ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN, and backend not-available construction errors (see IsAvailable in `internal/executor/backend_anthropic.go:71` and the checks at `internal/executor/backend_anthropic.go:59-64`);
+   - structural corroboration from the execution record: zero total tokens, empty commit SHA and PR URL, duration below a short threshold (default 60s, constant).
+2. In `internal/executor/dispatcher.go`, exempt env-class failures from `priorClaimsHadIdenticalFailureStreak` the same way the existing stall/infra carve-outs work (see the carve-out block around `internal/executor/dispatcher.go:1746-1848`). Env-class failures stay ordinary failed rows: they retry via `nextRetryGeneration` with the existing repick backoff pacing. They must NOT reach `escalateIdenticalFailureStreak`.
+3. Log a distinct reason when the carve-out applies (e.g. "env-class failure — exempt from identical-failure streak") so operators can see why a task keeps retrying.
+
+Do NOT change `HasTerminalCompletion`, the repick hard cap, or any label behavior — those are out of scope (a follow-up issue covers re-arming already-stalled tasks).
+
+## Acceptance
+
+- [x] Table-driven tests: an execution failing repeatedly with an env-class signature (identical error text, 0 tokens, no deliverable, instant duration) is never marked stalled and never receives the streak escalation, regardless of attempt count.
+- [x] A genuine code failure repeating identically still stalls at the existing threshold of 2 — proven by test.
+- [x] Text match alone (with tokens > 0 or a deliverable present) does NOT classify as env-class — proven by test.
+- [x] Existing dispatcher and runner tests pass unchanged; make test and make lint green.
+
+## Refs
+
+- #5008 (design issue, founder answers + plan in comments)
+- Threshold: `internal/executor/dispatcher.go:1427` · escalation chain: `internal/executor/dispatcher.go:1994-2139`
+- Existing carve-outs to mirror: `internal/executor/dispatcher.go:1746-1848`
+
+## Implementation (2026-08-25)
+
+- `internal/executor/runner.go`: added `envClassFailureSignatures` (the four
+  credential env var names plus the "no API key configured" /
+  "requires an API key" backend-not-available phrasings from
+  `backend_anthropic.go`/`backend_openai.go`/`preflight.go`),
+  `EnvClassFailureDurationThreshold` (60s), `IsEnvClassFailureText` (text-only
+  match), and `IsEnvClassFailure` (text match AND zero tokens AND empty
+  commit SHA AND empty PR URL AND sub-threshold duration).
+- `internal/executor/dispatcher.go`: added `priorClaimWasEnvClassFailure`
+  (mirrors `priorClaimWasStalled`/`priorClaimWasInfra` — reads the latest
+  claimed execution, applies `IsEnvClassFailure` to its stored
+  error/tokens/commit/PR/duration fields). Wired directly in front of the
+  `priorClaimsHadIdenticalFailureStreak` check in `beginWithGenerationRetry`:
+  when the prior claim is env-class, the streak check is skipped entirely
+  (never calls `escalateIdenticalFailureStreak`) and falls through to the
+  ordinary backoff/hard-cap path — no separate drop counter, unlike the
+  stall/infra carve-outs, since the task explicitly asked for ordinary
+  `nextRetryGeneration` pacing rather than a bespoke cap.
+- Logs `"dispatch re-pick: prior claim was an env-class (credential/environment)
+  failure — exempt from identical-failure streak escalation"` at Info when the
+  carve-out applies (item 3).
+- Tests: `TestIsEnvClassFailureText` / `TestIsEnvClassFailure` (runner_test.go,
+  table-driven) plus two dispatcher integration tests —
+  `TestDispatcher_BeginWithGenerationRetry_EnvClassFailureExemptFromStreakEscalation`
+  (3 consecutive identical env-class failures, never stalls, no alert) and
+  `TestDispatcher_BeginWithGenerationRetry_EnvClassTextMatchAloneStillEscalates`
+  (signature text present but tokens > 0 — still escalates at threshold 2,
+  proving structural corroboration is required, not just text).
+- `go build ./...`, `go vet ./...`, `go test ./internal/executor/...`, and
+  `golangci-lint run --new-from-rev=origin/main ./...` all green. Existing
+  `TestDispatcher_BeginWithGenerationRetry_IdenticalFailureStreakStopsRetrying`
+  unmodified and still passes.
+
+## Acceptance Criteria
+

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -1418,6 +1418,34 @@ func (d *Dispatcher) priorClaimWasInfra(taskID, projectPath string) bool {
 	return exec.Status == string(ExecStatusInfra)
 }
 
+// priorClaimWasEnvClassFailure reports whether (taskID, projectPath)'s
+// currently claimed execution — the one nextRetryGeneration just examined to
+// grant this retry — failed (status "failed") with a credential/environment
+// signature corroborated by the execution's own structural fields (zero
+// tokens, no commit, no PR, sub-threshold duration — see
+// executor.IsEnvClassFailure). GH-5211: a missing ANTHROPIC_API_KEY
+// reproduces byte-identically on every retry — 0 tokens, no diff, ~4s —
+// which otherwise trips priorClaimsHadIdenticalFailureStreak after just
+// consecutiveIdenticalFailureThreshold attempts and escalates a pure
+// infrastructure problem as if the task's own code were broken. Mirrors
+// priorClaimWasStalled/priorClaimWasInfra: errors are treated as "not
+// env-class" — the caller falls through to the ordinary backoff/hard-cap
+// path, which is the safe default.
+func (d *Dispatcher) priorClaimWasEnvClassFailure(taskID, projectPath string) bool {
+	_, execID, found, err := d.store.LatestClaimGeneration(taskID, projectPath)
+	if err != nil || !found {
+		return false
+	}
+	exec, err := d.store.GetExecution(execID)
+	if err != nil || exec == nil {
+		return false
+	}
+	if exec.Status != string(ExecStatusFailed) {
+		return false
+	}
+	return IsEnvClassFailure(exec.Error, exec.TokensTotal, exec.CommitSHA, exec.PRUrl, time.Duration(exec.DurationMs)*time.Millisecond)
+}
+
 // consecutiveIdenticalFailureThreshold is N in "the last N consecutive
 // generations for the same (task_id, project_path) failed with the exact
 // same error string" (GH-4586). A single failure could be any kind of
@@ -1685,13 +1713,33 @@ func (d *Dispatcher) beginWithGenerationRetry(task *Task, initial Status) (strin
 		return "", nil
 	}
 
-	// GH-4586: independent of error class, the last consecutiveIdenticalFailureThreshold
-	// consecutive generations failing with the exact same error string means
-	// the retry changed nothing about the outcome — the task is durably
-	// stuck, not transiently unlucky. Route to the same operator-attention
-	// path rather than burning another generation reproducing it a third
-	// time.
-	if hadStreak, errStr := d.priorClaimsHadIdenticalFailureStreak(task.ID, task.ProjectPath); hadStreak {
+	// GH-5211: an env-class (credential/environment) failure is not evidence
+	// the task's own code is broken — the process never got far enough to
+	// even attempt the task. Left uncarved-out, a missing ANTHROPIC_API_KEY
+	// reproduces byte-identically on every retry and trips the SAME
+	// identical-failure-streak escalation a genuine deterministic code
+	// failure does, below, escalating pure infrastructure to stalled +
+	// pilot-blocked after just consecutiveIdenticalFailureThreshold
+	// attempts. Checked immediately before the streak check so an env-class
+	// streak never reaches escalateIdenticalFailureStreak; unlike the
+	// stall/infra carve-outs, this does not mint free retries against a
+	// separate drop counter — it simply falls through to the ordinary
+	// backoff/hard-cap path below, retrying via nextRetryGeneration with the
+	// existing repick backoff pacing.
+	if d.priorClaimWasEnvClassFailure(task.ID, task.ProjectPath) {
+		d.log.Info("dispatch re-pick: prior claim was an env-class (credential/environment) failure — exempt from identical-failure streak escalation",
+			slog.String("task_id", task.ID),
+			slog.String("project", task.ProjectPath),
+			slog.Int("generation", gen),
+		)
+	} else if hadStreak, errStr := d.priorClaimsHadIdenticalFailureStreak(task.ID, task.ProjectPath); hadStreak {
+		// GH-4586: independent of error class, the last
+		// consecutiveIdenticalFailureThreshold consecutive generations
+		// failing with the exact same error string means the retry changed
+		// nothing about the outcome — the task is durably stuck, not
+		// transiently unlucky. Route to the same operator-attention path
+		// rather than burning another generation reproducing it a third
+		// time.
 		d.escalateIdenticalFailureStreak(task, gen, errStr)
 		return "", nil
 	}

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -4713,6 +4713,171 @@ func TestDispatcher_BeginWithGenerationRetry_IdenticalFailureStreakStopsRetrying
 	}
 }
 
+// TestDispatcher_BeginWithGenerationRetry_EnvClassFailureExemptFromStreakEscalation
+// is the GH-5211 acceptance test: an execution that fails repeatedly with an
+// env-class (credential/environment) signature — identical error text, 0
+// tokens, no deliverable, near-instant duration — must never be marked
+// stalled and must never trip the identical-failure streak escalation,
+// regardless of how many consecutive attempts reproduce it. It retries
+// ordinarily via nextRetryGeneration instead. Live repro: a missing
+// ANTHROPIC_API_KEY failed in ~4s with 0 tokens on every retry and was
+// wrongly escalated to stalled + pilot-blocked after just
+// consecutiveIdenticalFailureThreshold (2) attempts.
+func TestDispatcher_BeginWithGenerationRetry_EnvClassFailureExemptFromStreakEscalation(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GH-5211-ENV", ProjectPath: "/project-5211-env", Title: "Env-class exempt task"}
+	runner := NewRunner()
+	processor := &fakeAlertProcessor{}
+	runner.SetAlertProcessor(processor)
+	dispatcher := NewDispatcher(store, runner, nil)
+	lifecycle := NewExecutionLifecycle(store)
+
+	const envErr = "no API key configured for anthropic-api backend"
+
+	// markEnvClassFailed writes a failed execution row that is BOTH a
+	// text-signature match AND structurally corroborated (0 tokens, no
+	// commit, no PR, well under EnvClassFailureDurationThreshold).
+	markEnvClassFailed := func(execID string) {
+		if err := store.UpdateExecutionStatus(execID, "failed", envErr); err != nil {
+			t.Fatalf("setup: failed to mark %s as failed: %v", execID, err)
+		}
+		if err := store.UpdateExecutionResult(execID, "", "", 4000); err != nil {
+			t.Fatalf("setup: failed to set duration for %s: %v", execID, err)
+		}
+		if err := store.SaveExecutionMetrics(&memory.ExecutionMetrics{ExecutionID: execID, TokensTotal: 0}); err != nil {
+			t.Fatalf("setup: failed to zero tokens for %s: %v", execID, err)
+		}
+	}
+
+	// Generation 0 and 1: identical env-class failure, twice in a row —
+	// exactly the shape that trips priorClaimsHadIdenticalFailureStreak for
+	// an ordinary code failure at consecutiveIdenticalFailureThreshold.
+	gen0ExecID, err := lifecycle.Begin(task, ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("setup Begin gen0: %v", err)
+	}
+	markEnvClassFailed(gen0ExecID)
+
+	gen1ExecID, err := lifecycle.Begin(task, ExecStatusRunning, 1)
+	if err != nil {
+		t.Fatalf("setup Begin gen1: %v", err)
+	}
+	markEnvClassFailed(gen1ExecID)
+
+	freshTask := &Task{ID: task.ID, ProjectPath: task.ProjectPath, Title: task.Title}
+	retryExecID, err := dispatcher.beginWithGenerationRetry(freshTask, ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("beginWithGenerationRetry (after 2 identical env-class failures): %v", err)
+	}
+	if retryExecID == "" {
+		t.Fatal("expected a fresh generation to be granted — env-class failures must be exempt from the identical-failure streak escalation")
+	}
+
+	gen1Exec, err := store.GetExecution(gen1ExecID)
+	if err != nil {
+		t.Fatalf("GetExecution gen1: %v", err)
+	}
+	if gen1Exec.Status != "failed" {
+		t.Errorf("expected generation 1's execution to stay 'failed' (not stalled), got status=%q", gen1Exec.Status)
+	}
+	if len(processor.events) != 0 {
+		t.Fatalf("expected no alert events for an env-class streak, got %d: %+v", len(processor.events), processor.events)
+	}
+
+	// Push a THIRD consecutive identical env-class failure — "regardless of
+	// attempt count" means the exemption must keep holding, not just for the
+	// first repick past the threshold. Clear the ordinary repick backoff
+	// window first so this assertion isolates the streak-exemption behavior
+	// from the (separately tested) backoff pacing itself.
+	markEnvClassFailed(retryExecID)
+	if err := dispatcher.ClearRepickBackoffState(repickBackoffKey(task.ProjectPath, task.ID)); err != nil {
+		t.Fatalf("setup: failed to clear repick backoff state: %v", err)
+	}
+
+	retryExecID2, err := dispatcher.beginWithGenerationRetry(freshTask, ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("beginWithGenerationRetry (after 3 identical env-class failures): %v", err)
+	}
+	if retryExecID2 == "" {
+		t.Fatal("expected another fresh generation to be granted on a third consecutive env-class failure")
+	}
+	if genCheck, _, found, err := store.LatestClaimGeneration(task.ID, task.ProjectPath); err != nil {
+		t.Fatalf("LatestClaimGeneration: %v", err)
+	} else if !found || genCheck != 3 {
+		t.Errorf("expected generation 3 to be claimed, found=%v generation=%d", found, genCheck)
+	}
+	if len(processor.events) != 0 {
+		t.Fatalf("expected still no alert events after a third env-class failure, got %d: %+v", len(processor.events), processor.events)
+	}
+}
+
+// TestDispatcher_BeginWithGenerationRetry_EnvClassTextMatchAloneStillEscalates
+// is the GH-5211 negative-case acceptance test: matching an env-class
+// signature in the error text is NOT sufficient on its own. When the
+// execution record shows tokens were produced (structural corroboration
+// fails), the failure is an ordinary one and the identical-failure streak
+// escalation must still fire at the existing threshold — proving the
+// structural check, not just the text match, gates the carve-out.
+func TestDispatcher_BeginWithGenerationRetry_EnvClassTextMatchAloneStillEscalates(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GH-5211-TEXT-ONLY", ProjectPath: "/project-5211-text-only", Title: "Env-class text-only task"}
+	runner := NewRunner()
+	processor := &fakeAlertProcessor{}
+	runner.SetAlertProcessor(processor)
+	dispatcher := NewDispatcher(store, runner, nil)
+	lifecycle := NewExecutionLifecycle(store)
+
+	// Error text matches an env-class signature, but tokens > 0 — a genuine
+	// code failure whose output happened to mention the env var name (e.g.
+	// while inspecting config), not a credential/env failure.
+	const textOnlyErr = "quality gate failed: config test references ANTHROPIC_API_KEY incorrectly"
+
+	markTextOnlyFailed := func(execID string) {
+		if err := store.UpdateExecutionStatus(execID, "failed", textOnlyErr); err != nil {
+			t.Fatalf("setup: failed to mark %s as failed: %v", execID, err)
+		}
+		if err := store.SaveExecutionMetrics(&memory.ExecutionMetrics{ExecutionID: execID, TokensTotal: 15000}); err != nil {
+			t.Fatalf("setup: failed to set tokens for %s: %v", execID, err)
+		}
+	}
+
+	gen0ExecID, err := lifecycle.Begin(task, ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("setup Begin gen0: %v", err)
+	}
+	markTextOnlyFailed(gen0ExecID)
+
+	gen1ExecID, err := lifecycle.Begin(task, ExecStatusRunning, 1)
+	if err != nil {
+		t.Fatalf("setup Begin gen1: %v", err)
+	}
+	markTextOnlyFailed(gen1ExecID)
+
+	freshTask := &Task{ID: task.ID, ProjectPath: task.ProjectPath, Title: task.Title}
+	retryExecID, err := dispatcher.beginWithGenerationRetry(freshTask, ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("beginWithGenerationRetry: %v", err)
+	}
+	if retryExecID != "" {
+		t.Fatalf("expected the identical-failure streak to still stop retrying (text match alone is not env-class), got fresh execID %q", retryExecID)
+	}
+
+	gen1Exec, err := store.GetExecution(gen1ExecID)
+	if err != nil {
+		t.Fatalf("GetExecution gen1: %v", err)
+	}
+	if gen1Exec.Status != "stalled" {
+		t.Errorf("expected generation 1's execution to be escalated to stalled, got status=%q", gen1Exec.Status)
+	}
+	if len(processor.events) != 1 {
+		t.Fatalf("expected exactly 1 alert event for the ordinary identical-failure streak, got %d: %+v", len(processor.events), processor.events)
+	}
+}
+
 // TestRepickBackoffKey_FormatMatchesCmdPilotPackage is the GH-4394 subtask 4
 // counterpart to cmd/pilot's TestRepickBackoffKey_FormatMatchesDispatcherPackage.
 // cmd/pilot cannot import internal/executor's unexported repickBackoffKey (and

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -87,6 +87,71 @@ func IsDeterministicFailure(errStr string) bool {
 	return strings.HasPrefix(strings.TrimSpace(errStr), deterministicFailurePrefix)
 }
 
+// envClassFailureSignatures are substrings in error messages that indicate
+// the executor process itself could not authenticate to its model backend —
+// a missing or invalid credential/env var, or a backend construction
+// failure because none of the recognized credential env vars were set (see
+// AnthropicBackend.IsAvailable, backend_anthropic.go:71, and the env var
+// priority list at backend_anthropic.go:59-64) — rather than a genuine code
+// failure. GH-5211: a missing ANTHROPIC_API_KEY reproduces byte-identically
+// on every retry (same error text, 0 tokens, no diff, ~4s), which otherwise
+// trips the dispatcher's identical-failure streak escalation
+// (dispatcher.go priorClaimsHadIdenticalFailureStreak) after just
+// consecutiveIdenticalFailureThreshold attempts, treating pure
+// infrastructure as if the task's own code were broken.
+var envClassFailureSignatures = []string{
+	"ANTHROPIC_API_KEY",
+	"PILOT_ENGINE_API_KEY",
+	"ANTHROPIC_AUTH_TOKEN",
+	"CLAUDE_CODE_OAUTH_TOKEN",
+	// Backend-not-available construction errors — backend_anthropic.go:547
+	// ("no API key configured for anthropic-api backend"), the analogous
+	// backend_openai.go message, and preflight.go's checkOpenAIAPIKey
+	// ("<type> backend requires an API key: ...") all phrase the failure
+	// this way regardless of which specific env var was missing.
+	"no API key configured",
+	"requires an API key",
+}
+
+// EnvClassFailureDurationThreshold bounds how short an execution's duration
+// must be for a text-matching failure to additionally qualify as env-class
+// (IsEnvClassFailure). A genuine code failure that happens to mention one of
+// these env var names (e.g. quoting a diff or config file) still takes real
+// wall-clock time and produces tokens/output; a credential/env failure fails
+// at process-start, before any model call completes. GH-5211.
+const EnvClassFailureDurationThreshold = 60 * time.Second
+
+// IsEnvClassFailureText reports whether errStr matches a credential/env
+// signature. Text alone is NOT sufficient to classify a failure as
+// env-class — see IsEnvClassFailure, which additionally requires structural
+// corroboration from the execution record. GH-5211.
+func IsEnvClassFailureText(errStr string) bool {
+	if errStr == "" {
+		return false
+	}
+	return containsAny(errStr, envClassFailureSignatures)
+}
+
+// IsEnvClassFailure reports whether a failed execution represents a
+// credential/environment failure — infrastructure the executor could not
+// even start against, not a genuine code failure — and should therefore be
+// exempt from the dispatcher's identical-failure streak escalation. GH-5211.
+// Both text and structural corroboration must hold:
+//   - errStr matches a credential/env signature (IsEnvClassFailureText)
+//   - the execution produced zero total tokens, no commit SHA, no PR URL,
+//     and finished inside EnvClassFailureDurationThreshold
+//
+// The structural check guards against a genuine code failure that merely
+// mentions one of these env var names (e.g. in output or a diff) — which
+// would still have tokens and/or a deliverable — from being waved through
+// as infrastructure.
+func IsEnvClassFailure(errStr string, tokensTotal int64, commitSHA, prURL string, duration time.Duration) bool {
+	if !IsEnvClassFailureText(errStr) {
+		return false
+	}
+	return tokensTotal == 0 && commitSHA == "" && prURL == "" && duration < EnvClassFailureDurationThreshold
+}
+
 // reapErrorSignatures are substrings written by the dispatcher's stale-task
 // recovery (dispatcher.go recoverStaleRunningTasks / recoverStaleQueuedTasks)
 // when a daemon restart orphans a running or queued execution row. These

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -3935,6 +3935,77 @@ func TestIsInfraNoise(t *testing.T) {
 	}
 }
 
+// TestIsEnvClassFailureText verifies the text-only signature match used by
+// IsEnvClassFailure. Text alone is intentionally permissive — structural
+// corroboration (tokens/commit/PR/duration) is layered on separately by
+// IsEnvClassFailure, exercised in TestIsEnvClassFailure below. GH-5211.
+func TestIsEnvClassFailureText(t *testing.T) {
+	tests := []struct {
+		name string
+		err  string
+		want bool
+	}{
+		{"empty string", "", false},
+		{"missing ANTHROPIC_API_KEY", "no API key configured for anthropic-api backend", true},
+		{"missing PILOT_ENGINE_API_KEY mentioned", "PILOT_ENGINE_API_KEY not set", true},
+		{"missing ANTHROPIC_AUTH_TOKEN mentioned", "invalid ANTHROPIC_AUTH_TOKEN", true},
+		{"missing CLAUDE_CODE_OAUTH_TOKEN mentioned", "CLAUDE_CODE_OAUTH_TOKEN expired", true},
+		{"preflight requires-an-api-key phrasing", "anthropic-api backend requires an API key: set OPENAI_API_KEY (or configure executor.openai.api_key)", true},
+		{"case-insensitive match", "no api key configured for anthropic-api backend", true},
+		{"genuine code failure", "quality gate failed: 3 lint errors", false},
+		{"genuine planning failure", "unknown: exit status 1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsEnvClassFailureText(tt.err); got != tt.want {
+				t.Errorf("IsEnvClassFailureText(%q) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsEnvClassFailure is the GH-5211 acceptance test: a credential/env
+// signature is env-class ONLY when corroborated by the execution's own
+// structural fields (zero tokens, no commit, no PR, sub-threshold
+// duration). Text match alone — with tokens produced or a deliverable
+// present — must NOT classify as env-class, otherwise a genuine code
+// failure that happens to quote one of these env var names (e.g. in a diff)
+// would be waved through as infrastructure.
+func TestIsEnvClassFailure(t *testing.T) {
+	const envErr = "no API key configured for anthropic-api backend"
+
+	tests := []struct {
+		name        string
+		errStr      string
+		tokensTotal int64
+		commitSHA   string
+		prURL       string
+		duration    time.Duration
+		want        bool
+	}{
+		{"env-class: all structural signals corroborate", envErr, 0, "", "", 4 * time.Second, true},
+		{"env-class: duration just under threshold", envErr, 0, "", "", EnvClassFailureDurationThreshold - time.Second, true},
+		{"not env-class: duration at threshold", envErr, 0, "", "", EnvClassFailureDurationThreshold, false},
+		{"not env-class: duration over threshold", envErr, 0, "", "", 2 * time.Minute, false},
+		{"not env-class: tokens produced despite matching text", envErr, 1200, "", "", 4 * time.Second, false},
+		{"not env-class: commit SHA present despite matching text", envErr, 0, "abc1234", "", 4 * time.Second, false},
+		{"not env-class: PR URL present despite matching text", envErr, 0, "", "https://github.com/qf-studio/pilot/pull/1", 4 * time.Second, false},
+		{"not env-class: text does not match at all", "quality gate failed: 3 lint errors", 0, "", "", 4 * time.Second, false},
+		{"not env-class: empty error text", "", 0, "", "", 4 * time.Second, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsEnvClassFailure(tt.errStr, tt.tokensTotal, tt.commitSHA, tt.prURL, tt.duration)
+			if got != tt.want {
+				t.Errorf("IsEnvClassFailure(%q, tokens=%d, sha=%q, pr=%q, dur=%v) = %v, want %v",
+					tt.errStr, tt.tokensTotal, tt.commitSHA, tt.prURL, tt.duration, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestRunnerFallbackModelName verifies that the telemetry fallback model name
 // reflects the configured backend, not a hardcoded default. GH-2428.
 func TestRunnerFallbackModelName(t *testing.T) {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5211.

Closes #5211

## Changes

GitHub Issue GH-5211: feat(executor): env-class failure classifier — credential/env failures exempt from identical-failure streak escalation

## Context

Part of #5008 / TASK-485 (hosted retry path). Founder-scoped 2026-08-25.

Live repro: an execution failed in ~4s with a missing ANTHROPIC_API_KEY (0 tokens, no diff, exit 1). Because the failure reproduces byte-identically on every retry, it tripped `consecutiveIdenticalFailureStreak` (threshold 2, `internal/executor/dispatcher.go:1427`) and was escalated to stalled + pilot-blocked after just two attempts — treated as a genuine code failure when it is infrastructure.

No existing classifier recognizes this class: `permanentFailurePatterns` (`internal/executor/runner.go:30-47`), `rateLimitedSignatures` (`internal/executor/runner.go:201-205`), and `IsInfraNoise` (`internal/executor/runner.go:124-139`) all miss credential/env failures.

## Task

Do not decompose this issue — it is a single-subsystem change that must land as one PR.

Add an env-class failure predicate and route matching failures around the identical-failure streak escalation:

1. New signature set + predicate in `internal/executor/runner.go`, following the existing signature-set idiom there. A failure is env-class when BOTH hold:
   - error text matches credential/env signatures: missing or invalid ANTHROPIC_API_KEY / PILOT_ENGINE_API_KEY / ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN, and backend not-available construction errors (see IsAvailable in `internal/executor/backend_anthropic.go:71` and the checks at `internal/executor/backend_anthropic.go:59-64`);
   - structural corroboration from the execution record: zero total tokens, empty commit SHA and PR URL, duration below a short threshold (default 60s, constant).
2. In `internal/executor/dispatcher.go`, exempt env-class failures from `priorClaimsHadIdenticalFailureStreak` the same way the existing stall/infra carve-outs work (see the carve-out block around `internal/executor/dispatcher.go:1746-1848`). Env-class failures stay ordinary failed rows: they retry via `nextRetryGeneration` with the existing repick backoff pacing. They must NOT reach `escalateIdenticalFailureStreak`.
3. Log a distinct reason when the carve-out applies (e.g. "env-class failure — exempt from identical-failure streak") so operators can see why a task keeps retrying.

Do NOT change `HasTerminalCompletion`, the repick hard cap, or any label behavior — those are out of scope (a follow-up issue covers re-arming already-stalled tasks).

## Acceptance

- [ ] Table-driven tests: an execution failing repeatedly with an env-class signature (identical error text, 0 tokens, no deliverable, instant duration) is never marked stalled and never receives the streak escalation, regardless of attempt count.
- [ ] A genuine code failure repeating identically still stalls at the existing threshold of 2 — proven by test.
- [ ] Text match alone (with tokens > 0 or a deliverable present) does NOT classify as env-class — proven by test.
- [ ] Existing dispatcher and runner tests pass unchanged; make test and make lint green.

## Refs

- #5008 (design issue, founder answers + plan in comments)
- Threshold: `internal/executor/dispatcher.go:1427` · escalation chain: `internal/executor/dispatcher.go:1994-2139`
- Existing carve-outs to mirror: `internal/executor/dispatcher.go:1746-1848`