### PR TITLE
GH-5212: feat(daemon): re-arm stalled pilot-blocked tasks on label-cycle/reopen evidence — GH-5139 pattern extended to stalled rows

### DIFF
--- a/.agent/tasks/gh-5212.md
+++ b/.agent/tasks/gh-5212.md
@@ -1,0 +1,41 @@
+# GH-5212
+
+**Created:** 2026-08-25
+
+## Problem
+
+GitHub Issue GH-5212: feat(daemon): re-arm stalled pilot-blocked tasks on label-cycle/reopen evidence — GH-5139 pattern extended to stalled rows
+
+## Context
+
+Part of #5008 / TASK-485 (hosted retry path). Founder-scoped 2026-08-25. Sibling of #5211 (env-class classifier); no hard dependency, but sequenced after it.
+
+When the identical-failure streak escalates a task, `escalateStalledTask` (`internal/executor/dispatcher.go:2016`) marks the execution row stalled and `surfaceStalledIssue` (`internal/executor/dispatcher.go:2094`) applies the pilot-blocked label. The poller then excludes the issue from its candidate list unconditionally and silently (doc comment at `internal/executor/dispatcher.go:2086-2089`). Nothing ever re-arms it: GH-5139's re-arm machinery (`cmd/pilot/rearm_canceled.go`) probes GitHub for post-cancel operator evidence but covers ONLY canceled rows — `LatestCanceledExecution` (`internal/memory/store.go:1326-1342`) is a hard status filter. A hosted tenant whose task stalled on a since-fixed cause has no product lever.
+
+## Task
+
+Do not decompose this issue — it is a single-subsystem change that must land as one PR.
+
+Extend the GH-5139 re-arm pattern to stalled rows, so a trigger-label re-add (or issue reopen) after the stall re-arms the task through the ordinary retry path:
+
+1. In `internal/memory/store.go`: add LatestStalledExecution and ReclassifyStalledForRearm (demote status stalled to failed, reason recorded in the error column), mirroring the canceled pair at `internal/memory/store.go:1326-1366`. Follow the GH-4347 lesson: guard against the ordering trap where a fresh queued row sits alongside the old stalled row.
+2. New file in cmd/pilot (name it rearm_stalled.go) mirroring `cmd/pilot/rearm_canceled.go`: probe GitHub issue events for a labeled-with-trigger-label or reopened event timestamped AFTER the stalled row's timestamp (reuse the latestRearmEvent helper shape at `cmd/pilot/rearm_canceled.go:101-121`). On evidence: call ReclassifyStalledForRearm AND remove the pilot-blocked label from the issue — both must happen; a surviving pilot-blocked label keeps the poller excluding the issue forever regardless of row state.
+3. Wire next to tryRearmCanceled in the admission path (`cmd/pilot/main.go:4262-4285`), throttled by the same repickBackoff window so it never becomes a hot per-tick GitHub API loop. IMPORTANT placement note: pilot-blocked exclusion removes the issue from the poller candidate list BEFORE admission runs — verify where tryRearmCanceled gets its chance to run and hook the stalled probe so it actually sees relabeled issues; if the existing hook point never sees pilot-blocked issues, probe from the site that performs the candidate exclusion instead.
+4. After a successful re-arm, the next poll must dispatch the task at generation+1 via the existing `nextRetryGeneration` path — no new claim mechanics.
+
+## Acceptance
+
+- [ ] Test against real SQLite: stalled row + synthetic post-stall trigger-label event → row demoted to failed, pilot-blocked removal invoked, and a subsequent admission check dispatches at generation+1.
+- [ ] Test: stalled row with NO post-stall evidence → not re-armed, no GitHub API hot loop (backoff respected).
+- [ ] Test: reopen event after stall also counts as evidence.
+- [ ] Test: fresh queued row alongside old stalled row does not confuse the probe (GH-4347 ordering trap).
+- [ ] Existing canceled re-arm behavior unchanged; make test and make lint green.
+
+## Refs
+
+- #5008 (design issue) · #5211 (sibling leg)
+- GH-5139 template: `cmd/pilot/rearm_canceled.go:38-92` · `internal/memory/store.go:1344-1366`
+- Escalation chain: `internal/executor/dispatcher.go:1994-2139`
+
+## Acceptance Criteria
+

--- a/cmd/pilot/poller_github.go
+++ b/cmd/pilot/poller_github.go
@@ -497,18 +497,26 @@ func startGithubSDKPollerForRepo(ctx context.Context, deps *PollerDeps, log *slo
 	// GH-4347: terminalCompletionChecker wraps deps.Store rather than passing
 	// it directly — see its doc comment for why the raw Store.HasCompletedExecution
 	// method under-recognizes a no_op outcome as "done".
+	//
+	// execChecker is also kept as a local (not just handed to pollerDeps) so
+	// GH-5212's stalled re-arm sweep can be started against the same
+	// store/ghClient/repo/triggerLabel wiring below — that sweep runs
+	// outside the SDK poller's own admission path (see runStalledRearmSweepLoop's
+	// doc comment for why), so it can't simply reuse pollerDeps.ExecutionChecker.
+	var execChecker terminalCompletionChecker
 	if deps.Store != nil {
 		pollerDeps.TaskChecker = storeTaskChecker{store: deps.Store, projectPath: target.projectPath}
 		// GH-5139: ghClient/repoOwner/repoName/triggerLabel let
 		// terminalCompletionChecker probe GitHub for a genuine post-cancel
 		// relabel/reopen and re-arm the task-id — see its doc comment.
-		pollerDeps.ExecutionChecker = terminalCompletionChecker{
+		execChecker = terminalCompletionChecker{
 			store:        deps.Store,
 			ghClient:     newGitHubClient(deps.Cfg),
 			repoOwner:    repoOwner,
 			repoName:     repoName,
 			triggerLabel: pilotLabel,
 		}
+		pollerDeps.ExecutionChecker = execChecker
 	}
 
 	// GH-2802: pre-flight judge (CC subprocess, no API key) — mirrors the
@@ -663,5 +671,18 @@ func startGithubSDKPollerForRepo(ctx context.Context, deps *PollerDeps, log *slo
 			)
 		}
 	})
