### PR TITLE
GH-5221: fix(executor): auto-init must guarantee context-injection sections regardless of template source (plugin template bypasses #5216 fix)

### DIFF
--- a/.agent/tasks/gh-5221.md
+++ b/.agent/tasks/gh-5221.md
@@ -1,0 +1,39 @@
+# GH-5221
+
+**Created:** 2026-08-25
+
+## Problem
+
+GitHub Issue GH-5221: fix(executor): auto-init must guarantee context-injection sections regardless of template source (plugin template bypasses #5216 fix)
+
+## Context
+
+Follow-up to #5216 / PR #5219. That fix added the three sections `loadProjectContext()` (`internal/executor/prompt_builder.go:801-815`) extracts (`### Key Components`, `## Key Files`, `## Project Structure`) to the **embedded** template — but `Initialize()` (`internal/executor/navigator.go`) prefers the installed Navigator plugin's templates (`FindTemplatesPath()` → `~/.claude/plugins/cache/navigator-marketplace/navigator/<ver>/templates`) and only falls back to embedded when the plugin is absent.
+
+The plugin's own `DEVELOPMENT-README.md` template (verified against 6.18.1) contains **none** of those headers. Consequence, confirmed by running the suite on a machine with the plugin cache present:
+
+- Context injection is still a permanent no-op on plugin-bearing machines — including the production box.
+- `TestInitialize_ProjectContextInjectionActivates` fails there (`got empty string`) while passing on plugin-free CI runners — an environment-dependent flake.
+
+Pilot must guarantee its own consumption contract regardless of which template source wins.
+
+## Implementation
+
+1. In `Initialize()` (`internal/executor/navigator.go`), after `copyTemplate("DEVELOPMENT-README.md", ...)`, add an ensure-sections step: append skeleton sections to the generated README for any of the three headers that are missing (`### Key Components`, `## Key Files`, `## Project Structure`), using the same placeholder bodies the embedded template now carries. Idempotent: exact-header check, append only what's absent, never duplicate or reorder existing content.
+2. Apply the same invariant check for the `/nav-` command scrub is NOT needed (do not rewrite plugin template content beyond appending missing sections) — only guarantee presence of the three extraction anchors.
+3. Isolate the auto-init tests from the developer's real plugin cache: in `internal/executor/navigator_test.go`, the `TestInitialize_*` and `TestGeneratedReadme_NoNavCommandInstructions` tests should `t.Setenv("HOME", t.TempDir())` (same idiom `TestFindTemplatesPath_VersionSelection` already uses) so they exercise the embedded path deterministically.
+4. Add one new test that simulates a plugin cache whose `DEVELOPMENT-README.md` template lacks the three headers (temp HOME + fabricated `navigator/9.0.0/templates/DEVELOPMENT-README.md`) and asserts `loadProjectContext()` is non-empty after `Initialize()` — this is the regression test for the actual production path.
+
+## Acceptance
+
+- With a fabricated plugin template missing all three headers, `Initialize()` produces a README for which `loadProjectContext()` returns a non-empty string containing `Key Files` and `Project Structure` (new test).
+- Ensure-sections is idempotent: running the section-ensure logic on a README that already has all three headers changes nothing (test asserts byte-equality).
+- All `TestInitialize_*` tests pass identically whether or not `~/.claude/plugins/cache/navigator-marketplace` exists (HOME isolation).
+- `make build test lint` pass.
+
+## Refs
+
+- #5216, PR #5219 (review comment documents the reproduction)
+
+## Acceptance Criteria
+

--- a/internal/executor/navigator.go
+++ b/internal/executor/navigator.go
@@ -224,8 +224,12 @@ func (n *NavigatorInitializer) Initialize(projectPath string) error {
 	// Copy and customize templates — continue on individual failures
 	var initErrors []string
 
-	if err := n.copyTemplate("DEVELOPMENT-README.md", filepath.Join(agentDir, "DEVELOPMENT-README.md"), info); err != nil {
+	readmePath := filepath.Join(agentDir, "DEVELOPMENT-README.md")
+	if err := n.copyTemplate("DEVELOPMENT-README.md", readmePath, info); err != nil {
 		n.log.Warn("Failed to copy DEVELOPMENT-README.md", slog.Any("error", err))
+		initErrors = append(initErrors, err.Error())
+	} else if err := ensureContextSections(readmePath); err != nil {
+		n.log.Warn("Failed to ensure context-injection sections in DEVELOPMENT-README.md", slog.Any("error", err))
 		initErrors = append(initErrors, err.Error())
 	}
 
@@ -317,6 +321,91 @@ func (n *NavigatorInitializer) customizeTemplate(content string, info *ProjectIn
 	}
 
 	return result
+}
+
+// contextSection pairs a section header with the skeleton placeholder body
+// the embedded template (templates/DEVELOPMENT-README.md) carries for it.
+type contextSection struct {
+	header string
+	body   string
+}
+
+// contextInjectionSections are the three headers loadProjectContext()
+// (prompt_builder.go) extracts from DEVELOPMENT-README.md to build the
+// context Pilot injects into every task prompt.
+var contextInjectionSections = []contextSection{
+	{
+		header: "### Key Components",
+		body:   "\n_Describe the major components/services and their responsibilities — fill in\nduring the first task session._\n",
+	},
+	{
+		header: "## Key Files",
+		body:   "\n_List the files a new session should read first — fill in as the project grows._\n",
+	},
+	{
+		header: "## Project Structure",
+		body:   "\n```\n[Project Name]/\n└── .agent/              ← Navigator docs (this directory)\n```\n\n_Fill in the real source tree above during the first task session._\n",
+	},
+}
+
+// hasContextSectionHeader reports whether header appears on its own line
+// (with optional trailing whitespace), so "## Key Files" doesn't false-match
+// inside a longer or differently-leveled header like "### Key Files" or
+// "## Key Files Extended".
+func hasContextSectionHeader(text, header string) bool {
+	re := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(header) + `\s*$`)
+	return re.MatchString(text)
+}
+
+// ensureContextSections guarantees that the generated DEVELOPMENT-README.md
+// contains the three headers loadProjectContext() extracts, regardless of
+// which template source (installed Navigator plugin vs embedded fallback)
+// produced it.
+//
+// GH-5221: Initialize() prefers the installed plugin's templates
+// (FindTemplatesPath) over the embedded one added for GH-5216, and the
+// plugin's own DEVELOPMENT-README.md template (verified against 6.18.1)
+// carries none of these headers — so context injection stayed a permanent
+// no-op on any machine with the plugin installed, including production.
+// This guarantees Pilot's own consumption contract independent of which
+// template source wins: append skeleton sections for whichever headers are
+// missing, without touching content that's already present. Idempotent —
+// running it again on a README that already has all three headers is a
+// no-op (exact-header check, append-only, never reorders existing content).
+func ensureContextSections(readmePath string) error {
+	content, err := os.ReadFile(readmePath)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", readmePath, err)
+	}
+
+	text := string(content)
+	var toAppend strings.Builder
+
+	for _, section := range contextInjectionSections {
+		if hasContextSectionHeader(text, section.header) {
+			continue
+		}
+		toAppend.WriteString("\n")
+		toAppend.WriteString(section.header)
+		toAppend.WriteString("\n")
+		toAppend.WriteString(section.body)
+	}
+
+	if toAppend.Len() == 0 {
+		return nil
+	}
+
+	f, err := os.OpenFile(readmePath, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open %s for append: %w", readmePath, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := f.WriteString(toAppend.String()); err != nil {
+		return fmt.Errorf("failed to append context sections to %s: %w", readmePath, err)
+	}
+
+	return nil
 }
 
 // createNavConfig creates the .nav-config.json file.

--- a/internal/executor/navigator_test.go
+++ b/internal/executor/navigator_test.go
@@ -141,6 +141,7 @@ func TestIsInitialized(t *testing.T) {
 }
 
 func TestInitialize(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	tmpDir := t.TempDir()
 
 	// Create a go.mod for project detection
@@ -228,6 +229,7 @@ go 1.21
 }
 
 func TestInitialize_Idempotent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	tmpDir := t.TempDir()
 
 	initializer, err := NewNavigatorInitializer(logging.WithComponent("test"))
@@ -291,6 +293,7 @@ Detected: ${DETECTED_FROM}
 // from the generated DEVELOPMENT-README.md. Before this fix, the shipped
 // template contained none of those headers, so this always returned "".
 func TestInitialize_ProjectContextInjectionActivates(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	tmpDir := t.TempDir()
 
 	initializer, err := NewNavigatorInitializer(logging.WithComponent("test"))
@@ -321,6 +324,7 @@ func TestInitialize_ProjectContextInjectionActivates(t *testing.T) {
 // the "## Core Execution" table (anchor-based insertion), not appended past
 // unrelated trailing content — i.e. not the fallback-append branch.
 func TestInitialize_FeatureMatrixSeededAndUpdatable(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	tmpDir := t.TempDir()
 
 	initializer, err := NewNavigatorInitializer(logging.WithComponent("test"))
@@ -391,6 +395,7 @@ func TestInitialize_FeatureMatrixSeededAndUpdatable(t *testing.T) {
 // takes the parse path instead (still returns empty, since there are no
 // concepts/memories yet, but via a successful unmarshal).
 func TestInitialize_KnowledgeGraphSeededForRecall(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	tmpDir := t.TempDir()
 
 	initializer, err := NewNavigatorInitializer(logging.WithComponent("test"))
@@ -435,6 +440,7 @@ func TestInitialize_KnowledgeGraphSeededForRecall(t *testing.T) {
 // /nav-loop, /nav-compact — Navigator-plugin slash commands that don't exist
 // in a plain executor session (removed from public docs in commit 4b47e7a3).
 func TestGeneratedReadme_NoNavCommandInstructions(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	tmpDir := t.TempDir()
 
 	initializer, err := NewNavigatorInitializer(logging.WithComponent("test"))
@@ -506,6 +512,112 @@ func TestFindTemplatesPath_VersionSelection(t *testing.T) {
 				t.Errorf("FindTemplatesPath() = %q, want %q", got, want)
 			}
 		})
+	}
+}
+
+// TestInitialize_ContextSectionsGuaranteedForPluginTemplate is the GH-5221
+// regression test: the installed Navigator plugin's own
+// DEVELOPMENT-README.md template (verified against 6.18.1) carries none of
+// the three headers loadProjectContext() extracts, so on any machine with
+// the plugin cache present (FindTemplatesPath wins over the embedded
+// fallback), context injection stayed a permanent no-op even after the
+// GH-5216 fix to the embedded template. This fabricates a plugin cache
+// whose template lacks all three headers and asserts Initialize() still
+// guarantees them via ensureContextSections.
+func TestInitialize_ContextSectionsGuaranteedForPluginTemplate(t *testing.T) {
+	home := t.TempDir()
+	projectDir := t.TempDir()
+
+	pluginTemplatesDir := filepath.Join(home, ".claude", "plugins", "cache", "navigator-marketplace", "navigator", "9.0.0", "templates")
+	if err := os.MkdirAll(pluginTemplatesDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fabricated plugin template missing "### Key Components", "## Key
+	// Files" and "## Project Structure" — mirrors the real plugin template's
+	// shape.
+	pluginReadme := `# [Project Name] - Development Navigator
+
+**Project**: [Brief project description]
+**Tech Stack**: [Your tech stack]
+
+## Quick Start
+
+Some quick start instructions with no context-injection anchors.
+`
+	if err := os.WriteFile(filepath.Join(pluginTemplatesDir, "DEVELOPMENT-README.md"), []byte(pluginReadme), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+
+	initializer, err := NewNavigatorInitializer(logging.WithComponent("test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if initializer.templatesPath == "" {
+		t.Fatal("expected NewNavigatorInitializer to pick up the fabricated plugin templates path, got embedded fallback")
+	}
+
+	if err := initializer.Initialize(projectDir); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	agentDir := filepath.Join(projectDir, ".agent")
+	got := loadProjectContext(agentDir)
+	if got == "" {
+		t.Fatal("expected loadProjectContext to return non-empty context even when the winning template lacks context-injection headers, got empty string")
+	}
+
+	for _, header := range []string{"Key Files", "Project Structure"} {
+		if !strings.Contains(got, header) {
+			t.Errorf("expected injected context to include a %q section, got:\n%s", header, got)
+		}
+	}
+}
+
+// TestEnsureContextSections_IdempotentWhenHeadersPresent asserts
+// ensureContextSections is a true no-op — byte-for-byte — when a README
+// already carries all three context-injection headers, so it never
+// duplicates or reorders existing content on repeat auto-init runs.
+func TestEnsureContextSections_IdempotentWhenHeadersPresent(t *testing.T) {
+	tmpDir := t.TempDir()
+	readmePath := filepath.Join(tmpDir, "DEVELOPMENT-README.md")
+
+	content := `# Project
+
+## Quick Start
+
+Some instructions.
+
+### Key Components
+
+Some components.
+
+## Key Files
+
+Some files.
+
+## Project Structure
+
+Some structure.
+`
+	if err := os.WriteFile(readmePath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureContextSections(readmePath); err != nil {
+		t.Fatalf("ensureContextSections failed: %v", err)
+	}
+
+	got, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(got) != content {
+		t.Errorf("expected ensureContextSections to be a byte-for-byte no-op when all headers are already present\nwant:\n%s\ngot:\n%s", content, got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-5221.

Closes #5221

## Changes

GitHub Issue GH-5221: fix(executor): auto-init must guarantee context-injection sections regardless of template source (plugin template bypasses #5216 fix)

## Context

Follow-up to #5216 / PR #5219. That fix added the three sections `loadProjectContext()` (`internal/executor/prompt_builder.go:801-815`) extracts (`### Key Components`, `## Key Files`, `## Project Structure`) to the **embedded** template — but `Initialize()` (`internal/executor/navigator.go`) prefers the installed Navigator plugin's templates (`FindTemplatesPath()` → `~/.claude/plugins/cache/navigator-marketplace/navigator/<ver>/templates`) and only falls back to embedded when the plugin is absent.

The plugin's own `DEVELOPMENT-README.md` template (verified against 6.18.1) contains **none** of those headers. Consequence, confirmed by running the suite on a machine with the plugin cache present:

- Context injection is still a permanent no-op on plugin-bearing machines — including the production box.
- `TestInitialize_ProjectContextInjectionActivates` fails there (`got empty string`) while passing on plugin-free CI runners — an environment-dependent flake.

Pilot must guarantee its own consumption contract regardless of which template source wins.

## Implementation

1. In `Initialize()` (`internal/executor/navigator.go`), after `copyTemplate("DEVELOPMENT-README.md", ...)`, add an ensure-sections step: append skeleton sections to the generated README for any of the three headers that are missing (`### Key Components`, `## Key Files`, `## Project Structure`), using the same placeholder bodies the embedded template now carries. Idempotent: exact-header check, append only what's absent, never duplicate or reorder existing content.
2. Apply the same invariant check for the `/nav-` command scrub is NOT needed (do not rewrite plugin template content beyond appending missing sections) — only guarantee presence of the three extraction anchors.
3. Isolate the auto-init tests from the developer's real plugin cache: in `internal/executor/navigator_test.go`, the `TestInitialize_*` and `TestGeneratedReadme_NoNavCommandInstructions` tests should `t.Setenv("HOME", t.TempDir())` (same idiom `TestFindTemplatesPath_VersionSelection` already uses) so they exercise the embedded path deterministically.
4. Add one new test that simulates a plugin cache whose `DEVELOPMENT-README.md` template lacks the three headers (temp HOME + fabricated `navigator/9.0.0/templates/DEVELOPMENT-README.md`) and asserts `loadProjectContext()` is non-empty after `Initialize()` — this is the regression test for the actual production path.

## Acceptance

- With a fabricated plugin template missing all three headers, `Initialize()` produces a README for which `loadProjectContext()` returns a non-empty string containing `Key Files` and `Project Structure` (new test).
- Ensure-sections is idempotent: running the section-ensure logic on a README that already has all three headers changes nothing (test asserts byte-equality).
- All `TestInitialize_*` tests pass identically whether or not `~/.claude/plugins/cache/navigator-marketplace` exists (HOME isolation).
- `make build test lint` pass.

## Refs

- #5216, PR #5219 (review comment documents the reproduction)