### PR TITLE
GH-5217: feat(alerts): warning alert on persistent env-class failure streak — credential rot is currently a silent 16-min retry loop

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-08-24 (GH-5095)
+**Last Updated:** 2026-08-25 (GH-5217)
 
 ## Legend
 
@@ -199,6 +199,7 @@
 | Rate limit detection | ✅ | executor | - | - | Detect GitHub API rate limits, pause + resume at reset time (v0.34.0) |
 | GitHub token fallback + live validation | ✅ | cmd/pilot, health | `pilot doctor` | `adapters.github.token` | config → `GITHUB_TOKEN` env → `gh auth token` fallback; authenticated startup check logs ERROR + fires `config_error` alert on a dead/expired token (GH-3718) |
 | GitHub App installation-token auth | ✅ | adapters/github, cmd/pilot, executor | - | `adapters.github.app` | Opt-in `{app_id, installation_id, private_key_path}` block, validated eagerly at `Config.Validate()` (partial block errors naming the missing field). `github.TokenSource` (`apptoken.go`) mints an installation token via a hand-rolled RS256 JWT (no new go.mod dep) → `POST /app/installations/{id}/access_tokens`, caches it, and refreshes proactively 5min before the ~1h expiry. Sits ahead of the config-token/`GITHUB_TOKEN`/gh-CLI chain in `resolveGitHubToken`; on mint failure logs loudly and falls through to that chain rather than failing the caller. The same minted token authenticates pilot-worktree git push/fetch via a `GIT_ASKPASS` helper (`internal/executor/git_credentials.go`) that only ever passes the token through a child process's `PILOT_GIT_TOKEN` env var — never argv or a log line — installed once at daemon startup via `executor.SetGitCredentialProvider`. Kills the single-OAuth-grant SPOF and moves the daemon off the shared per-user 5000/hr rate pool onto a per-installation one (see `.agent/sops/config/github-token-architecture.md`). Known scope boundaries left for follow-up: `gh` CLI subprocess calls (PR creation, issue comments) still ride ambient `GITHUB_TOKEN`/gh-CLI login, not this token (GH-4743). Daemon-lifetime studio-sdk clients now hot-rotate too: `newGitHubSDKClient` (`cmd/pilot/main.go`) resolves per request via `githubSDK.NewClientWithTokenFunc`, and the SDK poller's adapter is injected with one shared instance via `githubSDK.WithAdapterClient` so the Poller/MergeWaiter/board sync all inherit it (TASK-461 Leg 2, GH-4824, sdk PR#108/PR#110) |
+| Env-class failure streak alert | ✅ | executor/alerts | - | - | GH-5211 made env-class (credential/environment) failures — missing/invalid credential, 0 tokens, no deliverable, instant exit — exempt from the identical-failure streak escalation so they retry forever via ordinary backoff (~16min window), correct by founder decision but previously announced only by an Info log line (PR#5214 review note). `Dispatcher.consecutiveEnvClassFailures` (`dispatcher.go`) scans the same recent-claims shape `priorClaimsHadIdenticalFailureStreak` uses, counting consecutive most-recent `IsEnvClassFailure` (`runner.go`, GH-5211) generations for (task, project); at `envClassFailureStreakThreshold` (5) fires `AlertEventTypeEnvClassFailureStreak` via the existing `Runner.EmitAlertEvent` seam, naming the task and the matched credential/env signature (`MatchedEnvClassFailureSignature`, e.g. `ANTHROPIC_API_KEY`). New `AlertTypeEnvClassFailureStreak` default rule (warning, 30m cooldown) mirrors the `AlertTypeSelfReviewFailureStreak`/`AlertTypeLabelLifecycleFailureStreak` rule shape but is caller-gated like `dispatch_loop_breaker`/`intent_judge_failure_streak` — the dispatcher computes and gates the exact threshold itself rather than delegating to a `DeadManTracker`. Purely additive: retry admission is unaffected, and a success or non-env-class generation resets the count naturally via the scan (v2.269.0, GH-5217) |
 
 ## Quality Gates
 
@@ -506,7 +507,7 @@
 | Intelligence | 15 | 0 | 0 | 0 |
 | Input Adapters | 35 | 0 | 0 | 0 |
 | Output/Notifications | 18 | 0 | 0 | 0 |
-| Alerts & Monitoring | 14 | 0 | 0 | 0 |
+| Alerts & Monitoring | 15 | 0 | 0 | 0 |
 | Quality Gates | 5 | 0 | 1 | 0 |
 | Memory & Learning | 23 | 0 | 0 | 0 |
 | Dashboard | 24 | 0 | 0 | 0 |

--- a/.agent/tasks/archive/gh-5217.md
+++ b/.agent/tasks/archive/gh-5217.md
@@ -1,0 +1,38 @@
+# GH-5217
+
+**Created:** 2026-08-25
+
+## Problem
+
+GitHub Issue GH-5217: feat(alerts): warning alert on persistent env-class failure streak — credential rot is currently a silent 16-min retry loop
+
+## Context
+
+Part of #5008 / TASK-485 follow-up, from PR#5214's review verdict. GH-5211 made env-class failures (missing/invalid credential, 0 tokens, no deliverable, instant exit) exempt from the identical-failure streak escalation — they now retry forever via the ordinary backoff path (window capped ~16 min), by founder decision. Correct, but it created a silence gap: a hosted tenant whose credential stays broken gets an infinite retry loop announced only by an Info-level log line ("dispatch re-pick: prior claim was an env-class ... failure"). Nothing pages anyone. Pre-GH-5211 the (wrong) stall escalation at least produced a visible alert.
+
+## Task
+
+Do not decompose this issue — it is a single-subsystem change that must land as one PR.
+
+Emit a warning alert when a task accumulates N consecutive env-class failures, without changing retry behavior:
+
+1. In `internal/executor/dispatcher.go`, inside the GH-5211 env-class carve-out branch of the retry path (the block that logs the exempt-from-streak Info line): count how many consecutive most-recent generations for this (task, project) are env-class failures — reuse the same recent-claims scan shape the identical-failure streak check uses, with `IsEnvClassFailure` (`internal/executor/runner.go`) as the per-row predicate.
+2. At threshold N (constant, default 5) emit an alert via the runner's existing EmitAlertEvent seam (the same call sites used at `internal/executor/dispatcher.go:2108` and `internal/executor/dispatcher.go:3371`), severity warning, message naming the task, the matched credential signature, and the consecutive count. Mirror the existing failure-streak alert idiom — see AlertTypeSelfReviewFailureStreak and AlertTypeLabelLifecycleFailureStreak in `internal/executor/alerts.go` and the corresponding rule entries in `internal/alerts/types.go` — including a rule with a cooldown so a persistent breakage alerts periodically, not per retry.
+3. Retries continue exactly as today — the alert is purely additive. Alert once per threshold crossing plus cooldown-paced repeats while the streak persists; a successful (or non-env-class) generation resets the count naturally since the scan is over most-recent consecutive rows.
+
+## Acceptance
+
+- [x] Test: N consecutive env-class failed generations → exactly one warning alert emitted (cooldown suppresses repeats within the window); retry admission unaffected (next generation still granted).
+- [x] Test: N-1 env-class failures then a non-env-class outcome → no alert.
+- [x] Test: alert fires again after cooldown expiry while the streak persists.
+- [x] Rule is registered/enabled in the default alert config path so it is live without operator config edits; existing alert tests pass.
+- [x] make test and make lint green.
+
+## Refs
+
+- PR#5214 review note 1 (silence gap) · #5008 · GH-5211
+- Carve-out branch: `internal/executor/dispatcher.go` (GH-5211 block ahead of the identical-failure streak check)
+- Classifier: `internal/executor/runner.go` (IsEnvClassFailure, EnvClassFailureDurationThreshold)
+
+## Acceptance Criteria
+

--- a/internal/alerts/engine.go
+++ b/internal/alerts/engine.go
@@ -206,6 +206,18 @@ const (
 	// until it was caught while diagnosing GH-4648. Metadata carries repo
 	// and consecutive_failures.
 	EventTypeIntentJudgeFailureStreak EventType = "intent_judge_failure_streak"
+
+	// Env-class failure streak events (GH-5217): fired by
+	// Dispatcher.beginWithGenerationRetry (internal/executor/dispatcher.go,
+	// the GH-5211 carve-out branch) when a task's consecutive env-class
+	// (credential/environment) failure count reaches
+	// envClassFailureStreakThreshold. GH-5211 exempted env-class failures
+	// from the identical-failure streak escalation so they retry forever
+	// via ordinary backoff — this event is the only thing that surfaces a
+	// persistent credential break to an operator instead of it retrying
+	// silently forever. Metadata carries task_id, project,
+	// consecutive_failures, and credential_signature.
+	EventTypeEnvClassFailureStreak EventType = "env_class_failure_streak"
 )
 
 const (
@@ -697,6 +709,8 @@ func (e *Engine) handleEvent(ctx context.Context, event Event) {
 		e.handleGithubSideEffect(ctx, event)
 	case EventTypeIntentJudgeFailureStreak:
 		e.handleIntentJudgeFailureStreak(ctx, event)
+	case EventTypeEnvClassFailureStreak:
+		e.handleEnvClassFailureStreak(ctx, event)
 	case EventTypeDeadManAttempt:
 		e.handleDeadManAttempt(event)
 	case EventTypeDeadManSuccess:
@@ -1092,6 +1106,39 @@ func (e *Engine) handleIntentJudgeFailureStreak(ctx context.Context, event Event
 	if !matched {
 		e.logger.Warn("intent judge failure streak event has no matching rule — alert dropped silently",
 			slog.String("repo", event.Metadata["repo"]),
+			slog.String("consecutive_failures", event.Metadata["consecutive_failures"]))
+	}
+}
+
+// handleEnvClassFailureStreak fires AlertTypeEnvClassFailureStreak rules
+// when a task's consecutive env-class (credential/environment) failure
+// streak reaches the caller's threshold (GH-5217). The caller
+// (Dispatcher.beginWithGenerationRetry, the GH-5211 carve-out branch)
+// already computed and gated on the exact threshold
+// (envClassFailureStreakThreshold) before emitting this event — mirroring
+// handleDispatchLoopBreaker/handleIntentJudgeFailureStreak — so no
+// Condition-based counting happens here. GH-5211 exempted env-class
+// failures from the identical-failure streak escalation so retries never
+// stop on their own; this rule is the only thing that pages an operator
+// about a persistent credential break instead of it retrying invisibly
+// forever behind an Info log line (PR#5214 review note 1).
+func (e *Engine) handleEnvClassFailureStreak(ctx context.Context, event Event) {
+	matched := false
+	for _, rule := range e.config.Rules {
+		if rule.Type != AlertTypeEnvClassFailureStreak {
+			continue
+		}
+		matched = true
+		if rule.Enabled && e.shouldFire(rule) {
+			message := fmt.Sprintf("Task %s has failed %s consecutive times with an env-class (credential/environment) signature (%s) — retries continue automatically, but no attempt has reached the model backend",
+				event.TaskID, event.Metadata["consecutive_failures"], event.Metadata["credential_signature"])
+			alert := e.createAlert(rule, event, message)
+			e.fireAlert(ctx, rule, alert)
+		}
+	}
+	if !matched {
+		e.logger.Warn("env-class failure streak event has no matching rule — alert dropped silently",
+			slog.String("task_id", event.TaskID),
 			slog.String("consecutive_failures", event.Metadata["consecutive_failures"]))
 	}
 }

--- a/internal/alerts/engine_test.go
+++ b/internal/alerts/engine_test.go
@@ -1731,6 +1731,237 @@ func TestHandleIntentJudgeFailureStreak(t *testing.T) {
 	})
 }
 
+// TestHandleEnvClassFailureStreak covers the GH-5217 env-class-failure-streak
+// rule: the emitting side (Dispatcher.beginWithGenerationRetry, the GH-5211
+// carve-out branch) does its own threshold counting
+// (consecutiveEnvClassFailures) and fires the event once the streak reaches
+// envClassFailureStreakThreshold, so this test only needs to verify the
+// event turns into an alert carrying the task/count/signature metadata and
+// respects cooldown — mirroring TestHandleDispatchLoopBreaker/
+// TestHandleIntentJudgeFailureStreak above.
+func TestHandleEnvClassFailureStreak(t *testing.T) {
+	newEvent := func(taskID, consecutiveFailures, signature string) Event {
+		return Event{
+			Type:   EventTypeEnvClassFailureStreak,
+			TaskID: taskID,
+			Metadata: map[string]string{
+				"task_id":              taskID,
+				"consecutive_failures": consecutiveFailures,
+				"credential_signature": signature,
+			},
+			Timestamp: time.Now(),
+		}
+	}
+
+	t.Run("fires with task_id, consecutive_failures, and credential_signature metadata", func(t *testing.T) {
+		config := &AlertConfig{
+			Enabled: true,
+			Channels: []ChannelConfig{
+				{Name: "test-channel", Type: "webhook", Enabled: true},
+			},
+			Rules: []AlertRule{
+				{
+					Name:     "env_class_failure_streak",
+					Type:     AlertTypeEnvClassFailureStreak,
+					Enabled:  true,
+					Severity: SeverityWarning,
+					Channels: []string{"test-channel"},
+					Cooldown: 0,
+				},
+			},
+		}
+
+		mockCh := newMockChannel("test-channel", "webhook")
+		dispatcher := NewDispatcher(config)
+		dispatcher.RegisterChannel(mockCh)
+
+		engine := NewEngine(config, WithDispatcher(dispatcher))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = engine.Start(ctx)
+
+		engine.ProcessEvent(newEvent("GH-5217-TASK", "5", "ANTHROPIC_API_KEY"))
+
+		waitForAlerts(t, mockCh, 1, 2*time.Second)
+		alerts := mockCh.getAlerts()
+		if len(alerts) != 1 {
+			t.Fatalf("expected 1 alert, got %d", len(alerts))
+		}
+		if alerts[0].Type != AlertTypeEnvClassFailureStreak {
+			t.Errorf("expected alert type %s, got %s", AlertTypeEnvClassFailureStreak, alerts[0].Type)
+		}
+		if alerts[0].Severity != SeverityWarning {
+			t.Errorf("expected severity warning, got %s", alerts[0].Severity)
+		}
+		if !strings.Contains(alerts[0].Message, "GH-5217-TASK") || !strings.Contains(alerts[0].Message, "5") || !strings.Contains(alerts[0].Message, "ANTHROPIC_API_KEY") {
+			t.Errorf("expected alert message to mention the task, consecutive count, and signature, got %q", alerts[0].Message)
+		}
+	})
+
+	t.Run("disabled rule does not fire", func(t *testing.T) {
+		config := &AlertConfig{
+			Enabled: true,
+			Channels: []ChannelConfig{
+				{Name: "test-channel", Type: "webhook", Enabled: true},
+			},
+			Rules: []AlertRule{
+				{
+					Name:     "env_class_failure_streak",
+					Type:     AlertTypeEnvClassFailureStreak,
+					Enabled:  false,
+					Severity: SeverityWarning,
+					Channels: []string{"test-channel"},
+					Cooldown: 0,
+				},
+			},
+		}
+
+		mockCh := newMockChannel("test-channel", "webhook")
+		dispatcher := NewDispatcher(config)
+		dispatcher.RegisterChannel(mockCh)
+
+		engine := NewEngine(config, WithDispatcher(dispatcher))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = engine.Start(ctx)
+
+		engine.ProcessEvent(newEvent("GH-5217-TASK", "5", "ANTHROPIC_API_KEY"))
+		engine.flushForTest()
+
+		if got := len(mockCh.getAlerts()); got != 0 {
+			t.Errorf("expected 0 alerts (rule disabled), got %d", got)
+		}
+	})
+
+	// An event that matches zero configured rules must not panic and must
+	// not fire — mirrors TestHandleDispatchLoopBreaker/
+	// TestHandleIntentJudgeFailureStreak's no-match subtest.
+	t.Run("no matching rule does not fire and does not panic", func(t *testing.T) {
+		config := &AlertConfig{
+			Enabled: true,
+			Channels: []ChannelConfig{
+				{Name: "test-channel", Type: "webhook", Enabled: true},
+			},
+			Rules: []AlertRule{
+				{
+					Name:     "unrelated_rule",
+					Type:     AlertTypeTaskFailed,
+					Enabled:  true,
+					Severity: SeverityWarning,
+					Channels: []string{"test-channel"},
+				},
+			},
+		}
+
+		mockCh := newMockChannel("test-channel", "webhook")
+		dispatcher := NewDispatcher(config)
+		dispatcher.RegisterChannel(mockCh)
+
+		engine := NewEngine(config, WithDispatcher(dispatcher))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = engine.Start(ctx)
+
+		engine.ProcessEvent(newEvent("GH-5217-TASK", "5", "ANTHROPIC_API_KEY"))
+		engine.flushForTest()
+
+		if got := len(mockCh.getAlerts()); got != 0 {
+			t.Errorf("expected 0 alerts (no matching rule), got %d", got)
+		}
+	})
+
+	// GH-5217 acceptance: N consecutive env-class failures fires once;
+	// further crossings within the cooldown window are suppressed even
+	// though the streak count keeps climbing — mirrors TestHandleLaneStarvation's
+	// "cooldown suppresses repeat fires" subtest below.
+	t.Run("cooldown suppresses repeat fires", func(t *testing.T) {
+		config := &AlertConfig{
+			Enabled: true,
+			Channels: []ChannelConfig{
+				{Name: "test-channel", Type: "webhook", Enabled: true},
+			},
+			Rules: []AlertRule{
+				{
+					Name:     "env_class_failure_streak",
+					Type:     AlertTypeEnvClassFailureStreak,
+					Enabled:  true,
+					Severity: SeverityWarning,
+					Channels: []string{"test-channel"},
+					Cooldown: 30 * time.Minute,
+				},
+			},
+		}
+
+		mockCh := newMockChannel("test-channel", "webhook")
+		dispatcher := NewDispatcher(config)
+		dispatcher.RegisterChannel(mockCh)
+		engine := NewEngine(config, WithDispatcher(dispatcher))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = engine.Start(ctx)
+
+		engine.ProcessEvent(newEvent("GH-5217-TASK", "5", "ANTHROPIC_API_KEY"))
+		waitForAlerts(t, mockCh, 1, 2*time.Second)
+
+		// The streak persists past the threshold on the next retry (6
+		// consecutive failures) — still within cooldown, must be
+		// suppressed.
+		engine.ProcessEvent(newEvent("GH-5217-TASK", "6", "ANTHROPIC_API_KEY"))
+		engine.flushForTest()
+
+		if got := len(mockCh.getAlerts()); got != 1 {
+			t.Errorf("expected 1 alert (second suppressed by cooldown), got %d", got)
+		}
+	})
+
+	// GH-5217 acceptance: once the cooldown window elapses, a persisting
+	// streak fires again — proving the alert is cooldown-*paced*, not a
+	// one-shot that goes silent forever once fired.
+	t.Run("fires again after cooldown expiry while streak persists", func(t *testing.T) {
+		config := &AlertConfig{
+			Enabled: true,
+			Channels: []ChannelConfig{
+				{Name: "test-channel", Type: "webhook", Enabled: true},
+			},
+			Rules: []AlertRule{
+				{
+					Name:     "env_class_failure_streak",
+					Type:     AlertTypeEnvClassFailureStreak,
+					Enabled:  true,
+					Severity: SeverityWarning,
+					Channels: []string{"test-channel"},
+					Cooldown: 50 * time.Millisecond,
+				},
+			},
+		}
+
+		mockCh := newMockChannel("test-channel", "webhook")
+		dispatcher := NewDispatcher(config)
+		dispatcher.RegisterChannel(mockCh)
+		engine := NewEngine(config, WithDispatcher(dispatcher))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = engine.Start(ctx)
+
+		engine.ProcessEvent(newEvent("GH-5217-TASK", "5", "ANTHROPIC_API_KEY"))
+		waitForAlerts(t, mockCh, 1, 2*time.Second)
+
+		time.Sleep(75 * time.Millisecond)
+
+		engine.ProcessEvent(newEvent("GH-5217-TASK", "6", "ANTHROPIC_API_KEY"))
+		waitForAlerts(t, mockCh, 1, 2*time.Second)
+
+		if got := len(mockCh.getAlerts()); got != 2 {
+			t.Errorf("expected 2 alerts (cooldown expired before the second crossing), got %d", got)
+		}
+	})
+}
+
 // TestHandleLaneStarvation covers the GH-4454 lane-starvation rule: the
 // emitting side (autopilot.Controller.reconcileLaneStarvation) does no
 // threshold filtering of its own and sends the raw streak on every starved

--- a/internal/alerts/types.go
+++ b/internal/alerts/types.go
@@ -110,6 +110,18 @@ const (
 	// failed, retrying" WARN lines with no dead-man coverage at all (the
 	// GH-4866 kill-drill's unwired-seam finding).
 	AlertTypePushRetryExhaustedFailureStreak AlertType = "push_retry_exhausted_failure_streak"
+
+	// AlertTypeEnvClassFailureStreak (GH-5217): a task's consecutive
+	// env-class (credential/environment) failure count — see
+	// executor.IsEnvClassFailure and the GH-5211 carve-out in
+	// Dispatcher.beginWithGenerationRetry — has reached the dispatcher's
+	// alert threshold (envClassFailureStreakThreshold). GH-5211 made
+	// env-class failures exempt from the identical-failure streak
+	// escalation so they retry forever via ordinary backoff; this type is
+	// the only thing that surfaces a persistent credential break to an
+	// operator instead of it retrying silently forever (PR#5214 review
+	// note 1).
+	AlertTypeEnvClassFailureStreak AlertType = "env_class_failure_streak"
 )
 
 // HandlerEmittedAlertTypes lists every AlertType whose handler
@@ -132,6 +144,7 @@ var HandlerEmittedAlertTypes = []AlertType{
 	AlertTypeSelfReviewFailureStreak,
 	AlertTypeFinishTripwireFailureStreak,
 	AlertTypePushRetryExhaustedFailureStreak,
+	AlertTypeEnvClassFailureStreak,
 }
 
 // CoverageGaps returns the subset of HandlerEmittedAlertTypes that cfg has
@@ -610,6 +623,28 @@ func defaultRules() []AlertRule {
 			Channels:    []string{},
 			Cooldown:    30 * time.Minute,
 			Description: "Alert when the git-push retry loop exhausts all attempts N+ consecutive times without a success",
+		},
+		// Env-class failure streak (GH-5217): caller
+		// (Dispatcher.beginWithGenerationRetry, the GH-5211 carve-out
+		// branch) does its own threshold counting
+		// (consecutiveEnvClassFailures) and fires the event once the
+		// streak reaches envClassFailureStreakThreshold, so no Condition
+		// field is needed here — mirrors dispatch_loop_breaker/
+		// intent_judge_failure_streak. Severity is Warning (not Critical):
+		// GH-5211 deliberately exempted env-class failures from stall
+		// escalation by founder decision — this rule closes the resulting
+		// silence gap (PR#5214 review) without treating a broken
+		// credential as page-critical the way a silently dead subsystem
+		// is.
+		{
+			Name:        "env_class_failure_streak",
+			Type:        AlertTypeEnvClassFailureStreak,
+			Enabled:     true,
+			Condition:   RuleCondition{},
+			Severity:    SeverityWarning,
+			Channels:    []string{},
+			Cooldown:    30 * time.Minute,
+			Description: "Alert when a task accumulates N+ consecutive env-class (credential/environment) failures without any attempt reaching the model backend",
 		},
 	}
 }