+
+	// GH-5212: stalled-row re-arm sweep, run alongside (not inside) the SDK
+	// poller's own admission loop — see runStalledRearmSweepLoop's doc
+	// comment for why a pilot-blocked issue can never reach that loop's
+	// ExecutionChecker hook directly. Same cadence as the poller itself so a
+	// relabel/reopen is noticed on a comparable timescale, throttled
+	// per-issue via the shared repickBackoff window so it never becomes a
+	// hot per-tick GitHub API loop.
+	if execChecker.ghClient != nil {
+		deps.SafeAdapterGo(ctx, "github:"+target.repoFullName+":stalled-rearm", func() {
+			runStalledRearmSweepLoop(ctx, execChecker, target.projectPath, interval, repoLog)
+		})
+	}
 	return true
 }

--- a/cmd/pilot/rearm_canceled_test.go
+++ b/cmd/pilot/rearm_canceled_test.go
@@ -26,6 +26,10 @@ func newRearmTestServer(t *testing.T, issue *github.Issue, events []*github.Issu
 			_ = json.NewEncoder(w).Encode(issue)
 		case r.URL.Path == "/repos/owner/repo/issues/5139/events" && r.Method == http.MethodGet:
 			_ = json.NewEncoder(w).Encode(events)
+		case r.URL.Path == "/repos/owner/repo/issues/5139/labels/"+github.LabelBlocked && r.Method == http.MethodDelete:
+			// Only exercised by GH-5212 stalled-rearm tests (tryRearmCanceled
+			// never removes labels) — kept here since this fixture is shared.
+			w.WriteHeader(http.StatusOK)
 		default:
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)

