### PR TITLE
GH-5216: fix(executor): navigator auto-init seeds context sections, feature matrix, and knowledge tree so dependent features activate

### DIFF
--- a/internal/executor/navigator.go
+++ b/internal/executor/navigator.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -79,10 +80,11 @@ func FindTemplatesPath() (string, error) {
 
 	var latestVersion string
 	for _, entry := range entries {
-		if entry.IsDir() && strings.HasPrefix(entry.Name(), "6.") {
-			if entry.Name() > latestVersion {
-				latestVersion = entry.Name()
-			}
+		if !entry.IsDir() || !isVersionDirName(entry.Name()) {
+			continue
+		}
+		if latestVersion == "" || compareVersions(entry.Name(), latestVersion) > 0 {
+			latestVersion = entry.Name()
 		}
 	}
 
@@ -96,6 +98,39 @@ func FindTemplatesPath() (string, error) {
 	}
 
 	return templatesPath, nil
+}
+
+// versionDirRe matches semver-shaped plugin version directory names (e.g.
+// "6.18.1", "7.0.0") of any major version.
+var versionDirRe = regexp.MustCompile(`^\d+(\.\d+)*$`)
+
+func isVersionDirName(name string) bool {
+	return versionDirRe.MatchString(name)
+}
+
+// compareVersions compares two dot-separated numeric version strings
+// segment-by-segment (numeric, not lexicographic). Returns >0 if a>b, <0 if
+// a<b, 0 if equal.
+//
+// GH-5216: the previous string comparison (`entry.Name() > latestVersion`)
+// ranked "6.9.0" above "6.18.1" because '9' > '1' lexicographically, and the
+// hardcoded "6." prefix filter meant no 7.x+ release would ever be found.
+func compareVersions(a, b string) int {
+	as := strings.Split(a, ".")
+	bs := strings.Split(b, ".")
+	for i := 0; i < len(as) || i < len(bs); i++ {
+		var av, bv int
+		if i < len(as) {
+			av, _ = strconv.Atoi(as[i])
+		}
+		if i < len(bs) {
+			bv, _ = strconv.Atoi(bs[i])
+		}
+		if av != bv {
+			return av - bv
+		}
+	}
+	return 0
 }
 
 // IsInitialized checks if .agent/ exists and has valid structure.
@@ -141,6 +176,8 @@ func (n *NavigatorInitializer) Initialize(projectPath string) error {
 
 	// Create directory structure
 	agentDir := filepath.Join(projectPath, ".agent")
+	knowledgeDir := filepath.Join(agentDir, "knowledge")
+	memoriesDir := filepath.Join(knowledgeDir, "memories")
 	dirs := []string{
 		agentDir,
 		filepath.Join(agentDir, "tasks"),
@@ -150,6 +187,11 @@ func (n *NavigatorInitializer) Initialize(projectPath string) error {
 		filepath.Join(agentDir, "sops", "debugging"),
 		filepath.Join(agentDir, "sops", "development"),
 		filepath.Join(agentDir, "sops", "deployment"),
+		knowledgeDir,
+		filepath.Join(memoriesDir, "patterns"),
+		filepath.Join(memoriesDir, "pitfalls"),
+		filepath.Join(memoriesDir, "decisions"),
+		filepath.Join(memoriesDir, "learnings"),
 	}
 
 	for _, dir := range dirs {
@@ -158,14 +200,18 @@ func (n *NavigatorInitializer) Initialize(projectPath string) error {
 		}
 	}
 
-	// Create .gitkeep files for empty directories
+	// Create .gitkeep files for empty directories. "system" is excluded since
+	// it's seeded with FEATURE-MATRIX.md below.
 	gitkeepDirs := []string{
 		filepath.Join(agentDir, "tasks"),
-		filepath.Join(agentDir, "system"),
 		filepath.Join(agentDir, "sops", "integrations"),
 		filepath.Join(agentDir, "sops", "debugging"),
 		filepath.Join(agentDir, "sops", "development"),
 		filepath.Join(agentDir, "sops", "deployment"),
+		filepath.Join(memoriesDir, "patterns"),
+		filepath.Join(memoriesDir, "pitfalls"),
+		filepath.Join(memoriesDir, "decisions"),
+		filepath.Join(memoriesDir, "learnings"),
 	}
 
 	for _, dir := range gitkeepDirs {
@@ -180,6 +226,22 @@ func (n *NavigatorInitializer) Initialize(projectPath string) error {
 
 	if err := n.copyTemplate("DEVELOPMENT-README.md", filepath.Join(agentDir, "DEVELOPMENT-README.md"), info); err != nil {
 		n.log.Warn("Failed to copy DEVELOPMENT-README.md", slog.Any("error", err))
+		initErrors = append(initErrors, err.Error())
+	}
+
+	// GH-5216: seed system/FEATURE-MATRIX.md so UpdateFeatureMatrix (docs.go)
+	// has a "## Core Execution" anchor to insert rows into instead of being a
+	// permanent no-op on auto-inited repos.
+	if err := n.createFeatureMatrix(filepath.Join(agentDir, "system"), info); err != nil {
+		n.log.Warn("Failed to create system/FEATURE-MATRIX.md", slog.Any("error", err))
+		initErrors = append(initErrors, err.Error())
+	}
+
+	// GH-5216: seed knowledge/graph.json so graphrecall.RecallRelevant parses
+	// a valid (if empty) graph instead of hitting its read-error fail-open
+	// path on every executor session.
+	if err := n.createKnowledgeGraph(knowledgeDir); err != nil {
+		n.log.Warn("Failed to create knowledge/graph.json", slog.Any("error", err))
 		initErrors = append(initErrors, err.Error())
 	}
 
@@ -258,20 +320,17 @@ func (n *NavigatorInitializer) customizeTemplate(content string, info *ProjectIn
 }
 
 // createNavConfig creates the .nav-config.json file.
+//
+// GH-5216: this used to hardcode "version": "6.1.0" (a lie the moment any
+// other plugin version is installed) plus keys from an outdated Navigator
+// config schema (auto_load_navigator, compact_strategy) that nothing in
+// Pilot reads. Kept minimal: only the keys Pilot itself relies on.
 func (n *NavigatorInitializer) createNavConfig(agentDir string, info *ProjectInfo) error {
 	config := map[string]interface{}{
-		"version":             "6.1.0",
-		"project_name":        info.Name,
-		"tech_stack":          info.TechStack,
-		"project_management":  "github", // Pilot uses GitHub by default
-		"task_prefix":         "GH",
-		"team_chat":           "none",
-		"auto_load_navigator": true,
-		"compact_strategy":    "conservative",
-		"auto_update": map[string]interface{}{
-			"enabled":              true,
-			"check_interval_hours": 1,
-		},
+		"project_name":       info.Name,
+		"tech_stack":         info.TechStack,
+		"project_management": "github", // Pilot uses GitHub by default
+		"task_prefix":        "GH",
 	}
 
 	data, err := json.MarshalIndent(config, "", "  ")
@@ -280,6 +339,44 @@ func (n *NavigatorInitializer) createNavConfig(agentDir string, info *ProjectInf
 	}
 
 	return os.WriteFile(filepath.Join(agentDir, ".nav-config.json"), data, 0644)
+}
+
+// createFeatureMatrix seeds system/FEATURE-MATRIX.md with a "## Core
+// Execution" table so UpdateFeatureMatrix (docs.go) has an anchor to insert
+// rows into.
+func (n *NavigatorInitializer) createFeatureMatrix(systemDir string, info *ProjectInfo) error {
+	content := fmt.Sprintf(`# %s Feature Matrix
+
+**Last Updated:** %s
+
+## Core Execution
+
+| Feature | Status | Version | Notes | Docs | Task |
+|---------|--------|---------|-------|------|------|
+`, info.Name, time.Now().Format("2006-01-02"))
+
+	return os.WriteFile(filepath.Join(systemDir, "FEATURE-MATRIX.md"), []byte(content), 0644)
+}
+
+// createKnowledgeGraph seeds knowledge/graph.json with the minimal valid
+// shape graphrecall.RecallRelevant expects, so recall takes the parse path
+// (empty result) instead of the read-error fail-open path.
+func (n *NavigatorInitializer) createKnowledgeGraph(knowledgeDir string) error {
+	graph := map[string]interface{}{
+		"version": 1,
+		"nodes": map[string]interface{}{
+			"concepts": map[string]interface{}{},
+			"memories": map[string]interface{}{},
+		},
+		"edges": []interface{}{},
+	}
+
+	data, err := json.MarshalIndent(graph, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(knowledgeDir, "graph.json"), data, 0644)
 }
 
 // DetectProjectInfo extracts project name and tech stack from config files.

--- a/internal/executor/navigator_test.go
+++ b/internal/executor/navigator_test.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/qf-studio/pilot/internal/logging"
+	"github.com/qf-studio/pilot/internal/memory/graphrecall"
 )
 
 func TestDetectProjectInfo_GoProject(t *testing.T) {
@@ -172,6 +174,12 @@ go 1.21
 		"sops/debugging",
 		"sops/development",
 		"sops/deployment",
+		"knowledge",
+		"knowledge/memories",
+		"knowledge/memories/patterns",
+		"knowledge/memories/pitfalls",
+		"knowledge/memories/decisions",
+		"knowledge/memories/learnings",
 	}
 
 	for _, dir := range dirs {
@@ -274,6 +282,230 @@ Detected: ${DETECTED_FROM}
 	// Date should be replaced (not contain [Date])
 	if contains(result, "[Date]") {
 		t.Error("template should have date placeholder replaced")
+	}
+}
+
+// TestInitialize_ProjectContextInjectionActivates is the GH-5216 regression
+// test for the permanent no-op described in GH-1387: loadProjectContext()
+// extracts "### Key Components", "## Key Files" and "## Project Structure"
+// from the generated DEVELOPMENT-README.md. Before this fix, the shipped
+// template contained none of those headers, so this always returned "".
+func TestInitialize_ProjectContextInjectionActivates(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	initializer, err := NewNavigatorInitializer(logging.WithComponent("test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := initializer.Initialize(tmpDir); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	agentDir := filepath.Join(tmpDir, ".agent")
+	got := loadProjectContext(agentDir)
+	if got == "" {
+		t.Fatal("expected loadProjectContext to return non-empty context after auto-init, got empty string")
+	}
+
+	for _, header := range []string{"Key Files", "Project Structure"} {
+		if !strings.Contains(got, header) {
+			t.Errorf("expected injected context to include a %q section, got:\n%s", header, got)
+		}
+	}
+}
+
+// TestInitialize_FeatureMatrixSeededAndUpdatable is the GH-5216 regression
+// test for GH-1388: UpdateFeatureMatrix (docs.go) is a permanent no-op when
+// system/FEATURE-MATRIX.md doesn't exist. This asserts the row lands inside
+// the "## Core Execution" table (anchor-based insertion), not appended past
+// unrelated trailing content — i.e. not the fallback-append branch.
+func TestInitialize_FeatureMatrixSeededAndUpdatable(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	initializer, err := NewNavigatorInitializer(logging.WithComponent("test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := initializer.Initialize(tmpDir); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	agentDir := filepath.Join(tmpDir, ".agent")
+	matrixPath := filepath.Join(agentDir, "system", "FEATURE-MATRIX.md")
+
+	before, err := os.ReadFile(matrixPath)
+	if err != nil {
+		t.Fatalf("expected system/FEATURE-MATRIX.md to be seeded by Initialize: %v", err)
+	}
+	if !strings.Contains(string(before), "## Core Execution") {
+		t.Fatalf("seeded FEATURE-MATRIX.md missing '## Core Execution' anchor:\n%s", before)
+	}
+
+	// Append an unrelated trailing section. If UpdateFeatureMatrix ever falls
+	// back to naive end-of-file append, the new row will land after this
+	// canary instead of inside the Core Execution table.
+	canary := "\n## Unrelated Trailing Section\n\nSome other content.\n"
+	if err := os.WriteFile(matrixPath, append(before, []byte(canary)...), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	task := &Task{ID: "GH-9999", Title: "feat(executor): add a widget"}
+	if err := UpdateFeatureMatrix(agentDir, task, "v9.9.9"); err != nil {
+		t.Fatalf("UpdateFeatureMatrix failed: %v", err)
+	}
+
+	after, err := os.ReadFile(matrixPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := strings.Split(string(after), "\n")
+	rowIdx, canaryIdx := -1, -1
+	for i, line := range lines {
+		if strings.Contains(line, "GH-9999") {
+			rowIdx = i
+		}
+		if strings.Contains(line, "Unrelated Trailing Section") {
+			canaryIdx = i
+		}
+	}
+
+	if rowIdx == -1 {
+		t.Fatalf("expected a row referencing GH-9999 in updated FEATURE-MATRIX.md:\n%s", after)
+	}
+	if canaryIdx == -1 {
+		t.Fatal("canary trailing section disappeared from FEATURE-MATRIX.md")
+	}
+	if rowIdx >= canaryIdx {
+		t.Errorf("expected new feature row (line %d) to be inserted inside the Core Execution table, before the trailing section (line %d) — got fallback append past it", rowIdx, canaryIdx)
+	}
+}
+
+// TestInitialize_KnowledgeGraphSeededForRecall is the GH-5216 regression test
+// for the knowledge tree never being seeded: graphrecall.RecallRelevant reads
+// .agent/knowledge/graph.json on every execution. Before this fix, auto-init
+// created neither the file nor its parent dirs, so recall silently took the
+// read-error fail-open path on every session. This asserts the seeded file
+// takes the parse path instead (still returns empty, since there are no
+// concepts/memories yet, but via a successful unmarshal).
+func TestInitialize_KnowledgeGraphSeededForRecall(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	initializer, err := NewNavigatorInitializer(logging.WithComponent("test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := initializer.Initialize(tmpDir); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	graphPath := filepath.Join(tmpDir, ".agent", "knowledge", "graph.json")
+	data, err := os.ReadFile(graphPath)
+	if err != nil {
+		t.Fatalf("expected knowledge/graph.json to be seeded by Initialize: %v", err)
+	}
+
+	var doc struct {
+		Nodes struct {
+			Concepts map[string]interface{} `json:"concepts"`
+			Memories map[string]interface{} `json:"memories"`
+		} `json:"nodes"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("seeded graph.json does not unmarshal into the recall schema: %v", err)
+	}
+	if doc.Nodes.Concepts == nil || doc.Nodes.Memories == nil {
+		t.Errorf("expected seeded graph.json to have (possibly empty) concepts/memories maps, got %+v", doc.Nodes)
+	}
+
+	got := graphrecall.RecallRelevant(tmpDir, "add a widget to the executor", 5)
+	if got == nil {
+		t.Error("expected RecallRelevant to return a non-nil empty slice, got nil")
+	}
+	if len(got) != 0 {
+		t.Errorf("expected no memories from a freshly seeded empty graph, got %d", len(got))
+	}
+}
+
+// TestGeneratedReadme_NoNavCommandInstructions is the GH-5216 regression test
+// for the template still telling sessions to run /nav-start, /nav-task,
+// /nav-loop, /nav-compact — Navigator-plugin slash commands that don't exist
+// in a plain executor session (removed from public docs in commit 4b47e7a3).
+func TestGeneratedReadme_NoNavCommandInstructions(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	initializer, err := NewNavigatorInitializer(logging.WithComponent("test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := initializer.Initialize(tmpDir); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(tmpDir, ".agent", "DEVELOPMENT-README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(string(content), "/nav-") {
+		t.Errorf("generated DEVELOPMENT-README.md still contains a /nav- command instruction:\n%s", content)
+	}
+}
+
+func TestFindTemplatesPath_VersionSelection(t *testing.T) {
+	tests := []struct {
+		name     string
+		versions []string
+		want     string
+	}{
+		{
+			name:     "numeric comparison beats lexicographic within major",
+			versions: []string{"6.9.0", "6.18.1", "6.2.0"},
+			want:     "6.18.1",
+		},
+		{
+			name:     "next major version is discovered, not pinned to 6.x",
+			versions: []string{"6.18.1", "7.0.0"},
+			want:     "7.0.0",
+		},
+		{
+			name:     "non-version directories are ignored",
+			versions: []string{"6.1.0", "not-a-version", "6.2.0"},
+			want:     "6.2.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			navDir := filepath.Join(home, ".claude", "plugins", "cache", "navigator-marketplace", "navigator")
+			if err := os.MkdirAll(navDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+
+			for _, v := range tt.versions {
+				dir := filepath.Join(navDir, v, "templates")
+				if err := os.MkdirAll(dir, 0755); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			t.Setenv("HOME", home)
+
+			got, err := FindTemplatesPath()
+			if err != nil {
+				t.Fatalf("FindTemplatesPath failed: %v", err)
+			}
+
+			want := filepath.Join(navDir, tt.want, "templates")
+			if got != want {
+				t.Errorf("FindTemplatesPath() = %q, want %q", got, want)
+			}
+		})
 	}
 }
 

--- a/internal/executor/templates/DEVELOPMENT-README.md
+++ b/internal/executor/templates/DEVELOPMENT-README.md
@@ -18,8 +18,15 @@
 ```
 .agent/
 ├── DEVELOPMENT-README.md     ← You are here
-├── tasks/                    ← Implementation plans
-├── system/                   ← Architecture docs
+├── tasks/                    ← Implementation plans (archive/ when done)
+├── system/                   ← Architecture docs, incl. FEATURE-MATRIX.md
+├── knowledge/                ← Knowledge graph consumed every session
+│   ├── graph.json            ← Indexed concept/memory nodes
+│   └── memories/             ← One markdown file per memory
+│       ├── patterns/
+│       ├── pitfalls/
+│       ├── decisions/
+│       └── learnings/
 └── sops/                     ← Standard Operating Procedures
     ├── integrations/
     ├── debugging/
@@ -29,12 +36,25 @@
 
 ---
 
-## Navigator Commands
+## Project Structure
 
-- `/nav-start` - Load project context
-- `/nav-task` - Plan implementation
-- `/nav-loop` - Run until complete
-- `/nav-compact` - Clear context
+```
+[Project Name]/
+└── .agent/              ← Navigator docs (this directory)
+```
+
+_Fill in the real source tree above during the first task session._
+
+## Key Files
+
+_List the files a new session should read first — fill in as the project grows._
+
+## Architecture
+
+### Key Components
+
+_Describe the major components/services and their responsibilities — fill in
+during the first task session._
 
 ---
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5216.

Closes #5216

## Changes

GitHub Issue GH-5216: fix(executor): navigator auto-init seeds context sections, feature matrix, and knowledge tree so dependent features activate

## Context

Navigator auto-init (`internal/executor/navigator.go`, `Initialize()`) creates a minimal `.agent/` scaffold, and the graceful-degradation design means nothing crashes when files are missing — but three of Pilot's own features silently never activate on any auto-inited repo:

1. **Project-context injection is a permanent no-op.** `loadProjectContext()` (`internal/executor/prompt_builder.go:801-815`) extracts `### Key Components`, `## Key Files`, and `## Project Structure` from `DEVELOPMENT-README.md`. The shipped template (`internal/executor/templates/DEVELOPMENT-README.md`) contains none of those headers, so the GH-1387 injection returns an empty string forever. No warning is logged.
2. **Feature-matrix updates are a permanent no-op.** `UpdateFeatureMatrix` (`internal/executor/docs.go:83-92`) returns nil when `system/FEATURE-MATRIX.md` is missing, and nothing ever creates it — the GH-1388 DOCUMENT-phase update only works where a human hand-authored the file. Its inserter looks for a `## Core Execution` table and appends 6-column rows (`| Feature | ✅ | version | - | - | task-id |`, docs.go:96-135).
3. **Knowledge tree is never seeded, though Pilot consumes it.** `graphrecall.RecallRelevant` (`internal/executor/prompt_builder.go:450`) reads `.agent/knowledge/graph.json` on every execution to inject relevant memories, and `internal/executor/git.go` stages `.agent/knowledge/memories/` + `graph.json` at commit time. Auto-init creates neither, so recall is empty and executor sessions have no valid graph to append memories to. The recall schema (`internal/memory/graphrecall/recall.go:25-30`) needs `{"nodes":{"concepts":{},"memories":{}}}` at minimum.

Additionally, the template's "Navigator Commands" section instructs `/nav-start`, `/nav-task`, `/nav-loop`, `/nav-compact` — those are Navigator-plugin slash commands that don't exist in a plain executor session; the equivalent instructions were removed from the public docs in commit 4b47e7a3.

Two adjacent defects in the same file, in scope:

- `FindTemplatesPath` (`navigator.go:80-91`) picks the "latest" plugin version by lexicographic string comparison, so `6.9.0` beats `6.18.1`, and the hardcoded `"6."` prefix filter breaks entirely at 7.x.
- `createNavConfig` (`navigator.go:263`) writes a hardcoded `"version": "6.1.0"` with an outdated key schema (`auto_load_navigator`, `compact_strategy`).

## Implementation

1. **Template** (`internal/executor/templates/DEVELOPMENT-README.md`):
   - Add `## Project Structure` (placeholder tree the initializer can fill or the first session completes), `## Key Files`, and a section containing `### Key Components` — headers must exactly match what `loadProjectContext`/`extractSection` looks for.
   - Remove the "Navigator Commands" section; replace with a short structure-conventions note (task docs in `tasks/`, archive when done, memories under `knowledge/memories/`).
2. **`Initialize()`** (`internal/executor/navigator.go`):
   - Create `knowledge/` and `knowledge/memories/{patterns,pitfalls,decisions,learnings}` (with `.gitkeep`s, same idiom as existing dirs).
   - Write a minimal valid `knowledge/graph.json` that unmarshals cleanly in `graphrecall` — e.g. `{"version": 1, "nodes": {"concepts": {}, "memories": {}}, "edges": []}`.
   - Seed `system/FEATURE-MATRIX.md` with a `## Core Execution` header and an empty 6-column table (`| Feature | Status | Version | Notes | Docs | Task |` + separator) so `UpdateFeatureMatrix`'s inserter finds its anchor.
3. **`FindTemplatesPath`**: replace lexicographic latest-version pick with numeric segment-wise comparison and drop the hardcoded `"6."` major pin (accept any `N.` semver-shaped dir name).
4. **`createNavConfig`**: stop hardcoding `"version": "6.1.0"`; keep the config minimal — only keys Pilot itself relies on plus `project_name`/`tech_stack`/`project_management`/`task_prefix`.
5. Do NOT change `IsInitialized` semantics (README-presence check) — partial hand-rolled `.agent/` dirs must not be overwritten.

## Acceptance

- On a fresh temp project, `Initialize()` produces a `DEVELOPMENT-README.md` for which `loadProjectContext()` returns a non-empty string (table-driven test).
- After `Initialize()`, `UpdateFeatureMatrix` with a `feat(x): ...` task appends a row inside the `## Core Execution` table (test asserts row placement, not fallback append).
- After `Initialize()`, `graphrecall.RecallRelevant` takes the parse path, not the read-error path: test that the seeded `graph.json` unmarshals into the recall schema and returns an empty slice without error.
- Generated README and template contain no `/nav-` command instructions (test greps output).
- `FindTemplatesPath` version pick: `6.18.1` beats `6.9.0`, and `7.0.0` is discovered (table-driven test over temp dirs).
- Existing `navigator_test.go` stays green; `make build test lint` pass.

## Refs

- Docs cleanup this aligns with: commit 4b47e7a3 (removed `/nav-*` instructions from the docs site)
- GH-1387 (context injection), GH-1388 (feature matrix), GH-664 (no-decompose label)