--- a/internal/alerts/types_test.go
+++ b/internal/alerts/types_test.go
@@ -79,6 +79,8 @@ func TestDefaultRules(t *testing.T) {
 		AlertTypeFinishTripwireFailureStreak: {"finish_tripwire_failure_streak", true},
 		// Push-retry-exhausted dead-man tracker (GH-4866)
 		AlertTypePushRetryExhaustedFailureStreak: {"push_retry_exhausted_failure_streak", true},
+		// Env-class failure streak (GH-5217)
+		AlertTypeEnvClassFailureStreak: {"env_class_failure_streak", true},
 	}
 
 	if len(rules) != len(expectedRules) {

--- a/internal/executor/alerts.go
+++ b/internal/executor/alerts.go
@@ -90,6 +90,21 @@ const (
 	// pilot-failed-retry-exhausted hook (title_rejection.go), populates
 	// Error rather than that metadata.
 	AlertEventTypeEscalation AlertEventType = "escalation"
+
+	// AlertEventTypeEnvClassFailureStreak (GH-5217) mirrors
+	// alerts.EventTypeEnvClassFailureStreak ("env_class_failure_streak")
+	// byte-for-byte — EngineAdapter.ProcessEvent forwards AlertEventType
+	// values across the executor/alerts package boundary via a direct
+	// string cast, so this value must match exactly. GH-5211 exempted
+	// env-class (credential/environment) failures from the
+	// identical-failure streak escalation so they retry forever via
+	// ordinary backoff — correct, by founder decision, but it left a
+	// silent infinite retry loop announced only by an Info log line
+	// (PR#5214 review note 1). Dispatcher.beginWithGenerationRetry emits
+	// this once the consecutive env-class failure count reaches
+	// envClassFailureStreakThreshold, purely additive to the existing
+	// retry behavior.
+	AlertEventTypeEnvClassFailureStreak AlertEventType = "env_class_failure_streak"
 )
 
 // SelfReviewDeadManTrackerName is the alerts.DeadManTracker registration

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -1431,19 +1431,66 @@ func (d *Dispatcher) priorClaimWasInfra(taskID, projectPath string) bool {
 // priorClaimWasStalled/priorClaimWasInfra: errors are treated as "not
 // env-class" — the caller falls through to the ordinary backoff/hard-cap
 // path, which is the safe default.
-func (d *Dispatcher) priorClaimWasEnvClassFailure(taskID, projectPath string) bool {
+// Returns the claimed execution's error string alongside the bool (GH-5217)
+// so the caller can derive the matched credential/env signature
+// (MatchedEnvClassFailureSignature) for the failure-streak alert without a
+// second store round-trip.
+func (d *Dispatcher) priorClaimWasEnvClassFailure(taskID, projectPath string) (bool, string) {
 	_, execID, found, err := d.store.LatestClaimGeneration(taskID, projectPath)
 	if err != nil || !found {
-		return false
+		return false, ""
 	}
 	exec, err := d.store.GetExecution(execID)
 	if err != nil || exec == nil {
-		return false
+		return false, ""
 	}
 	if exec.Status != string(ExecStatusFailed) {
-		return false
+		return false, ""
 	}
-	return IsEnvClassFailure(exec.Error, exec.TokensTotal, exec.CommitSHA, exec.PRUrl, time.Duration(exec.DurationMs)*time.Millisecond)
+	if !IsEnvClassFailure(exec.Error, exec.TokensTotal, exec.CommitSHA, exec.PRUrl, time.Duration(exec.DurationMs)*time.Millisecond) {
+		return false, ""
+	}
+	return true, exec.Error
+}
+
+// envClassFailureStreakThreshold is N in "N consecutive env-class
+// (credential/environment) failures in a row for the same (task_id,
+// project_path)" (GH-5217). GH-5211 exempted env-class failures from the
+// identical-failure streak escalation so they retry forever via ordinary
+// backoff — correct (a broken credential is not evidence the task's own
+// code is wrong), by founder decision, but it left a silent infinite retry
+// loop announced only by an Info log line (PR#5214 review note 1). At this
+// threshold, beginWithGenerationRetry emits a warning alert — purely
+// additive; retries continue exactly as before — so a persistent
+// credential break pages an operator instead of retrying invisibly
+// forever.
+const envClassFailureStreakThreshold = 5
+
+// consecutiveEnvClassFailures counts how many of the most recent executions
+// for (taskID, projectPath) — read newest-first via ListExecutionsForTask,
+// the same recent-claims scan shape priorClaimsHadIdenticalFailureStreak
+// uses below — are consecutive env-class (credential/environment) failures
+// per IsEnvClassFailure. The scan stops at the first row that doesn't
+// match (a success, a non-env-class failure, or any other status), so a
+// successful or non-env-class generation resets the count to 0 on the very
+// next call — no separate reset bookkeeping needed. GH-5217. Errors are
+// treated as "no streak" (count 0), the safe default.
+func (d *Dispatcher) consecutiveEnvClassFailures(taskID, projectPath string) int {
+	execs, err := d.store.ListExecutionsForTask(taskID, projectPath)
+	if err != nil {
+		return 0
+	}
+	count := 0
+	for _, exec := range execs {
+		if exec.Status != string(ExecStatusFailed) {
+			break
+		}
+		if !IsEnvClassFailure(exec.Error, exec.TokensTotal, exec.CommitSHA, exec.PRUrl, time.Duration(exec.DurationMs)*time.Millisecond) {
+			break
+		}
+		count++
+	}
+	return count
 }
 
 // consecutiveIdenticalFailureThreshold is N in "the last N consecutive
@@ -1726,12 +1773,44 @@ func (d *Dispatcher) beginWithGenerationRetry(task *Task, initial Status) (strin
 	// separate drop counter — it simply falls through to the ordinary
 	// backoff/hard-cap path below, retrying via nextRetryGeneration with the
 	// existing repick backoff pacing.
-	if d.priorClaimWasEnvClassFailure(task.ID, task.ProjectPath) {
+	if wasEnvClass, envErrStr := d.priorClaimWasEnvClassFailure(task.ID, task.ProjectPath); wasEnvClass {
+		streak := d.consecutiveEnvClassFailures(task.ID, task.ProjectPath)
 		d.log.Info("dispatch re-pick: prior claim was an env-class (credential/environment) failure — exempt from identical-failure streak escalation",
 			slog.String("task_id", task.ID),
 			slog.String("project", task.ProjectPath),
 			slog.Int("generation", gen),
+			slog.Int("consecutive_env_class_failures", streak),
 		)
+
+		// GH-5217: retries continue exactly as above (this branch falls
+		// through to the ordinary backoff path below, unchanged) — the
+		// alert is purely additive. It closes the silence gap PR#5214's
+		// review flagged: without it, a hosted tenant with a persistently
+		// broken credential retries forever announced only by the Info
+		// line above. Fires once the streak crosses
+		// envClassFailureStreakThreshold and again on any later crossing
+		// call that clears the rule's cooldown (alerts.Engine
+		// handleEnvClassFailureStreak) while the streak persists; a
+		// successful or non-env-class generation resets the count to 0 on
+		// the very next call, so the alert stops on its own once the
+		// credential is fixed.
+		if streak >= envClassFailureStreakThreshold && d.runner != nil {
+			signature := MatchedEnvClassFailureSignature(envErrStr)
+			d.runner.EmitAlertEvent(AlertEvent{
+				Type:      AlertEventTypeEnvClassFailureStreak,
+				TaskID:    task.ID,
+				TaskTitle: task.Title,
+				Project:   task.ProjectPath,
+				Error:     envErrStr,
+				Metadata: map[string]string{
+					"task_id":              task.ID,
+					"project":              task.ProjectPath,
+					"consecutive_failures": fmt.Sprintf("%d", streak),
+					"credential_signature": signature,
+				},
+				Timestamp: time.Now(),
+			})
+		}
 	} else if hadStreak, errStr := d.priorClaimsHadIdenticalFailureStreak(task.ID, task.ProjectPath); hadStreak {
 		// GH-4586: independent of error class, the last
 		// consecutiveIdenticalFailureThreshold consecutive generations

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -4878,6 +4878,223 @@ func TestDispatcher_BeginWithGenerationRetry_EnvClassTextMatchAloneStillEscalate
 	}
 }
 
+// TestDispatcher_BeginWithGenerationRetry_EnvClassFailureStreakAlert is the
+// GH-5217 acceptance test: once a task accumulates
+// envClassFailureStreakThreshold consecutive env-class (credential/
+// environment) failures, beginWithGenerationRetry must emit exactly one
+// AlertEventTypeEnvClassFailureStreak alert naming the task, the
+// consecutive count, and the matched credential signature — purely
+// additive: retry admission is unaffected (mirrors the GH-5211 exemption
+// test above, which asserts the SAME streak never trips
+// escalateIdenticalFailureStreak).
+func TestDispatcher_BeginWithGenerationRetry_EnvClassFailureStreakAlert(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GH-5217-STREAK", ProjectPath: "/project-5217-streak", Title: "Env-class streak task"}
+	runner := NewRunner()
+	processor := &fakeAlertProcessor{}
+	runner.SetAlertProcessor(processor)
+	dispatcher := NewDispatcher(store, runner, nil)
+	lifecycle := NewExecutionLifecycle(store)
+
+	const envErr = "no API key configured for anthropic-api backend"
+
+	markEnvClassFailed := func(execID string) {
+		if err := store.UpdateExecutionStatus(execID, "failed", envErr); err != nil {
+			t.Fatalf("setup: failed to mark %s as failed: %v", execID, err)
+		}
+		if err := store.UpdateExecutionResult(execID, "", "", 4000); err != nil {
+			t.Fatalf("setup: failed to set duration for %s: %v", execID, err)
+		}
+		if err := store.SaveExecutionMetrics(&memory.ExecutionMetrics{ExecutionID: execID, TokensTotal: 0}); err != nil {
+			t.Fatalf("setup: failed to zero tokens for %s: %v", execID, err)
+		}
+	}
+
+	// envClassFailureStreakThreshold consecutive env-class failures
+	// (generations 0..threshold-1).
+	for gen := 0; gen < envClassFailureStreakThreshold; gen++ {
+		var execID string
+		var err error
+		if gen == 0 {
+			execID, err = lifecycle.Begin(task, ExecStatusRunning)
+		} else {
+			execID, err = lifecycle.Begin(task, ExecStatusRunning, gen)
+		}
+		if err != nil {
+			t.Fatalf("setup Begin gen%d: %v", gen, err)
+		}
+		markEnvClassFailed(execID)
+	}
+
+	freshTask := &Task{ID: task.ID, ProjectPath: task.ProjectPath, Title: task.Title}
+	retryExecID, err := dispatcher.beginWithGenerationRetry(freshTask, ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("beginWithGenerationRetry: %v", err)
+	}
+	if retryExecID == "" {
+		t.Fatal("expected a fresh generation to still be granted — the alert is purely additive to retry admission")
+	}
+
+	var streakEvents []AlertEvent
+	for _, ev := range processor.events {
+		if ev.Type == AlertEventTypeEnvClassFailureStreak {
+			streakEvents = append(streakEvents, ev)
+		}
+	}
+	if len(streakEvents) != 1 {
+		t.Fatalf("expected exactly 1 env-class-failure-streak alert at the threshold, got %d: %+v", len(streakEvents), processor.events)
+	}
+
+	ev := streakEvents[0]
+	if ev.TaskID != task.ID {
+		t.Errorf("expected alert TaskID %q, got %q", task.ID, ev.TaskID)
+	}
+	if got := ev.Metadata["consecutive_failures"]; got != fmt.Sprintf("%d", envClassFailureStreakThreshold) {
+		t.Errorf("expected consecutive_failures metadata %d, got %q", envClassFailureStreakThreshold, got)
+	}
+	if got := ev.Metadata["credential_signature"]; got == "" {
+		t.Errorf("expected a non-empty matched credential signature, got %q", got)
+	}
+}
+
+// TestDispatcher_BeginWithGenerationRetry_EnvClassFailureStreakBelowThresholdNoAlert
+// covers GH-5217 acceptance bullet 2 (the "N-1" half): one short of
+// envClassFailureStreakThreshold consecutive env-class failures must not
+// fire the streak alert yet, even though the carve-out branch runs and
+// retry is still granted.
+func TestDispatcher_BeginWithGenerationRetry_EnvClassFailureStreakBelowThresholdNoAlert(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GH-5217-BELOW", ProjectPath: "/project-5217-below", Title: "Env-class below-threshold task"}
+	runner := NewRunner()
+	processor := &fakeAlertProcessor{}
+	runner.SetAlertProcessor(processor)
+	dispatcher := NewDispatcher(store, runner, nil)
+	lifecycle := NewExecutionLifecycle(store)
+
+	const envErr = "no API key configured for anthropic-api backend"
+
+	markEnvClassFailed := func(execID string) {
+		if err := store.UpdateExecutionStatus(execID, "failed", envErr); err != nil {
+			t.Fatalf("setup: failed to mark %s as failed: %v", execID, err)
+		}
+		if err := store.UpdateExecutionResult(execID, "", "", 4000); err != nil {
+			t.Fatalf("setup: failed to set duration for %s: %v", execID, err)
+		}
+		if err := store.SaveExecutionMetrics(&memory.ExecutionMetrics{ExecutionID: execID, TokensTotal: 0}); err != nil {
+			t.Fatalf("setup: failed to zero tokens for %s: %v", execID, err)
+		}
+	}
+
+	for gen := 0; gen < envClassFailureStreakThreshold-1; gen++ {
+		var execID string
+		var err error
+		if gen == 0 {
+			execID, err = lifecycle.Begin(task, ExecStatusRunning)
+		} else {
+			execID, err = lifecycle.Begin(task, ExecStatusRunning, gen)
+		}
+		if err != nil {
+			t.Fatalf("setup Begin gen%d: %v", gen, err)
+		}
+		markEnvClassFailed(execID)
+	}
+
+	freshTask := &Task{ID: task.ID, ProjectPath: task.ProjectPath, Title: task.Title}
+	retryExecID, err := dispatcher.beginWithGenerationRetry(freshTask, ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("beginWithGenerationRetry: %v", err)
+	}
+	if retryExecID == "" {
+		t.Fatal("expected a fresh generation to be granted below the streak threshold")
+	}
+
+	if len(processor.events) != 0 {
+		t.Fatalf("expected no alert events below the streak threshold, got %d: %+v", len(processor.events), processor.events)
+	}
+}
+
+// TestDispatcher_BeginWithGenerationRetry_EnvClassFailureStreakResetsOnNonEnvClassOutcome
+// covers GH-5217 acceptance bullet 2 (the "then a non-env-class outcome"
+// half): envClassFailureStreakThreshold-1 consecutive env-class failures
+// followed by a genuine code failure (tokens produced, so IsEnvClassFailure's
+// structural check fails) as the LATEST generation must not fire the
+// env-class-failure-streak alert — priorClaimWasEnvClassFailure gates on the
+// latest claim only, so a non-env-class outcome breaks the run before
+// consecutiveEnvClassFailures is ever consulted, exactly as spec item 3
+// describes ("a successful (or non-env-class) generation resets the count
+// naturally since the scan is over most-recent consecutive rows").
+func TestDispatcher_BeginWithGenerationRetry_EnvClassFailureStreakResetsOnNonEnvClassOutcome(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GH-5217-RESET", ProjectPath: "/project-5217-reset", Title: "Env-class streak reset task"}
+	runner := NewRunner()
+	processor := &fakeAlertProcessor{}
+	runner.SetAlertProcessor(processor)
+	dispatcher := NewDispatcher(store, runner, nil)
+	lifecycle := NewExecutionLifecycle(store)
+
+	const envErr = "no API key configured for anthropic-api backend"
+	markEnvClassFailed := func(execID string) {
+		if err := store.UpdateExecutionStatus(execID, "failed", envErr); err != nil {
+			t.Fatalf("setup: failed to mark %s as failed: %v", execID, err)
+		}
+		if err := store.UpdateExecutionResult(execID, "", "", 4000); err != nil {
+			t.Fatalf("setup: failed to set duration for %s: %v", execID, err)
+		}
+		if err := store.SaveExecutionMetrics(&memory.ExecutionMetrics{ExecutionID: execID, TokensTotal: 0}); err != nil {
+			t.Fatalf("setup: failed to zero tokens for %s: %v", execID, err)
+		}
+	}
+
+	for gen := 0; gen < envClassFailureStreakThreshold-1; gen++ {
+		var execID string
+		var err error
+		if gen == 0 {
+			execID, err = lifecycle.Begin(task, ExecStatusRunning)
+		} else {
+			execID, err = lifecycle.Begin(task, ExecStatusRunning, gen)
+		}
+		if err != nil {
+			t.Fatalf("setup Begin gen%d: %v", gen, err)
+		}
+		markEnvClassFailed(execID)
+	}
+
+	// The most recent generation is a genuine code failure: tokens were
+	// produced, so the structural check fails even though nothing here
+	// matches an env-class signature at all.
+	const codeErr = "quality gate failed: nil pointer dereference in handler.go"
+	lastGen := envClassFailureStreakThreshold - 1
+	lastExecID, err := lifecycle.Begin(task, ExecStatusRunning, lastGen)
+	if err != nil {
+		t.Fatalf("setup Begin gen%d: %v", lastGen, err)
+	}
+	if err := store.UpdateExecutionStatus(lastExecID, "failed", codeErr); err != nil {
+		t.Fatalf("setup: failed to mark %s as failed: %v", lastExecID, err)
+	}
+	if err := store.SaveExecutionMetrics(&memory.ExecutionMetrics{ExecutionID: lastExecID, TokensTotal: 8000}); err != nil {
+		t.Fatalf("setup: failed to set tokens for %s: %v", lastExecID, err)
+	}
+
+	freshTask := &Task{ID: task.ID, ProjectPath: task.ProjectPath, Title: task.Title}
+	retryExecID, err := dispatcher.beginWithGenerationRetry(freshTask, ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("beginWithGenerationRetry: %v", err)
+	}
+	if retryExecID == "" {
+		t.Fatal("expected a fresh generation to be granted — a single non-env-class failure is not (yet) an identical-failure streak")
+	}
+
+	if len(processor.events) != 0 {
+		t.Fatalf("expected no alert events once the latest generation is non-env-class, got %d: %+v", len(processor.events), processor.events)
+	}
+}
+
 // TestRepickBackoffKey_FormatMatchesCmdPilotPackage is the GH-4394 subtask 4
 // counterpart to cmd/pilot's TestRepickBackoffKey_FormatMatchesDispatcherPackage.
 // cmd/pilot cannot import internal/executor's unexported repickBackoffKey (and

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -152,6 +152,26 @@ func IsEnvClassFailure(errStr string, tokensTotal int64, commitSHA, prURL string
 	return tokensTotal == 0 && commitSHA == "" && prURL == "" && duration < EnvClassFailureDurationThreshold
 }
 
+// MatchedEnvClassFailureSignature returns the first envClassFailureSignatures
+// entry found in errStr (case-insensitive, the same matching logic
+// IsEnvClassFailureText's containsAny uses), or "" if none match. GH-5217:
+// the dispatcher's env-class failure streak alert names which
+// credential/env signature is recurring (e.g. "ANTHROPIC_API_KEY") so an
+// operator can tell which credential rotted without reading the raw error
+// text.
+func MatchedEnvClassFailureSignature(errStr string) string {
+	if errStr == "" {
+		return ""
+	}
+	textLower := toLowerASCII(errStr)
+	for _, sig := range envClassFailureSignatures {
+		if containsSubstr(textLower, toLowerASCII(sig)) {
+			return sig
+		}
+	}
+	return ""
+}
+
 // reapErrorSignatures are substrings written by the dispatcher's stale-task
 // recovery (dispatcher.go recoverStaleRunningTasks / recoverStaleQueuedTasks)
 // when a daemon restart orphans a running or queued execution row. These

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -4006,6 +4006,37 @@ func TestIsEnvClassFailure(t *testing.T) {
 	}
 }
 
+// TestMatchedEnvClassFailureSignature verifies MatchedEnvClassFailureSignature
+// (GH-5217) names the specific credential/env signature matched in an error
+// string, for use in the dispatcher's env-class failure streak alert.
+func TestMatchedEnvClassFailureSignature(t *testing.T) {
+	tests := []struct {
+		name   string
+		errStr string
+		want   string
+	}{
+		{"empty string", "", ""},
+		{"ANTHROPIC_API_KEY", "no ANTHROPIC_API_KEY set in environment", "ANTHROPIC_API_KEY"},
+		{"PILOT_ENGINE_API_KEY", "PILOT_ENGINE_API_KEY is missing", "PILOT_ENGINE_API_KEY"},
+		{"ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_AUTH_TOKEN invalid", "ANTHROPIC_AUTH_TOKEN"},
+		{"CLAUDE_CODE_OAUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN expired", "CLAUDE_CODE_OAUTH_TOKEN"},
+		{"no API key configured", "no API key configured for anthropic-api backend", "no API key configured"},
+		{"requires an API key", "openai backend requires an API key: set OPENAI_API_KEY", "requires an API key"},
+		{"case-insensitive match", "no anthropic_api_key set in environment", "ANTHROPIC_API_KEY"},
+		{"no match", "quality gate failed: 3 lint errors", ""},
+		{"first-match-wins order", "ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN both missing", "ANTHROPIC_API_KEY"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MatchedEnvClassFailureSignature(tt.errStr)
+			if got != tt.want {
+				t.Errorf("MatchedEnvClassFailureSignature(%q) = %q, want %q", tt.errStr, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestRunnerFallbackModelName verifies that the telemetry fallback model name
 // reflects the configured backend, not a hardcoded default. GH-2428.
 func TestRunnerFallbackModelName(t *testing.T) {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5217.

Closes #5217

## Changes

GitHub Issue GH-5217: feat(alerts): warning alert on persistent env-class failure streak — credential rot is currently a silent 16-min retry loop

## Context

Part of #5008 / TASK-485 follow-up, from PR#5214's review verdict. GH-5211 made env-class failures (missing/invalid credential, 0 tokens, no deliverable, instant exit) exempt from the identical-failure streak escalation — they now retry forever via the ordinary backoff path (window capped ~16 min), by founder decision. Correct, but it created a silence gap: a hosted tenant whose credential stays broken gets an infinite retry loop announced only by an Info-level log line ("dispatch re-pick: prior claim was an env-class ... failure"). Nothing pages anyone. Pre-GH-5211 the (wrong) stall escalation at least produced a visible alert.

## Task

Do not decompose this issue — it is a single-subsystem change that must land as one PR.

Emit a warning alert when a task accumulates N consecutive env-class failures, without changing retry behavior:

1. In `internal/executor/dispatcher.go`, inside the GH-5211 env-class carve-out branch of the retry path (the block that logs the exempt-from-streak Info line): count how many consecutive most-recent generations for this (task, project) are env-class failures — reuse the same recent-claims scan shape the identical-failure streak check uses, with `IsEnvClassFailure` (`internal/executor/runner.go`) as the per-row predicate.
2. At threshold N (constant, default 5) emit an alert via the runner's existing EmitAlertEvent seam (the same call sites used at `internal/executor/dispatcher.go:2108` and `internal/executor/dispatcher.go:3371`), severity warning, message naming the task, the matched credential signature, and the consecutive count. Mirror the existing failure-streak alert idiom — see AlertTypeSelfReviewFailureStreak and AlertTypeLabelLifecycleFailureStreak in `internal/executor/alerts.go` and the corresponding rule entries in `internal/alerts/types.go` — including a rule with a cooldown so a persistent breakage alerts periodically, not per retry.
3. Retries continue exactly as today — the alert is purely additive. Alert once per threshold crossing plus cooldown-paced repeats while the streak persists; a successful (or non-env-class) generation resets the count naturally since the scan is over most-recent consecutive rows.

## Acceptance

- [ ] Test: N consecutive env-class failed generations → exactly one warning alert emitted (cooldown suppresses repeats within the window); retry admission unaffected (next generation still granted).
- [ ] Test: N-1 env-class failures then a non-env-class outcome → no alert.
- [ ] Test: alert fires again after cooldown expiry while the streak persists.
- [ ] Rule is registered/enabled in the default alert config path so it is live without operator config edits; existing alert tests pass.
- [ ] make test and make lint green.

## Refs

- PR#5214 review note 1 (silence gap) · #5008 · GH-5211
- Carve-out branch: `internal/executor/dispatcher.go` (GH-5211 block ahead of the identical-failure streak check)
- Classifier: `internal/executor/runner.go` (IsEnvClassFailure, EnvClassFailureDurationThreshold)