--- a/cmd/pilot/rearm_stalled.go
+++ b/cmd/pilot/rearm_stalled.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/logging"
+)
+
+// stalledRearmSweepTimeout bounds one sweepStalledRearm pass: the ListIssues
+// call plus however many tryRearmStalled probes (each individually bounded
+// by rearmProbeTimeout) it triggers within that pass.
+const stalledRearmSweepTimeout = 60 * time.Second
+
+// tryRearmStalled is GH-5212's re-arm probe for stalled rows — GH-5139's
+// operator-cancel re-arm pattern extended to the escalate-and-hold path
+// (repick hard cap / identical-failure streak, escalateStalledTask in
+// internal/executor/dispatcher.go). A trigger-label re-add or issue reopen
+// timestamped after the stall re-admits the task_id through the ordinary
+// retry path — before this, nothing ever checked for that, so a hosted
+// tenant whose task stalled on a since-fixed cause had no product lever.
+//
+// Deliberately NOT reachable via terminalCompletionChecker.HasCompletedExecution
+// (GH-5139's own call site, next to tryRearmCanceled) for two independent
+// reasons:
+//  1. executor.HasTerminalCompletion never counts a 'stalled' row as done (only
+//     'canceled' and error-free 'no_op' are), so HasCompletedExecution's own
+//     `if err != nil || !done { return done, err }` guard returns before a
+//     stalled-row branch could ever run.
+//  2. surfaceStalledIssue (internal/executor/dispatcher.go) unconditionally
+//     labels the issue pilot-blocked, and the vendored SDK poller's candidate
+//     loop (studio-sdk/sdk/integrations/github/poller.go: checkForNewIssues /
+//     findOldestUnprocessedIssue) excludes any pilot-blocked issue via
+//     HasLabel(issue, LabelBlocked) BEFORE ever calling the ExecutionChecker —
+//     there is no host hook point between the two to intercept.
+//
+// So this is driven instead by sweepStalledRearm below, a host-side scan
+// run outside the SDK's per-tick admission chokepoint. tryRearmStalled itself
+// still mirrors tryRearmCanceled (cmd/pilot/rearm_canceled.go) almost exactly,
+// down to reusing latestRearmEvent unchanged — only the store pair and the
+// extra pilot-blocked label removal differ.
+func (c terminalCompletionChecker) tryRearmStalled(taskID, projectPath, backoffKey string) (bool, error) {
+	exec, found, err := c.store.LatestStalledExecution(taskID, projectPath)
+	if err != nil {
+		return false, fmt.Errorf("looking up stalled execution: %w", err)
+	}
+	if !found || exec.CompletedAt == nil {
+		// No stalled row (this task_id's terminal-ish state came from
+		// something else entirely) or a stalled row somehow missing its
+		// stall timestamp — either way, nothing to evaluate re-arm evidence
+		// against.
+		return false, nil
+	}
+
+	var issueNum int
+	if _, scanErr := fmt.Sscanf(taskID, "GH-%d", &issueNum); scanErr != nil || issueNum <= 0 {
+		return false, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), rearmProbeTimeout)
+	defer cancel()
+
+	issue, err := c.ghClient.GetIssue(ctx, c.repoOwner, c.repoName, issueNum)
+	if err != nil {
+		return false, fmt.Errorf("fetching issue #%d: %w", issueNum, err)
+	}
+	if issue.State != "open" || !github.HasLabel(issue, c.triggerLabel) {
+		// Re-arm requires BOTH open and (still/again) carrying the trigger
+		// label right now — mirrors tryRearmCanceled's same requirement.
+		return false, nil
+	}
+
+	events, err := c.ghClient.ListIssueEvents(ctx, c.repoOwner, c.repoName, issueNum)
+	if err != nil {
+		return false, fmt.Errorf("listing issue #%d events: %w", issueNum, err)
+	}
+	rearmEvent := latestRearmEvent(events, c.triggerLabel, *exec.CompletedAt)
+	if rearmEvent == nil {
+		// Open + labeled, but nothing in the timeline shows that state was
+		// reached AFTER the stall — not a deliberate re-arm gesture.
+		return false, nil
+	}
+
+	reason := fmt.Sprintf("GH-5212: re-armed by issue #%d %s event at %s (stalled at %s)",
+		issueNum, rearmEvent.Event, rearmEvent.CreatedAt.Format(time.RFC3339), exec.CompletedAt.Format(time.RFC3339))
+	if err := c.store.ReclassifyStalledForRearm(taskID, projectPath, reason); err != nil {
+		return false, fmt.Errorf("reclassifying stalled row: %w", err)
+	}
+
+	// Both must happen (task spec): a surviving pilot-blocked label keeps the
+	// SDK poller's candidate loop excluding the issue forever regardless of
+	// the store-side row status. Best-effort: the store demotion above is
+	// already durable, so a label-removal failure is logged, not fatal — the
+	// next sweep pass will simply retry the label removal (LatestStalledExecution
+	// now finds nothing, since the row is 'failed' not 'stalled', so this
+	// specific retry path only applies while the row is still stalled; a
+	// failure here after a successful reclassify is the one case where the
+	// label can persist stale, same class of best-effort gap surfaceStalledIssue's
+	// own labeling already accepts).
+	if err := c.ghClient.RemoveLabel(ctx, c.repoOwner, c.repoName, issueNum, github.LabelBlocked); err != nil {
+		logging.WithComponent("dispatch").Warn("GH-5212: stalled task reclassified but pilot-blocked label removal failed — issue may stay excluded from poller candidacy until manually cleared",
+			slog.String("task_id", taskID), slog.Int("issue", issueNum), slog.Any("error", err))
+	}
+
+	repickBackoff.recordSuccess(backoffKey)
+	logging.WithComponent("dispatch").Info("GH-5212: stalled task re-armed via GitHub reopen/relabel",
+		slog.String("task_id", taskID), slog.Int("issue", issueNum), slog.String("event", rearmEvent.Event))
+	return true, nil
+}
+
+// sweepStalledRearm scans repoOwner/repoName for open issues currently
+// carrying pilot-blocked and, for each one backed by a stalled execution row
+// under projectPath, probes for post-stall re-arm evidence via
+// tryRearmStalled. See tryRearmStalled's doc comment for why this scan
+// exists instead of a hook inside the SDK's admission chokepoint.
+//
+// Per-issue throttling reuses the exact repickBackoff window/key
+// (repickBackoffKey(projectPath, taskID)) GH-4469's HasCompletedExecution
+// gate and GH-5139's tryRearmCanceled already use — a pilot-blocked issue
+// with no re-arm evidence yet must not pay for a GetIssue+ListIssueEvents
+// call on every sweep pass. gateStatus is consulted before ListIssues even
+// runs is not possible (ListIssues has to run first to discover which
+// issues are pilot-blocked at all), but every individual probe past that
+// point is gated, so a quiet backlog of blocked issues costs one list call
+// per sweep interval and nothing more.
+func (c terminalCompletionChecker) sweepStalledRearm(ctx context.Context, projectPath string) {
+	if c.ghClient == nil {
+		return
+	}
+
+	issues, err := c.ghClient.ListIssues(ctx, c.repoOwner, c.repoName, &github.ListIssuesOptions{
+		Labels: []string{github.LabelBlocked},
+		State:  github.StateOpen,
+	})
+	if err != nil {
+		logging.WithComponent("dispatch").Warn("GH-5212: stalled re-arm sweep failed to list pilot-blocked issues",
+			slog.String("repo", c.repoOwner+"/"+c.repoName), slog.Any("error", err))
+		return
+	}
+
+	for _, issue := range issues {
+		taskID := fmt.Sprintf("GH-%d", issue.Number)
+		backoffKey := repickBackoffKey(projectPath, taskID)
+
+		if gated, _ := repickBackoff.gateStatus(backoffKey); gated {
+			continue
+		}
+
+		_, found, err := c.store.LatestStalledExecution(taskID, projectPath)
+		if err != nil {
+			logging.WithComponent("dispatch").Warn("GH-5212: stalled re-arm sweep: store lookup failed",
+				slog.String("task_id", taskID), slog.Any("error", err))
+			continue
+		}
+		if !found {
+			// pilot-blocked from a different cause (e.g. GH-2402 deterministic
+			// title-guard escalation) or belongs to another project sharing
+			// this repo — nothing for this probe to evaluate.
+			continue
+		}
+
+		rearmed, err := c.tryRearmStalled(taskID, projectPath, backoffKey)
+		if err != nil {
+			logging.WithComponent("dispatch").Warn("GH-5212 stalled re-arm probe failed",
+				slog.String("task_id", taskID), slog.Any("error", err))
+			repickBackoff.recordClaimLostDrop(backoffKey)
+			continue
+		}
+		if !rearmed {
+			repickBackoff.recordClaimLostDrop(backoffKey)
+		}
+	}
+}
+
+// runStalledRearmSweepLoop drives sweepStalledRearm on the same cadence as
+// the SDK poller's own candidate polling (interval) — frequent enough that a
+// relabel/reopen is noticed promptly, but never tighter, so this never
+// becomes a hot loop independent of the poller it rides alongside. Runs one
+// immediate pass before entering the ticker, matching github.Cleaner.Start's
+// "run initial pass, then tick" shape.
+func runStalledRearmSweepLoop(ctx context.Context, checker terminalCompletionChecker, projectPath string, interval time.Duration, log *slog.Logger) {
+	sweep := func() {
+		sweepCtx, cancel := context.WithTimeout(ctx, stalledRearmSweepTimeout)
+		defer cancel()
+		checker.sweepStalledRearm(sweepCtx, projectPath)
+	}
+
+	sweep()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			log.Debug("GH-5212: stalled re-arm sweep loop stopped (context canceled)")
+			return
+		case <-ticker.C:
+			sweep()
+		}
+	}
+}

