### PR TITLE
fix(tests): scrub leaked GIT_DIR from pre-push gate and all git-spawning test packages

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -5185,7 +5185,7 @@
       },
       "mem-177": {
         "type": "pitfall",
-        "summary": "core.bare flips ROOT-CAUSED (all 5 occurrences): git exports GIT_DIR to pre-push hooks; from a linked worktree it is ABSOLUTE and overrides git -C, so the gate's go test runs executor git_test.go fixtures against the REAL repo \u2014 init --bare flips core.bare, fixture commits/pushes hit real branches and the real remote (phantom counter/greeter PRs). Root pushes immune (relative .git). SIGTERM was never the trigger. Fix: #5223 (scrub GIT_* in gate + tests). Until merged: never push from a linked worktree without --no-verify or a scrubbed env.",
+        "summary": "core.bare flips ROOT-CAUSED (all 5 occurrences): git exports GIT_DIR to pre-push hooks; from a linked worktree it is ABSOLUTE and overrides git -C, so the gate's go test runs executor git_test.go fixtures against the REAL repo \u2014 init --bare flips core.bare, fixture commits/pushes hit real branches and the real remote (phantom counter/greeter PRs). Root pushes immune (relative .git). SIGTERM was never the trigger. FIXED by #5223: pre-push-gate.sh scrubs GIT_* env; TestMain in executor/autopilot/orchestrator/desktop/cmd-pilot calls testutil.UnsetLeakedGitEnv; regression pin TestGitFixtures_ImmuneToLeakedGITDIR proves decoy repo untouched under a leaked absolute GIT_DIR.",
         "path": "memories/pitfalls/mem-177.md",
         "confidence": 0.98,
         "concepts": [

--- a/.agent/knowledge/memories/pitfalls/mem-177.md
+++ b/.agent/knowledge/memories/pitfalls/mem-177.md
@@ -1,16 +1,24 @@
 # Pitfall: core.bare flips ROOT-CAUSED (all 5 occurrences): git exports GIT_DIR to pre-push
 
 ## Summary
-core.bare flips ROOT-CAUSED (all 5 occurrences): git exports GIT_DIR to pre-push hooks; from a linked worktree it is ABSOLUTE and overrides git -C, so the gate's go test runs executor git_test.go fixtures against the REAL repo — init --bare flips core.bare, fixture commits/pushes hit real branches and the real remote (phantom counter/greeter PRs). Root pushes immune (relative .git). SIGTERM was never the trigger. Fix: #5223 (scrub GIT_* in gate + tests). Until merged: never push from a linked worktree without --no-verify or a scrubbed env.
+core.bare flips ROOT-CAUSED (all 5 occurrences): git exports GIT_DIR to pre-push hooks; from a linked worktree it is ABSOLUTE and overrides git -C, so the gate's go test runs executor git_test.go fixtures against the REAL repo — init --bare flips core.bare, fixture commits/pushes hit real branches and the real remote (phantom counter/greeter PRs). Root pushes immune (relative .git). SIGTERM was never the trigger. FIXED by #5223: scripts/pre-push-gate.sh unsets all leaked GIT_* vars (except GIT_AUTHOR_*/GIT_COMMITTER_*) before running any check; internal/testutil.UnsetLeakedGitEnv is called from TestMain in every package whose tests spawn real git subprocesses against temp/fixture repos (executor, autopilot, orchestrator, desktop, cmd/pilot); regression pin TestGitFixtures_ImmuneToLeakedGITDIR (internal/executor) proves a decoy repo is byte-identical before/after a full package test run with an absolute GIT_DIR exported.
 
 ## Context
 Discovered during development.
 
 ## Details
-core.bare flips ROOT-CAUSED (all 5 occurrences): git exports GIT_DIR to pre-push hooks; from a linked worktree it is ABSOLUTE and overrides git -C, so the gate's go test runs executor git_test.go fixtures against the REAL repo — init --bare flips core.bare, fixture commits/pushes hit real branches and the real remote (phantom counter/greeter PRs). Root pushes immune (relative .git). SIGTERM was never the trigger. Fix: #5223 (scrub GIT_* in gate + tests). Until merged: never push from a linked worktree without --no-verify or a scrubbed env.
+core.bare flips ROOT-CAUSED (all 5 occurrences): git exports GIT_DIR to pre-push hooks; from a linked worktree it is ABSOLUTE and overrides git -C, so the gate's go test runs executor git_test.go fixtures against the REAL repo — init --bare flips core.bare, fixture commits/pushes hit real branches and the real remote (phantom counter/greeter PRs). Root pushes immune (relative .git). SIGTERM was never the trigger.
+
+FIXED by #5223 (two layers):
+1. Gate layer: `scripts/pre-push-gate.sh` unsets every `GIT_*` env var (except `GIT_AUTHOR_*`/`GIT_COMMITTER_*`) right after `set -e`, before any check runs, so the gate's own git calls and everything `go test` spawns re-resolve from CWD.
+2. Test layer (defense in depth): `internal/testutil.ScrubbedGitEnv()`/`UnsetLeakedGitEnv()` filter `GIT_*` out of a command's env; `TestMain` in `internal/executor`, `internal/autopilot`, `internal/orchestrator`, `desktop`, and `cmd/pilot` calls `UnsetLeakedGitEnv()` before any test runs — the packages whose test files spawn real `git` subprocesses (init/commit/push) against temp dirs. `internal/health` was audited and excluded: it only shells out to `git --version` / `LookPath`, never mutates a repo.
+
+Regression pin: `internal/executor/git_gh5223_env_leak_test.go` (`TestGitFixtures_ImmuneToLeakedGITDIR`) sets `GIT_DIR` to a decoy bare repo via `t.Setenv`, runs a bare-init/commit/push fixture flow through `testutil.ScrubbedGitEnv`, and asserts the decoy's `core.bare` and refs are unchanged. Verified manually too: `GIT_DIR=<absolute decoy path> go test -short ./internal/executor/...` (and the other 4 packages) run green with the decoy's config/refs byte-identical before/after.
+
+Residual risk: production `internal/executor/git.go` (`GitOperations`) still doesn't scrub its own `cmd.Env` — out of scope for #5223 because Pilot's runtime process isn't invoked through a git hook context, so it was never exposed to this specific leak path. If that assumption ever changes, `GitOperations` would need the same scrub.
 
 ## Recommended Approach
-Apply this knowledge when working on related topics.
+Any new package whose tests spawn real `git` subprocesses against temp/fixture repos (init/commit/push, not just `--version`/`LookPath`) must add a `TestMain` calling `testutil.UnsetLeakedGitEnv()` — copy the pattern from `internal/executor/gitenv_testmain_test.go`.
 
 ## Related
 - None documented

--- a/cmd/pilot/gitenv_testmain_test.go
+++ b/cmd/pilot/gitenv_testmain_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// TestMain scrubs git-injected environment variables (GIT_DIR,
+// GIT_WORK_TREE, GIT_INDEX_FILE, GIT_PREFIX, GIT_COMMON_DIR, ...) before any
+// test in this package runs.
+//
+// GH-5223: mustGit (repo_allowlist_test.go) and runGit
+// (handler_common_test.go) spawn real `git` subprocesses against temp
+// directories. If GIT_DIR is leaked into the test binary's environment
+// (git exports it into the pre-push hook, where it resolves to an ABSOLUTE
+// path when the push runs from a linked worktree), those subprocesses
+// silently operate on the REAL repo instead. See testutil.UnsetLeakedGitEnv.
+func TestMain(m *testing.M) {
+	testutil.UnsetLeakedGitEnv()
+	os.Exit(m.Run())
+}

--- a/desktop/gitenv_testmain_test.go
+++ b/desktop/gitenv_testmain_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// TestMain scrubs git-injected environment variables (GIT_DIR,
+// GIT_WORK_TREE, GIT_INDEX_FILE, GIT_PREFIX, GIT_COMMON_DIR, ...) before any
+// test in this package runs.
+//
+// GH-5223: newGitGraphFixtureRepo (app_test.go) spawns real `git`
+// subprocesses against a temp directory. If GIT_DIR is leaked into the test
+// binary's environment (git exports it into the pre-push hook, where it
+// resolves to an ABSOLUTE path when the push runs from a linked worktree),
+// those subprocesses silently operate on the REAL repo instead. See
+// testutil.UnsetLeakedGitEnv.
+func TestMain(m *testing.M) {
+	testutil.UnsetLeakedGitEnv()
+	os.Exit(m.Run())
+}

--- a/internal/autopilot/gitenv_testmain_test.go
+++ b/internal/autopilot/gitenv_testmain_test.go
@@ -1,0 +1,26 @@
+package autopilot
+
+import (
+	"os"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// TestMain scrubs git-injected environment variables (GIT_DIR,
+// GIT_WORK_TREE, GIT_INDEX_FILE, GIT_PREFIX, GIT_COMMON_DIR, ...) before any
+// test in this package runs.
+//
+// GH-5223: this package's conflict/controller fixture tests (runFixtureGit
+// and neighbors) spawn real `git` subprocesses — including pushes to
+// fixture "origin" remotes — against temp directories. If GIT_DIR is leaked
+// into the test binary's environment (git exports it into the pre-push
+// hook, where it resolves to an ABSOLUTE path when the push runs from a
+// linked worktree), every one of those subprocesses silently operates on
+// the REAL repo instead of the temp fixture, up to and including pushing
+// fixture branches to the real GitHub remote. See
+// testutil.UnsetLeakedGitEnv.
+func TestMain(m *testing.M) {
+	testutil.UnsetLeakedGitEnv()
+	os.Exit(m.Run())
+}

--- a/internal/executor/git_gh5223_env_leak_test.go
+++ b/internal/executor/git_gh5223_env_leak_test.go
@@ -1,0 +1,123 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// runScrubbed runs `git <args...>` with GIT_DIR (and friends) removed from
+// its environment via testutil.ScrubbedGitEnv, regardless of what's leaked
+// into the ambient process environment. dir, if non-empty, sets cmd.Dir.
+func runScrubbed(t *testing.T, dir string, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.CommandContext(context.Background(), "git", args...)
+	cmd.Env = testutil.ScrubbedGitEnv()
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func mustScrubbed(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	out, err := runScrubbed(t, dir, args...)
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+	return out
+}
+
+// TestGitFixtures_ImmuneToLeakedGITDIR is the GH-5223 regression pin. It
+// reproduces the exact leak that caused 5 core.bare-flip incidents
+// (GH-5063): GIT_DIR exported into the process environment, resolving to
+// an ABSOLUTE path, exactly as git passes it to a pre-push hook run from a
+// linked worktree (verified repro: with GIT_DIR set to a worktree's
+// gitdir, `git -C /tmp/anywhere rev-parse --absolute-git-dir` resolves to
+// the real repo, overriding `-C` discovery entirely).
+//
+// It proves a git fixture flow built on testutil.ScrubbedGitEnv (the same
+// scrub TestMain applies process-wide at suite start, see
+// gitenv_testmain_test.go) leaves a decoy repo untouched even while a
+// hostile GIT_DIR is set. Without the scrub, this exact sequence — bare
+// init on a temp "remote", local init/commit, push — is what corrupted the
+// real repo: `git init --bare` against a leaked absolute GIT_DIR
+// re-initializes the real repo as bare, and the push lands fixture refs on
+// the real remote.
+func TestGitFixtures_ImmuneToLeakedGITDIR(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	// Decoy stands in for "the real repo" an absolute leaked GIT_DIR would
+	// point at. Built before GIT_DIR is set, using the scrubbed helper.
+	decoyDir, err := os.MkdirTemp("", "pilot-git-decoy-*")
+	if err != nil {
+		t.Fatalf("failed to create decoy dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(decoyDir) }()
+	mustScrubbed(t, "", "init", "--bare", decoyDir)
+
+	snapshotDecoy := func() (bareCfg, refs string) {
+		t.Helper()
+		bareCfg = strings.TrimSpace(mustScrubbed(t, decoyDir, "config", "--get", "core.bare"))
+		refs, _ = runScrubbed(t, decoyDir, "show-ref")
+		return
+	}
+	wantBare, wantRefs := snapshotDecoy()
+	if wantBare != "true" {
+		t.Fatalf("sanity check failed: decoy core.bare = %q, want true", wantBare)
+	}
+
+	// Simulate the leak: GIT_DIR exported to the decoy's absolute path, as
+	// it would be inherited from a pre-push hook run in a linked worktree.
+	t.Setenv("GIT_DIR", decoyDir)
+
+	// Run the same fixture shape that historically corrupted the real repo
+	// (see TestRemoteBranchExists_WithRemote): bare "remote" init, local
+	// init+commit, add remote, push — all via the scrubbed helper despite
+	// the hostile ambient GIT_DIR set above.
+	remoteDir, err := os.MkdirTemp("", "pilot-git-remote-*")
+	if err != nil {
+		t.Fatalf("failed to create remote dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(remoteDir) }()
+
+	localDir, err := os.MkdirTemp("", "pilot-git-local-*")
+	if err != nil {
+		t.Fatalf("failed to create local dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(localDir) }()
+
+	mustScrubbed(t, "", "init", "--bare", remoteDir)
+	mustScrubbed(t, localDir, "init")
+	mustScrubbed(t, localDir, "config", "user.email", "test@test.com")
+	mustScrubbed(t, localDir, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(localDir, "test.txt"), []byte("initial"), 0644); err != nil {
+		t.Fatalf("failed to write fixture file: %v", err)
+	}
+	mustScrubbed(t, localDir, "add", ".")
+	mustScrubbed(t, localDir, "commit", "-m", "initial")
+	mustScrubbed(t, localDir, "remote", "add", "origin", remoteDir)
+	mustScrubbed(t, localDir, "push", "-u", "origin", "HEAD:main")
+
+	// The fixture flow above must have landed on remoteDir, not the decoy.
+	fixtureRefs := mustScrubbed(t, remoteDir, "show-ref", "--heads", "main")
+	if strings.TrimSpace(fixtureRefs) == "" {
+		t.Error("expected fixture push to land on the fixture remote (main branch), got no refs")
+	}
+
+	gotBare, gotRefs := snapshotDecoy()
+	if gotBare != wantBare {
+		t.Errorf("decoy core.bare changed under leaked GIT_DIR: got %q, want %q", gotBare, wantBare)
+	}
+	if gotRefs != wantRefs {
+		t.Errorf("decoy refs changed under leaked GIT_DIR: got %q, want %q", gotRefs, wantRefs)
+	}
+}

--- a/internal/executor/gitenv_testmain_test.go
+++ b/internal/executor/gitenv_testmain_test.go
@@ -1,0 +1,26 @@
+package executor
+
+import (
+	"os"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// TestMain scrubs git-injected environment variables (GIT_DIR,
+// GIT_WORK_TREE, GIT_INDEX_FILE, GIT_PREFIX, GIT_COMMON_DIR, ...) before any
+// test in this package runs.
+//
+// GH-5223: this package's git fixture tests (git_test.go and neighbors)
+// spawn real `git` subprocesses against temp directories. If GIT_DIR is
+// leaked into the test binary's environment — as git does to the pre-push
+// hook, where it resolves to an ABSOLUTE path when the push runs from a
+// linked worktree — every one of those subprocesses silently operates on
+// the REAL repo instead of the temp fixture: `git init --bare` flips the
+// real repo's core.bare, fixture commits land on real branches, and
+// fixture pushes hit the real GitHub remote. This was the root cause of 5
+// core.bare-flip incidents (GH-5063). See testutil.UnsetLeakedGitEnv.
+func TestMain(m *testing.M) {
+	testutil.UnsetLeakedGitEnv()
+	os.Exit(m.Run())
+}

--- a/internal/orchestrator/gitenv_testmain_test.go
+++ b/internal/orchestrator/gitenv_testmain_test.go
@@ -1,0 +1,23 @@
+package orchestrator
+
+import (
+	"os"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// TestMain scrubs git-injected environment variables (GIT_DIR,
+// GIT_WORK_TREE, GIT_INDEX_FILE, GIT_PREFIX, GIT_COMMON_DIR, ...) before any
+// test in this package runs.
+//
+// GH-5223: setupTestGitRepo (quality_integration_test.go) spawns real `git`
+// subprocesses against a temp directory. If GIT_DIR is leaked into the test
+// binary's environment (git exports it into the pre-push hook, where it
+// resolves to an ABSOLUTE path when the push runs from a linked worktree),
+// those subprocesses silently operate on the REAL repo instead. See
+// testutil.UnsetLeakedGitEnv.
+func TestMain(m *testing.M) {
+	testutil.UnsetLeakedGitEnv()
+	os.Exit(m.Run())
+}

--- a/internal/testutil/gitenv.go
+++ b/internal/testutil/gitenv.go
@@ -1,0 +1,69 @@
+package testutil
+
+import (
+	"os"
+	"strings"
+)
+
+// gitEnvAllowlist holds GIT_* environment variables that are intentional
+// and safe to leave in a test subprocess's environment (commit identity
+// overrides). Everything else prefixed GIT_ is git-injected plumbing state
+// and must never leak into a test that spawns its own git subprocesses.
+var gitEnvAllowlist = map[string]bool{
+	"GIT_AUTHOR_NAME":     true,
+	"GIT_AUTHOR_EMAIL":    true,
+	"GIT_AUTHOR_DATE":     true,
+	"GIT_COMMITTER_NAME":  true,
+	"GIT_COMMITTER_EMAIL": true,
+	"GIT_COMMITTER_DATE":  true,
+}
+
+// isDangerousGitEnvVar reports whether name is a git-injected environment
+// variable (GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE, GIT_PREFIX,
+// GIT_COMMON_DIR, and so on) that must be scrubbed before spawning a git
+// subprocess against a temp/fixture repo.
+func isDangerousGitEnvVar(name string) bool {
+	return strings.HasPrefix(name, "GIT_") && !gitEnvAllowlist[name]
+}
+
+// ScrubbedGitEnv returns a copy of the current process environment with all
+// git-injected variables removed, suitable for assigning directly to
+// exec.Cmd.Env before spawning a git subprocess.
+//
+// Why this exists (GH-5223 — root cause of 5 core.bare-flip incidents,
+// GH-5063): git exports GIT_DIR (and friends) into the pre-push hook's
+// environment. From a linked worktree, GIT_DIR is an ABSOLUTE path into the
+// shared .git dir, and an absolute GIT_DIR overrides `git -C <dir>`
+// discovery entirely — verified repro: with GIT_DIR set to a worktree's
+// gitdir, `git -C /tmp/anywhere rev-parse --absolute-git-dir` resolves to
+// the real repo. Any test that spawns `git` against a temp directory while
+// GIT_DIR is leaked silently operates on the REAL repo instead: `git init
+// --bare` flips the real repo's core.bare, fixture commits land on real
+// branches, and fixture pushes hit the real GitHub remote.
+func ScrubbedGitEnv() []string {
+	environ := os.Environ()
+	out := make([]string, 0, len(environ))
+	for _, kv := range environ {
+		name, _, ok := strings.Cut(kv, "=")
+		if ok && isDangerousGitEnvVar(name) {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
+// UnsetLeakedGitEnv removes git-injected environment variables from the
+// current process's environment outright. Call it from a package's
+// TestMain so that every exec.Command/exec.CommandContext git invocation in
+// the package — including ones that leave cmd.Env nil and inherit the
+// ambient environment — is immune to a leaked GIT_DIR for the lifetime of
+// the test binary. See ScrubbedGitEnv for the full threat model (GH-5223).
+func UnsetLeakedGitEnv() {
+	for _, kv := range os.Environ() {
+		name, _, ok := strings.Cut(kv, "=")
+		if ok && isDangerousGitEnvVar(name) {
+			_ = os.Unsetenv(name)
+		}
+	}
+}

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -13,6 +13,24 @@
 
 set -e
 
+# Scrub git-injected environment variables (GH-5223 — root cause of 5
+# core.bare-flip incidents, GH-5063). Git exports GIT_DIR (and friends)
+# into the pre-push hook's environment; from a LINKED WORKTREE, GIT_DIR is
+# an ABSOLUTE path into the shared .git dir, and an absolute GIT_DIR
+# overrides `git -C <dir>` discovery entirely. Left unscrubbed, this gate's
+# own git invocations — and every `git` subprocess spawned by `go test`
+# below, including test fixtures that git-init/commit/push against temp
+# dirs — silently retarget the REAL repo instead of the intended one.
+# Unset everything git-injected except intentional identity overrides so
+# every git call in this script (and its child processes) re-resolves from
+# CWD.
+while IFS='=' read -r _gh_var _; do
+    case "$_gh_var" in
+        GIT_AUTHOR_*|GIT_COMMITTER_*) ;;
+        GIT_*) unset "$_gh_var" ;;
+    esac
+done < <(env)
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 


### PR DESCRIPTION
## Summary

Root cause of all 5 core.bare-flip incidents (GH-5063), root-caused today: git exports `GIT_DIR` into the pre-push hook's environment. From a **linked worktree** (e.g. `pilot-worktree-GH-*`), `GIT_DIR` is an **absolute** path into the shared `.git` dir — and an absolute `GIT_DIR` overrides `git -C <dir>` discovery entirely (verified repro: with `GIT_DIR` set to a worktree's gitdir, `git -C /tmp/anywhere rev-parse --absolute-git-dir` resolves to the real repo).

The gate's `go test -short -race ./...` inherits that leaked env, so every git subprocess spawned by fixture tests against a temp dir silently targets the **real repo** instead:
- `git init --bare` flips the real repo's `core.bare` (the writer behind all 5 flip incidents; SIGTERM correlation was coincidental)
- fixture commits land on real branches
- fixture pushes hit the real GitHub remote (phantom counter/greeter PRs)

## Fix (both layers)

1. **Gate layer** — `scripts/pre-push-gate.sh` unsets every `GIT_*` env var (except `GIT_AUTHOR_*`/`GIT_COMMITTER_*`) immediately after `set -e`, before any check runs, so the gate's own git calls and everything `go test` spawns re-resolve from CWD.
2. **Test layer (defense in depth)** — `internal/testutil` adds `ScrubbedGitEnv()`/`UnsetLeakedGitEnv()`. `TestMain` calls `UnsetLeakedGitEnv()` before any test runs in every package whose tests spawn real `git` subprocesses (init/commit/push) against temp/fixture repos: `internal/executor`, `internal/autopilot`, `internal/orchestrator`, `desktop`, `cmd/pilot`.
3. **Regression pin** — `internal/executor/git_gh5223_env_leak_test.go` (`TestGitFixtures_ImmuneToLeakedGITDIR`) sets `GIT_DIR` to a decoy bare repo, runs a bare-init/local-init/commit/push fixture flow through `testutil.ScrubbedGitEnv`, and asserts the decoy's `core.bare` and refs are byte-identical before/after.

### Audit result (exec.Command with "git" in test files)

Grepped every `_test.go` in the repo for git-spawning `exec.Command`/`exec.CommandContext`. Packages that mutate a real/temp repo (init/commit/push) — all now covered by `TestMain`: `internal/executor`, `internal/autopilot`, `internal/orchestrator`, `desktop`, `cmd/pilot`. `internal/health` was reviewed and excluded — it only shells out to `git --version` / `exec.LookPath("git")`, never mutates a repo. `internal/quality/runner_test.go`'s only `exec.Command` call is `rm`, not git.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full suite, all packages green)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` → 0 issues
- [x] ShellCheck on `scripts/pre-push-gate.sh` → no new findings introduced (pre-existing warnings in unrelated `run_check`/`run_check_warn` code untouched)
- [x] **Acceptance criterion, manually verified**: `GIT_DIR=<absolute decoy bare repo> go test -short ./internal/executor/... ./internal/autopilot/... ./internal/orchestrator/... ./desktop/... ./cmd/pilot/...` — all green, decoy's `core.bare` (`true`) and refs (`show-ref` empty) byte-identical before/after
- [x] `check-secret-patterns.sh`, `check-mocks.sh`, `check-destructive-calls.sh --self-test` + main run, `check-graph.py` all pass

## Refs

- GH-5063 (tripwire issue), PR#5208 (watcher), PR#5222 (watcher packaging)
- Closes GH-5223