--- a/cmd/pilot/rearm_stalled_test.go
+++ b/cmd/pilot/rearm_stalled_test.go
@@ -1,0 +1,374 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/memory"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+func seedStalledRow(t *testing.T, store *memory.Store, id, taskID, projectPath string, completedAt time.Time) {
+	t.Helper()
+	if err := store.SaveExecution(&memory.Execution{
+		ID: id, TaskID: taskID, ProjectPath: projectPath,
+		Status: "stalled", Error: "consecutive identical failures (will not retry): boom", CompletedAt: &completedAt,
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+}
+
+// TestTryRearmStalled_NoStalledRow_NoGitHubCallMade proves the probe is
+// scoped strictly to stalled rows: a task_id with no stalled row at all
+// must never trigger a GitHub API call.
+func TestTryRearmStalled_NoStalledRow_NoGitHubCallMade(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	srv := failIfCalledServer(t)
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5212-NOROW", "/project-norow"
+	rearmed, err := checker.tryRearmStalled(taskID, projectPath, repickBackoffKey(projectPath, taskID))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rearmed {
+		t.Fatal("expected rearmed=false with no stalled row to evaluate")
+	}
+}
+
+// TestTryRearmStalled_NoPostStallEvidence_StaysStalledAndGatesBackoff is
+// acceptance criterion 2: a stalled row with no post-stall relabel/reopen
+// evidence must not be re-armed, and the caller (sweepStalledRearm) must arm
+// the repick backoff so the next sweep pass doesn't re-probe GitHub on every
+// tick.
+func TestTryRearmStalled_NoPostStallEvidence_StaysStalledAndGatesBackoff(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	stallTime := time.Now().Add(-time.Hour)
+
+	srv := newRearmTestServer(t,
+		&github.Issue{Number: 5139, State: "open", Labels: []github.Label{{Name: "pilot"}, {Name: github.LabelBlocked}}},
+		[]*github.IssueEvent{
+			{Event: "labeled", CreatedAt: stallTime.Add(-24 * time.Hour), Label: &github.Label{Name: "pilot"}},
+			{Event: "labeled", CreatedAt: stallTime, Label: &github.Label{Name: github.LabelBlocked}},
+		},
+	)
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	// newRearmTestServer hardcodes issue #5139 in its routes (see
+	// rearm_canceled_test.go), so this test's task_id must match.
+	taskID, projectPath := "GH-5139", "/project-no-evidence"
+	seedStalledRow(t, store, "exec-stalled-no-evidence", taskID, projectPath, stallTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+
+	rearmed, err := checker.tryRearmStalled(taskID, projectPath, key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rearmed {
+		t.Fatal("expected rearmed=false — no re-arm evidence after the stall timestamp")
+	}
+
+	exec, err := store.GetExecution("exec-stalled-no-evidence")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "stalled" {
+		t.Errorf("expected the row to remain status=stalled (not reclassified), got %q", exec.Status)
+	}
+}
+
+// TestTryRearmStalled_RelabelAfterStall_RearmsAndRemovesBlockedLabel is
+// acceptance criterion 1: a synthetic post-stall trigger-label event
+// re-admits the task — the row is demoted stalled->failed AND the
+// pilot-blocked label removal is invoked (both must happen per the task
+// spec, since a surviving label keeps the poller excluding the issue
+// forever regardless of row state).
+func TestTryRearmStalled_RelabelAfterStall_RearmsAndRemovesBlockedLabel(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	stallTime := time.Now().Add(-time.Hour)
+	relabelTime := stallTime.Add(30 * time.Minute)
+
+	var blockedLabelRemoved bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues/5212" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(&github.Issue{
+				Number: 5212, State: "open",
+				Labels: []github.Label{{Name: "pilot"}, {Name: github.LabelBlocked}},
+			})
+		case r.URL.Path == "/repos/owner/repo/issues/5212/events" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode([]*github.IssueEvent{
+				{Event: "labeled", CreatedAt: stallTime.Add(-24 * time.Hour), Label: &github.Label{Name: "pilot"}},
+				{Event: "labeled", CreatedAt: stallTime, Label: &github.Label{Name: github.LabelBlocked}},
+				{Event: "labeled", CreatedAt: relabelTime, Label: &github.Label{Name: "pilot"}},
+			})
+		case r.URL.Path == "/repos/owner/repo/issues/5212/labels/"+github.LabelBlocked && r.Method == http.MethodDelete:
+			blockedLabelRemoved = true
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5212", "/project-rearmed"
+	seedStalledRow(t, store, "exec-stalled-rearmed", taskID, projectPath, stallTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+
+	rearmed, err := checker.tryRearmStalled(taskID, projectPath, key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !rearmed {
+		t.Fatal("expected rearmed=true — a labeled event postdates the stall on an open, labeled issue")
+	}
+	if !blockedLabelRemoved {
+		t.Error("expected the pilot-blocked label removal to be invoked")
+	}
+
+	exec, err := store.GetExecution("exec-stalled-rearmed")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "failed" {
+		t.Errorf("expected the stalled row to be reclassified to status=failed (demote-don't-delete), got %q", exec.Status)
+	}
+
+	// The re-armed generation must flow through the ordinary retry path —
+	// same invariant rearm_canceled_test.go checks for the canceled case.
+	stillDone, err := store.HasTerminalCompletion(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("HasTerminalCompletion: %v", err)
+	}
+	if stillDone {
+		t.Fatal("expected HasTerminalCompletion to report false after re-arm, so nextRetryGeneration can grant the next generation normally")
+	}
+
+	if gated, _ := repickBackoff.gateStatus(key); gated {
+		t.Error("expected repick backoff to be cleared on a successful re-arm, not left gated")
+	}
+}
+
+// TestTryRearmStalled_ReopenAfterStall_Rearms is acceptance criterion 3: a
+// reopen event (not just a relabel) after the stall also counts as evidence.
+func TestTryRearmStalled_ReopenAfterStall_Rearms(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	stallTime := time.Now().Add(-time.Hour)
+	reopenTime := stallTime.Add(45 * time.Minute)
+
+	srv := newRearmTestServer(t,
+		&github.Issue{Number: 5139, State: "open", Labels: []github.Label{{Name: "pilot"}, {Name: github.LabelBlocked}}},
+		[]*github.IssueEvent{
+			{Event: "labeled", CreatedAt: stallTime.Add(-24 * time.Hour), Label: &github.Label{Name: "pilot"}},
+			{Event: "closed", CreatedAt: stallTime.Add(-time.Minute)},
+			{Event: "reopened", CreatedAt: reopenTime},
+		},
+	)
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	// newRearmTestServer hardcodes issue #5139 in its routes (see
+	// rearm_canceled_test.go), so this test's task_id must match.
+	taskID, projectPath := "GH-5139", "/project-reopen"
+	seedStalledRow(t, store, "exec-stalled-reopen", taskID, projectPath, stallTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+
+	rearmed, err := checker.tryRearmStalled(taskID, projectPath, key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !rearmed {
+		t.Fatal("expected rearmed=true — a reopened event postdates the stall on an open, labeled issue")
+	}
+
+	exec, err := store.GetExecution("exec-stalled-reopen")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "failed" {
+		t.Errorf("expected status=failed after reopen-triggered reclassify, got %q", exec.Status)
+	}
+}
+
+// TestTryRearmStalled_ClosedIssue_NotRearmed mirrors the canceled path's
+// closed-issue guard: even with a labeled event after the stall, a
+// currently-CLOSED issue must not re-arm.
+func TestTryRearmStalled_ClosedIssue_NotRearmed(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	stallTime := time.Now().Add(-time.Hour)
+
+	srv := newRearmTestServer(t,
+		&github.Issue{Number: 5139, State: "closed", Labels: []github.Label{{Name: "pilot"}, {Name: github.LabelBlocked}}},
+		[]*github.IssueEvent{
+			{Event: "labeled", CreatedAt: stallTime.Add(time.Minute), Label: &github.Label{Name: "pilot"}},
+		},
+	)
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5139", "/project-closed-stalled"
+	seedStalledRow(t, store, "exec-stalled-closed", taskID, projectPath, stallTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+
+	rearmed, err := checker.tryRearmStalled(taskID, projectPath, key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rearmed {
+		t.Fatal("expected no re-arm — the issue is currently closed, regardless of a post-stall labeled event")
+	}
+}
+
+// TestSweepStalledRearm_ListsBlockedIssues_RearmsMatchingStalledRow proves
+// the sweep's end-to-end shape: it lists open pilot-blocked issues (the
+// site that stands in for the SDK poller's unreachable candidate-exclusion
+// checkpoint — see tryRearmStalled's doc comment), finds the one backed by a
+// stalled store row, and re-arms it.
+func TestSweepStalledRearm_ListsBlockedIssues_RearmsMatchingStalledRow(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	stallTime := time.Now().Add(-time.Hour)
+	relabelTime := stallTime.Add(30 * time.Minute)
+
+	var listCalls, removeCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodGet:
+			listCalls++
+			if r.URL.Query().Get("page") != "1" && r.URL.Query().Get("page") != "" {
+				_ = json.NewEncoder(w).Encode([]*github.Issue{})
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]*github.Issue{
+				{Number: 5212, State: "open", Labels: []github.Label{{Name: "pilot"}, {Name: github.LabelBlocked}}},
+			})
+		case r.URL.Path == "/repos/owner/repo/issues/5212" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(&github.Issue{
+				Number: 5212, State: "open",
+				Labels: []github.Label{{Name: "pilot"}, {Name: github.LabelBlocked}},
+			})
+		case r.URL.Path == "/repos/owner/repo/issues/5212/events" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode([]*github.IssueEvent{
+				{Event: "labeled", CreatedAt: stallTime.Add(-24 * time.Hour), Label: &github.Label{Name: "pilot"}},
+				{Event: "labeled", CreatedAt: relabelTime, Label: &github.Label{Name: "pilot"}},
+			})
+		case r.URL.Path == "/repos/owner/repo/issues/5212/labels/"+github.LabelBlocked && r.Method == http.MethodDelete:
+			removeCalls++
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5212", "/project-sweep"
+	seedStalledRow(t, store, "exec-stalled-sweep", taskID, projectPath, stallTime)
+	key := repickBackoffKey(projectPath, taskID)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+
+	checker.sweepStalledRearm(context.Background(), projectPath)
+
+	if listCalls == 0 {
+		t.Fatal("expected sweepStalledRearm to list pilot-blocked issues")
+	}
+	if removeCalls != 1 {
+		t.Errorf("expected exactly 1 pilot-blocked label removal, got %d", removeCalls)
+	}
+
+	exec, err := store.GetExecution("exec-stalled-sweep")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "failed" {
+		t.Errorf("expected status=failed after sweep-driven reclassify, got %q", exec.Status)
+	}
+}
+
+// TestSweepStalledRearm_GatedIssue_NoGitHubProbeCall is acceptance criterion
+// 2's sweep-level half: once an issue's backoff key is gated (a prior sweep
+// pass already probed it and found no evidence), a later sweep pass must
+// list issues but skip the expensive GetIssue+ListIssueEvents probe entirely
+// — no hot per-tick GitHub API loop.
+func TestSweepStalledRearm_GatedIssue_NoGitHubProbeCall(t *testing.T) {
+	store := newTerminalCompletionCheckerTestStore(t)
+	stallTime := time.Now().Add(-time.Hour)
+
+	var probeCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodGet:
+			if r.URL.Query().Get("page") != "1" && r.URL.Query().Get("page") != "" {
+				_ = json.NewEncoder(w).Encode([]*github.Issue{})
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]*github.Issue{
+				{Number: 5212, State: "open", Labels: []github.Label{{Name: "pilot"}, {Name: github.LabelBlocked}}},
+			})
+		default:
+			probeCalls++
+			t.Errorf("unexpected request while gated: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	checker := terminalCompletionChecker{
+		store: store, ghClient: github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL),
+		repoOwner: "owner", repoName: "repo", triggerLabel: "pilot",
+	}
+
+	taskID, projectPath := "GH-5212", "/project-gated-sweep"
+	seedStalledRow(t, store, "exec-stalled-gated", taskID, projectPath, stallTime)
+	key := repickBackoffKey(projectPath, taskID)
+	// Pre-arm the gate exactly like a prior "no evidence yet" probe would
+	// (mirrors HasCompletedExecution's own GH-4469 throttle test shape).
+	repickBackoff.recordClaimLostDrop(key)
+	t.Cleanup(func() { repickBackoff.recordSuccess(key) })
+
+	checker.sweepStalledRearm(context.Background(), projectPath)
+
+	if probeCalls != 0 {
+		t.Errorf("expected zero probe calls while the backoff key is gated, got %d", probeCalls)
+	}
+
+	exec, err := store.GetExecution("exec-stalled-gated")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "stalled" {
+		t.Errorf("expected the row to remain untouched while gated, got status %q", exec.Status)
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1365,6 +1365,71 @@ func (s *Store) ReclassifyCanceledForRearm(taskID, projectPath, reason string) e
 	})
 }
 
+// LatestStalledExecution returns the most recent status='stalled' row for
+// taskID/projectPath — GH-5212's counterpart to LatestCanceledExecution,
+// extending GH-5139's re-arm pattern from operator-canceled rows to
+// escalate-and-hold stalls (repick hard cap / identical-failure streak,
+// internal/executor/dispatcher.go's escalateStalledTask). Exact task_id +
+// status match, same as LatestCanceledExecution: filtering on the literal
+// status='stalled' column is what keeps this safe against the GH-4347
+// ordering trap (a fresh 'queued' row for the same task_id sitting alongside
+// the old stalled one) — a queued row simply never matches this WHERE
+// clause, so it can never be mistaken for the stalled row callers act on.
+// found=false when no stalled row exists.
+//
+// completed_at on the returned row is the stall timestamp
+// (escalateStalledTask's UpdateExecutionStatus stamps it CURRENT_TIMESTAMP,
+// same as every other terminal transition) — the reference point the GH-5212
+// re-arm probe compares GitHub issue-event timestamps against to decide
+// whether a relabel/reopen happened AFTER the stall, not before it.
+func (s *Store) LatestStalledExecution(taskID, projectPath string) (exec *Execution, found bool, err error) {
+	row := s.db.QueryRow(`
+		SELECT `+executionDetailColumns+`
+		FROM executions
+		WHERE task_id = ? AND project_path = ? AND status = 'stalled'
+		ORDER BY completed_at DESC, rowid DESC
+		LIMIT 1
+	`, taskID, projectPath)
+	exec, err = scanExecutionDetail(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return exec, true, nil
+}
+
+// ReclassifyStalledForRearm demotes every status='stalled' row for
+// taskID/projectPath to 'failed' with reason recorded — GH-5212's
+// counterpart to ReclassifyCanceledForRearm, same "demote, don't delete"
+// idiom: the row (and its history) stays visible to `pilot trace`, but a
+// 'failed' row is not terminal per HasTerminalCompletion, so the ordinary
+// nextRetryGeneration retry-with-backoff/hard-cap path
+// (internal/executor/dispatcher.go) grants the next generation exactly the
+// way it would for any other post-failure retry — no bespoke bypass of
+// those invariants. The UPDATE's own `status = 'stalled'` filter is what
+// protects against the GH-4347 ordering trap (see LatestStalledExecution):
+// a fresh 'queued' row for the same task_id is never touched by this call.
+//
+// Callers must independently confirm GitHub-side re-arm evidence (issue
+// open + carries the trigger label + a labeled/reopened event after the
+// stall timestamp LatestStalledExecution returned) before calling this, AND
+// must remove the pilot-blocked label from the issue themselves — this
+// method only ever touches the store side. A surviving pilot-blocked label
+// keeps the poller excluding the issue from candidacy regardless of this
+// row's status.
+func (s *Store) ReclassifyStalledForRearm(taskID, projectPath, reason string) error {
+	return s.withRetry("ReclassifyStalledForRearm", func() error {
+		_, err := s.db.Exec(`
+			UPDATE executions
+			SET status = 'failed', error = ?, completed_at = CURRENT_TIMESTAMP
+			WHERE task_id = ? AND project_path = ? AND status = 'stalled'
+		`, reason, taskID, projectPath)
+		return err
+	})
+}
+
 // decomposedChildRefRegex extracts "#123"-style issue references from a
 // StageDecomposed execution_events detail string, e.g. "decomposed into 2
 // children: #4212, #4213" (see executor.formatDecomposedChildrenSummary).

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -5873,3 +5873,214 @@ func TestReclassifyCanceledForRearm_DemotesToFailedAndUnblocksRetry(t *testing.T
 		t.Errorf("expected the other task's canceled row to remain untouched, got status %q", otherExec.Status)
 	}
 }
+
+// TestLatestStalledExecution_FindsMostRecentStalledRow is GH-5212's coverage
+// for LatestStalledExecution — mirrors TestLatestCanceledExecution_FindsMostRecentCanceledRow
+// exactly, for status='stalled' instead of 'canceled'.
+func TestLatestStalledExecution_FindsMostRecentStalledRow(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	taskID, projectPath := "GH-5212-LSE", "/project-lse"
+
+	_, found, err := store.LatestStalledExecution(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("LatestStalledExecution (before any row): %v", err)
+	}
+	if found {
+		t.Fatal("expected found=false before any execution row exists")
+	}
+
+	if err := store.SaveExecution(&Execution{
+		ID: "exec-completed-first-lse", TaskID: taskID, ProjectPath: projectPath,
+		Status: "completed", PRUrl: "https://github.com/o/r/pull/1",
+	}); err != nil {
+		t.Fatalf("SaveExecution (completed): %v", err)
+	}
+	_, found, err = store.LatestStalledExecution(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("LatestStalledExecution (only a completed row): %v", err)
+	}
+	if found {
+		t.Fatal("expected found=false when the only row is completed, not stalled")
+	}
+
+	// CompletedAt is set explicitly here to mirror production: escalateStalledTask's
+	// UpdateExecutionStatus stamps completed_at = CURRENT_TIMESTAMP on the stall
+	// transition (that stamp becomes the "stall timestamp" the GH-5212 re-arm
+	// probe compares GitHub event times against) — SaveExecution itself does
+	// not default it.
+	stallTime := time.Now()
+	if err := store.SaveExecution(&Execution{
+		ID: "exec-stalled", TaskID: taskID, ProjectPath: projectPath,
+		Status: "stalled", Error: "consecutive identical failures (will not retry): boom", CompletedAt: &stallTime,
+	}); err != nil {
+		t.Fatalf("SaveExecution (stalled): %v", err)
+	}
+
+	exec, found, err := store.LatestStalledExecution(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("LatestStalledExecution (after stall): %v", err)
+	}
+	if !found {
+		t.Fatal("expected found=true once a stalled row exists")
+	}
+	if exec.ID != "exec-stalled" {
+		t.Errorf("expected the stalled row, got %q", exec.ID)
+	}
+	if exec.CompletedAt == nil {
+		t.Error("expected CompletedAt to be set (the stall timestamp) on the stalled row")
+	}
+
+	// Different task_id / project_path must not match (exact-key isolation,
+	// mirroring LatestCanceledExecution's own test).
+	if _, found, err := store.LatestStalledExecution("GH-OTHER", projectPath); err != nil || found {
+		t.Errorf("expected no match for a different task_id, found=%v err=%v", found, err)
+	}
+	if _, found, err := store.LatestStalledExecution(taskID, "/other-project"); err != nil || found {
+		t.Errorf("expected no match for a different project_path, found=%v err=%v", found, err)
+	}
+}
+
+// TestLatestStalledExecution_FreshQueuedRowAlongsideStalledRow_GH4347 is
+// acceptance criterion 4: a fresh 'queued' row for the same task_id created
+// alongside the old stalled row (e.g. a duplicate pickup race, or a manual
+// re-queue) must not confuse LatestStalledExecution — it filters on the
+// literal status='stalled' column, so the queued row simply never matches,
+// and the stalled row is still found correctly.
+func TestLatestStalledExecution_FreshQueuedRowAlongsideStalledRow_GH4347(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	taskID, projectPath := "GH-5212-ORDERING", "/project-ordering"
+	stallTime := time.Now().Add(-time.Hour)
+
+	if err := store.SaveExecution(&Execution{
+		ID: "exec-stalled-old", TaskID: taskID, ProjectPath: projectPath,
+		Status: "stalled", Error: "consecutive identical failures (will not retry): boom", CompletedAt: &stallTime,
+	}); err != nil {
+		t.Fatalf("SaveExecution (stalled): %v", err)
+	}
+
+	// A fresh queued row for the SAME task_id, created after the stall (the
+	// GH-4347 ordering trap shape: a duplicate pickup or manual re-queue
+	// racing against the escalation).
+	if err := store.SaveExecution(&Execution{
+		ID: "exec-queued-fresh", TaskID: taskID, ProjectPath: projectPath,
+		Status: "queued",
+	}); err != nil {
+		t.Fatalf("SaveExecution (queued): %v", err)
+	}
+
+	exec, found, err := store.LatestStalledExecution(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("LatestStalledExecution: %v", err)
+	}
+	if !found {
+		t.Fatal("expected found=true — the stalled row must still be found despite a fresher queued row for the same task_id")
+	}
+	if exec.ID != "exec-stalled-old" {
+		t.Errorf("expected the stalled row (not the queued one), got %q", exec.ID)
+	}
+
+	// ReclassifyStalledForRearm must likewise leave the queued row untouched.
+	if err := store.ReclassifyStalledForRearm(taskID, projectPath, "GH-5212: re-armed by issue reopened event"); err != nil {
+		t.Fatalf("ReclassifyStalledForRearm: %v", err)
+	}
+	queuedExec, err := store.GetExecution("exec-queued-fresh")
+	if err != nil {
+		t.Fatalf("GetExecution (queued): %v", err)
+	}
+	if queuedExec.Status != "queued" {
+		t.Errorf("expected the queued row to remain untouched, got status %q", queuedExec.Status)
+	}
+	stalledExec, err := store.GetExecution("exec-stalled-old")
+	if err != nil {
+		t.Fatalf("GetExecution (stalled): %v", err)
+	}
+	if stalledExec.Status != "failed" {
+		t.Errorf("expected the stalled row to be demoted to failed, got status %q", stalledExec.Status)
+	}
+}
+
+// TestReclassifyStalledForRearm_DemotesToFailedAndUnblocksRetry is GH-5212's
+// coverage for the "demote don't delete" re-arm write, mirroring
+// TestReclassifyCanceledForRearm_DemotesToFailedAndUnblocksRetry: after
+// reclassifying, the row must no longer count as terminal
+// (HasTerminalCompletion already never counted 'stalled' as terminal either,
+// but the 'failed' status it demotes to must also stay non-terminal), so the
+// ordinary nextRetryGeneration retry path can grant the next generation.
+func TestReclassifyStalledForRearm_DemotesToFailedAndUnblocksRetry(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	taskID, projectPath := "GH-5212-RSFR", "/project-rsfr"
+
+	if err := store.SaveExecution(&Execution{
+		ID: "exec-stalled-rsfr", TaskID: taskID, ProjectPath: projectPath,
+		Status: "stalled", Error: "consecutive identical failures (will not retry): boom",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	done, err := store.HasTerminalCompletion(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("HasTerminalCompletion (before reclassify): %v", err)
+	}
+	if done {
+		t.Fatal("expected done=false before reclassify — HasTerminalCompletion never counts 'stalled' as terminal")
+	}
+
+	reason := "GH-5212: re-armed by issue #5212 reopened event"
+	if err := store.ReclassifyStalledForRearm(taskID, projectPath, reason); err != nil {
+		t.Fatalf("ReclassifyStalledForRearm: %v", err)
+	}
+
+	exec, err := store.GetExecution("exec-stalled-rsfr")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "failed" {
+		t.Errorf("expected status=failed after reclassify, got %q", exec.Status)
+	}
+	if exec.Error != reason {
+		t.Errorf("expected error=%q, got %q", reason, exec.Error)
+	}
+
+	done, err = store.HasTerminalCompletion(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("HasTerminalCompletion (after reclassify): %v", err)
+	}
+	if done {
+		t.Fatal("expected done=false after reclassify — a failed row is not terminal, unblocking the normal retry path")
+	}
+
+	// A different task_id's stalled row must be untouched (exact-key
+	// isolation, mirroring ReclassifyCanceledForRearm's own cross-task test).
+	otherTaskID := "GH-5212-RSFR-OTHER"
+	if err := store.SaveExecution(&Execution{
+		ID: "exec-stalled-other", TaskID: otherTaskID, ProjectPath: projectPath,
+		Status: "stalled", Error: "unrelated",
+	}); err != nil {
+		t.Fatalf("SaveExecution (other task): %v", err)
+	}
+	if err := store.ReclassifyStalledForRearm(taskID, projectPath, "unrelated reclassify"); err != nil {
+		t.Fatalf("ReclassifyStalledForRearm (second call): %v", err)
+	}
+	otherExec, err := store.GetExecution("exec-stalled-other")
+	if err != nil {
+		t.Fatalf("GetExecution (other task): %v", err)
+	}
+	if otherExec.Status != "stalled" {
+		t.Errorf("expected the other task's stalled row to remain untouched, got status %q", otherExec.Status)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5212.

Closes #5212

## Changes

GitHub Issue GH-5212: feat(daemon): re-arm stalled pilot-blocked tasks on label-cycle/reopen evidence — GH-5139 pattern extended to stalled rows

## Context

Part of #5008 / TASK-485 (hosted retry path). Founder-scoped 2026-08-25. Sibling of #5211 (env-class classifier); no hard dependency, but sequenced after it.

When the identical-failure streak escalates a task, `escalateStalledTask` (`internal/executor/dispatcher.go:2016`) marks the execution row stalled and `surfaceStalledIssue` (`internal/executor/dispatcher.go:2094`) applies the pilot-blocked label. The poller then excludes the issue from its candidate list unconditionally and silently (doc comment at `internal/executor/dispatcher.go:2086-2089`). Nothing ever re-arms it: GH-5139's re-arm machinery (`cmd/pilot/rearm_canceled.go`) probes GitHub for post-cancel operator evidence but covers ONLY canceled rows — `LatestCanceledExecution` (`internal/memory/store.go:1326-1342`) is a hard status filter. A hosted tenant whose task stalled on a since-fixed cause has no product lever.

## Task

Do not decompose this issue — it is a single-subsystem change that must land as one PR.

Extend the GH-5139 re-arm pattern to stalled rows, so a trigger-label re-add (or issue reopen) after the stall re-arms the task through the ordinary retry path:

1. In `internal/memory/store.go`: add LatestStalledExecution and ReclassifyStalledForRearm (demote status stalled to failed, reason recorded in the error column), mirroring the canceled pair at `internal/memory/store.go:1326-1366`. Follow the GH-4347 lesson: guard against the ordering trap where a fresh queued row sits alongside the old stalled row.
2. New file in cmd/pilot (name it rearm_stalled.go) mirroring `cmd/pilot/rearm_canceled.go`: probe GitHub issue events for a labeled-with-trigger-label or reopened event timestamped AFTER the stalled row's timestamp (reuse the latestRearmEvent helper shape at `cmd/pilot/rearm_canceled.go:101-121`). On evidence: call ReclassifyStalledForRearm AND remove the pilot-blocked label from the issue — both must happen; a surviving pilot-blocked label keeps the poller excluding the issue forever regardless of row state.
3. Wire next to tryRearmCanceled in the admission path (`cmd/pilot/main.go:4262-4285`), throttled by the same repickBackoff window so it never becomes a hot per-tick GitHub API loop. IMPORTANT placement note: pilot-blocked exclusion removes the issue from the poller candidate list BEFORE admission runs — verify where tryRearmCanceled gets its chance to run and hook the stalled probe so it actually sees relabeled issues; if the existing hook point never sees pilot-blocked issues, probe from the site that performs the candidate exclusion instead.
4. After a successful re-arm, the next poll must dispatch the task at generation+1 via the existing `nextRetryGeneration` path — no new claim mechanics.

## Acceptance

- [ ] Test against real SQLite: stalled row + synthetic post-stall trigger-label event → row demoted to failed, pilot-blocked removal invoked, and a subsequent admission check dispatches at generation+1.
- [ ] Test: stalled row with NO post-stall evidence → not re-armed, no GitHub API hot loop (backoff respected).
- [ ] Test: reopen event after stall also counts as evidence.
- [ ] Test: fresh queued row alongside old stalled row does not confuse the probe (GH-4347 ordering trap).
- [ ] Existing canceled re-arm behavior unchanged; make test and make lint green.

## Refs

- #5008 (design issue) · #5211 (sibling leg)
- GH-5139 template: `cmd/pilot/rearm_canceled.go:38-92` · `internal/memory/store.go:1344-1366`
- Escalation chain: `internal/executor/dispatcher.go:1994-2139`